### PR TITLE
Get records where no `updatedAtTimestamp` exists

### DIFF
--- a/demos/client-example/src/components/ExtensionAccountSelect.tsx
+++ b/demos/client-example/src/components/ExtensionAccountSelect.tsx
@@ -31,7 +31,6 @@ export const ExtensionAccountSelect = ({
 	const [selectedAccount, setSelectedAccount] = useState<
 		InjectedAccountWithMeta | ""
 	>("");
-	const selectInputRef = useRef();
 
 	useEffect(() => {
 		const prom = web3Enable(dappName).then(() => {
@@ -42,10 +41,8 @@ export const ExtensionAccountSelect = ({
 		};
 	}, [dappName]);
 
-	const account: InjectedAccountWithMeta | null =
-		accounts.find((a) => a.address === value) || null;
-
 	const selectAccount = (e: unknown) => {
+		// @ts-ignore
 		const value = e.target.value;
 		console.log("account option clicked");
 		const account = accounts.find((a) => a.address === value) || null;

--- a/demos/client-example/src/components/ExtensionAccountSelect.tsx
+++ b/demos/client-example/src/components/ExtensionAccountSelect.tsx
@@ -45,7 +45,7 @@ export const ExtensionAccountSelect = ({
 	const account: InjectedAccountWithMeta | null =
 		accounts.find((a) => a.address === value) || null;
 
-	const selectAccount = (e) => {
+	const selectAccount = (e: unknown) => {
 		const value = e.target.value;
 		console.log("account option clicked");
 		const account = accounts.find((a) => a.address === value) || null;

--- a/demos/client-example/src/components/ExtensionAccountSelect.tsx
+++ b/demos/client-example/src/components/ExtensionAccountSelect.tsx
@@ -44,7 +44,7 @@ export const ExtensionAccountSelect = ({
 		// react select box
 		<select
 			id="select-account"
-			onChange={(e) => {
+			onChange={(e: unknown) => {
 				const value = e.target.value;
 				const account = accounts.find((a) => a.address === value) || null;
 				if (account) {

--- a/packages/database/src/databases/client.ts
+++ b/packages/database/src/databases/client.ts
@@ -70,7 +70,7 @@ export class ClientDatabase extends MongoDatabase implements IClientDatabase {
 		// get remote client records that have been updated since the last task
 		const newClientRecords = await this.tables.emails
 			.find<ClientRecord>(
-				{ updatedAtTimestamp: { $gt: updatedAtTimestamp }, activated: true },
+				{$or: [{ updatedAtTimestamp: { $gt: updatedAtTimestamp }}, {$updatedAtTimestamp: {$exists:false}}], activated: true },
 				{ account: 1, settings: 1 },
 			)
 			.lean<ClientRecord[]>();

--- a/packages/database/src/databases/client.ts
+++ b/packages/database/src/databases/client.ts
@@ -73,7 +73,7 @@ export class ClientDatabase extends MongoDatabase implements IClientDatabase {
 				{
 					$or: [
 						{ updatedAtTimestamp: { $gt: updatedAtTimestamp } },
-						{ $updatedAtTimestamp: { $exists: false } },
+						{ updatedAtTimestamp: { $exists: false } },
 					],
 					activated: true,
 				},

--- a/packages/database/src/databases/client.ts
+++ b/packages/database/src/databases/client.ts
@@ -70,7 +70,13 @@ export class ClientDatabase extends MongoDatabase implements IClientDatabase {
 		// get remote client records that have been updated since the last task
 		const newClientRecords = await this.tables.emails
 			.find<ClientRecord>(
-				{$or: [{ updatedAtTimestamp: { $gt: updatedAtTimestamp }}, {$updatedAtTimestamp: {$exists:false}}], activated: true },
+				{
+					$or: [
+						{ updatedAtTimestamp: { $gt: updatedAtTimestamp } },
+						{ $updatedAtTimestamp: { $exists: false } },
+					],
+					activated: true,
+				},
 				{ account: 1, settings: 1 },
 			)
 			.lean<ClientRecord[]>();


### PR DESCRIPTION
Client records were only being pulled through when the user updated their site settings. This hotfix adddresses the issue by changing the database query to select activated accounts that have no `updatedAtTimestamp` records.