### PR TITLE
Zod native enum bug workaround

### DIFF
--- a/packages/types/src/client/captchaType.ts
+++ b/packages/types/src/client/captchaType.ts
@@ -18,13 +18,12 @@ const powStr = "pow";
 const frictionlessStr = "frictionless";
 
 export enum CaptchaType {
+	// biome-ignore lint/style/useLiteralEnumMembers: zod workaround
 	image = imageStr,
+	// biome-ignore lint/style/useLiteralEnumMembers: zod workaround
 	pow = powStr,
+	// biome-ignore lint/style/useLiteralEnumMembers: zod workaround
 	frictionless = frictionlessStr,
 }
 
-export const CaptchaTypeSpec = z.enum([
-	imageStr,
-	powStr,
-	frictionlessStr,
-]);
+export const CaptchaTypeSpec = z.enum([imageStr, powStr, frictionlessStr]);

--- a/packages/types/src/client/captchaType.ts
+++ b/packages/types/src/client/captchaType.ts
@@ -11,12 +11,20 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-import { nativeEnum } from "zod";
+import { nativeEnum, z } from "zod";
+
+const imageStr = "image";
+const powStr = "pow";
+const frictionlessStr = "frictionless";
 
 export enum CaptchaType {
-	image = "image",
-	pow = "pow",
-	frictionless = "frictionless",
+	image = imageStr,
+	pow = powStr,
+	frictionless = frictionlessStr,
 }
 
-export const CaptchaTypeSpec = nativeEnum(CaptchaType);
+export const CaptchaTypeSpec = z.enum([
+	imageStr,
+	powStr,
+	frictionlessStr,
+]);

--- a/packages/types/src/client/index.ts
+++ b/packages/types/src/client/index.ts
@@ -12,6 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 export * from "./user.js";
-export { ClientSettingsSchema } from "./settings.js";
-export type { IUserSettings } from "./settings.js";
+export * from "./settings.js";
 export * from "./captchaType.js";

--- a/packages/types/src/client/user.ts
+++ b/packages/types/src/client/user.ts
@@ -22,12 +22,15 @@ const professionalTier = "professional";
 const enterpriseTier = "enterprise";
 
 export enum Tier {
+	// biome-ignore lint/style/useLiteralEnumMembers: zod workaround
 	Free = freeTier,
+	// biome-ignore lint/style/useLiteralEnumMembers: zod workaround
 	Professional = professionalTier,
+	// biome-ignore lint/style/useLiteralEnumMembers: zod workaround
 	Enterprise = enterpriseTier,
 }
 
-export const TierSchema = z.nativeEnum(Tier)//[freeTier, professionalTier, enterpriseTier]);
+export const TierSchema = z.nativeEnum(Tier); //[freeTier, professionalTier, enterpriseTier]);
 
 export const TierMonthlyLimits = {
 	[Tier.Free]: {

--- a/packages/types/src/client/user.ts
+++ b/packages/types/src/client/user.ts
@@ -12,15 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { z } from "zod";
 import type { Timestamp } from "../datasets/index.js";
 
 import type { IUserSettings } from "./settings.js";
 
+const freeTier = "free";
+const professionalTier = "professional";
+const enterpriseTier = "enterprise";
+
 export enum Tier {
-	Free = "free",
-	Professional = "professional",
-	Enterprise = "enterprise",
+	Free = freeTier,
+	Professional = professionalTier,
+	Enterprise = enterpriseTier,
 }
+
+export const TierSchema = z.nativeEnum(Tier)//[freeTier, professionalTier, enterpriseTier]);
 
 export const TierMonthlyLimits = {
 	[Tier.Free]: {


### PR DESCRIPTION
Zod native enum has an issue with the enum values being typed correctly. This works around the issue until I find a fix. These are the only two nativeEnums used in the shared types pkg I'm working on for the portal + api, so this is the mvp workaround