### PR TITLE
fix/release5

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,7 +121,11 @@ jobs:
                 done
                 affected='[]'
                 if [ -n "$package_files" ]; then
-                    affected=$(echo "$package_files" | xargs -I{} jq -r '.name' {} | jq -R -s -c 'split(" ") | map(select(. != ""))')
+                    affected='[]'
+                    for file in $package_files; do
+                        name=$(jq -r '.name' "$file")
+                        affected=$(echo "$affected" | jq --arg name "$name" '. + [$name]')
+                    done
                 else 
                     echo "No package.json files changed, no affected packages"
                 fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,7 +124,7 @@ jobs:
                     affected='[]'
                     for file in $package_files; do
                         name=$(jq -r '.name' "$file")
-                        affected=$(echo "$affected" | jq -r --arg name "$name" '. + [$name]')
+                        affected=$(echo "$affected" | jq -c --arg name "$name" '. + [$name]')
                     done
                 else 
                     echo "No package.json files changed, no affected packages"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,11 +112,11 @@ jobs:
 
                 # Find all package.json files changed in the last commit (by changesets version bump)
                 package_files=$(git diff --name-only HEAD~1 HEAD | grep 'package.json$' || true)
-                if [ -z "$package_files" ]; then
-                    echo "No package.json files found in the last commit."
-                    affected='[]'
-                else
+                affected='[]'
+                if [ -n "$package_files" ]; then
                     affected=$(echo "$package_files" | xargs -I{} jq -r '.name' {} | jq -R -s -c 'split("\n")[:-1]')
+                else 
+                    echo "No package.json files changed, no affected packages"
                 fi
                 echo "affected: $affected"
                 echo "affected=$affected" >> $GITHUB_ENV

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,10 +111,17 @@ jobs:
                 git status
 
                 # Find all package.json files changed in the last commit (by changesets version bump)
-                package_files=$(git diff --name-only HEAD~1 HEAD | grep 'package.json$' || true)
+                changed_pkg_jsons=$(git diff --name-only HEAD~1 HEAD | grep 'package.json$' || true)
+                package_files=""
+                for file in $changed_pkg_jsons; do
+                  # Check if the version property changed in this package.json
+                  if git diff HEAD~1 HEAD -- "$file" | grep -q '+\s"version":'; then
+                    package_files="$package_files $file"
+                  fi
+                done
                 affected='[]'
                 if [ -n "$package_files" ]; then
-                    affected=$(echo "$package_files" | xargs -I{} jq -r '.name' {} | jq -R -s -c 'split("\n")[:-1]')
+                    affected=$(echo "$package_files" | xargs -I{} jq -r '.name' {} | jq -R -s -c 'split(" ")[:-1]')
                 else 
                     echo "No package.json files changed, no affected packages"
                 fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,7 +115,7 @@ jobs:
                 package_files=""
                 for file in $changed_pkg_jsons; do
                   # Check if the version property changed in this package.json
-                  if git diff HEAD~1 HEAD -- "$file" | grep -q '+\s"version":'; then
+                  if git diff HEAD~1 HEAD -- "$file" | grep -q '+[[:space:]]"version":'; then
                     package_files="$package_files $file"
                   fi
                 done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,7 +124,7 @@ jobs:
                     affected='[]'
                     for file in $package_files; do
                         name=$(jq -r '.name' "$file")
-                        affected=$(echo "$affected" | jq --arg name "$name" '. + [$name]')
+                        affected=$(echo "$affected" | jq -r --arg name "$name" '. + [$name]')
                     done
                 else 
                     echo "No package.json files changed, no affected packages"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,7 +110,8 @@ jobs:
                 git commit -m "chore: version bump"
                 git status
 
-                affected=$(npx nx show projects --json --affected --base=${{ github.sha }} --head=HEAD)
+                # Find all package.json files changed in the last commit (by changesets version bump)
+                affected=$(git diff --name-only HEAD~1 HEAD | grep 'package.json$' | xargs -I{} jq -r '.name' {} | jq -R -s -c 'split("\n")[:-1]')
                 echo "affected: $affected"
                 echo "affected=$affected" >> $GITHUB_ENV
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,7 +119,11 @@ jobs:
               run: |
                 # tag each affected package with the new version
                 for pkg in $(echo '${{ env.affected }}' | jq -r '.[]'); do
-                    version=$(npm pkg --workspace $pkg get version | jq -r ".[\"$pkg\"]")
+                    if [ "$pkg" == "$(cat package.json | jq -r '.name')" ]; then
+                      version=$(npm pkg get version | jq -r '.')
+                    else  
+                      version=$(npm pkg --workspace $pkg get version | jq -r ".[\"$pkg\"]")
+                    fi
                     echo "Tagging $pkg with version $version"
                     git tag "$pkg@$version"
                     echo

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,7 +111,13 @@ jobs:
                 git status
 
                 # Find all package.json files changed in the last commit (by changesets version bump)
-                affected=$(git diff --name-only HEAD~1 HEAD | grep 'package.json$' | xargs -I{} jq -r '.name' {} | jq -R -s -c 'split("\n")[:-1]')
+                package_files=$(git diff --name-only HEAD~1 HEAD | grep 'package.json$' || true)
+                if [ -z "$package_files" ]; then
+                    echo "No package.json files found in the last commit."
+                    affected='[]'
+                else
+                    affected=$(echo "$package_files" | xargs -I{} jq -r '.name' {} | jq -R -s -c 'split("\n")[:-1]')
+                fi
                 echo "affected: $affected"
                 echo "affected=$affected" >> $GITHUB_ENV
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,7 +115,7 @@ jobs:
                 package_files=""
                 for file in $changed_pkg_jsons; do
                   # Check if the version property changed in this package.json
-                  if git diff HEAD~1 HEAD -- "$file" | grep -q '+[[:space:]]"version":'; then
+                  if git diff HEAD~1 HEAD -- "$file" | grep -qE '\+[[:space:]]+"version":'; then
                     package_files="$package_files $file"
                   fi
                 done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,7 +121,7 @@ jobs:
                 done
                 affected='[]'
                 if [ -n "$package_files" ]; then
-                    affected=$(echo "$package_files" | xargs -I{} jq -r '.name' {} | jq -R -s -c 'split(" ")[:-1]')
+                    affected=$(echo "$package_files" | xargs -I{} jq -r '.name' {} | jq -R -s -c 'split(" ") | map(select(. != ""))')
                 else 
                     echo "No package.json files changed, no affected packages"
                 fi


### PR DESCRIPTION
- **fix workspace tagging in release workflow**
- **fix workspace tagging in release workflow (#1901)**
- **manually discover touched projects instead of using nx because nx includes workspace for any change**
- **Update .github/workflows/release.yml**
- **optimise affected handling**
- **fix/release5 (#1902)**
- **fix affected packages detecting non-bumped packages**
- **Update .github/workflows/release.yml**
- **fix newline / last el handling**
- **fix grep regex**
- **Update .github/workflows/release.yml**
- **jq fix**
- **jq fix**
