### PR TITLE
Fixes for score image captcha PR running in conjunction with private

### DIFF
--- a/packages/common/src/error.ts
+++ b/packages/common/src/error.ts
@@ -194,8 +194,12 @@ export const unwrapError = (err: ProsopoBaseError | SyntaxError | ZodError) => {
 		jsonError.key =
 			err.context.translationKey || err.translationKey || "API.UNKNOWN";
 		jsonError.message = err.message;
-		// Don't move to the next error if it is an instance of `Error` only
-		if (err.context.error && err.context.error instanceof ProsopoBaseError) {
+		// Only move to the next error if ProsopoBaseError or ZodError
+		if (
+			err.context.error &&
+			(err.context.error instanceof ProsopoBaseError ||
+				isZodError(err.context.error))
+		) {
 			err = err.context.error;
 		} else {
 			break;

--- a/packages/common/src/error.ts
+++ b/packages/common/src/error.ts
@@ -194,7 +194,8 @@ export const unwrapError = (err: ProsopoBaseError | SyntaxError | ZodError) => {
 		jsonError.key =
 			err.context.translationKey || err.translationKey || "API.UNKNOWN";
 		jsonError.message = err.message;
-		if (err.context.error) {
+		// Don't move to the next error if it is an instance of `Error` only
+		if (err.context.error && err.context.error instanceof ProsopoBaseError) {
 			err = err.context.error;
 		} else {
 			break;

--- a/packages/provider/src/api/verify.ts
+++ b/packages/provider/src/api/verify.ts
@@ -198,7 +198,7 @@ export function prosopoVerifyRouter(env: ProviderEnvironment): Router {
 			tasks.logger.error({ err, body: req.body });
 			return next(
 				new ProsopoApiError("API.BAD_REQUEST", {
-					context: { code: 500 },
+					context: { code: 500, error: err },
 				}),
 			);
 		}

--- a/packages/provider/src/tasks/powCaptcha/powTasks.ts
+++ b/packages/provider/src/tasks/powCaptcha/powTasks.ts
@@ -178,12 +178,8 @@ export class PowCaptchaManager extends CaptchaManager {
 			await this.db.getPowCaptchaRecordByChallenge(challenge);
 
 		if (!challengeRecord) {
-			throw new ProsopoEnvError("DATABASE.CAPTCHA_GET_FAILED", {
-				context: {
-					failedFuncName: this.serverVerifyPowCaptchaSolution.name,
-					challenge,
-				},
-			});
+			this.logger.debug(`No record of this challenge: ${challenge}`);
+			return { verified: false };
 		}
 
 		if (challengeRecord.result.status !== CaptchaStatus.approved) {

--- a/packages/provider/src/tests/integration/registerSitekey.ts
+++ b/packages/provider/src/tests/integration/registerSitekey.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import { ProviderDatabase } from "@prosopo/database";
-import type { CaptchaType } from "@prosopo/types";
+import { type CaptchaType, Tier } from "@prosopo/types";
 import type { ClientRecord } from "@prosopo/types-database";
 
 export const registerSiteKey = async (
@@ -34,6 +34,7 @@ export const registerSiteKey = async (
 		await db.updateClientRecords([
 			{
 				account: siteKey,
+				tier: Tier.Free,
 				settings: {
 					captchaType: captchaType,
 					domains: ["example.com"],

--- a/packages/provider/src/tests/unit/tasks/powCaptcha/powTasks.unit.test.ts
+++ b/packages/provider/src/tests/unit/tasks/powCaptcha/powTasks.unit.test.ts
@@ -319,7 +319,7 @@ describe("PowCaptchaManager", () => {
 			);
 		});
 
-		it("should throw an error if challenge record is not found", async () => {
+		it("should return verified:false if a challenge cannot be found", async () => {
 			const dappAccount = "dappAccount";
 			const timestamp = 123456678;
 			const userAccount = "testUserAccount";
@@ -328,20 +328,12 @@ describe("PowCaptchaManager", () => {
 			// biome-ignore lint/suspicious/noExplicitAny: TODO fix
 			(db.getPowCaptchaRecordByChallenge as any).mockResolvedValue(null);
 
-			await expect(
-				powCaptchaManager.serverVerifyPowCaptchaSolution(
-					dappAccount,
-					challenge,
-					timeout,
-				),
-			).rejects.toThrow(
-				new ProsopoEnvError("DATABASE.CAPTCHA_GET_FAILED", {
-					context: {
-						failedFuncName: "serverVerifyPowCaptchaSolution",
-						challenge,
-					},
-				}),
+			const result = await powCaptchaManager.serverVerifyPowCaptchaSolution(
+				dappAccount,
+				challenge,
+				timeout,
 			);
+			expect(result.verified).toBe(false);
 
 			expect(db.getPowCaptchaRecordByChallenge).toHaveBeenCalledWith(challenge);
 		});


### PR DESCRIPTION
- [x] don't error if a pow challenge can't be found, just return `verified: false`
- [x] update tests
- [x] set a tier in tests register site key function
- [x] unwrap errors only if they are `ProsopoBaseError` or `ZodError`