### PR TITLE
Add image server docker to repo

### DIFF
--- a/docker/images/image.server.dockerfile
+++ b/docker/images/image.server.dockerfile
@@ -1,0 +1,5 @@
+FROM nginx:alpine
+COPY ./128_target_flattened/images/ /usr/share/nginx/html/
+COPY ./image.server.nginx.conf /etc/nginx/conf.d/default.conf
+
+

--- a/docker/images/image.server.nginx.conf
+++ b/docker/images/image.server.nginx.conf
@@ -1,0 +1,54 @@
+server {
+    #
+    # Wide-open CORS config for nginx
+    #
+
+    listen       80;
+    listen  [::]:80;
+    server_name  localhost;
+
+    #access_log  /var/log/nginx/host.access.log  main;
+
+    #error_page  404              /404.html;
+
+    # redirect server error pages to the static page /50x.html
+    #
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+
+    # serve static files
+    location /  {
+         root   /usr/share/nginx/html;
+         index  index.html index.htm;
+         expires 30d;
+         if ($request_method = 'OPTIONS') {
+            add_header 'Access-Control-Allow-Origin' '*';
+            add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+            #
+            # Custom headers and headers various browsers *should* be OK with but aren't
+            #
+            add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
+            #
+            # Tell client that this pre-flight info is valid for 20 days
+            #
+            add_header 'Access-Control-Max-Age' 1728000;
+            add_header 'Content-Type' 'text/plain; charset=utf-8';
+            add_header 'Content-Length' 0;
+            return 204;
+         }
+         if ($request_method = 'POST') {
+            add_header 'Access-Control-Allow-Origin' '*' always;
+            add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS' always;
+            add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range' always;
+            add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range' always;
+         }
+         if ($request_method = 'GET') {
+            add_header 'Access-Control-Allow-Origin' '*' always;
+            add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS' always;
+            add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range' always;
+            add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range' always;
+         }
+    }
+}


### PR DESCRIPTION
Adds a basic image server docker image that must be build from the folder that contains the target directory `./128_target_flattened/images/` and the nginx config file.

The image can be specified when calling `docker build -f ../Dockerfile .` but required files must be present in the context.