### PR TITLE
make image_provider workflow only trigger on main branch pushes

### DIFF
--- a/.github/workflows/image_provider.yml
+++ b/.github/workflows/image_provider.yml
@@ -6,12 +6,7 @@ on:
       - 'main'
     paths:
       - 'packages/**'
-  pull_request:
-    branches: [ main ]
-    paths:
-      - 'packages/**'
-      - '.github/workflows/image_provider.yml'
-
+      
 env:
   CARGO_TERM_COLOR: always
   GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Previously, the image_provider job would run for all PRs. This means that whenever the version number is bumped in a PR, the image built in that PR is pushed to docker. If subsequent changes are made to that PR, the docker image is not replaced as the version number has not changed.

The image should only be pushed to docker __after__ the PR has been merged