### PR TITLE
Fix modal overflowing on laptops and remove height:100%

### DIFF
--- a/dev/config/src/vite/vite.commonjs.config.ts
+++ b/dev/config/src/vite/vite.commonjs.config.ts
@@ -28,7 +28,7 @@ export default async function (name: string, tsConfigPath: string, entry?: strin
                 root: 'src',
                 copy: '**/*.css',
             }),
-            tsconfigPaths({ projects: [path.resolve('./tsconfig.cjs.json')] }),
+            tsconfigPaths({ projects: [path.resolve(tsConfigPath)] }),
             VitePluginCloseAndCopy(),
         ],
         build: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4840,6 +4840,117 @@
                 "webidl-conversions": "^3.0.0"
             }
         },
+        "node_modules/@microsoft/api-extractor": {
+            "version": "7.39.0",
+            "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.39.0.tgz",
+            "integrity": "sha512-PuXxzadgnvp+wdeZFPonssRAj/EW4Gm4s75TXzPk09h3wJ8RS3x7typf95B4vwZRrPTQBGopdUl+/vHvlPdAcg==",
+            "dev": true,
+            "dependencies": {
+                "@microsoft/api-extractor-model": "7.28.3",
+                "@microsoft/tsdoc": "0.14.2",
+                "@microsoft/tsdoc-config": "~0.16.1",
+                "@rushstack/node-core-library": "3.62.0",
+                "@rushstack/rig-package": "0.5.1",
+                "@rushstack/ts-command-line": "4.17.1",
+                "colors": "~1.2.1",
+                "lodash": "~4.17.15",
+                "resolve": "~1.22.1",
+                "semver": "~7.5.4",
+                "source-map": "~0.6.1",
+                "typescript": "5.3.3"
+            },
+            "bin": {
+                "api-extractor": "bin/api-extractor"
+            }
+        },
+        "node_modules/@microsoft/api-extractor-model": {
+            "version": "7.28.3",
+            "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.28.3.tgz",
+            "integrity": "sha512-wT/kB2oDbdZXITyDh2SQLzaWwTOFbV326fP0pUwNW00WeliARs0qjmXBWmGWardEzp2U3/axkO3Lboqun6vrig==",
+            "dev": true,
+            "dependencies": {
+                "@microsoft/tsdoc": "0.14.2",
+                "@microsoft/tsdoc-config": "~0.16.1",
+                "@rushstack/node-core-library": "3.62.0"
+            }
+        },
+        "node_modules/@microsoft/api-extractor/node_modules/colors": {
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/colors/-/colors-1.2.5.tgz",
+            "integrity": "sha512-erNRLao/Y3Fv54qUa0LBB+//Uf3YwMUmdJinN20yMXm9zdKKqH9wt7R9IIVZ+K7ShzfpLV/Zg8+VyrBJYB4lpg==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.1.90"
+            }
+        },
+        "node_modules/@microsoft/api-extractor/node_modules/semver": {
+            "version": "7.5.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+            "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+            "dev": true,
+            "dependencies": {
+                "lru-cache": "^6.0.0"
+            },
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@microsoft/api-extractor/node_modules/source-map": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/@microsoft/api-extractor/node_modules/typescript": {
+            "version": "5.3.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+            "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+            "dev": true,
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=14.17"
+            }
+        },
+        "node_modules/@microsoft/tsdoc": {
+            "version": "0.14.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.14.2.tgz",
+            "integrity": "sha512-9b8mPpKrfeGRuhFH5iO1iwCLeIIsV6+H1sRfxbkoGXIyQE2BTsPd9zqSqQJ+pv5sJ/hT5M1zvOFL02MnEezFug==",
+            "dev": true
+        },
+        "node_modules/@microsoft/tsdoc-config": {
+            "version": "0.16.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/tsdoc-config/-/tsdoc-config-0.16.2.tgz",
+            "integrity": "sha512-OGiIzzoBLgWWR0UdRJX98oYO+XKGf7tiK4Zk6tQ/E4IJqGCe7dvkTvgDZV5cFJUzLGDOjeAXrnZoA6QkVySuxw==",
+            "dev": true,
+            "dependencies": {
+                "@microsoft/tsdoc": "0.14.2",
+                "ajv": "~6.12.6",
+                "jju": "~1.4.0",
+                "resolve": "~1.19.0"
+            }
+        },
+        "node_modules/@microsoft/tsdoc-config/node_modules/resolve": {
+            "version": "1.19.0",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
+            "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
+            "dev": true,
+            "dependencies": {
+                "is-core-module": "^2.1.0",
+                "path-parse": "^1.0.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/@mongodb-js/saslprep": {
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.4.tgz",
@@ -8211,6 +8322,134 @@
             "integrity": "sha512-RbhOOTCNoCrbfkRyoXODZp75MlpiHMgbE5MEBZAnnnLyQNgrigEj4p0lzsMDyc1zVsJDLrivB58tgg3emX0eEA==",
             "dev": true
         },
+        "node_modules/@rushstack/node-core-library": {
+            "version": "3.62.0",
+            "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-3.62.0.tgz",
+            "integrity": "sha512-88aJn2h8UpSvdwuDXBv1/v1heM6GnBf3RjEy6ZPP7UnzHNCqOHA2Ut+ScYUbXcqIdfew9JlTAe3g+cnX9xQ/Aw==",
+            "dev": true,
+            "dependencies": {
+                "colors": "~1.2.1",
+                "fs-extra": "~7.0.1",
+                "import-lazy": "~4.0.0",
+                "jju": "~1.4.0",
+                "resolve": "~1.22.1",
+                "semver": "~7.5.4",
+                "z-schema": "~5.0.2"
+            },
+            "peerDependencies": {
+                "@types/node": "*"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@rushstack/node-core-library/node_modules/colors": {
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/colors/-/colors-1.2.5.tgz",
+            "integrity": "sha512-erNRLao/Y3Fv54qUa0LBB+//Uf3YwMUmdJinN20yMXm9zdKKqH9wt7R9IIVZ+K7ShzfpLV/Zg8+VyrBJYB4lpg==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.1.90"
+            }
+        },
+        "node_modules/@rushstack/node-core-library/node_modules/fs-extra": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+            "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+            "dev": true,
+            "dependencies": {
+                "graceful-fs": "^4.1.2",
+                "jsonfile": "^4.0.0",
+                "universalify": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=6 <7 || >=8"
+            }
+        },
+        "node_modules/@rushstack/node-core-library/node_modules/import-lazy": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-4.0.0.tgz",
+            "integrity": "sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@rushstack/node-core-library/node_modules/jsonfile": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+            "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+            "dev": true,
+            "optionalDependencies": {
+                "graceful-fs": "^4.1.6"
+            }
+        },
+        "node_modules/@rushstack/node-core-library/node_modules/semver": {
+            "version": "7.5.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+            "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+            "dev": true,
+            "dependencies": {
+                "lru-cache": "^6.0.0"
+            },
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@rushstack/node-core-library/node_modules/universalify": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+            "dev": true,
+            "engines": {
+                "node": ">= 4.0.0"
+            }
+        },
+        "node_modules/@rushstack/rig-package": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/@rushstack/rig-package/-/rig-package-0.5.1.tgz",
+            "integrity": "sha512-pXRYSe29TjRw7rqxD4WS3HN/sRSbfr+tJs4a9uuaSIBAITbUggygdhuG0VrO0EO+QqH91GhYMN4S6KRtOEmGVA==",
+            "dev": true,
+            "dependencies": {
+                "resolve": "~1.22.1",
+                "strip-json-comments": "~3.1.1"
+            }
+        },
+        "node_modules/@rushstack/ts-command-line": {
+            "version": "4.17.1",
+            "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-4.17.1.tgz",
+            "integrity": "sha512-2jweO1O57BYP5qdBGl6apJLB+aRIn5ccIRTPDyULh0KMwVzFqWtw6IZWt1qtUoZD/pD2RNkIOosH6Cq45rIYeg==",
+            "dev": true,
+            "dependencies": {
+                "@types/argparse": "1.0.38",
+                "argparse": "~1.0.9",
+                "colors": "~1.2.1",
+                "string-argv": "~0.3.1"
+            }
+        },
+        "node_modules/@rushstack/ts-command-line/node_modules/argparse": {
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+            "dev": true,
+            "dependencies": {
+                "sprintf-js": "~1.0.2"
+            }
+        },
+        "node_modules/@rushstack/ts-command-line/node_modules/colors": {
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/colors/-/colors-1.2.5.tgz",
+            "integrity": "sha512-erNRLao/Y3Fv54qUa0LBB+//Uf3YwMUmdJinN20yMXm9zdKKqH9wt7R9IIVZ+K7ShzfpLV/Zg8+VyrBJYB4lpg==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.1.90"
+            }
+        },
         "node_modules/@scure/base": {
             "version": "1.1.5",
             "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.5.tgz",
@@ -8939,6 +9178,12 @@
             "peerDependencies": {
                 "mongoose": "~7.3.0"
             }
+        },
+        "node_modules/@types/argparse": {
+            "version": "1.0.38",
+            "resolved": "https://registry.npmjs.org/@types/argparse/-/argparse-1.0.38.tgz",
+            "integrity": "sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==",
+            "dev": true
         },
         "node_modules/@types/aws-lambda": {
             "version": "8.10.133",
@@ -10217,6 +10462,34 @@
                 "url": "https://opencollective.com/vitest"
             }
         },
+        "node_modules/@volar/language-core": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-1.11.1.tgz",
+            "integrity": "sha512-dOcNn3i9GgZAcJt43wuaEykSluAuOkQgzni1cuxLxTV0nJKanQztp7FxyswdRILaKH+P2XZMPRp2S4MV/pElCw==",
+            "dev": true,
+            "dependencies": {
+                "@volar/source-map": "1.11.1"
+            }
+        },
+        "node_modules/@volar/source-map": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-1.11.1.tgz",
+            "integrity": "sha512-hJnOnwZ4+WT5iupLRnuzbULZ42L7BWWPMmruzwtLhJfpDVoZLjNBxHDi2sY2bgZXCKlpU5XcsMFoYrsQmPhfZg==",
+            "dev": true,
+            "dependencies": {
+                "muggle-string": "^0.3.1"
+            }
+        },
+        "node_modules/@volar/typescript": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-1.11.1.tgz",
+            "integrity": "sha512-iU+t2mas/4lYierSnoFOeRFQUhAEMgsFuQxoxvwn5EdQopw43j+J27a4lt9LMInx1gLJBC6qL14WYGlgymaSMQ==",
+            "dev": true,
+            "dependencies": {
+                "@volar/language-core": "1.11.1",
+                "path-browserify": "^1.0.1"
+            }
+        },
         "node_modules/@vue/compiler-core": {
             "version": "3.4.15",
             "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.4.15.tgz",
@@ -10277,6 +10550,55 @@
             "dependencies": {
                 "@vue/compiler-dom": "3.4.15",
                 "@vue/shared": "3.4.15"
+            }
+        },
+        "node_modules/@vue/language-core": {
+            "version": "1.8.27",
+            "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-1.8.27.tgz",
+            "integrity": "sha512-L8Kc27VdQserNaCUNiSFdDl9LWT24ly8Hpwf1ECy3aFb9m6bDhBGQYOujDm21N7EW3moKIOKEanQwe1q5BK+mA==",
+            "dev": true,
+            "dependencies": {
+                "@volar/language-core": "~1.11.1",
+                "@volar/source-map": "~1.11.1",
+                "@vue/compiler-dom": "^3.3.0",
+                "@vue/shared": "^3.3.0",
+                "computeds": "^0.0.1",
+                "minimatch": "^9.0.3",
+                "muggle-string": "^0.3.1",
+                "path-browserify": "^1.0.1",
+                "vue-template-compiler": "^2.7.14"
+            },
+            "peerDependencies": {
+                "typescript": "*"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@vue/language-core/node_modules/brace-expansion": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+            "dev": true,
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/@vue/language-core/node_modules/minimatch": {
+            "version": "9.0.3",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+            "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/@vue/shared": {
@@ -12925,6 +13247,12 @@
             "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
             "dev": true
         },
+        "node_modules/computeds": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/computeds/-/computeds-0.0.1.tgz",
+            "integrity": "sha512-7CEBgcMjVmitjYo5q8JTJVra6X5mQ20uTThdK+0kR7UEaDrAWEQcRiBtWJzga4eRpP6afNwwLsX2SET2JhVB1Q==",
+            "dev": true
+        },
         "node_modules/concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -13758,6 +14086,12 @@
             "version": "1.11.10",
             "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.10.tgz",
             "integrity": "sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ==",
+            "dev": true
+        },
+        "node_modules/de-indent": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
+            "integrity": "sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==",
             "dev": true
         },
         "node_modules/debug": {
@@ -18638,6 +18972,15 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/he": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+            "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+            "dev": true,
+            "bin": {
+                "he": "bin/he"
+            }
+        },
         "node_modules/hmac-drbg": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -20613,6 +20956,12 @@
                 "node": ">=6"
             }
         },
+        "node_modules/kolorist": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/kolorist/-/kolorist-1.8.0.tgz",
+            "integrity": "sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==",
+            "dev": true
+        },
         "node_modules/language-subtag-registry": {
             "version": "0.3.22",
             "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.22.tgz",
@@ -21074,6 +21423,12 @@
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
             "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="
+        },
+        "node_modules/lodash.isequal": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+            "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+            "dev": true
         },
         "node_modules/lodash.isinteger": {
             "version": "4.0.4",
@@ -22259,6 +22614,12 @@
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "node_modules/muggle-string": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.3.1.tgz",
+            "integrity": "sha512-ckmWDJjphvd/FvZawgygcUeQCxzvohjFO5RxTjj4eq8kw359gFF3E1brjfI+viLMxss5JrHTDRHZvu2/tuy0Qg==",
+            "dev": true
         },
         "node_modules/multicast-dns": {
             "version": "7.2.5",
@@ -28062,6 +28423,15 @@
             "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
             "dev": true
         },
+        "node_modules/string-argv": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+            "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.6.19"
+            }
+        },
         "node_modules/string-natural-compare": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/string-natural-compare/-/string-natural-compare-3.0.1.tgz",
@@ -30244,6 +30614,15 @@
                 "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
             }
         },
+        "node_modules/validator": {
+            "version": "13.11.0",
+            "resolved": "https://registry.npmjs.org/validator/-/validator-13.11.0.tgz",
+            "integrity": "sha512-Ii+sehpSfZy+At5nPdnyMhx78fEoPDkR2XW/zimHEL3MyGJQOCQ7WeP20jPYRz7ZCpcKLB21NxuXHF3bxjStBQ==",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
         "node_modules/varuint-bitcoin": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/varuint-bitcoin/-/varuint-bitcoin-1.1.2.tgz",
@@ -30373,6 +30752,49 @@
             "version": "4.3.4",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
             "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+            "dependencies": {
+                "ms": "2.1.2"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/vite-plugin-dts": {
+            "version": "3.7.3",
+            "resolved": "https://registry.npmjs.org/vite-plugin-dts/-/vite-plugin-dts-3.7.3.tgz",
+            "integrity": "sha512-26eTlBYdpjRLWCsTJebM8vkCieE+p9gP3raf+ecDnzzK5E3FG6VE1wcy55OkRpfWWVlVvKkYFe6uvRHYWx7Nog==",
+            "dev": true,
+            "dependencies": {
+                "@microsoft/api-extractor": "7.39.0",
+                "@rollup/pluginutils": "^5.1.0",
+                "@vue/language-core": "^1.8.26",
+                "debug": "^4.3.4",
+                "kolorist": "^1.8.0",
+                "vue-tsc": "^1.8.26"
+            },
+            "engines": {
+                "node": "^14.18.0 || >=16.0.0"
+            },
+            "peerDependencies": {
+                "typescript": "*",
+                "vite": "*"
+            },
+            "peerDependenciesMeta": {
+                "vite": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/vite-plugin-dts/node_modules/debug": {
+            "version": "4.3.4",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+            "dev": true,
             "dependencies": {
                 "ms": "2.1.2"
             },
@@ -31012,6 +31434,48 @@
             "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.8.tgz",
             "integrity": "sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw==",
             "dev": true
+        },
+        "node_modules/vue-template-compiler": {
+            "version": "2.7.16",
+            "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.7.16.tgz",
+            "integrity": "sha512-AYbUWAJHLGGQM7+cNTELw+KsOG9nl2CnSv467WobS5Cv9uk3wFcnr1Etsz2sEIHEZvw1U+o9mRlEO6QbZvUPGQ==",
+            "dev": true,
+            "dependencies": {
+                "de-indent": "^1.0.2",
+                "he": "^1.2.0"
+            }
+        },
+        "node_modules/vue-tsc": {
+            "version": "1.8.27",
+            "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-1.8.27.tgz",
+            "integrity": "sha512-WesKCAZCRAbmmhuGl3+VrdWItEvfoFIPXOvUJkjULi+x+6G/Dy69yO3TBRJDr9eUlmsNAwVmxsNZxvHKzbkKdg==",
+            "dev": true,
+            "dependencies": {
+                "@volar/typescript": "~1.11.1",
+                "@vue/language-core": "1.8.27",
+                "semver": "^7.5.4"
+            },
+            "bin": {
+                "vue-tsc": "bin/vue-tsc.js"
+            },
+            "peerDependencies": {
+                "typescript": "*"
+            }
+        },
+        "node_modules/vue-tsc/node_modules/semver": {
+            "version": "7.6.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+            "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+            "dev": true,
+            "dependencies": {
+                "lru-cache": "^6.0.0"
+            },
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
         },
         "node_modules/w3c-xmlserializer": {
             "version": "4.0.0",
@@ -31923,6 +32387,36 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/z-schema": {
+            "version": "5.0.5",
+            "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-5.0.5.tgz",
+            "integrity": "sha512-D7eujBWkLa3p2sIpJA0d1pr7es+a7m0vFAnZLlCEKq/Ij2k0MLi9Br2UPxoxdYystm5K1yeBGzub0FlYUEWj2Q==",
+            "dev": true,
+            "dependencies": {
+                "lodash.get": "^4.4.2",
+                "lodash.isequal": "^4.5.0",
+                "validator": "^13.7.0"
+            },
+            "bin": {
+                "z-schema": "bin/z-schema"
+            },
+            "engines": {
+                "node": ">=8.0.0"
+            },
+            "optionalDependencies": {
+                "commander": "^9.4.1"
+            }
+        },
+        "node_modules/z-schema/node_modules/commander": {
+            "version": "9.5.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+            "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+            "dev": true,
+            "optional": true,
+            "engines": {
+                "node": "^12.20.0 || >=14"
+            }
+        },
         "node_modules/zod": {
             "version": "3.22.4",
             "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
@@ -32285,7 +32779,8 @@
             },
             "devDependencies": {
                 "tslib": "2.6.2",
-                "typescript": "5.1.6"
+                "typescript": "5.1.6",
+                "vite-plugin-dts": "^3.7.3"
             },
             "engines": {
                 "node": ">=18",

--- a/packages/procaptcha-react/package.json
+++ b/packages/procaptcha-react/package.json
@@ -47,7 +47,8 @@
     },
     "devDependencies": {
         "tslib": "2.6.2",
-        "typescript": "5.1.6"
+        "typescript": "5.1.6",
+        "vite-plugin-dts": "^3.7.3"
     },
     "repository": {
         "type": "git",

--- a/packages/procaptcha-react/package.json
+++ b/packages/procaptcha-react/package.json
@@ -20,7 +20,7 @@
     "source": "./src/index.ts",
     "scripts": {
         "clean": "tsc --build --clean",
-        "build": "tsc --build --verbose tsconfig.json",
+        "build": "npx vite --config vite.config.ts build",
         "build:cjs": "npx vite --config vite.cjs.config.ts build",
         "eslint": "npx eslint . --no-error-on-unmatched-pattern --ignore-path ../../.eslintignore",
         "eslint:fix": "npm run eslint -- --fix",

--- a/packages/procaptcha-react/public/style/Modal.css
+++ b/packages/procaptcha-react/public/style/Modal.css
@@ -34,5 +34,8 @@
     width: 400px;
     background-color: rgb(255, 255, 255);
     border: none;
-    box-shadow: rgba(0, 0, 0, 0.2) 0px 11px 15px -7px, rgba(0, 0, 0, 0.14) 0px 24px 38px 3px, rgba(0, 0, 0, 0.12) 0px 9px 46px 8px;
+    box-shadow:
+        rgba(0, 0, 0, 0.2) 0px 11px 15px -7px,
+        rgba(0, 0, 0, 0.14) 0px 24px 38px 3px,
+        rgba(0, 0, 0, 0.12) 0px 9px 46px 8px;
 }

--- a/packages/procaptcha-react/public/style/Modal.css
+++ b/packages/procaptcha-react/public/style/Modal.css
@@ -1,33 +1,38 @@
 .modalOuter {
-    overflow: auto;
-    width: 100%;
-    max-height: 100%;
     position: fixed;
+    z-index: 1300;
+    inset: 0;
+}
+
+.modalBackground {
+    position: fixed;
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-align-items: center;
+    -webkit-box-align: center;
+    -ms-flex-align: center;
+    align-items: center;
+    -webkit-box-pack: center;
+    -ms-flex-pack: center;
+    -webkit-justify-content: center;
+    justify-content: center;
+    right: 0;
+    bottom: 0;
     top: 0;
     left: 0;
-    height: 100%;
-    background: rgba(0, 0, 0, 0.6);
-    z-index: 2147483646;
-    transition: all 0.5s;
+    background-color: rgba(0, 0, 0, 0.5);
+    -webkit-tap-highlight-color: transparent;
+    z-index: -1;
 }
 .modalInner {
-    max-width: 500px;
-    margin: auto;
-    position: fixed;
-    background: white;
-    max-height: max-content;
+    position: absolute;
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
-    z-index: 2147483647;
-    transition: all 0.5s;
-}
-/* avoid the captcha modal from disappearing beneath the fold on smaller screens */
-@media only screen and (max-height: 500px) {
-    .modalInner {
-        max-height: 90%;
-    }
-    .modalOuter {
-        max-height: 90%;
-    }
+    width: 400px;
+    background-color: rgb(255, 255, 255);
+    border: none;
+    box-shadow: rgba(0, 0, 0, 0.2) 0px 11px 15px -7px, rgba(0, 0, 0, 0.14) 0px 24px 38px 3px, rgba(0, 0, 0, 0.12) 0px 9px 46px 8px;
 }

--- a/packages/procaptcha-react/public/style/Modal.css
+++ b/packages/procaptcha-react/public/style/Modal.css
@@ -22,3 +22,12 @@
     z-index: 2147483647;
     transition: all 0.5s;
 }
+/* avoid the captcha modal from disappearing beneath the fold on smaller screens */
+@media only screen and (max-height: 500px) {
+    .modalInner {
+        max-height: 90%;
+    }
+    .modalOuter {
+        max-height: 90%;
+    }
+}

--- a/packages/procaptcha-react/public/style/Modal.css
+++ b/packages/procaptcha-react/public/style/Modal.css
@@ -15,7 +15,7 @@
     margin: auto;
     position: fixed;
     background: white;
-    max-height: 100%;
+    max-height: max-content;
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);

--- a/packages/procaptcha-react/src/components/CaptchaWidget.tsx
+++ b/packages/procaptcha-react/src/components/CaptchaWidget.tsx
@@ -80,6 +80,7 @@ export const CaptchaWidget = ({ challenge, solution, onClick, themeColor }: Capt
                                         display: 'block', // removes whitespace below imgs
                                         objectFit: 'contain', // contain the entire image in the img tag
                                         aspectRatio: '1/1', // force AR to be 1, letterboxing images with different aspect ratios
+                                        height: 'auto', // make the img tag responsive to its container
                                     }}
                                     src={item.data}
                                     alt={`Captcha image ${index + 1}`}

--- a/packages/procaptcha-react/src/components/Modal.css
+++ b/packages/procaptcha-react/src/components/Modal.css
@@ -1,0 +1,24 @@
+.modalOuter {
+    overflow: auto;
+    width: 100%;
+    max-height: 100%;
+    position: fixed;
+    top: 0;
+    left: 0;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.6);
+    z-index: 2147483646;
+    transition: all 0.5s;
+}
+.modalInner {
+    max-width: 500px;
+    margin: auto;
+    position: fixed;
+    background: white;
+    max-height: 100%;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    z-index: 2147483647;
+    transition: all 0.5s;
+}

--- a/packages/procaptcha-react/src/components/Modal.tsx
+++ b/packages/procaptcha-react/src/components/Modal.tsx
@@ -1,5 +1,5 @@
+import './Modal.css'
 import React, { CSSProperties } from 'react'
-
 type ModalProps = {
     show: boolean
     children: React.ReactNode
@@ -10,35 +10,13 @@ const ModalComponent = React.memo((props: ModalProps, nextProps: ModalProps) => 
     console.log('rendering modal with show: ', show)
     const display = show ? 'flex' : 'none'
     const ModalOuterDivCss: CSSProperties = {
-        overflow: 'auto',
-        width: '100%',
-        maxHeight: '100%',
-        position: 'fixed',
-        top: '0',
-        left: '0',
-        height: '100%',
-        background: 'rgba(0, 0, 0, 0.6)',
-        zIndex: '2147483646',
-        transition: 'all 0.5s',
+
         display: display,
-    }
-    const ModalInnerDivCSS: CSSProperties = {
-        maxWidth: '500px',
-        margin: 'auto',
-        position: 'fixed',
-        background: 'white',
-        height: '100%',
-        maxHeight: '100%',
-        top: '50%',
-        left: '50%',
-        transform: 'translate(-50%, -50%)',
-        zIndex: '2147483647',
-        transition: 'all 0.5s',
     }
 
     return (
-        <div style={ModalOuterDivCss}>
-            <div style={ModalInnerDivCSS}>{children}</div>
+        <div className="modalOuter" style={ModalOuterDivCss}>
+            <div className="modalInner">{children}</div>
         </div>
     )
 })

--- a/packages/procaptcha-react/src/components/Modal.tsx
+++ b/packages/procaptcha-react/src/components/Modal.tsx
@@ -1,4 +1,4 @@
-import './Modal.css'
+import '../style/Modal.css'
 import React, { CSSProperties } from 'react'
 type ModalProps = {
     show: boolean
@@ -10,7 +10,6 @@ const ModalComponent = React.memo((props: ModalProps, nextProps: ModalProps) => 
     console.log('rendering modal with show: ', show)
     const display = show ? 'flex' : 'none'
     const ModalOuterDivCss: CSSProperties = {
-
         display: display,
     }
 

--- a/packages/procaptcha-react/src/components/Modal.tsx
+++ b/packages/procaptcha-react/src/components/Modal.tsx
@@ -8,13 +8,14 @@ type ModalProps = {
 const ModalComponent = React.memo((props: ModalProps, nextProps: ModalProps) => {
     const { show, children } = props
     console.log('rendering modal with show: ', show)
-    const display = show ? 'flex' : 'none'
+    const display = show ? 'block' : 'none'
     const ModalOuterDivCss: CSSProperties = {
         display: display,
     }
 
     return (
         <div className="modalOuter" style={ModalOuterDivCss}>
+            <div className="modalBackground"></div>
             <div className="modalInner">{children}</div>
         </div>
     )

--- a/packages/procaptcha-react/vite.config.ts
+++ b/packages/procaptcha-react/vite.config.ts
@@ -1,0 +1,19 @@
+import { ViteCommonJSConfig } from '@prosopo/config'
+import path from 'path'
+const base = path.resolve('./tsconfig.json')
+export default async function () {
+    const commonJSconfig = await ViteCommonJSConfig('procaptcha-react', base)
+    return {
+        ...commonJSconfig,
+        base,
+        build: {
+            ssr: false,
+            ...commonJSconfig.build,
+            outDir: 'dist',
+            lib: {
+                ...commonJSconfig.build?.lib,
+                formats: ['es'],
+            },
+        },
+    }
+}

--- a/packages/procaptcha-react/vite.config.ts
+++ b/packages/procaptcha-react/vite.config.ts
@@ -1,10 +1,14 @@
 import { ViteCommonJSConfig } from '@prosopo/config'
+import dts from 'vite-plugin-dts'
 import path from 'path'
+
 const base = path.resolve('./tsconfig.json')
+
 export default async function () {
     const commonJSconfig = await ViteCommonJSConfig('procaptcha-react', base)
     return {
         ...commonJSconfig,
+        plugins: [...(commonJSconfig.plugins || []), dts({ rollupTypes: true })], // add the declaration files (d.ts) generation plugin
         build: {
             ssr: false,
             ...commonJSconfig.build,

--- a/packages/procaptcha-react/vite.config.ts
+++ b/packages/procaptcha-react/vite.config.ts
@@ -5,7 +5,6 @@ export default async function () {
     const commonJSconfig = await ViteCommonJSConfig('procaptcha-react', base)
     return {
         ...commonJSconfig,
-        base,
         build: {
             ssr: false,
             ...commonJSconfig.build,


### PR DESCRIPTION
This PR adds the CSS from [mui react modal](https://mui.com/material-ui/react-modal/) into our modal component. There are a bunch of CSS attributes that [cannot be specified using inline CSS](https://github.com/facebook/react/issues/2020) so I switched to CSS files. This meant using vite to build procaptcha-react.

Challenges here were:

- css files not being copied
- .d.ts files not being generated

Solutions being:

- css files are copied by being placed in a public folder. This is default vite behaviour.
- .d.ts files are copied using [vite-plugin-dts](https://github.com/qmhc/vite-plugin-dts)

This isn't an approach I want to use with the rest of the packages but it feels ok since procaptcha-react is a UI package.

On PC, responsive down to ~477px height

![image](https://github.com/prosopo/captcha/assets/7630866/42adf17a-24a9-4128-9409-fb0b9e0b2a9e)

![image](https://github.com/prosopo/captcha/assets/7630866/64210f9d-466f-4765-8aaf-0860231c9f2b)

On laptop, captcha no longer disappears beneath the fold:

![Screenshot from 2024-02-21 17-04-01](https://github.com/prosopo/captcha/assets/7630866/e5662197-a224-4122-9b7c-2aacd7a2aca8)
