### PR TITLE
Only change image protocol on http https

### DIFF
--- a/packages/procaptcha/src/modules/ProsopoCaptchaApi.ts
+++ b/packages/procaptcha/src/modules/ProsopoCaptchaApi.ts
@@ -66,12 +66,17 @@ export class ProsopoCaptchaApi implements ProcaptchaApiInterface {
 			}
 
 			// convert https/http to match page
-			for (const captcha of captchaChallenge.captchas) {
-				for (const item of captcha.items) {
-					if (item.data) {
-						// drop the 'http(s):' prefix, leaving '//'. The '//' will autodetect http/https from the page load type
-						// https://stackoverflow.com/a/18320348/7215926
-						item.data = item.data.replace(/^http(s)*:\/\//, "//");
+			if (
+				window.location.protocol === "https:" ||
+				window.location.protocol === "http:"
+			) {
+				for (const captcha of captchaChallenge.captchas) {
+					for (const item of captcha.items) {
+						if (item.data) {
+							// drop the 'http(s):' prefix, leaving '//'. The '//' will autodetect http/https from the page load type
+							// https://stackoverflow.com/a/18320348/7215926
+							item.data = item.data.replace(/^http(s)*:\/\//, "//");
+						}
 					}
 				}
 			}


### PR DESCRIPTION
- [x]  stops file protocol being used on localhost android application deployments of procaptcha

![image](https://github.com/user-attachments/assets/47f94713-a91e-4d47-b26c-073c990ee9cd)
