### PR TITLE
defaults for docker image parameter

### DIFF
--- a/protocol/dev/src/cli.ts
+++ b/protocol/dev/src/cli.ts
@@ -193,7 +193,6 @@ export async function processArgs(args: string[]) {
             type: 'string',
             demand: false,
             desc: 'Use a docker contracts-ci image to build instead of local toolchain',
-            default: 'prosopo/contracts-ci-linux:3.0.1',
         })
     }
 
@@ -201,7 +200,8 @@ export async function processArgs(args: string[]) {
         const rest = argv._.slice(1).join(' ') // remove the first arg (the command) to get the rest of the args
         const toolchain = argv.toolchain ? `+${argv.toolchain}` : ''
         const relDir = path.relative(repoDir, dir || '..')
-        const dockerImage = argv.docker || ''
+        const dockerImage = argv.docker === '' ? 'prosopo/contracts-ci-linux:3.0.1' : argv.docker ?? ''
+        console.log('dockerImage', dockerImage)
 
         if (cmd.startsWith('contract') && argv.contract) {
             throw new Error('Cannot run contract commands on specific packages')


### PR DESCRIPTION
if unspecified, build locally without docker

if specified but empty string (i.e. --docker), use prosopo/contracts-ci-linux:3.0.1

if specified and non-empty string, use the docker image specified