### PR TITLE
rename Hash20 to U8x20 in proxy contract

### DIFF
--- a/protocol/contracts/proxy/src/lib.rs
+++ b/protocol/contracts/proxy/src/lib.rs
@@ -59,7 +59,7 @@ pub mod proxy {
     #[derive(PartialEq, Debug, Eq, Clone, Copy, scale::Encode, scale::Decode)]
     #[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
     pub enum ProxyReturnTypes {
-        Hash20([u8; 20]),
+        U8x20([u8; 20]),
         AccountId(AccountId),
         Void,
     }
@@ -199,7 +199,7 @@ pub mod proxy {
         pub fn handler(&mut self, msg: ProxyMessages) -> Result<ProxyReturnTypes, Error> {
             match msg {
                 ProxyMessages::GetGitCommitId => {
-                    Ok(ProxyReturnTypes::Hash20(self.get_git_commit_id()))
+                    Ok(ProxyReturnTypes::U8x20(self.get_git_commit_id()))
                 }
                 ProxyMessages::GetAuthor => Ok(ProxyReturnTypes::AccountId(self.get_author())),
                 ProxyMessages::GetAdmin => Ok(ProxyReturnTypes::AccountId(self.get_admin())),


### PR DESCRIPTION
This is so it matches other types (e.g. `U8x32`) which are coming from other PRs