### PR TITLE
Disable HTTP3 and add robots header

### DIFF
--- a/docker/provider.Caddyfile
+++ b/docker/provider.Caddyfile
@@ -8,6 +8,7 @@
 	# Caddy must be told custom rate_limit module its order
 	order rate_limit before basicauth
 	servers {
+		protocols h1 h2
 		listener_wrappers {
 			http_redirect
 			tls
@@ -22,6 +23,17 @@
 }
 
 {$CADDY_DOMAIN} {
+	header / {
+		# Enable HTTP Strict Transport Security (HSTS)
+		Strict-Transport-Security "max-age=31536000;"
+		# Enable cross-site filter (XSS) and tell browser to block detected attacks
+		X-XSS-Protection "1; mode=block"
+		# Disallow the site to be rendered within a frame (clickjacking protection)
+		X-Frame-Options "DENY"
+		# Prevent search engines from indexing
+		X-Robots-Tag "none"
+	}
+
 	# basicauth /metrics {
 	# 	 # this has to be the username<space><bcrypted password>
 	# 	 # to generate, run `htpasswd -nbB <username> <password>` which will spit out `<username>:<bcrypted password>`


### PR DESCRIPTION
```
access-control-allow-origin:
*
content-length:
139
content-security-policy:
default-src 'none'

content-type:
text/html; charset=utf-8
date:
Tue, 14 Jan 2025 09:48:20 GMT
server:
Caddy
strict-transport-security:
max-age=31536000;
x-content-type-options:
nosniff
x-frame-options:
DENY
x-powered-by:
Express
x-robots-tag:
none
x-xss-protection:
1; mode=block

```