### PR TITLE
Output provider logs as JSON

### DIFF
--- a/.github/workflows/provider_image.yml
+++ b/.github/workflows/provider_image.yml
@@ -5,7 +5,7 @@ name: provider_image
 on:
     pull_request:
         branches: [main, dev, staging, release/*]
-        types: 
+        types:
             - opened # when a PR is opened
             - synchronize # when a PR is pushed to
             - reopened # when a PR is reopened
@@ -151,7 +151,7 @@ jobs:
                     sleep 20s
                     docker logs "$CONTAINER" >& provider.log
                     cat provider.log
-                    grep -oE "Version: \".*\"" provider.log || (cat provider.log && exit 1)
+                    grep -oE "Version: \\\\\".*\\\\\"" provider.log || (cat provider.log && exit 1)
 
             - name: Build the provider-mock package
               id: build_provider_mock_package

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -32,8 +32,6 @@ async function main() {
 		unsolved: { count: 0 },
 	});
 
-	log.info(config);
-
 	if (config.devOnlyWatchEvents) {
 		log.warn(
 			`

--- a/packages/cli/src/tests/bundle/bundle.unit.test.ts
+++ b/packages/cli/src/tests/bundle/bundle.unit.test.ts
@@ -29,6 +29,6 @@ describe("provider bundle", () => {
 		const { stdout: runOut, stderr: runErr } = await execPromise(
 			`cd ${rootDir} && node dist/bundle/provider.cli.bundle.js version`,
 		);
-		assert(runOut.includes("Version:"));
+		assert(runErr.includes("Version:"));
 	}, 120000);
 });

--- a/packages/common/src/logger.ts
+++ b/packages/common/src/logger.ts
@@ -11,7 +11,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-import { LogLevels as ConsolaLogLevels, createConsola } from "consola/browser";
+import consola, {
+	LogLevels as ConsolaLogLevels,
+	createConsola,
+} from "consola/browser";
 import { enum as zEnum, type infer as zInfer } from "zod";
 import { ProsopoEnvError } from "./error.js";
 
@@ -47,8 +50,18 @@ export function getLoggerDefault(): Logger {
 	return defaultLogger;
 }
 
+// biome-ignore lint/suspicious/noExplicitAny: <explanation>
+const JSONReporter = (message: any) => {
+	process.stderr.write(`${JSON.stringify(message)}\n`);
+};
+
 const getLoggerAdapterConsola = (logLevel: LogLevel, scope: string): Logger => {
 	const logger = createConsola({
+		reporters: [
+			{
+				log: JSONReporter,
+			},
+		],
 		formatOptions: { colors: true, date: true },
 	}).withTag(scope);
 	let currentLevel = logLevel;

--- a/packages/common/src/logger.ts
+++ b/packages/common/src/logger.ts
@@ -50,7 +50,7 @@ export function getLoggerDefault(): Logger {
 	return defaultLogger;
 }
 
-// biome-ignore lint/suspicious/noExplicitAny: <explanation>
+// biome-ignore lint/suspicious/noExplicitAny: we should be able to log anything we want, plus we can't control what external libraries log
 const JSONReporter = (message: any) => {
 	process.stderr.write(`${JSON.stringify(message)}\n`);
 };


### PR DESCRIPTION
Will allow us to count types of logs.
```
{"date":"2024-11-13T12:22:00.024Z","args":["GetClientList task...."],"type":"info","tag":"ProsopoEnvironment","level":3}
{"date":"2024-11-13T12:22:00.043Z","args":["Mongo url: mongodb+srv://prosopo-<Credentials>@cluster0.xxx.mongodb.net/prosopo?retryWrites=true&w=majority"],"type":"info","tag":"Tasks","level":3}
{"date":"2024-11-13T12:22:00.046Z","args":["Database disconnected from mongodb+srv://prosopo-<Credentials>@cluster0.xxx.mongodb.net/prosopo?retryWrites=true&w=majority"],"type":"info","tag":"Tasks","level":3}
{"date":"2024-11-13T12:22:00.046Z","args":["Database error: Error: querySrv ESERVFAIL _mongodb._tcp.cluster0.xxx.mongodb.net"],"type":"error","tag":"Tasks","level":0}
{"date":"2024-11-13T12:22:00.046Z","args":["Database connection error: Error: querySrv ESERVFAIL _mongodb._tcp.cluster0.xxx.mongodb.net"],"type":"error","tag":"Tasks","level":0}
{"date":"2024-11-13T12:22:00.046Z","args":[{"code":"ESERVFAIL","syscall":"querySrv","hostname":"_mongodb._tcp.cluster0.xxx.mongodb.net"}],"type":"error","tag":"Tasks","level":0}
```

Based on: https://github.com/unjs/consola/issues/262