### PR TITLE
Bugfix 476 - adding build step to npm release process

### DIFF
--- a/.github/workflows/npm_release_process.yml
+++ b/.github/workflows/npm_release_process.yml
@@ -44,6 +44,9 @@ jobs:
                   restore-keys: |
                       project-cache-${{ runner.os }}-${{ runner.arch }}-
 
+            - name: Install dependencies
+              run: npm ci
+
             - name: Build the packages
               run: npm run build:all
 

--- a/.github/workflows/npm_release_process.yml
+++ b/.github/workflows/npm_release_process.yml
@@ -44,6 +44,9 @@ jobs:
                   restore-keys: |
                       project-cache-${{ runner.os }}-${{ runner.arch }}-
 
+            - name: Build the packages
+              run: npm run build:all
+
             - name: Check provider image version
               id: check_provider_image_version
               run: |


### PR DESCRIPTION
Adds npm ci and npm run build:all as a step prior to npm release for version bumps