### PR TITLE
Fix vite/vitest hanging

### DIFF
--- a/dev/config/src/vite/vite-plugin-close-and-copy.ts
+++ b/dev/config/src/vite/vite-plugin-close-and-copy.ts
@@ -36,7 +36,6 @@ export default function VitePluginCloseAndCopy(options?: ClosePluginOptions): Pl
                 log.info(`Bundle copied to ${options.destDir}`)
             }
             log.info('Bundle closed')
-            process.exit(0)
         },
     }
 }

--- a/packages/common/src/i18n.ts
+++ b/packages/common/src/i18n.ts
@@ -42,7 +42,7 @@ if (isClientSide()) {
         .use(initReactI18next)
         .init({ ...commonOptions, ...reactOptions })
 } else {
-    i18n.use(Backend)
+    i18n.use(new Backend(undefined, { reloadInterval: false })) // THIS IS THE LINE THAT CAUSES THE ERROR WHERE VITE NEVER EXITS THE BUNDLING PROCESS! It is due to a setInterval call in this class. Set reloadInterval to false to avoid the interval setup.
         .use(MiddlewareLanguageDetector)
         .init({ ...commonOptions, ...nodeOptions })
 }

--- a/packages/util/src/tests/util.test.ts
+++ b/packages/util/src/tests/util.test.ts
@@ -14,6 +14,14 @@
 import { at, get, merge, permutations } from '../util.js'
 import { describe, expect, test } from 'vitest'
 
+describe('fail', () => {
+    test('fail', () => {
+        expect(() => {
+            throw new Error('test')
+        }).to.throw()
+    })
+})
+
 describe('util', () => {
     describe('merge', () => {
         // factors:


### PR DESCRIPTION
fix i18n setup to avoid setInterval call, allowing node to exit cleanly