### PR TITLE
Tests provider workflow cache

### DIFF
--- a/.github/workflows/tests_provider.yml
+++ b/.github/workflows/tests_provider.yml
@@ -15,12 +15,7 @@ env:
 
 jobs:
   build:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ ubuntu-latest ]
-    runs-on: ${{ matrix.os }}
-
+    runs-on: ubuntu-latest
     steps:
       - name: Check github refname
         run: |

--- a/.github/workflows/tests_provider.yml
+++ b/.github/workflows/tests_provider.yml
@@ -23,6 +23,7 @@ jobs:
       - run: mkdir -p protocol/cargo-cache
       - run: mkdir -p protocol/target
       - run: mkdir -p node_modules
+      - run: mkdir -p .cache/Cypress
 
       - name: Restore cache
         uses: actions/cache/restore@v3
@@ -31,6 +32,7 @@ jobs:
                 protocol/cargo-cache
                 protocol/target
                 node_modules
+                .cache/Cypress
             # note that restoring a cache in github is a pain. The trailing '-' matches any string after the '-', therefore 'abc-' would match a cache named 'abc-1234' or 'abc-5678', etc.
             # the problem is 'abc-' will not match a cache named 'abc'! So if you're using wildcard cache name selectors like this, you need a field that changes as the suffix to become the wildcard
             # here we're setting the key to an unused cache key so it falls back to the wildcard selector in `restore-keys`

--- a/.github/workflows/tests_provider.yml
+++ b/.github/workflows/tests_provider.yml
@@ -17,23 +17,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Check github refname
-        run: |
-          echo ${{ github.ref }}
-          echo ${{ github.ref_name }}
-          echo ${{ github.head_ref }}
-          echo ${{ github.base_ref }}
-
-      - name: Remove stopped containers
-        run: docker rm $(docker ps -a -q) || true
-
-      - name: Clone captcha
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ github.head_ref }}
-          repository: prosopo/captcha
-          path: captcha
-          submodules: recursive
+      # Checkout the repo
+      - uses: actions/checkout@v3
 
       - run: mkdir -p protocol/cargo-cache
       - run: mkdir -p protocol/target

--- a/.github/workflows/tests_provider.yml
+++ b/.github/workflows/tests_provider.yml
@@ -62,6 +62,8 @@ jobs:
           docker compose --file ./docker/docker-compose.test.yml up -d
           docker container ls
 
+      - run: ls -lah
+
       - run: npm install
 
       # Checks if the git hash of packages is the same after running linting by comparing the git tree hash before

--- a/.github/workflows/tests_provider.yml
+++ b/.github/workflows/tests_provider.yml
@@ -145,8 +145,3 @@ jobs:
           cd demos/client-example && NODE_ENV=test npm run cypress:run
           
 
-      - name: Remove the docker containers
-        run: |
-          cd captcha
-          docker compose --file ./docker/docker-compose.test.yml down
-

--- a/.github/workflows/tests_provider.yml
+++ b/.github/workflows/tests_provider.yml
@@ -43,7 +43,6 @@ jobs:
 
       - name: Start the docker images
         run: |
-          cd captcha
           docker compose --file ./docker/docker-compose.test.yml up -d
           docker container ls
 
@@ -55,7 +54,6 @@ jobs:
       # linting to a temporary git index file and root tree hash after linting
       - name: Linting check
         run: |
-          cd captcha
           PACKAGES_HASH=$(git show HEAD --format=%T | head -1)
           npm run lint:fix
           cp .git/index /tmp/git_index
@@ -72,7 +70,6 @@ jobs:
       - name: Build provider and dependencies
         # Next few lines should contain the number of packages that provider depends on (check tsconfig.json)
         run: |
-          cd captcha
           echo $(npx tsc --version)
           cd dev && echo $(pwd) && echo $(git rev-parse HEAD) && npm run build
           cp env.test .env.test
@@ -82,7 +79,6 @@ jobs:
 
       - name: Deploy the contracts and run the unit tests
         run: |
-          cd captcha
           npm run deploy_protocol
           npm run deploy_dapp
           git status | head -n 1
@@ -94,7 +90,6 @@ jobs:
 
       - name: Reset the docker containers
         run: |
-          cd captcha
           docker compose --file ./docker/docker-compose.test.yml down
           docker compose --file ./docker/docker-compose.test.yml up -d
           docker container ls
@@ -105,7 +100,6 @@ jobs:
 
       - name: Deploy the contracts and run the cypress tests on client-example
         run: |
-          cd captcha
           cp demos/client-example-server/env.development demos/client-example-server/.env.test
           cp demos/client-example/env.development demos/client-example/.env.test
           cp dev/env.test dev/.env.test

--- a/.github/workflows/tests_provider.yml
+++ b/.github/workflows/tests_provider.yml
@@ -1,4 +1,4 @@
-name: Provider Tests
+name: tests_provider
 
 on:
   pull_request:

--- a/.github/workflows/tests_provider.yml
+++ b/.github/workflows/tests_provider.yml
@@ -40,27 +40,26 @@ jobs:
           path: captcha
           submodules: recursive
 
+      - run: mkdir -p protocol/cargo-cache
+      - run: mkdir -p protocol/target
+      - run: mkdir -p node_modules
 
-      - run: mkdir -p ~/image-cache
-
-      - id: image-cache
-        uses: actions/cache@v3
+      - name: Restore cache
+        uses: actions/cache/restore@v3
         with:
-          path: ~/image-cache
-          key: image-cache-docker-${{ runner.os }}-${{ hashFiles('./captcha/docker/docker-compose.test.yml') }}
+            path: |
+                protocol/cargo-cache
+                protocol/target
+                node_modules
+            # note that restoring a cache in github is a pain. The trailing '-' matches any string after the '-', therefore 'abc-' would match a cache named 'abc-1234' or 'abc-5678', etc.
+            # the problem is 'abc-' will not match a cache named 'abc'! So if you're using wildcard cache name selectors like this, you need a field that changes as the suffix to become the wildcard
+            # here we're setting the key to an unused cache key so it falls back to the wildcard selector in `restore-keys`
+            key: some-unused-cache-key
+            restore-keys: |
+                project-cache-${{ runner.os }}-${{ runner.arch }}-
 
-      - if: steps.image-cache.outputs.cache-hit != 'true'
-        run: |
-          docker pull prosopo/substrate-contracts-node:v0.25
-          docker save -o ~/image-cache/prosopo.tar prosopo/substrate-contracts-node:v0.25
-          docker pull mongo:5.0.4
-          docker save -o ~/image-cache/mongo.tar mongo:5.0.4
-
-      - if: steps.image-cache.outputs.cache-hit == 'true'
-        run: |
-          ls ~/image-cache
-          docker load -i ~/image-cache/prosopo.tar
-          docker load -i ~/image-cache/mongo.tar
+      - run: docker pull prosopo/substrate-contracts-node:v0.25
+      - run: docker pull mongo:5.0.4
 
       - name: Start the docker images
         run: |
@@ -68,24 +67,7 @@ jobs:
           docker compose --file ./docker/docker-compose.test.yml up -d
           docker container ls
 
-      - id: node-cache
-        uses: actions/cache@v3
-        with:
-          path: ~/.npm
-          key: node-cache-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            node-cache-${{ runner.os }}-
-
-      - if: ${{ steps.node-cache.outputs.cache-hit == 'true' }}
-        run: |
-          cd ~/.npm
-          ls
-
-      - name: Install dependencies
-        run: |
-          cd captcha
-          ls .
-          npm install
+      - run: npm install
 
       # Checks if the git hash of packages is the same after running linting by comparing the git tree hash before
       # linting to a temporary git index file and root tree hash after linting


### PR DESCRIPTION
this adds the project cache into the tests_provider workflow

I've removed the image cache as it's actually quicker to do a docker pull each run. Further, cache space on github actions is limited to 10Gb so we want to maximise the cache space for our own content over docker images

I've also removed the docker down command, as github actions should kill the docker containers upon finishing