### PR TITLE
Remove requirement of provider secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ via HTTPS and can
 be placed anywhere on the page. Inside the <head> tag or immediately after the `.procaptcha` container are both fine.
 
 ```html
-<script src="https://js.prosopo.io/js/procaptcha.bundle.js" async defer></script>
+<script type="module" src="https://js.prosopo.io/js/procaptcha.bundle.js" async defer></script>
 ```
 
 Now, you can either render the Procaptcha widget implicitly or explicitly.
@@ -52,7 +52,7 @@ solved.
 <html>
     <head>
         <title>Procaptcha Demo</title>
-        <script src="https://js.prosopo.io/js/procaptcha.bundle.js" async defer></script>
+        <script type="module" src="https://js.prosopo.io/js/procaptcha.bundle.js" async defer></script>
     </head>
     <body>
         <form action="" method="POST">
@@ -79,7 +79,7 @@ id `procaptcha-container` where the widget will be rendered.
 ```html
 <html>
     <head>
-        <script id="procaptcha-script" src="https://js.prosopo.io/js/procaptcha.bundle.js" async defer></script>
+        <script type="module" id="procaptcha-script" src="https://js.prosopo.io/js/procaptcha.bundle.js" async defer></script>
     </head>
     <body>
         <div id="procaptcha-container"></div>

--- a/README.md
+++ b/README.md
@@ -79,7 +79,13 @@ id `procaptcha-container` where the widget will be rendered.
 ```html
 <html>
     <head>
-        <script type="module" id="procaptcha-script" src="https://js.prosopo.io/js/procaptcha.bundle.js" async defer></script>
+        <script
+            type="module"
+            id="procaptcha-script"
+            src="https://js.prosopo.io/js/procaptcha.bundle.js"
+            async
+            defer
+        ></script>
     </head>
     <body>
         <div id="procaptcha-container"></div>

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -14,7 +14,6 @@
 import { LogLevel, getLogger } from '@prosopo/common'
 import { ProsopoConfigOutput } from '@prosopo/types'
 import { getPairAsync } from '@prosopo/contract'
-import { getSecret } from './process.env.js'
 import { isMain } from '@prosopo/util'
 import { loadEnv } from './env.js'
 import { processArgs } from './argv.js'
@@ -27,15 +26,17 @@ const log = getLogger(LogLevel.enum.info, 'CLI')
 async function main() {
     const envPath = loadEnv()
 
-    const secret = getSecret()
-
     // quick fix to allow for new dataset structure that only has `{ solved: true }` captchas
     const config: ProsopoConfigOutput = getConfig(undefined, undefined, undefined, {
         solved: { count: 2 },
         unsolved: { count: 0 },
     })
 
-    const pair = await getPairAsync(config.networks[config.defaultNetwork], secret, '')
+    const pair = await getPairAsync(
+        config.networks[config.defaultNetwork],
+        config.account.secret,
+        config.account.address
+    )
 
     log.info(`Pair address: ${pair.address}`)
 

--- a/packages/cli/src/process.env.ts
+++ b/packages/cli/src/process.env.ts
@@ -22,21 +22,18 @@ export function getPairType(): KeypairType {
     return (process.env.PROSOPO_PAIR_TYPE as KeypairType) || ('sr25519' as KeypairType)
 }
 
-export function getSecret(who?: string): string {
+export function getSecret(who?: string): string | undefined {
     if (!who) {
         who = 'PROVIDER'
     } else {
         who = who.toUpperCase()
     }
-    const secret =
+    return (
         process.env[`PROSOPO_${who}_MNEMONIC`] ||
         process.env[`PROSOPO_${who}_SEED`] ||
         process.env[`PROSOPO_${who}_URI`] ||
         process.env[`PROSOPO_${who}_JSON`]
-    if (!secret) {
-        throw new ProsopoEnvError('GENERAL.NO_MNEMONIC_OR_SEED')
-    }
-    return secret
+    )
 }
 
 export function getDB(): string {


### PR DESCRIPTION
Removes the error that occurred if the provider CLI was initialised without a secret. This will enable read-only providers to serve captchas.