### PR TITLE
restrict publish workflow triggers and concurrency

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,10 +11,6 @@ on:
     # or run manually
     workflow_dispatch:
 
-# enqueues multiple jobs to run sequentially, not in parallel. This avoids race conditions related to version bumping
-concurrency:
-    group: ${{ github.workflow }}
-
 jobs:
     publish:
         runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,9 @@ on:
         # only on the main branch
         branches:
             - main
+        paths:
+            # only when the package.json file changes
+            - package.json
     # or run manually
     workflow_dispatch:
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -64,6 +64,18 @@ jobs:
                   echo "Logging into Docker Hub."
                   echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin 2> /dev/null
 
+            # could have a fail-fast step here which checks the git history for a change to the version line in package.json
+            # however, this would make running the workflow manually a pain, as it wouldn't be able to publish a release if the version line hadn't changed
+            # this could be skipped for a manual run, however
+            # but at that point I wonder the value of this check
+            # anyway, here's how to do it: git show --pretty=format: --no-notes ${{github.event.before}}..${{github.event.after}} package.json | grep -e "[-\+]\s*\"version\""
+            # if there's lines returned, then the version line has changed. The lines will look like:
+            # -    "version": "0.2.24",
+            # +    "version": "0.2.25",
+            # -    "version": "0.2.23",
+            # +    "version": "0.2.24",
+            # note there may be multiple changes if the version line has been changed multiple times. - == removed, + == added
+
             # get next version from root package.json
             - name: Next version
               id: next_version


### PR DESCRIPTION
- restrict publish workflow trigger
- fail-fast step docs for publish workflow
- revert publish workflow concurrency to default
