### PR TITLE
remove cache restore step from post_pr workflow

### DIFF
--- a/.github/workflows/post_pr.yml
+++ b/.github/workflows/post_pr.yml
@@ -32,26 +32,6 @@ jobs:
             - run: mkdir -p node_modules
             - run: mkdir -p ~/.cache/Cypress
 
-            - name: Restore cache
-              uses: actions/cache/restore@v3
-              with:
-                  path: |
-                      protocol/cargo-cache
-                      protocol/target
-                      node_modules
-                      ~/.cache/Cypress
-                  # note that restoring a cache in github is a pain. The trailing '-' matches any string after the '-', therefore 'abc-' would match a cache named 'abc-1234' or 'abc-5678', etc.
-                  # the problem is 'abc-' will not match a cache named 'abc'! So if you're using wildcard cache name selectors like this, you need a field that changes as the suffix to become the wildcard
-                  # here we're setting the key to an unused cache key so it falls back to the wildcard selector in `restore-keys`
-                  key: some-unused-cache-key
-                  restore-keys: |
-                      project-cache-${{ runner.os }}-${{ runner.arch }}-
-
-            - run: ls -la ~/.cache/Cypress || true
-            - run: ls -la protocol/cargo-cache || true
-            - run: ls -la protocol/target/ink || true
-            - run: ls -la node_modules || true
-
             - run: npm install
             - run: npm run removePolkadotJSWarnings
 


### PR DESCRIPTION
this stops the cache bloating due to old rust crates sitting around in the cache. Instead of using the cache, we build from scratch after a PR. This will take a bit longer, but will make the cache only contain files relevant to the current PR build rather than all PRs in the whole history