### PR TITLE
Cargo cache fix

### DIFF
--- a/.github/workflows/post_pr.yml
+++ b/.github/workflows/post_pr.yml
@@ -59,15 +59,11 @@ jobs:
 
             - run: npm install
 
-            - name: Build contracts
+            - name: Rust formatting check
               run: |
                   cd protocol/dev
-                  npm run cli -- build --docker
-
-            - name: Test contracts
-              run: |
-                  cd protocol/dev
-                  RUST_BACKTRACE=1 npm run cli -- test --docker
+                  npm run build
+                  npm run cli -- fmt --all --verbose --docker
 
             - name: Clippy
               run: |
@@ -75,11 +71,15 @@ jobs:
                   npm run build
                   npm run cli -- clippy --docker -- -- -D warnings
 
-            - name: Rust formatting check
+            - name: Build contracts
               run: |
                   cd protocol/dev
-                  npm run build
-                  npm run cli -- fmt --all --verbose --docker
+                  npm run cli -- build --docker --skip-env
+
+            - name: Test contracts
+              run: |
+                  cd protocol/dev
+                  RUST_BACKTRACE=1 npm run cli -- test --docker
 
             # install cypress so we don't have to do that every time
             - name: Cypress install

--- a/.gitignore
+++ b/.gitignore
@@ -119,6 +119,7 @@ secrets.json
 
 # Ingnore build target
 protocol/target
+protocol/cargo-cache
 
 /db/
 /data/

--- a/protocol/dev/src/cli.ts
+++ b/protocol/dev/src/cli.ts
@@ -227,7 +227,9 @@ export async function processArgs(args: string[]) {
                 // if not, pull it
                 await exec(`docker pull ${dockerImage}`)
             }
-            script = `docker run --rm -v ${repoDir}:/repo -v ${cargoCacheDir}:/cargo-cache ${dockerImage} cargo ${toolchain} ${cmd} --manifest-path=${manifestPath} ${rest}`
+            const uid = process.getuid?.() ?? '1000'
+            const gid = process.getgid?.() ?? '1000'
+            script = `docker run --rm -u ${uid}:${gid} -v ${repoDir}:/repo -v ${cargoCacheDir}:/cargo-cache ${dockerImage} cargo ${toolchain} ${cmd} --manifest-path=${manifestPath} ${rest}`
         } else {
             script = `cargo ${toolchain} ${cmd} ${rest}`
             if (dir) {
@@ -242,11 +244,6 @@ export async function processArgs(args: string[]) {
             // error should be printed to console in the exec function
             // error out after cleanup
             error = true
-        }
-
-        if (dockerImage) {
-            // docker ci image runs as root, so chown the target dir
-            await exec(`cd ${repoDir} && sudo chown -R $(whoami):$(whoami) ${targetDir} || true`)
         }
 
         await new Promise((resolve, reject) => {

--- a/protocol/dev/src/cli.ts
+++ b/protocol/dev/src/cli.ts
@@ -215,6 +215,9 @@ export async function processArgs(args: string[]) {
 
         let script = ''
         if (dockerImage) {
+            if (toolchain !== undefined) {
+                throw new Error('Cannot specify toolchain when using docker')
+            }
             const manifestPath = path.join('/repo', relDir, '/Cargo.toml')
             // check if the docker image is already pulled
             try {
@@ -223,7 +226,7 @@ export async function processArgs(args: string[]) {
                 // if not, pull it
                 await exec(`docker pull ${dockerImage}`)
             }
-            script = `docker run --rm -v ${repoDir}:/repo -v ${cargoCacheDir}:/cargo-cache --entrypoint /bin/sh ${dockerImage} -c 'cargo ${toolchain} ${cmd} --manifest-path=${manifestPath} ${rest}'`
+            script = `docker run --rm -v ${repoDir}:/repo -v ${cargoCacheDir}:/cargo-cache ${dockerImage} ${cmd} --manifest-path=${manifestPath} ${rest}'`
         } else {
             script = `cargo ${toolchain} ${cmd} ${rest}`
             if (dir) {


### PR DESCRIPTION
The `cargo-cache` dir was not being used properly. This was due to the cargo-cache symlinks being improperly setup and the incorrect command being invoked on the docker ci image. I've changed both of these, the former being in our cargo-contract fork and published to docker under `contracts-ci-linux:3.0.1`

Once this PR is merged we'll need the `post_pr` workflow to do a run to build the cache. This __should__ include the cargo-cache contents from that point onwards, greatly speeding up rust based operations

I've also made the protocol cli call docker with the current user's UID and GID so that new files get created with the current user as the owner, removing the need for chown'ing after (+ sudo password!)