### PR TITLE
Add API endpoints for adding and removing block rules

### DIFF
--- a/packages/cli/src/RateLimiter.ts
+++ b/packages/cli/src/RateLimiter.ts
@@ -59,5 +59,21 @@ export const getRateLimitConfig = () => {
 			windowMs: process.env.PROSOPO_GET_FR_CAPTCHA_CHALLENGE_WINDOW,
 			limit: process.env.PROSOPO_GET_FR_CAPTCHA_CHALLENGE_LIMIT,
 		},
+		[AdminApiPaths.BlockRuleIPAdd]: {
+			windowMs: process.env.PROSOPO_BLOCK_RULE_IP_ADD_WINDOW,
+			limit: process.env.PROSOPO_BLOCK_RULE_IP_ADD_LIMIT,
+		},
+		[AdminApiPaths.BlockRuleIPRemove]: {
+			windowMs: process.env.PROSOPO_BLOCK_RULE_IP_REMOVE_WINDOW,
+			limit: process.env.PROSOPO_BLOCK_RULE_IP_REMOVE_LIMIT,
+		},
+		[AdminApiPaths.BlocKRuleUserAdd]: {
+			windowMs: process.env.PROSOPO_BLOCK_RULE_USER_ADD_WINDOW,
+			limit: process.env.PROSOPO_BLOCK_RULE_USER_ADD_LIMIT,
+		},
+		[AdminApiPaths.BlockRuleUserRemove]: {
+			windowMs: process.env.PROSOPO_BLOCK_RULE_USER_REMOVE_WINDOW,
+			limit: process.env.PROSOPO_BLOCK_RULE_USER_REMOVE_LIMIT,
+		},
 	};
 };

--- a/packages/cli/src/commands/addBlockRules.ts
+++ b/packages/cli/src/commands/addBlockRules.ts
@@ -103,6 +103,7 @@ export default (
 							captchaConfig,
 						}),
 					);
+					logger.info("IP Block rules added");
 				}
 				if (argv.users) {
 					await tasks.clientTaskManager.addUserBlockRules(
@@ -114,8 +115,8 @@ export default (
 							captchaConfig,
 						}),
 					);
+					logger.info("User Block rules added");
 				}
-				logger.info("IP Block rules added");
 			} catch (err) {
 				logger.error(err);
 			}

--- a/packages/cli/src/commands/addBlockRules.ts
+++ b/packages/cli/src/commands/addBlockRules.ts
@@ -16,10 +16,13 @@ import type { KeyringPair } from "@polkadot/keyring/types";
 import { LogLevel, type Logger, getLogger } from "@prosopo/common";
 import { ProviderEnvironment } from "@prosopo/env";
 import { Tasks } from "@prosopo/provider";
-import type { CaptchaConfig, ProsopoConfigOutput } from "@prosopo/types";
+import {
+	AddBlockRulesIPSpec,
+	AddBlockRulesUserSpec,
+	type ProsopoCaptchaCountConfigSchemaOutput,
+	type ProsopoConfigOutput,
+} from "@prosopo/types";
 import type { ArgumentsCamelCase, Argv } from "yargs";
-import * as z from "zod";
-import { loadJSONFile } from "../files.js";
 
 export default (
 	pair: KeyringPair,
@@ -78,7 +81,7 @@ export default (
 				const env = new ProviderEnvironment(config, pair);
 				await env.isReady();
 				const tasks = new Tasks(env);
-				let captchaConfig: CaptchaConfig | undefined;
+				let captchaConfig: ProsopoCaptchaCountConfigSchemaOutput | undefined;
 				if (argv.solved) {
 					captchaConfig = {
 						solved: {
@@ -92,20 +95,24 @@ export default (
 
 				if (argv.ips) {
 					await tasks.clientTaskManager.addIPBlockRules(
-						argv.ips as unknown as string[],
-						argv.global as boolean,
-						argv.hardBlock as boolean,
-						argv.dapp as unknown as string,
-						captchaConfig,
+						AddBlockRulesIPSpec.parse({
+							ips: argv.ips,
+							global: argv.global,
+							hardBlock: argv.hardBlock,
+							dapp: argv.dapp,
+							captchaConfig,
+						}),
 					);
 				}
 				if (argv.users) {
 					await tasks.clientTaskManager.addUserBlockRules(
-						argv.users as unknown as string[],
-						argv.hardBlock as boolean,
-						argv.global as boolean,
-						argv.dapp as unknown as string,
-						captchaConfig,
+						AddBlockRulesUserSpec.parse({
+							users: argv.users,
+							global: argv.global,
+							hardBlock: argv.hardBlock,
+							dapp: argv.dapp,
+							captchaConfig,
+						}),
 					);
 				}
 				logger.info("IP Block rules added");

--- a/packages/database/src/databases/provider.ts
+++ b/packages/database/src/databases/provider.ts
@@ -1455,7 +1455,7 @@ export class ProviderDatabase
 	}
 
 	/**
-	 * @description Check if a request has a blocking rule associated with it
+	 * @description Store IP blocking rule records
 	 */
 	async storeIPBlockRuleRecords(rules: IPBlockRuleRecord[]) {
 		await this.tables?.ipblockrules.bulkWrite(
@@ -1467,6 +1467,21 @@ export class ProviderDatabase
 				},
 			})),
 		);
+	}
+
+	/**
+	 * @description Remove IP blocking rule records
+	 */
+	async removeIPBlockRuleRecords(ipAddresses: bigint[], dappAccount?: string) {
+		const filter: {
+			[key in keyof Pick<IPBlockRuleRecord, "ip">]: { $in: number[] };
+		} & {
+			[key in keyof Pick<IPBlockRuleRecord, "dappAccount">]?: string; // Optional `dappAccount` key
+		} = { ip: { $in: ipAddresses.map(Number) } };
+		if (dappAccount) {
+			filter.dappAccount = dappAccount;
+		}
+		await this.tables?.ipblockrules.deleteMany(filter);
 	}
 
 	/**
@@ -1502,5 +1517,25 @@ export class ProviderDatabase
 				},
 			})),
 		);
+	}
+
+	/**
+	 * @description Remove user blocking rule records
+	 */
+	async removeUserBlockRuleRecords(
+		userAccounts: string[],
+		dappAccount?: string,
+	) {
+		const filter: {
+			[key in keyof Pick<UserAccountBlockRule, "userAccount">]: {
+				$in: string[];
+			};
+		} & {
+			[key in keyof Pick<UserAccountBlockRule, "dappAccount">]?: string; // Optional `dappAccount` key
+		} = { userAccount: { $in: userAccounts } };
+		if (dappAccount) {
+			filter.dappAccount = dappAccount;
+		}
+		await this.tables?.userblockrules.deleteMany(filter);
 	}
 }

--- a/packages/provider/src/api/admin.ts
+++ b/packages/provider/src/api/admin.ts
@@ -13,9 +13,14 @@ import { Logger, logError } from "@prosopo/common";
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import {
+	AddBlockRulesIPSpec,
+	AddBlockRulesUserSpec,
 	AdminApiPaths,
 	type ApiResponse,
+	BlockRuleIPAddBody,
 	RegisterSitekeyBody,
+	RemoveBlockRulesIPSpec,
+	RemoveBlockRulesUserSpec,
 } from "@prosopo/types";
 import type { ProviderEnvironment } from "@prosopo/types-env";
 import { Router } from "express";
@@ -39,6 +44,66 @@ export function prosopoAdminRouter(env: ProviderEnvironment): Router {
 		} catch (err) {
 			logError(err, tasks.logger);
 			res.status(500).send("An internal server error occurred.");
+		}
+	});
+
+	router.post(AdminApiPaths.BlockRuleIPAdd, async (req, res, next) => {
+		try {
+			tasks.logger.info("Adding block rules");
+			const parsed = AddBlockRulesIPSpec.parse(req.body);
+			await tasks.clientTaskManager.addIPBlockRules(parsed);
+			const response: ApiResponse = {
+				status: "success",
+			};
+			res.json(response);
+		} catch (err) {
+			logError(err, tasks.logger);
+			res.status(400).send("An internal server error occurred.");
+		}
+	});
+
+	router.post(AdminApiPaths.BlockRuleIPRemove, async (req, res, next) => {
+		try {
+			tasks.logger.info("Removing block rules");
+			const parsed = RemoveBlockRulesIPSpec.parse(req.body);
+			await tasks.clientTaskManager.removeIPBlockRules(parsed);
+			const response: ApiResponse = {
+				status: "success",
+			};
+			res.json(response);
+		} catch (err) {
+			logError(err, tasks.logger);
+			res.status(400).send("An internal server error occurred.");
+		}
+	});
+
+	router.post(AdminApiPaths.BlocKRuleUserAdd, async (req, res, next) => {
+		try {
+			tasks.logger.info("Adding block rules");
+			const parsed = AddBlockRulesUserSpec.parse(req.body);
+			await tasks.clientTaskManager.addUserBlockRules(parsed);
+			const response: ApiResponse = {
+				status: "success",
+			};
+			res.json(response);
+		} catch (err) {
+			logError(err, tasks.logger);
+			res.status(400).send("An internal server error occurred.");
+		}
+	});
+
+	router.post(AdminApiPaths.BlockRuleUserRemove, async (req, res, next) => {
+		try {
+			tasks.logger.info("Removing block rules");
+			const parsed = RemoveBlockRulesUserSpec.parse(req.body);
+			await tasks.clientTaskManager.removeUserBlockRules(parsed);
+			const response: ApiResponse = {
+				status: "success",
+			};
+			res.json(response);
+		} catch (err) {
+			logError(err, tasks.logger);
+			res.status(400).send("An internal server error occurred.");
 		}
 	});
 

--- a/packages/provider/src/rules/ip.ts
+++ b/packages/provider/src/rules/ip.ts
@@ -1,3 +1,4 @@
+import type { BlockRule, IPAddress } from "@prosopo/types";
 // Copyright 2021-2024 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,12 +12,12 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-import type { BlockRule, IProviderDatabase } from "@prosopo/types-database";
-import type { Address4, Address6 } from "ip-address";
+
+import type { IProviderDatabase } from "@prosopo/types-database";
 
 export const checkIpRules = async (
 	db: IProviderDatabase,
-	ipAddress: Address4 | Address6,
+	ipAddress: IPAddress,
 	dapp: string,
 ): Promise<BlockRule | undefined> => {
 	const rule = await db.getIPBlockRuleRecord(ipAddress.bigInt());

--- a/packages/provider/src/rules/ip.ts
+++ b/packages/provider/src/rules/ip.ts
@@ -1,4 +1,3 @@
-import type { BlockRule, IPAddress } from "@prosopo/types";
 // Copyright 2021-2024 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,6 +12,7 @@ import type { BlockRule, IPAddress } from "@prosopo/types";
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import type { BlockRule, IPAddress } from "@prosopo/types";
 import type { IProviderDatabase } from "@prosopo/types-database";
 
 export const checkIpRules = async (

--- a/packages/provider/src/rules/user.ts
+++ b/packages/provider/src/rules/user.ts
@@ -11,7 +11,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-import type { BlockRule, IProviderDatabase } from "@prosopo/types-database";
+
+import type { BlockRule } from "@prosopo/types";
+import type { IProviderDatabase } from "@prosopo/types-database";
 
 export const checkUserRules = async (
 	db: IProviderDatabase,

--- a/packages/provider/src/tasks/dataset/datasetTasks.ts
+++ b/packages/provider/src/tasks/dataset/datasetTasks.ts
@@ -14,8 +14,8 @@ import type { Logger } from "@prosopo/common";
 // limitations under the License.
 import { parseCaptchaDataset } from "@prosopo/datasets";
 import type {
-	CaptchaConfig,
 	DatasetRaw,
+	ProsopoCaptchaCountConfigSchemaOutput,
 	ProsopoConfigOutput,
 } from "@prosopo/types";
 import type { IProviderDatabase } from "@prosopo/types-database";
@@ -24,13 +24,13 @@ import { providerValidateDataset } from "./datasetTasksUtils.js";
 export class DatasetManager {
 	config: ProsopoConfigOutput;
 	logger: Logger;
-	captchaConfig: CaptchaConfig;
+	captchaConfig: ProsopoCaptchaCountConfigSchemaOutput;
 	db: IProviderDatabase;
 
 	constructor(
 		config: ProsopoConfigOutput,
 		logger: Logger,
-		captchaConfig: CaptchaConfig,
+		captchaConfig: ProsopoCaptchaCountConfigSchemaOutput,
 		db: IProviderDatabase,
 	) {
 		this.config = config;

--- a/packages/provider/src/tasks/frictionless/frictionlessTasks.ts
+++ b/packages/provider/src/tasks/frictionless/frictionlessTasks.ts
@@ -19,6 +19,7 @@ import {
 	type CaptchaResult,
 	CaptchaStatus,
 	type GetFrictionlessCaptchaResponse,
+	type IPAddress,
 	POW_SEPARATOR,
 	type PoWCaptcha,
 	type PoWChallengeId,
@@ -49,10 +50,7 @@ export class FrictionlessManager {
 		this.db = db;
 	}
 
-	async checkIpRules(
-		ipAddress: Address4 | Address6,
-		dapp: string,
-	): Promise<boolean> {
+	async checkIpRules(ipAddress: IPAddress, dapp: string): Promise<boolean> {
 		const rule = await checkIpRules(this.db, ipAddress, dapp);
 		return !!rule;
 	}

--- a/packages/provider/src/tasks/imgCaptcha/imgCaptchaTasks.ts
+++ b/packages/provider/src/tasks/imgCaptcha/imgCaptchaTasks.ts
@@ -23,12 +23,12 @@ import {
 } from "@prosopo/datasets";
 import {
 	type Captcha,
-	type CaptchaConfig,
 	type CaptchaSolution,
 	CaptchaStatus,
 	DEFAULT_IMAGE_CAPTCHA_TIMEOUT,
 	type DappUserSolutionResult,
 	type Hash,
+	type IPAddress,
 	type ImageVerificationResponse,
 	type PendingCaptchaRequest,
 	type ProsopoCaptchaCountConfigSchemaOutput,
@@ -88,9 +88,9 @@ export class ImgCaptchaManager {
 	async getRandomCaptchasAndRequestHash(
 		datasetId: Hash,
 		userAccount: string,
-		ipAddress: Address4 | Address6,
+		ipAddress: IPAddress,
 		headers: RequestHeaders,
-		captchaConfig: CaptchaConfig,
+		captchaConfig: ProsopoCaptchaCountConfigSchemaOutput,
 	): Promise<{
 		captchas: Captcha[];
 		requestHash: string;

--- a/packages/provider/src/tasks/imgCaptcha/imgCaptchaTasksUtils.ts
+++ b/packages/provider/src/tasks/imgCaptcha/imgCaptchaTasksUtils.ts
@@ -17,12 +17,12 @@ import {
 	computeCaptchaSolutionHash,
 } from "@prosopo/datasets";
 import type {
-	CaptchaConfig,
 	CaptchaSolution,
+	IPAddress,
+	ProsopoCaptchaCountConfigSchemaOutput,
 	ProsopoConfigOutput,
 } from "@prosopo/types";
 import type { IProviderDatabase } from "@prosopo/types-database";
-import type { Address4, Address6 } from "ip-address";
 import { checkIpRules } from "../../rules/ip.js";
 import { checkUserRules } from "../../rules/user.js";
 
@@ -67,10 +67,10 @@ export const buildTreeAndGetCommitmentId = (
 export const getCaptchaConfig = async (
 	db: IProviderDatabase,
 	config: ProsopoConfigOutput,
-	ipAddress: Address4 | Address6,
+	ipAddress: IPAddress,
 	user: string,
 	dapp: string,
-): Promise<CaptchaConfig> => {
+): Promise<ProsopoCaptchaCountConfigSchemaOutput> => {
 	const ipRule = await checkIpRules(db, ipAddress, dapp);
 	if (ipRule) {
 		return {

--- a/packages/provider/src/tasks/powCaptcha/powTasks.ts
+++ b/packages/provider/src/tasks/powCaptcha/powTasks.ts
@@ -22,6 +22,7 @@ import {
 	ApiParams,
 	type CaptchaResult,
 	CaptchaStatus,
+	type IPAddress,
 	POW_SEPARATOR,
 	type PoWCaptcha,
 	type PoWChallengeId,
@@ -29,7 +30,6 @@ import {
 } from "@prosopo/types";
 import type { IProviderDatabase } from "@prosopo/types-database";
 import { at, verifyRecency } from "@prosopo/util";
-import type { Address4, Address6 } from "ip-address";
 import { checkPowSignature, validateSolution } from "./powTasksUtils.js";
 
 const logger = getLoggerDefault();
@@ -95,7 +95,7 @@ export class PowCaptchaManager {
 		nonce: number,
 		timeout: number,
 		userTimestampSignature: string,
-		ipAddress: Address4 | Address6,
+		ipAddress: IPAddress,
 		headers: RequestHeaders,
 	): Promise<boolean> {
 		// Check signatures before doing DB reads to avoid unnecessary network connections

--- a/packages/provider/src/tasks/tasks.ts
+++ b/packages/provider/src/tasks/tasks.ts
@@ -13,7 +13,10 @@ import { type Logger, ProsopoEnvError, getLogger } from "@prosopo/common";
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-import type { CaptchaConfig, ProsopoConfigOutput } from "@prosopo/types";
+import type {
+	ProsopoCaptchaCountConfigSchemaOutput,
+	ProsopoConfigOutput,
+} from "@prosopo/types";
 import type { IProviderDatabase } from "@prosopo/types-database";
 import type { ProviderEnvironment } from "@prosopo/types-env";
 import { ClientTaskManager } from "./client/clientTasks.js";
@@ -27,7 +30,7 @@ import { PowCaptchaManager } from "./powCaptcha/powTasks.js";
  */
 export class Tasks {
 	db: IProviderDatabase;
-	captchaConfig: CaptchaConfig;
+	captchaConfig: ProsopoCaptchaCountConfigSchemaOutput;
 	logger: Logger;
 	config: ProsopoConfigOutput;
 	pair: KeyringPair;

--- a/packages/provider/src/tests/unit/tasks/dataset/datasetTasks.unit.test.ts
+++ b/packages/provider/src/tests/unit/tasks/dataset/datasetTasks.unit.test.ts
@@ -15,8 +15,8 @@
 import type { Logger } from "@prosopo/common";
 import { parseCaptchaDataset } from "@prosopo/datasets";
 import type {
-	CaptchaConfig,
 	DatasetRaw,
+	ProsopoCaptchaCountConfigSchemaOutput,
 	ProsopoConfigOutput,
 	ScheduledTaskNames,
 	ScheduledTaskResult,
@@ -52,7 +52,7 @@ type TestScheduledTaskRecord = Pick<
 describe("DatasetManager", () => {
 	let config: ProsopoConfigOutput;
 	let logger: Logger;
-	let captchaConfig: CaptchaConfig;
+	let captchaConfig: ProsopoCaptchaCountConfigSchemaOutput;
 	let providerDB: IProviderDatabase;
 	let datasetManager: DatasetManager;
 	// biome-ignore lint/suspicious/noExplicitAny: <explanation>
@@ -74,7 +74,7 @@ describe("DatasetManager", () => {
 		captchaConfig = {
 			solved: { count: 5 },
 			unsolved: { count: 5 },
-		} as CaptchaConfig;
+		} as ProsopoCaptchaCountConfigSchemaOutput;
 
 		collections.schedulers = {} as {
 			records: Record<string, TestScheduledTaskRecord>;

--- a/packages/provider/src/tests/unit/tasks/imgCaptcha/imgCaptchaTasksUtils.unit.test.ts
+++ b/packages/provider/src/tests/unit/tasks/imgCaptcha/imgCaptchaTasksUtils.unit.test.ts
@@ -16,13 +16,11 @@ import {
 	CaptchaMerkleTree,
 	computeCaptchaSolutionHash,
 } from "@prosopo/datasets";
-import type { CaptchaSolution } from "@prosopo/types";
-import {
-	BlockRuleType,
-	type IPAddressBlockRule,
-	type IProviderDatabase,
-	type UserAccountBlockRule,
-	type UserAccountBlockRuleRecord,
+import { BlockRuleType, type CaptchaSolution } from "@prosopo/types";
+import type {
+	IPAddressBlockRule,
+	IProviderDatabase,
+	UserAccountBlockRule,
 } from "@prosopo/types-database";
 import { Address4 } from "ip-address";
 import { beforeEach, describe, expect, it, vi } from "vitest";

--- a/packages/provider/src/util.ts
+++ b/packages/provider/src/util.ts
@@ -15,7 +15,11 @@ import { decodeAddress, encodeAddress } from "@polkadot/util-crypto/address";
 import { hexToU8a } from "@polkadot/util/hex";
 import { isHex } from "@polkadot/util/is";
 import { ProsopoContractError, ProsopoEnvError } from "@prosopo/common";
-import { type ScheduledTaskNames, ScheduledTaskStatus } from "@prosopo/types";
+import {
+	type IPAddress,
+	type ScheduledTaskNames,
+	ScheduledTaskStatus,
+} from "@prosopo/types";
 import type { IDatabase, IProviderDatabase } from "@prosopo/types-database";
 import { at } from "@prosopo/util";
 import { Address4, Address6 } from "ip-address";
@@ -67,7 +71,7 @@ export async function checkIfTaskIsRunning(
 	return false;
 }
 
-export const getIPAddress = (ipAddressString: string): Address4 | Address6 => {
+export const getIPAddress = (ipAddressString: string): IPAddress => {
 	try {
 		if (ipAddressString.match(/^((25[0-5]|(2[0-4]|1\d|[1-9]|)\d)\.?\b){4}$/)) {
 			return new Address4(ipAddressString);

--- a/packages/types-database/src/types/provider.ts
+++ b/packages/types-database/src/types/provider.ts
@@ -14,8 +14,9 @@
 
 import { type TranslationKey, TranslationKeysSchema } from "@prosopo/locale";
 import {
+	type BlockRule,
+	BlockRuleType,
 	type Captcha,
-	type CaptchaConfig,
 	type CaptchaResult,
 	type CaptchaSolution,
 	CaptchaSolutionSchema,
@@ -32,6 +33,7 @@ import {
 	type PoWCaptchaUser,
 	type PoWChallengeComponents,
 	type PoWChallengeId,
+	ProsopoCaptchaCountConfigSchema,
 	type RequestHeaders,
 	ScheduledTaskNames,
 	type ScheduledTaskResult,
@@ -39,7 +41,6 @@ import {
 	type Timestamp,
 	TimestampSchema,
 } from "@prosopo/types";
-import type { DeleteResult } from "mongodb";
 import mongoose from "mongoose";
 import { type Document, type Model, type ObjectId, Schema } from "mongoose";
 import {
@@ -384,18 +385,6 @@ export const SessionRecordSchema = new Schema<SessionRecord>({
 
 SessionRecordSchema.index({ sessionId: 1 }, { unique: true });
 
-export type BlockRule = {
-	global: boolean;
-	type: BlockRuleType;
-	hardBlock: boolean;
-	captchaConfig?: CaptchaConfig;
-};
-
-export enum BlockRuleType {
-	ipAddress = "ipAddress",
-	userAccount = "userAccount",
-}
-
 export interface IPAddressBlockRule extends BlockRule {
 	ip: number;
 	dappAccount?: string;
@@ -622,10 +611,17 @@ export interface IProviderDatabase extends IDatabase {
 
 	storeIPBlockRuleRecords(rules: IPAddressBlockRule[]): Promise<void>;
 
+	removeIPBlockRuleRecords(ips: bigint[], dappAccount?: string): Promise<void>;
+
 	getUserBlockRuleRecord(
 		userAccount: string,
 		dappAccount: string,
 	): Promise<UserAccountBlockRuleRecord | undefined>;
 
 	storeUserBlockRuleRecords(rules: UserAccountBlockRule[]): Promise<void>;
+
+	removeUserBlockRuleRecords(
+		users: string[],
+		dappAccount?: string,
+	): Promise<void>;
 }

--- a/packages/types/src/config/config.ts
+++ b/packages/types/src/config/config.ts
@@ -125,7 +125,7 @@ export const ProsopoCaptchaCountConfigSchema = object({
 		count: number().nonnegative(),
 	})
 		.optional()
-		.default({ count: 1 }),
+		.default({ count: 0 }),
 });
 
 export type ProsopoCaptchaCountConfigSchemaInput = input<

--- a/packages/types/src/config/config.ts
+++ b/packages/types/src/config/config.ts
@@ -24,6 +24,7 @@ import type { infer as zInfer } from "zod";
 import z, { boolean } from "zod";
 import {
 	ApiPathRateLimits,
+	ProsopoCaptchaCountConfigSchema,
 	ProviderDefaultRateLimits,
 } from "../provider/index.js";
 import {
@@ -114,27 +115,6 @@ export const ProsopoBasicConfigSchema = ProsopoBaseConfigSchema.merge(
 
 export type ProsopoBasicConfigInput = input<typeof ProsopoBasicConfigSchema>;
 export type ProsopoBasicConfigOutput = output<typeof ProsopoBasicConfigSchema>;
-
-export const ProsopoCaptchaCountConfigSchema = object({
-	solved: object({
-		count: number().positive(),
-	})
-		.optional()
-		.default({ count: 1 }),
-	unsolved: object({
-		count: number().nonnegative(),
-	})
-		.optional()
-		.default({ count: 0 }),
-});
-
-export type ProsopoCaptchaCountConfigSchemaInput = input<
-	typeof ProsopoCaptchaCountConfigSchema
->;
-
-export type ProsopoCaptchaCountConfigSchemaOutput = output<
-	typeof ProsopoCaptchaCountConfigSchema
->;
 
 export const ProsopoImageServerConfigSchema = object({
 	baseURL: string().url(),

--- a/packages/types/src/datasets/captcha.ts
+++ b/packages/types/src/datasets/captcha.ts
@@ -160,21 +160,6 @@ export interface PoWCaptchaUser extends PoWCaptcha {
 	dappAccount: DappAccount;
 }
 
-export type CaptchaConfig = {
-	solved: {
-		count: number;
-	};
-	unsolved: {
-		count: number;
-	};
-};
-
-export type CaptchaSolutionConfig = {
-	requiredNumberOfSolutions: number;
-	solutionWinningPercentage: number;
-	captchaBlockRecency: number;
-};
-
 export const CaptchaSchema = object({
 	captchaId: union([string(), zUndefined()]),
 	captchaContentId: union([string(), zUndefined()]),

--- a/packages/types/src/provider/api.ts
+++ b/packages/types/src/provider/api.ts
@@ -20,8 +20,10 @@ import {
 	type ZodObject,
 	type ZodOptional,
 	array,
+	boolean,
 	coerce,
 	type input,
+	nativeEnum,
 	number,
 	object,
 	type output,
@@ -30,6 +32,7 @@ import {
 	type infer as zInfer,
 } from "zod";
 import { ApiParams } from "../api/params.js";
+import { ProsopoCaptchaCountConfigSchema } from "../config/index.js";
 import {
 	DEFAULT_IMAGE_MAX_VERIFIED_TIME_CACHED,
 	DEFAULT_POW_CAPTCHA_VERIFIED_TIMEOUT,
@@ -74,14 +77,12 @@ export type TGetImageCaptchaChallengePathAndParams =
 export type TGetImageCaptchaChallengeURL =
 	`${string}${TGetImageCaptchaChallengePathAndParams}`;
 
-export type TGetPowCaptchaChallengeURL =
-	`${string}${ApiPaths.GetPowCaptchaChallenge}`;
-
-export type TSubmitPowCaptchaSolutionURL =
-	`${string}${ApiPaths.SubmitPowCaptchaSolution}`;
-
 export enum AdminApiPaths {
 	SiteKeyRegister = "/v1/prosopo/provider/admin/sitekey/register",
+	BlockRuleIPAdd = "/v1/prosopo/provider/admin/blockrule/ip/add",
+	BlockRuleIPRemove = "/v1/prosopo/provider/admin/blockrule/ip/remove",
+	BlocKRuleUserAdd = "/v1/prosopo/provider/admin/blockrule/user/add",
+	BlockRuleUserRemove = "/v1/prosopo/provider/admin/blockrule/user/remove",
 }
 
 export type CombinedApiPaths = ApiPaths | AdminApiPaths;
@@ -98,6 +99,10 @@ export const ProviderDefaultRateLimits = {
 	[ApiPaths.GetProviderDetails]: { windowMs: 60000, limit: 60 },
 	[ApiPaths.SubmitUserEvents]: { windowMs: 60000, limit: 60 },
 	[AdminApiPaths.SiteKeyRegister]: { windowMs: 60000, limit: 5 },
+	[AdminApiPaths.BlockRuleIPAdd]: { windowMs: 60000, limit: 5 },
+	[AdminApiPaths.BlockRuleIPRemove]: { windowMs: 60000, limit: 5 },
+	[AdminApiPaths.BlocKRuleUserAdd]: { windowMs: 60000, limit: 5 },
+	[AdminApiPaths.BlockRuleUserRemove]: { windowMs: 60000, limit: 5 },
 };
 
 type RateLimit = {
@@ -344,6 +349,55 @@ export const RegisterSitekeyBody = object({
 		[ApiParams.powDifficulty]: number(),
 	}).optional(),
 });
+
+export enum BlockRuleType {
+	ipAddress = "ipAddress",
+	userAccount = "userAccount",
+}
+
+const BlockRuleTypeSpec = nativeEnum(BlockRuleType);
+
+export const BlockRuleSpec = object({
+	global: boolean(),
+	hardBlock: boolean(),
+	type: BlockRuleTypeSpec,
+	dappAccount: string().optional(),
+	captchaConfig: ProsopoCaptchaCountConfigSchema.optional(),
+});
+
+export type BlockRule = zInfer<typeof BlockRuleSpec>;
+
+export const AddBlockRulesIPSpec = BlockRuleSpec.merge(
+	object({
+		ips: array(string()),
+	}),
+);
+
+export type AddBlockRulesIP = zInfer<typeof AddBlockRulesIPSpec>;
+
+export const RemoveBlockRulesIPSpec = object({
+	ips: array(string()),
+	dappAccount: string().optional(),
+});
+
+export type RemoveBlockRulesIP = zInfer<typeof RemoveBlockRulesIPSpec>;
+
+export const BlockRuleIPAddBody = array(AddBlockRulesIPSpec);
+
+export const AddBlockRulesUserSpec = BlockRuleSpec.merge(
+	object({
+		users: array(string()),
+	}),
+);
+
+export type AddBlockRulesUser = zInfer<typeof AddBlockRulesUserSpec>;
+
+export const RemoveBlockRulesUserSpec = object({
+	users: array(string()),
+	dappAccount: string().optional(),
+});
+
+export type RemoveBlockRulesUser = zInfer<typeof RemoveBlockRulesUserSpec>;
 
 export const DappDomainRequestBody = object({
 	[ApiParams.dapp]: string(),

--- a/packages/types/src/provider/api.ts
+++ b/packages/types/src/provider/api.ts
@@ -32,7 +32,6 @@ import {
 	type infer as zInfer,
 } from "zod";
 import { ApiParams } from "../api/params.js";
-import { ProsopoCaptchaCountConfigSchema } from "../config/index.js";
 import {
 	DEFAULT_IMAGE_MAX_VERIFIED_TIME_CACHED,
 	DEFAULT_POW_CAPTCHA_VERIFIED_TIMEOUT,
@@ -349,6 +348,27 @@ export const RegisterSitekeyBody = object({
 		[ApiParams.powDifficulty]: number(),
 	}).optional(),
 });
+
+export const ProsopoCaptchaCountConfigSchema = object({
+	solved: object({
+		count: number().positive(),
+	})
+		.optional()
+		.default({ count: 1 }),
+	unsolved: object({
+		count: number().nonnegative(),
+	})
+		.optional()
+		.default({ count: 0 }),
+});
+
+export type ProsopoCaptchaCountConfigSchemaInput = input<
+	typeof ProsopoCaptchaCountConfigSchema
+>;
+
+export type ProsopoCaptchaCountConfigSchemaOutput = output<
+	typeof ProsopoCaptchaCountConfigSchema
+>;
 
 export enum BlockRuleType {
 	ipAddress = "ipAddress",


### PR DESCRIPTION
- [x] Allow adding and removing IP and user block rules via the API
- [x] Sort out types so they are shared between config