### PR TITLE
Fix at+get fns

### DIFF
--- a/packages/contract/src/contract/storage.ts
+++ b/packages/contract/src/contract/storage.ts
@@ -140,7 +140,7 @@ export function getStorageKeyAndType(
         }
 
         const rootKeyReversed = reverseHexString(rootKey.slice(2))
-        const item = get<PortableType>(abi.registry.lookup.types, storage.layout.leaf.ty)
+        const item = at(abi.registry.lookup.types, parseInt(storage.layout.leaf.ty))
         return {
             storageType: item,
             storageKey: rootKeyReversed,

--- a/packages/detector/src/index.d.ts
+++ b/packages/detector/src/index.d.ts
@@ -1,3 +1,16 @@
+// Copyright 2021-2024 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 export function isBot(): Promise<{
     fingerprint: {
         resistance:

--- a/packages/procaptcha/src/modules/Manager.ts
+++ b/packages/procaptcha/src/modules/Manager.ts
@@ -308,7 +308,7 @@ export function Manager(
             const blockNumber = getBlockNumber()
             const signer = getExtension(account).signer
 
-            const first = at<CaptchaWithProof>(challenge.captchas, 0)
+            const first = at(challenge.captchas, 0)
             if (!first.captcha.datasetId) {
                 throw new ProsopoDatasetError('CAPTCHA.INVALID_CAPTCHA_ID', {
                     context: { error: 'No datasetId set for challenge' },
@@ -384,7 +384,7 @@ export function Manager(
         }
         const index = state.index
         const solutions = state.solutions
-        const solution = at<string[]>(solutions, index)
+        const solution = at(solutions, index)
         if (solution.includes(hash)) {
             // remove the hash from the solution
             solution.splice(solution.indexOf(hash), 1)

--- a/packages/util/src/at.ts
+++ b/packages/util/src/at.ts
@@ -30,6 +30,10 @@ export function at<T extends readonly unknown[]>(items: T | string, index: numbe
         throw new Error('Array is empty')
     }
 
+    if (!isFinite(index)) {
+        throw new Error(`Index ${index} is not a finite number`)
+    }
+
     if (!options?.noWrap) {
         if (index > 0) {
             index = index % items.length

--- a/packages/util/src/at.ts
+++ b/packages/util/src/at.ts
@@ -24,7 +24,11 @@ export function at<T extends readonly unknown[]>(
     index: number,
     options: AtOptions & { optional: true }
 ): T[number] | undefined
-export function at<T extends readonly unknown[]>(items: T, index: number, options?: AtOptions): Exclude<T[number], undefined>
+export function at<T extends readonly unknown[]>(
+    items: T,
+    index: number,
+    options?: AtOptions
+): Exclude<T[number], undefined>
 export function at<T extends readonly unknown[]>(items: T | string, index: number, options?: AtOptions): T[number] {
     if (items.length === 0) {
         throw new Error('Array is empty')

--- a/packages/util/src/at.ts
+++ b/packages/util/src/at.ts
@@ -16,16 +16,16 @@ export type AtOptions = {
     noWrap?: boolean // whether to wrap the index around the bounds of the array (true == no wrap, false == wrap indices)
 }
 // Get an element from an array, throwing an error if it's index is out of bounds or if the element is undefined or null (can be overridden with the options)
+
 export function at(str: string, index: number, options: AtOptions & { optional: true }): string | undefined
 export function at(str: string, index: number, options?: AtOptions): string
-export function at<T>(items: T[] | string, index: number, options: AtOptions & { optional: false }): T
-export function at<T>(
-    items: (T | undefined)[] | string,
+export function at<T extends readonly unknown[]>(
+    items: T,
     index: number,
     options: AtOptions & { optional: true }
-): T | undefined
-export function at<T>(items: T[], index: number, options?: AtOptions): T
-export function at<T>(items: T[] | string, index: number, options?: AtOptions): T {
+): T[number] | undefined
+export function at<T extends readonly unknown[]>(items: T, index: number, options?: AtOptions): Exclude<T[number], undefined>
+export function at<T extends readonly unknown[]>(items: T | string, index: number, options?: AtOptions): T[number] {
     if (items.length === 0) {
         throw new Error('Array is empty')
     }

--- a/packages/util/src/get.ts
+++ b/packages/util/src/get.ts
@@ -11,10 +11,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-export function get<T>(obj: T, key: unknown, required?: true): Exclude<T[keyof T], undefined>
-export function get<T>(obj: T, key: unknown, required: false): T[keyof T] | undefined
-export function get<T>(obj: unknown, key: string | number | symbol, required?: true): Exclude<T, undefined>
-export function get<T>(obj: unknown, key: string | number | symbol, required: false): T | undefined
+
+export function get<T>(obj: T, key: string | number | symbol, required?: true): Exclude<T[keyof T], undefined>
+export function get<T>(obj: T, key: string | number | symbol, required: false): T[keyof T] | undefined
 export function get<T, V>(obj: T, key: unknown, required = true): V {
     const value = obj[key as unknown as keyof T]
     if (required && value === undefined) {

--- a/packages/util/src/tests/at.test.ts
+++ b/packages/util/src/tests/at.test.ts
@@ -42,6 +42,12 @@ describe('at', () => {
 
     })
 
+    test('infinite index', () => {
+        expect(() => at([1, 2, 3], Infinity)).to.throw()
+        expect(() => at([1, 2, 3], -Infinity)).to.throw()
+        expect(() => at([1, 2, 3], NaN)).to.throw()
+    })
+
     test('compatible with string', () => {
         expect(at('abc', 0)).to.equal('a')
         expect(at('abc', 1)).to.equal('b')

--- a/packages/util/src/tests/at.test.ts
+++ b/packages/util/src/tests/at.test.ts
@@ -34,9 +34,12 @@ describe('at', () => {
         const a5: string = at('abc', 0)
         const a10: string = at('abc', 0, { optional: false })
         const a11: string | undefined = at('abc', 0, { optional: true })
-        const a12: undefined = at([undefined, undefined, undefined], 0)
+        const a12: never = at([undefined, undefined, undefined], 0)
         const a13: undefined = at([undefined, undefined, undefined], 0, { optional: true })
         const a14: undefined = at([undefined, undefined, undefined], 0, { optional: false })
+
+        const a15: string = at(['a', 'b', 'c'] as readonly string[], 0)
+
     })
 
     test('compatible with string', () => {

--- a/packages/util/src/tests/at.test.ts
+++ b/packages/util/src/tests/at.test.ts
@@ -39,7 +39,6 @@ describe('at', () => {
         const a14: undefined = at([undefined, undefined, undefined], 0, { optional: false })
 
         const a15: string = at(['a', 'b', 'c'] as readonly string[], 0)
-
     })
 
     test('infinite index', () => {


### PR DESCRIPTION
- [x] finite index check (because nan and inf suck)
- [x] generic array inference fix (ts infers the array correctly so you don't have to)
- [x] undefined case handling fix (make sure an array containing an undefined cannot return Exclude<X, undefined>)
- [x] fix string calling of at fn (wouldn't always pickup string correctly)
- [x] fix return types with/wo undefined excluded
- [x] accept readonly arrays in `at` fn