### PR TITLE
fix: update license headers to 2026 and fix linting issues

### DIFF
--- a/.changeset/jolly-deer-pump.md
+++ b/.changeset/jolly-deer-pump.md
@@ -1,0 +1,63 @@
+---
+"@prosopo/angular-procaptcha-integration-demo": patch
+"@prosopo/svelte-procaptcha-integration-demo": patch
+"@prosopo/react-procaptcha-integration-demo": patch
+"@prosopo/vue-procaptcha-integration-demo": patch
+"@prosopo/angular-procaptcha-wrapper": patch
+"@prosopo/svelte-procaptcha-wrapper": patch
+"@prosopo/react-procaptcha-wrapper": patch
+"@prosopo/vue-procaptcha-wrapper": patch
+"@prosopo/procaptcha-integration-build-config": patch
+"@prosopo/procaptcha-frictionless": patch
+"@prosopo/vite-plugin-watch-workspace": patch
+"@prosopo/client-bundle-example": patch
+"@prosopo/client-example-server": patch
+"@prosopo/api-express-router": patch
+"@prosopo/procaptcha-wrapper": patch
+"@prosopo/user-access-policy": patch
+"@prosopo/procaptcha-bundle": patch
+"@prosopo/procaptcha-common": patch
+"@prosopo/procaptcha-react": patch
+"@prosopo/widget-skeleton": patch
+"@prosopo/http-blackhole": patch
+"@prosopo/procaptcha-pow": patch
+"@prosopo/types-database": patch
+"@prosopo/load-balancer": patch
+"@prosopo/redis-client": patch
+"@prosopo/cypress-shared": patch
+"@prosopo/prosoponator-bot": patch
+"@prosopo/datasets-fs": patch
+"@prosopo/file-server": patch
+"@prosopo/fingerprint": patch
+"@prosopo/util-crypto": patch
+"@prosopo/provider-mock": patch
+"@prosopo/procaptcha": patch
+"@prosopo/api-route": patch
+"@prosopo/types-env": patch
+"@prosopo/database": patch
+"@prosopo/datasets": patch
+"@prosopo/detector": patch
+"@prosopo/provider": patch
+"@prosopo/testpkg2": patch
+"@prosopo/account": patch
+"@prosopo/keyring": patch
+"@prosopo/common": patch
+"@prosopo/dotenv": patch
+"@prosopo/locale": patch
+"@prosopo/server": patch
+"@prosopo/gh-actions": patch
+"@prosopo/types": patch
+"@prosopo/workspace": patch
+"@prosopo/util": patch
+"@prosopo/ts-brand": patch
+"@prosopo/api": patch
+"@prosopo/cli": patch
+"@prosopo/env": patch
+"@prosopo/scripts": patch
+"@prosopo/config": patch
+"@prosopo/flux": patch
+"@prosopo/lint": patch
+---
+
+bump license year
+  

--- a/demos/client-bundle-example/src/index.ts
+++ b/demos/client-bundle-example/src/index.ts
@@ -1,17 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/demos/client-bundle-example/src/plugins/explanation-injector.ts
+++ b/demos/client-bundle-example/src/plugins/explanation-injector.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/demos/client-bundle-example/src/plugins/form-filler-injector.ts
+++ b/demos/client-bundle-example/src/plugins/form-filler-injector.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/demos/client-bundle-example/src/plugins/navigation-injector.ts
+++ b/demos/client-bundle-example/src/plugins/navigation-injector.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/demos/client-bundle-example/src/plugins/status-log-injector.ts
+++ b/demos/client-bundle-example/src/plugins/status-log-injector.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/demos/client-bundle-example/vite.cjs.config.ts
+++ b/demos/client-bundle-example/vite.cjs.config.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/demos/client-bundle-example/vite.config.ts
+++ b/demos/client-bundle-example/vite.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/demos/client-bundle-example/vite.esm.config.ts
+++ b/demos/client-bundle-example/vite.esm.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/demos/client-example-server/src/app.ts
+++ b/demos/client-example-server/src/app.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/demos/client-example-server/src/controllers/auth.ts
+++ b/demos/client-example-server/src/controllers/auth.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/demos/client-example-server/src/models/user.ts
+++ b/demos/client-example-server/src/models/user.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/demos/client-example-server/src/routes/routes.ts
+++ b/demos/client-example-server/src/routes/routes.ts
@@ -1,6 +1,6 @@
 import type { ProsopoServerConfigOutput } from "@prosopo/types";
 import express from "express";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/demos/client-example-server/src/utils/connection.ts
+++ b/demos/client-example-server/src/utils/connection.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/demos/client-example-server/src/utils/database.ts
+++ b/demos/client-example-server/src/utils/database.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/demos/client-example-server/typedoc.config.js
+++ b/demos/client-example-server/typedoc.config.js
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/demos/client-example-server/vite.cjs.config.ts
+++ b/demos/client-example-server/vite.cjs.config.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/demos/client-example-server/vite.config.ts
+++ b/demos/client-example-server/vite.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/demos/client-example-server/vite.esm.config.ts
+++ b/demos/client-example-server/vite.esm.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/demos/cypress-shared/cypress.frictionless.config.js
+++ b/demos/cypress-shared/cypress.frictionless.config.js
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/demos/cypress-shared/cypress.image.config.js
+++ b/demos/cypress-shared/cypress.image.config.js
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/demos/cypress-shared/cypress.invisible.config.js
+++ b/demos/cypress-shared/cypress.invisible.config.js
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/demos/cypress-shared/cypress.pow.config.js
+++ b/demos/cypress-shared/cypress.pow.config.js
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/demos/cypress-shared/cypress/e2e/captcha.cy.ts
+++ b/demos/cypress-shared/cypress/e2e/captcha.cy.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/demos/cypress-shared/cypress/e2e/correct.captcha.cy.ts
+++ b/demos/cypress-shared/cypress/e2e/correct.captcha.cy.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/demos/cypress-shared/cypress/e2e/correct.captcha.signup.cy.ts
+++ b/demos/cypress-shared/cypress/e2e/correct.captcha.signup.cy.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/demos/cypress-shared/cypress/e2e/frictionless.cy.ts
+++ b/demos/cypress-shared/cypress/e2e/frictionless.cy.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/demos/cypress-shared/cypress/e2e/invisible.cy.ts
+++ b/demos/cypress-shared/cypress/e2e/invisible.cy.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/demos/cypress-shared/cypress/e2e/pow.cy.ts
+++ b/demos/cypress-shared/cypress/e2e/pow.cy.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/demos/cypress-shared/cypress/index.ts
+++ b/demos/cypress-shared/cypress/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/demos/cypress-shared/cypress/support/commands.ts
+++ b/demos/cypress-shared/cypress/support/commands.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/demos/cypress-shared/cypress/support/e2e.ts
+++ b/demos/cypress-shared/cypress/support/e2e.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/demos/cypress-shared/vite.cjs.config.ts
+++ b/demos/cypress-shared/vite.cjs.config.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/demos/cypress-shared/vite.esm.config.ts
+++ b/demos/cypress-shared/vite.esm.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/demos/provider-mock/src/api.ts
+++ b/demos/provider-mock/src/api.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/demos/provider-mock/src/db.ts
+++ b/demos/provider-mock/src/db.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/demos/provider-mock/src/start.ts
+++ b/demos/provider-mock/src/start.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/demos/provider-mock/vite.cjs.config.ts
+++ b/demos/provider-mock/vite.cjs.config.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/demos/provider-mock/vite.config.ts
+++ b/demos/provider-mock/vite.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/demos/provider-mock/vite.esm.config.ts
+++ b/demos/provider-mock/vite.esm.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/config/src/dependencies.ts
+++ b/dev/config/src/dependencies.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/config/src/index.ts
+++ b/dev/config/src/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/config/src/vite/NodejsPolarsDirnamePlugin.ts
+++ b/dev/config/src/vite/NodejsPolarsDirnamePlugin.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/config/src/vite/NodejsPolarsNativeFilePlugin.ts
+++ b/dev/config/src/vite/NodejsPolarsNativeFilePlugin.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/config/src/vite/TsNoCheckPlugin.ts
+++ b/dev/config/src/vite/TsNoCheckPlugin.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/config/src/vite/index.ts
+++ b/dev/config/src/vite/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/config/src/vite/types.ts
+++ b/dev/config/src/vite/types.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/config/src/vite/vite-plugin-close-and-copy.ts
+++ b/dev/config/src/vite/vite-plugin-close-and-copy.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/config/src/vite/vite-plugin-copy.ts
+++ b/dev/config/src/vite/vite-plugin-copy.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/config/src/vite/vite-plugin-fix-absolute-imports.ts
+++ b/dev/config/src/vite/vite-plugin-fix-absolute-imports.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/config/src/vite/vite-plugin-remove-unused-translations.ts
+++ b/dev/config/src/vite/vite-plugin-remove-unused-translations.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/config/src/vite/vite-plugin-sourcemap-exclude.ts
+++ b/dev/config/src/vite/vite-plugin-sourcemap-exclude.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/config/src/vite/vite.backend.config.ts
+++ b/dev/config/src/vite/vite.backend.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/config/src/vite/vite.commonjs.config.ts
+++ b/dev/config/src/vite/vite.commonjs.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/config/src/vite/vite.esm.config.ts
+++ b/dev/config/src/vite/vite.esm.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/config/src/vite/vite.frontend.config.ts
+++ b/dev/config/src/vite/vite.frontend.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/config/src/vite/vite.test.config.ts
+++ b/dev/config/src/vite/vite.test.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/config/src/vite/vite.threads.test.config.ts
+++ b/dev/config/src/vite/vite.threads.test.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/config/src/webpack/index.ts
+++ b/dev/config/src/webpack/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/config/src/webpack/webpack.config.ts
+++ b/dev/config/src/webpack/webpack.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/config/vite.cjs.config.ts
+++ b/dev/config/vite.cjs.config.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/config/vite.esm.config.ts
+++ b/dev/config/vite.esm.config.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/flux/src/commands/auth.ts
+++ b/dev/flux/src/commands/auth.ts
@@ -1,6 +1,6 @@
 import { LogLevel, type Logger, getLogger } from "@prosopo/common";
 import type { ArgumentsCamelCase, Argv } from "yargs";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/flux/src/commands/formatEnv.ts
+++ b/dev/flux/src/commands/formatEnv.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { LogLevel, type Logger, getLogger } from "@prosopo/common";
 import type { ArgumentsCamelCase, Argv } from "yargs";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/flux/src/commands/getDapp.ts
+++ b/dev/flux/src/commands/getDapp.ts
@@ -1,6 +1,6 @@
 import { LogLevel, type Logger, getLogger } from "@prosopo/common";
 import type { ArgumentsCamelCase, Argv } from "yargs";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/flux/src/commands/getDapps.ts
+++ b/dev/flux/src/commands/getDapps.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/flux/src/commands/index.ts
+++ b/dev/flux/src/commands/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/flux/src/commands/logs.ts
+++ b/dev/flux/src/commands/logs.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { LogLevel, type Logger, getLogger } from "@prosopo/common";
 import { consoleTableWithWrapping } from "@prosopo/util";
 import type { ArgumentsCamelCase, Argv } from "yargs";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/flux/src/commands/process.env.ts
+++ b/dev/flux/src/commands/process.env.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/flux/src/commands/redeploy.ts
+++ b/dev/flux/src/commands/redeploy.ts
@@ -1,6 +1,6 @@
 import { LogLevel, type Logger, getLogger } from "@prosopo/common";
 import type { ArgumentsCamelCase, Argv } from "yargs";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/flux/src/commands/sign.ts
+++ b/dev/flux/src/commands/sign.ts
@@ -3,7 +3,7 @@ import { base58Decode, base64Encode } from "@polkadot/util-crypto";
 import type { Keypair } from "@polkadot/util-crypto/types";
 import { LogLevel, type Logger, getLogger } from "@prosopo/common";
 import type { ArgumentsCamelCase, Argv } from "yargs";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/flux/src/commands/terminal.ts
+++ b/dev/flux/src/commands/terminal.ts
@@ -1,6 +1,6 @@
 import { LogLevel, type Logger, getLogger } from "@prosopo/common";
 import type { ArgumentsCamelCase, Argv } from "yargs";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/flux/src/errorHandler.ts
+++ b/dev/flux/src/errorHandler.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/flux/src/index.ts
+++ b/dev/flux/src/index.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/flux/src/lib/appUpdateSpecification.ts
+++ b/dev/flux/src/lib/appUpdateSpecification.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/flux/src/lib/auth.ts
+++ b/dev/flux/src/lib/auth.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/flux/src/lib/encryptMessage.ts
+++ b/dev/flux/src/lib/encryptMessage.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/flux/src/lib/formatEnv.ts
+++ b/dev/flux/src/lib/formatEnv.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/flux/src/lib/getDapps.ts
+++ b/dev/flux/src/lib/getDapps.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/flux/src/lib/logs.ts
+++ b/dev/flux/src/lib/logs.ts
@@ -1,6 +1,6 @@
 import { getLogger } from "@prosopo/common";
 import { at } from "@prosopo/util";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/flux/src/lib/redeploy.ts
+++ b/dev/flux/src/lib/redeploy.ts
@@ -1,6 +1,6 @@
 import { getLogger } from "@prosopo/common";
 import { errorHandler } from "../errorHandler.js";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/flux/src/lib/sep256k1Sign.ts
+++ b/dev/flux/src/lib/sep256k1Sign.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/flux/src/lib/terminal.ts
+++ b/dev/flux/src/lib/terminal.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/flux/src/lib/url.ts
+++ b/dev/flux/src/lib/url.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/flux/vite.cjs.config.ts
+++ b/dev/flux/vite.cjs.config.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/flux/vite.esm.config.ts
+++ b/dev/flux/vite.esm.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/gh-actions/src/dockerTags.ts
+++ b/dev/gh-actions/src/dockerTags.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/gh-actions/src/enableAutoMerge.ts
+++ b/dev/gh-actions/src/enableAutoMerge.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/gh-actions/src/index.ts
+++ b/dev/gh-actions/src/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/gh-actions/src/listDockerTags.ts
+++ b/dev/gh-actions/src/listDockerTags.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/gh-actions/src/previousDockerTag.ts
+++ b/dev/gh-actions/src/previousDockerTag.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/gh-actions/vite.cjs.config.ts
+++ b/dev/gh-actions/vite.cjs.config.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/gh-actions/vite.esm.config.ts
+++ b/dev/gh-actions/vite.esm.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/lint/src/engines.ts
+++ b/dev/lint/src/engines.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/lint/src/index.ts
+++ b/dev/lint/src/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/lint/src/json.ts
+++ b/dev/lint/src/json.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/lint/src/license.ts
+++ b/dev/lint/src/license.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/lint/src/redirects.ts
+++ b/dev/lint/src/redirects.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/lint/src/refs.ts
+++ b/dev/lint/src/refs.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/lint/src/testCheck.ts
+++ b/dev/lint/src/testCheck.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/lint/src/tsconfigIncludes.ts
+++ b/dev/lint/src/tsconfigIncludes.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/lint/src/workflowNames.ts
+++ b/dev/lint/src/workflowNames.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/lint/vite.cjs.config.ts
+++ b/dev/lint/vite.cjs.config.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/lint/vite.esm.config.ts
+++ b/dev/lint/vite.esm.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/prosoponator-bot/src/bot.ts
+++ b/dev/prosoponator-bot/src/bot.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/prosoponator-bot/src/index.ts
+++ b/dev/prosoponator-bot/src/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/prosoponator-bot/vite.cjs.config.ts
+++ b/dev/prosoponator-bot/vite.cjs.config.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/prosoponator-bot/vite.esm.config.ts
+++ b/dev/prosoponator-bot/vite.esm.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/scripts/src/cli/index.ts
+++ b/dev/scripts/src/cli/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/scripts/src/index.ts
+++ b/dev/scripts/src/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/scripts/src/scripts/bytesToHex.ts
+++ b/dev/scripts/src/scripts/bytesToHex.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/scripts/src/scripts/convertAccount.ts
+++ b/dev/scripts/src/scripts/convertAccount.ts
@@ -1,6 +1,6 @@
 import { hexToU8a, isHex, u8aToHex } from "@polkadot/util";
 import { isAddress } from "@polkadot/util-crypto";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/scripts/src/scripts/encodeDecode.ts
+++ b/dev/scripts/src/scripts/encodeDecode.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/scripts/src/scripts/findUnused.ts
+++ b/dev/scripts/src/scripts/findUnused.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/scripts/src/scripts/generateMnemonic.ts
+++ b/dev/scripts/src/scripts/generateMnemonic.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/scripts/src/scripts/hash.ts
+++ b/dev/scripts/src/scripts/hash.ts
@@ -10,7 +10,7 @@ import {
 	u8aToHex,
 	u8aToString,
 } from "@polkadot/util";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/scripts/src/scripts/hexToBytes.ts
+++ b/dev/scripts/src/scripts/hexToBytes.ts
@@ -1,5 +1,5 @@
 import { hexToU8a } from "@polkadot/util";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/scripts/src/scripts/mnemonicToAddr.ts
+++ b/dev/scripts/src/scripts/mnemonicToAddr.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/scripts/src/scripts/providerApiSign.ts
+++ b/dev/scripts/src/scripts/providerApiSign.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/scripts/src/scripts/setVersion.ts
+++ b/dev/scripts/src/scripts/setVersion.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/scripts/src/scripts/sign.ts
+++ b/dev/scripts/src/scripts/sign.ts
@@ -1,5 +1,5 @@
 import { stringToU8a, u8aToHex } from "@polkadot/util";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/scripts/src/scripts/testImport.ts
+++ b/dev/scripts/src/scripts/testImport.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/scripts/src/setup/index.ts
+++ b/dev/scripts/src/setup/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/scripts/src/setup/provider.ts
+++ b/dev/scripts/src/setup/provider.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/scripts/src/setup/setup.ts
+++ b/dev/scripts/src/setup/setup.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/scripts/src/setup/site.ts
+++ b/dev/scripts/src/setup/site.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/scripts/src/util/exec.ts
+++ b/dev/scripts/src/util/exec.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/scripts/src/util/fluxLogDappDetails.ts
+++ b/dev/scripts/src/util/fluxLogDappDetails.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/scripts/src/util/index.ts
+++ b/dev/scripts/src/util/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/scripts/src/util/updateEnv.ts
+++ b/dev/scripts/src/util/updateEnv.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/scripts/vite.cjs.config.ts
+++ b/dev/scripts/vite.cjs.config.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/scripts/vite.esm.config.ts
+++ b/dev/scripts/vite.esm.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/ts-brand/src/index.ts
+++ b/dev/ts-brand/src/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/ts-brand/src/tests/brand.unit.test.ts
+++ b/dev/ts-brand/src/tests/brand.unit.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, expectTypeOf, test } from "vitest";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/ts-brand/vite.cjs.config.ts
+++ b/dev/ts-brand/vite.cjs.config.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/ts-brand/vite.esm.config.ts
+++ b/dev/ts-brand/vite.esm.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/ts-brand/vite.test.config.ts
+++ b/dev/ts-brand/vite.test.config.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/vite-plugin-watch-workspace/src/index.ts
+++ b/dev/vite-plugin-watch-workspace/src/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/vite-plugin-watch-workspace/src/vite-plugin-watch-workspace.ts
+++ b/dev/vite-plugin-watch-workspace/src/vite-plugin-watch-workspace.ts
@@ -4,7 +4,7 @@ import debug from "debug";
 import { build } from "esbuild";
 import fg from "fast-glob";
 import ts from "typescript";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/vite-plugin-watch-workspace/vite.cjs.config.ts
+++ b/dev/vite-plugin-watch-workspace/vite.cjs.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/vite-plugin-watch-workspace/vite.esm.config.ts
+++ b/dev/vite-plugin-watch-workspace/vite.esm.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/workspace/src/index.ts
+++ b/dev/workspace/src/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/workspace/src/projectInfo.ts
+++ b/dev/workspace/src/projectInfo.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/workspace/vite.cjs.config.ts
+++ b/dev/workspace/vite.cjs.config.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/workspace/vite.esm.config.ts
+++ b/dev/workspace/vite.esm.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/integration/frameworks/angular/angular-procaptcha-integration-demo/src/app/app.component.ts
+++ b/integration/frameworks/angular/angular-procaptcha-integration-demo/src/app/app.component.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/integration/frameworks/angular/angular-procaptcha-integration-demo/src/app/app.config.ts
+++ b/integration/frameworks/angular/angular-procaptcha-integration-demo/src/app/app.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/integration/frameworks/angular/angular-procaptcha-integration-demo/src/app/app.routes.ts
+++ b/integration/frameworks/angular/angular-procaptcha-integration-demo/src/app/app.routes.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/integration/frameworks/angular/angular-procaptcha-integration-demo/src/environments/environment.ts
+++ b/integration/frameworks/angular/angular-procaptcha-integration-demo/src/environments/environment.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/integration/frameworks/angular/angular-procaptcha-integration-demo/src/main.ts
+++ b/integration/frameworks/angular/angular-procaptcha-integration-demo/src/main.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/integration/frameworks/angular/angular-procaptcha-integration-demo/vite.cjs.config.ts
+++ b/integration/frameworks/angular/angular-procaptcha-integration-demo/vite.cjs.config.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/integration/frameworks/angular/angular-procaptcha-integration-demo/vite.esm.config.ts
+++ b/integration/frameworks/angular/angular-procaptcha-integration-demo/vite.esm.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/integration/frameworks/angular/angular-procaptcha-integration-demo/webpack.config.cjs
+++ b/integration/frameworks/angular/angular-procaptcha-integration-demo/webpack.config.cjs
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/integration/frameworks/angular/angular-procaptcha-wrapper/src/lib/procaptcha.component.ts
+++ b/integration/frameworks/angular/angular-procaptcha-wrapper/src/lib/procaptcha.component.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/integration/frameworks/angular/angular-procaptcha-wrapper/src/public_api.ts
+++ b/integration/frameworks/angular/angular-procaptcha-wrapper/src/public_api.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/integration/frameworks/angular/angular-procaptcha-wrapper/vite.cjs.config.ts
+++ b/integration/frameworks/angular/angular-procaptcha-wrapper/vite.cjs.config.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/integration/frameworks/angular/angular-procaptcha-wrapper/vite.esm.config.ts
+++ b/integration/frameworks/angular/angular-procaptcha-wrapper/vite.esm.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/integration/frameworks/react/react-procaptcha-integration-demo/src/app.tsx
+++ b/integration/frameworks/react/react-procaptcha-integration-demo/src/app.tsx
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/integration/frameworks/react/react-procaptcha-integration-demo/src/index.ts
+++ b/integration/frameworks/react/react-procaptcha-integration-demo/src/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/integration/frameworks/react/react-procaptcha-integration-demo/src/integrationDemo.tsx
+++ b/integration/frameworks/react/react-procaptcha-integration-demo/src/integrationDemo.tsx
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/integration/frameworks/react/react-procaptcha-integration-demo/vite.cjs.config.ts
+++ b/integration/frameworks/react/react-procaptcha-integration-demo/vite.cjs.config.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/integration/frameworks/react/react-procaptcha-integration-demo/vite.config.ts
+++ b/integration/frameworks/react/react-procaptcha-integration-demo/vite.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/integration/frameworks/react/react-procaptcha-integration-demo/vite.esm.config.ts
+++ b/integration/frameworks/react/react-procaptcha-integration-demo/vite.esm.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/integration/frameworks/react/react-procaptcha-wrapper/src/index.ts
+++ b/integration/frameworks/react/react-procaptcha-wrapper/src/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/integration/frameworks/react/react-procaptcha-wrapper/src/procaptchaComponent.tsx
+++ b/integration/frameworks/react/react-procaptcha-wrapper/src/procaptchaComponent.tsx
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/integration/frameworks/react/react-procaptcha-wrapper/vite.cjs.config.ts
+++ b/integration/frameworks/react/react-procaptcha-wrapper/vite.cjs.config.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/integration/frameworks/react/react-procaptcha-wrapper/vite.config.ts
+++ b/integration/frameworks/react/react-procaptcha-wrapper/vite.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/integration/frameworks/react/react-procaptcha-wrapper/vite.esm.config.ts
+++ b/integration/frameworks/react/react-procaptcha-wrapper/vite.esm.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/integration/frameworks/svelte/svelte-procaptcha-integration-demo/src/index.ts
+++ b/integration/frameworks/svelte/svelte-procaptcha-integration-demo/src/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/integration/frameworks/svelte/svelte-procaptcha-integration-demo/vite.cjs.config.ts
+++ b/integration/frameworks/svelte/svelte-procaptcha-integration-demo/vite.cjs.config.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/integration/frameworks/svelte/svelte-procaptcha-integration-demo/vite.config.ts
+++ b/integration/frameworks/svelte/svelte-procaptcha-integration-demo/vite.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/integration/frameworks/svelte/svelte-procaptcha-integration-demo/vite.esm.config.ts
+++ b/integration/frameworks/svelte/svelte-procaptcha-integration-demo/vite.esm.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/integration/frameworks/svelte/svelte-procaptcha-wrapper/src/index.ts
+++ b/integration/frameworks/svelte/svelte-procaptcha-wrapper/src/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/integration/frameworks/svelte/svelte-procaptcha-wrapper/vite.cjs.config.ts
+++ b/integration/frameworks/svelte/svelte-procaptcha-wrapper/vite.cjs.config.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/integration/frameworks/svelte/svelte-procaptcha-wrapper/vite.esm.config.ts
+++ b/integration/frameworks/svelte/svelte-procaptcha-wrapper/vite.esm.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/integration/frameworks/vue/vue-procaptcha-integration-demo/src/index.ts
+++ b/integration/frameworks/vue/vue-procaptcha-integration-demo/src/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/integration/frameworks/vue/vue-procaptcha-integration-demo/vite.cjs.config.ts
+++ b/integration/frameworks/vue/vue-procaptcha-integration-demo/vite.cjs.config.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/integration/frameworks/vue/vue-procaptcha-integration-demo/vite.config.ts
+++ b/integration/frameworks/vue/vue-procaptcha-integration-demo/vite.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/integration/frameworks/vue/vue-procaptcha-integration-demo/vite.esm.config.ts
+++ b/integration/frameworks/vue/vue-procaptcha-integration-demo/vite.esm.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/integration/frameworks/vue/vue-procaptcha-wrapper/src/index.ts
+++ b/integration/frameworks/vue/vue-procaptcha-wrapper/src/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/integration/frameworks/vue/vue-procaptcha-wrapper/vite.cjs.config.ts
+++ b/integration/frameworks/vue/vue-procaptcha-wrapper/vite.cjs.config.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/integration/frameworks/vue/vue-procaptcha-wrapper/vite.config.ts
+++ b/integration/frameworks/vue/vue-procaptcha-wrapper/vite.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/integration/frameworks/vue/vue-procaptcha-wrapper/vite.esm.config.ts
+++ b/integration/frameworks/vue/vue-procaptcha-wrapper/vite.esm.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/integration/procaptcha-integration-build-config/src/index.ts
+++ b/integration/procaptcha-integration-build-config/src/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/integration/procaptcha-integration-build-config/vite.cjs.config.ts
+++ b/integration/procaptcha-integration-build-config/vite.cjs.config.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/integration/procaptcha-integration-build-config/vite.esm.config.ts
+++ b/integration/procaptcha-integration-build-config/vite.esm.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/account/src/extension/Extension.ts
+++ b/packages/account/src/extension/Extension.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/account/src/extension/ExtensionWeb2.ts
+++ b/packages/account/src/extension/ExtensionWeb2.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/account/src/extension/ExtensionWeb3.ts
+++ b/packages/account/src/extension/ExtensionWeb3.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/account/src/index.ts
+++ b/packages/account/src/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/account/vite.cjs.config.ts
+++ b/packages/account/vite.cjs.config.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/account/vite.esm.config.ts
+++ b/packages/account/vite.esm.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/api-express-router/express.d.ts
+++ b/packages/api-express-router/express.d.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/api-express-router/src/apiExpressRouterFactory.ts
+++ b/packages/api-express-router/src/apiExpressRouterFactory.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/api-express-router/src/endpointAdapter/apiExpressDefaultEndpointAdapter.ts
+++ b/packages/api-express-router/src/endpointAdapter/apiExpressDefaultEndpointAdapter.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/api-express-router/src/endpointAdapter/apiExpressEndpointAdapter.ts
+++ b/packages/api-express-router/src/endpointAdapter/apiExpressEndpointAdapter.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/api-express-router/src/errorHandler.ts
+++ b/packages/api-express-router/src/errorHandler.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/api-express-router/src/index.ts
+++ b/packages/api-express-router/src/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/api-express-router/src/middlewares/authMiddleware.ts
+++ b/packages/api-express-router/src/middlewares/authMiddleware.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/api-express-router/src/middlewares/requestLoggerMiddleware.ts
+++ b/packages/api-express-router/src/middlewares/requestLoggerMiddleware.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/api-express-router/src/tests/unit/errorHandler.unit.test.ts
+++ b/packages/api-express-router/src/tests/unit/errorHandler.unit.test.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/api-express-router/src/tests/unit/middlewares/authMiddleware.unit.test.ts
+++ b/packages/api-express-router/src/tests/unit/middlewares/authMiddleware.unit.test.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/api-express-router/vite.cjs.config.ts
+++ b/packages/api-express-router/vite.cjs.config.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/api-express-router/vite.esm.config.ts
+++ b/packages/api-express-router/vite.esm.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/api-express-router/vite.test.config.ts
+++ b/packages/api-express-router/vite.test.config.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/api-route/src/.export.ts
+++ b/packages/api-route/src/.export.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/api-route/src/apiRoutes.ts
+++ b/packages/api-route/src/apiRoutes.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/api-route/src/endpoint/.export.ts
+++ b/packages/api-route/src/endpoint/.export.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/api-route/src/endpoint/apiEndpoint.ts
+++ b/packages/api-route/src/endpoint/apiEndpoint.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/api-route/src/endpoint/apiEndpointResponse.ts
+++ b/packages/api-route/src/endpoint/apiEndpointResponse.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/api-route/src/endpoint/apiEndpointResponseStatus.ts
+++ b/packages/api-route/src/endpoint/apiEndpointResponseStatus.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/api-route/src/index.ts
+++ b/packages/api-route/src/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/api-route/vite.cjs.config.ts
+++ b/packages/api-route/vite.cjs.config.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/api-route/vite.esm.config.ts
+++ b/packages/api-route/vite.esm.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/api/src/api/HttpClientBase.ts
+++ b/packages/api/src/api/HttpClientBase.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/api/src/api/HttpError.ts
+++ b/packages/api/src/api/HttpError.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/api/src/api/ProviderApi.ts
+++ b/packages/api/src/api/ProviderApi.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/api/src/api/apiClient.ts
+++ b/packages/api/src/api/apiClient.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/api/src/api/index.ts
+++ b/packages/api/src/api/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/api/vite.cjs.config.ts
+++ b/packages/api/vite.cjs.config.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/api/vite.esm.config.ts
+++ b/packages/api/vite.esm.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/cli/src/RateLimiter.ts
+++ b/packages/cli/src/RateLimiter.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/cli/src/argv.ts
+++ b/packages/cli/src/argv.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/cli/src/commands/ensureExternalIndexes.ts
+++ b/packages/cli/src/commands/ensureExternalIndexes.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/cli/src/commands/ensureIndexes.ts
+++ b/packages/cli/src/commands/ensureIndexes.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/cli/src/commands/providerSetDataset.ts
+++ b/packages/cli/src/commands/providerSetDataset.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/cli/src/commands/siteKeyRegister.ts
+++ b/packages/cli/src/commands/siteKeyRegister.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/cli/src/commands/siteKeyRegisterApi.ts
+++ b/packages/cli/src/commands/siteKeyRegisterApi.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/cli/src/commands/storeCaptchasExternally.ts
+++ b/packages/cli/src/commands/storeCaptchasExternally.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/cli/src/commands/validators.ts
+++ b/packages/cli/src/commands/validators.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/cli/src/commands/version.ts
+++ b/packages/cli/src/commands/version.ts
@@ -1,5 +1,5 @@
 import { LogLevel, type Logger, getLogger } from "@prosopo/common";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/cli/src/files.ts
+++ b/packages/cli/src/files.ts
@@ -1,6 +1,6 @@
 import fs, { type WriteStream, createWriteStream } from "node:fs";
 import { Readable } from "node:stream";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/cli/src/process.env.ts
+++ b/packages/cli/src/process.env.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/cli/src/prosopo.config.ts
+++ b/packages/cli/src/prosopo.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/cli/src/reloader.ts
+++ b/packages/cli/src/reloader.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/cli/src/start.ts
+++ b/packages/cli/src/start.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/cli/src/tests/bundle/bundle.unit.test.ts
+++ b/packages/cli/src/tests/bundle/bundle.unit.test.ts
@@ -1,7 +1,7 @@
 import { exec } from "node:child_process";
 import { promisify } from "node:util";
 import { getCliPkgDir } from "@prosopo/workspace";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/cli/vite.cjs.config.ts
+++ b/packages/cli/vite.cjs.config.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/cli/vite.config.ts
+++ b/packages/cli/vite.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/cli/vite.esm.config.ts
+++ b/packages/cli/vite.esm.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/cli/vite.test.config.ts
+++ b/packages/cli/vite.test.config.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/common/error.unit.test.ts
+++ b/packages/common/error.unit.test.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/common/src/batches.ts
+++ b/packages/common/src/batches.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/common/src/error.ts
+++ b/packages/common/src/error.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/common/src/logger.ts
+++ b/packages/common/src/logger.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/common/src/tests/batches.unit.test.ts
+++ b/packages/common/src/tests/batches.unit.test.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/common/src/tests/logger.unit.test.ts
+++ b/packages/common/src/tests/logger.unit.test.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/common/src/utils.ts
+++ b/packages/common/src/utils.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/common/vite.cjs.config.ts
+++ b/packages/common/vite.cjs.config.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/common/vite.esm.config.ts
+++ b/packages/common/vite.esm.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/common/vite.test.config.ts
+++ b/packages/common/vite.test.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/database/src/base/index.ts
+++ b/packages/database/src/base/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/database/src/base/mongo.ts
+++ b/packages/database/src/base/mongo.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/database/src/base/mongoMemory.ts
+++ b/packages/database/src/base/mongoMemory.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/database/src/databases/captcha.ts
+++ b/packages/database/src/databases/captcha.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/database/src/databases/client.ts
+++ b/packages/database/src/databases/client.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/database/src/databases/index.ts
+++ b/packages/database/src/databases/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/database/src/databases/provider.ts
+++ b/packages/database/src/databases/provider.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/database/src/index.ts
+++ b/packages/database/src/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/database/vite.cjs.config.ts
+++ b/packages/database/vite.cjs.config.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/database/vite.esm.config.ts
+++ b/packages/database/vite.esm.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/datasets-fs/src/cli.ts
+++ b/packages/datasets-fs/src/cli.ts
@@ -7,7 +7,7 @@ import { Get } from "./commands/get.js";
 import { Labels } from "./commands/labels.js";
 import { Relocate } from "./commands/relocate.js";
 import { Resize } from "./commands/resize.js";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/datasets-fs/src/cli/cli.ts
+++ b/packages/datasets-fs/src/cli/cli.ts
@@ -1,7 +1,7 @@
 import { LogLevel, ProsopoCliError, getLogger } from "@prosopo/common";
 import yargs, { type Argv } from "yargs";
 import { hideBin } from "yargs/helpers";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/datasets-fs/src/cli/cliCommand.ts
+++ b/packages/datasets-fs/src/cli/cliCommand.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/datasets-fs/src/cli/cliCommandComposite.ts
+++ b/packages/datasets-fs/src/cli/cliCommandComposite.ts
@@ -1,5 +1,5 @@
 import type { Options } from "yargs";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/datasets-fs/src/commands/flatten.ts
+++ b/packages/datasets-fs/src/commands/flatten.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/datasets-fs/src/commands/generate.ts
+++ b/packages/datasets-fs/src/commands/generate.ts
@@ -8,7 +8,7 @@ import {
 	LabelsContainerSchema,
 } from "@prosopo/types";
 import { lodash, setSeedGlobal } from "@prosopo/util/lodash";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/datasets-fs/src/commands/generateV1.ts
+++ b/packages/datasets-fs/src/commands/generateV1.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/datasets-fs/src/commands/generateV2.ts
+++ b/packages/datasets-fs/src/commands/generateV2.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/datasets-fs/src/commands/get.ts
+++ b/packages/datasets-fs/src/commands/get.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import { get } from "@prosopo/util";
 import { lodash } from "@prosopo/util/lodash";
 import cliProgress from "cli-progress";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/datasets-fs/src/commands/labels.ts
+++ b/packages/datasets-fs/src/commands/labels.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import { ProsopoDatasetError } from "@prosopo/common";
 import { LabelledDataSchema, type LabelledItem } from "@prosopo/types";
 import { lodash } from "@prosopo/util/lodash";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/datasets-fs/src/commands/relocate.ts
+++ b/packages/datasets-fs/src/commands/relocate.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import { get } from "@prosopo/util";
 import { lodash } from "@prosopo/util/lodash";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/datasets-fs/src/commands/resize.ts
+++ b/packages/datasets-fs/src/commands/resize.ts
@@ -6,7 +6,7 @@ import { u8aToHex } from "@prosopo/util";
 import { lodash } from "@prosopo/util/lodash";
 import cliProgress from "cli-progress";
 import sharp from "sharp";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/datasets-fs/src/dummy.ts
+++ b/packages/datasets-fs/src/dummy.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/datasets-fs/src/index.ts
+++ b/packages/datasets-fs/src/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/datasets-fs/src/tests/lodash.unit.test.ts
+++ b/packages/datasets-fs/src/tests/lodash.unit.test.ts
@@ -1,5 +1,5 @@
 import { rng, seedLodash } from "@prosopo/util/lodash";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/datasets-fs/src/tests/mocked.unit.test.ts
+++ b/packages/datasets-fs/src/tests/mocked.unit.test.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/datasets-fs/src/tests/utils.ts
+++ b/packages/datasets-fs/src/tests/utils.ts
@@ -1,5 +1,5 @@
 import fs from "node:fs";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/datasets-fs/src/utils/input.ts
+++ b/packages/datasets-fs/src/utils/input.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import { ProsopoDatasetError, ProsopoError } from "@prosopo/common";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/datasets-fs/src/utils/inputOutput.ts
+++ b/packages/datasets-fs/src/utils/inputOutput.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/datasets-fs/src/utils/output.ts
+++ b/packages/datasets-fs/src/utils/output.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import { ProsopoEnvError, ProsopoError } from "@prosopo/common";
 import { lodash } from "@prosopo/util/lodash";
 import { boolean, object, string, type infer as zInfer } from "zod";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/datasets-fs/vite.cjs.config.ts
+++ b/packages/datasets-fs/vite.cjs.config.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/datasets-fs/vite.esm.config.ts
+++ b/packages/datasets-fs/vite.esm.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/datasets-fs/vite.test.config.ts
+++ b/packages/datasets-fs/vite.test.config.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/datasets/src/captcha/captcha.ts
+++ b/packages/datasets/src/captcha/captcha.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/datasets/src/captcha/dataset.ts
+++ b/packages/datasets/src/captcha/dataset.ts
@@ -1,5 +1,5 @@
 import { ProsopoEnvError, getLogger } from "@prosopo/common";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/datasets/src/captcha/index.ts
+++ b/packages/datasets/src/captcha/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/datasets/src/captcha/merkle.ts
+++ b/packages/datasets/src/captcha/merkle.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/datasets/src/captcha/util.ts
+++ b/packages/datasets/src/captcha/util.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/datasets/src/index.ts
+++ b/packages/datasets/src/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/datasets/src/tests/captcha.unit.test.ts
+++ b/packages/datasets/src/tests/captcha.unit.test.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/datasets/src/tests/dataset.unit.test.ts
+++ b/packages/datasets/src/tests/dataset.unit.test.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/datasets/src/tests/merkle.unit.test.ts
+++ b/packages/datasets/src/tests/merkle.unit.test.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/datasets/src/tests/mocks/data/captchas.ts
+++ b/packages/datasets/src/tests/mocks/data/captchas.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/datasets/vite.cjs.config.ts
+++ b/packages/datasets/vite.cjs.config.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/datasets/vite.esm.config.ts
+++ b/packages/datasets/vite.esm.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/datasets/vite.test.config.ts
+++ b/packages/datasets/vite.test.config.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/detector/src/index.d.ts
+++ b/packages/detector/src/index.d.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/detector/src/index.js
+++ b/packages/detector/src/index.js
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/detector/vite.cjs.config.ts
+++ b/packages/detector/vite.cjs.config.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/detector/vite.esm.config.ts
+++ b/packages/detector/vite.esm.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/detector/vite.test.config.ts
+++ b/packages/detector/vite.test.config.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dotenv/src/env.ts
+++ b/packages/dotenv/src/env.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dotenv/src/index.ts
+++ b/packages/dotenv/src/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dotenv/vite.cjs.config.ts
+++ b/packages/dotenv/vite.cjs.config.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dotenv/vite.esm.config.ts
+++ b/packages/dotenv/vite.esm.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dotenv/vite.test.config.ts
+++ b/packages/dotenv/vite.test.config.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/env/src/env.ts
+++ b/packages/env/src/env.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/env/src/provider.ts
+++ b/packages/env/src/provider.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/env/vite.cjs.config.ts
+++ b/packages/env/vite.cjs.config.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/env/vite.esm.config.ts
+++ b/packages/env/vite.esm.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/env/vite.test.config.ts
+++ b/packages/env/vite.test.config.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/file-server/src/index.ts
+++ b/packages/file-server/src/index.ts
@@ -1,5 +1,5 @@
 import stream from "node:stream";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/file-server/vite.cjs.config.ts
+++ b/packages/file-server/vite.cjs.config.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/file-server/vite.esm.config.ts
+++ b/packages/file-server/vite.esm.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/file-server/vite.test.config.ts
+++ b/packages/file-server/vite.test.config.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/fingerprint/src/index.ts
+++ b/packages/fingerprint/src/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/fingerprint/vite.cjs.config.ts
+++ b/packages/fingerprint/vite.cjs.config.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/fingerprint/vite.esm.config.ts
+++ b/packages/fingerprint/vite.esm.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/http-blackhole/src/index.ts
+++ b/packages/http-blackhole/src/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/http-blackhole/vite.cjs.config.ts
+++ b/packages/http-blackhole/vite.cjs.config.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/http-blackhole/vite.esm.config.ts
+++ b/packages/http-blackhole/vite.esm.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/keyring/src/accounts/getPair.ts
+++ b/packages/keyring/src/accounts/getPair.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/keyring/src/accounts/index.ts
+++ b/packages/keyring/src/accounts/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/keyring/src/accounts/mnemonic.ts
+++ b/packages/keyring/src/accounts/mnemonic.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/keyring/src/accounts/testAccounts.ts
+++ b/packages/keyring/src/accounts/testAccounts.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/keyring/src/index.ts
+++ b/packages/keyring/src/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/keyring/src/keyring/index.ts
+++ b/packages/keyring/src/keyring/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/keyring/src/keyring/keyring.ts
+++ b/packages/keyring/src/keyring/keyring.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/keyring/vite.cjs.config.ts
+++ b/packages/keyring/vite.cjs.config.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/keyring/vite.esm.config.ts
+++ b/packages/keyring/vite.esm.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/keyring/vite.test.config.ts
+++ b/packages/keyring/vite.test.config.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/load-balancer/src/balancer.ts
+++ b/packages/load-balancer/src/balancer.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/load-balancer/src/index.ts
+++ b/packages/load-balancer/src/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/load-balancer/src/providers.ts
+++ b/packages/load-balancer/src/providers.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/load-balancer/src/tests/providers.unit.test.ts
+++ b/packages/load-balancer/src/tests/providers.unit.test.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/load-balancer/vite.cjs.config.ts
+++ b/packages/load-balancer/vite.cjs.config.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/load-balancer/vite.esm.config.ts
+++ b/packages/load-balancer/vite.esm.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/load-balancer/vite.test.config.ts
+++ b/packages/load-balancer/vite.test.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/locale/src/i18SharedOptions.ts
+++ b/packages/locale/src/i18SharedOptions.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/locale/src/i18nBackend.ts
+++ b/packages/locale/src/i18nBackend.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/locale/src/i18nFrontend.ts
+++ b/packages/locale/src/i18nFrontend.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/locale/src/i18nMiddleware.ts
+++ b/packages/locale/src/i18nMiddleware.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/locale/src/index.ts
+++ b/packages/locale/src/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/locale/src/loadI18next.ts
+++ b/packages/locale/src/loadI18next.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/locale/src/tests/locales.unit.test.ts
+++ b/packages/locale/src/tests/locales.unit.test.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/locale/src/translationKey.ts
+++ b/packages/locale/src/translationKey.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/locale/src/translations.ts
+++ b/packages/locale/src/translations.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/locale/src/useTranslation.ts
+++ b/packages/locale/src/useTranslation.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/locale/src/util.ts
+++ b/packages/locale/src/util.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/locale/vite.cjs.config.ts
+++ b/packages/locale/vite.cjs.config.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/locale/vite.esm.config.ts
+++ b/packages/locale/vite.esm.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/locale/vite.test.config.ts
+++ b/packages/locale/vite.test.config.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha-bundle/src/components.ts
+++ b/packages/procaptcha-bundle/src/components.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha-bundle/src/index.ts
+++ b/packages/procaptcha-bundle/src/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha-bundle/src/tests/procaptchaReady.unit.test.ts
+++ b/packages/procaptcha-bundle/src/tests/procaptchaReady.unit.test.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha-bundle/src/tests/util/captchaType.test.ts
+++ b/packages/procaptcha-bundle/src/tests/util/captchaType.test.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha-bundle/src/tests/util/config.test.ts
+++ b/packages/procaptcha-bundle/src/tests/util/config.test.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha-bundle/src/tests/util/renderLogic.test.tsx
+++ b/packages/procaptcha-bundle/src/tests/util/renderLogic.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha-bundle/src/util/captcha/captchaComponentProvider.tsx
+++ b/packages/procaptcha-bundle/src/util/captcha/captchaComponentProvider.tsx
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha-bundle/src/util/captcha/captchaComponentsList.ts
+++ b/packages/procaptcha-bundle/src/util/captcha/captchaComponentsList.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha-bundle/src/util/captcha/captchaProps.ts
+++ b/packages/procaptcha-bundle/src/util/captcha/captchaProps.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha-bundle/src/util/captcha/captchaRenderer.tsx
+++ b/packages/procaptcha-bundle/src/util/captcha/captchaRenderer.tsx
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha-bundle/src/util/captcha/captchaType.ts
+++ b/packages/procaptcha-bundle/src/util/captcha/captchaType.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha-bundle/src/util/captcha/components/frictionlessCaptcha.tsx
+++ b/packages/procaptcha-bundle/src/util/captcha/components/frictionlessCaptcha.tsx
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha-bundle/src/util/captcha/components/imageCaptcha.tsx
+++ b/packages/procaptcha-bundle/src/util/captcha/components/imageCaptcha.tsx
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha-bundle/src/util/captcha/components/powCaptcha.tsx
+++ b/packages/procaptcha-bundle/src/util/captcha/components/powCaptcha.tsx
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha-bundle/src/util/config.ts
+++ b/packages/procaptcha-bundle/src/util/config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha-bundle/src/util/configCreator.ts
+++ b/packages/procaptcha-bundle/src/util/configCreator.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha-bundle/src/util/language.ts
+++ b/packages/procaptcha-bundle/src/util/language.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha-bundle/src/util/timeout.ts
+++ b/packages/procaptcha-bundle/src/util/timeout.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha-bundle/src/util/widgetFactory.ts
+++ b/packages/procaptcha-bundle/src/util/widgetFactory.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha-bundle/src/util/widgetThemeResolver.ts
+++ b/packages/procaptcha-bundle/src/util/widgetThemeResolver.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha-bundle/vite.cjs.config.ts
+++ b/packages/procaptcha-bundle/vite.cjs.config.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha-bundle/vite.config.ts
+++ b/packages/procaptcha-bundle/vite.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha-bundle/vite.esm.config.ts
+++ b/packages/procaptcha-bundle/vite.esm.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha-bundle/vite.serve.config.ts
+++ b/packages/procaptcha-bundle/vite.serve.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha-bundle/vite.test.config.ts
+++ b/packages/procaptcha-bundle/vite.test.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha-bundle/webpack.config.cjs
+++ b/packages/procaptcha-bundle/webpack.config.cjs
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha-common/src/callbacks/defaultCallbacks.ts
+++ b/packages/procaptcha-common/src/callbacks/defaultCallbacks.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha-common/src/callbacks/defaultEvents.ts
+++ b/packages/procaptcha-common/src/callbacks/defaultEvents.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha-common/src/elements/form.ts
+++ b/packages/procaptcha-common/src/elements/form.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha-common/src/elements/window.ts
+++ b/packages/procaptcha-common/src/elements/window.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha-common/src/extensionLoader.ts
+++ b/packages/procaptcha-common/src/extensionLoader.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha-common/src/index.ts
+++ b/packages/procaptcha-common/src/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha-common/src/providers.ts
+++ b/packages/procaptcha-common/src/providers.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha-common/src/reactComponents/Checkbox.tsx
+++ b/packages/procaptcha-common/src/reactComponents/Checkbox.tsx
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha-common/src/reactComponents/Reload.tsx
+++ b/packages/procaptcha-common/src/reactComponents/Reload.tsx
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha-common/src/state/builder.ts
+++ b/packages/procaptcha-common/src/state/builder.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha-common/src/tests/defaultCallbacks.test.ts
+++ b/packages/procaptcha-common/src/tests/defaultCallbacks.test.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha-common/src/tests/defaultEvents.test.ts
+++ b/packages/procaptcha-common/src/tests/defaultEvents.test.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha-common/src/tests/extensionLoader.test.ts
+++ b/packages/procaptcha-common/src/tests/extensionLoader.test.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha-common/src/tests/form.test.ts
+++ b/packages/procaptcha-common/src/tests/form.test.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha-common/src/tests/providers.test.ts
+++ b/packages/procaptcha-common/src/tests/providers.test.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha-common/src/tests/state-builder.test.ts
+++ b/packages/procaptcha-common/src/tests/state-builder.test.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha-common/src/tests/window.test.ts
+++ b/packages/procaptcha-common/src/tests/window.test.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha-common/vite.cjs.config.ts
+++ b/packages/procaptcha-common/vite.cjs.config.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha-common/vite.esm.config.ts
+++ b/packages/procaptcha-common/vite.esm.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha-common/vite.test.config.ts
+++ b/packages/procaptcha-common/vite.test.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha-frictionless/src/ProcaptchaFrictionless.tsx
+++ b/packages/procaptcha-frictionless/src/ProcaptchaFrictionless.tsx
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha-frictionless/src/customDetectBot.ts
+++ b/packages/procaptcha-frictionless/src/customDetectBot.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha-frictionless/src/detectorLoader.ts
+++ b/packages/procaptcha-frictionless/src/detectorLoader.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha-frictionless/src/index.ts
+++ b/packages/procaptcha-frictionless/src/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha-frictionless/src/tests/customDetectBot.test.ts
+++ b/packages/procaptcha-frictionless/src/tests/customDetectBot.test.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha-frictionless/vite.cjs.config.ts
+++ b/packages/procaptcha-frictionless/vite.cjs.config.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha-frictionless/vite.esm.config.ts
+++ b/packages/procaptcha-frictionless/vite.esm.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha-frictionless/vite.test.config.ts
+++ b/packages/procaptcha-frictionless/vite.test.config.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha-pow/src/components/ProcaptchaPoW.tsx
+++ b/packages/procaptcha-pow/src/components/ProcaptchaPoW.tsx
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha-pow/src/components/ProcaptchaWidget.tsx
+++ b/packages/procaptcha-pow/src/components/ProcaptchaWidget.tsx
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha-pow/src/index.ts
+++ b/packages/procaptcha-pow/src/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha-pow/src/services/Manager.ts
+++ b/packages/procaptcha-pow/src/services/Manager.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha-pow/vite.cjs.config.ts
+++ b/packages/procaptcha-pow/vite.cjs.config.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha-pow/vite.esm.config.ts
+++ b/packages/procaptcha-pow/vite.esm.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha-react/src/components/Button.tsx
+++ b/packages/procaptcha-react/src/components/Button.tsx
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha-react/src/components/CaptchaComponent.tsx
+++ b/packages/procaptcha-react/src/components/CaptchaComponent.tsx
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha-react/src/components/CaptchaWidget.tsx
+++ b/packages/procaptcha-react/src/components/CaptchaWidget.tsx
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha-react/src/components/Modal.tsx
+++ b/packages/procaptcha-react/src/components/Modal.tsx
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha-react/src/components/Procaptcha.tsx
+++ b/packages/procaptcha-react/src/components/Procaptcha.tsx
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha-react/src/components/ProcaptchaWidget.tsx
+++ b/packages/procaptcha-react/src/components/ProcaptchaWidget.tsx
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha-react/src/components/collector.tsx
+++ b/packages/procaptcha-react/src/components/collector.tsx
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha-react/src/components/index.ts
+++ b/packages/procaptcha-react/src/components/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha-react/src/index.ts
+++ b/packages/procaptcha-react/src/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha-react/src/util/index.ts
+++ b/packages/procaptcha-react/src/util/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha-react/vite.cjs.config.ts
+++ b/packages/procaptcha-react/vite.cjs.config.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha-react/vite.esm.config.ts
+++ b/packages/procaptcha-react/vite.esm.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha-wrapper/src/index.ts
+++ b/packages/procaptcha-wrapper/src/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha-wrapper/src/render/renderFunction.ts
+++ b/packages/procaptcha-wrapper/src/render/renderFunction.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha-wrapper/src/render/renderer.ts
+++ b/packages/procaptcha-wrapper/src/render/renderer.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha-wrapper/vite.cjs.config.ts
+++ b/packages/procaptcha-wrapper/vite.cjs.config.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha-wrapper/vite.esm.config.ts
+++ b/packages/procaptcha-wrapper/vite.esm.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha/src/index.ts
+++ b/packages/procaptcha/src/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha/src/modules/Manager.ts
+++ b/packages/procaptcha/src/modules/Manager.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha/src/modules/ProsopoCaptchaApi.ts
+++ b/packages/procaptcha/src/modules/ProsopoCaptchaApi.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha/src/modules/collector.ts
+++ b/packages/procaptcha/src/modules/collector.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha/src/modules/index.ts
+++ b/packages/procaptcha/src/modules/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha/vite.cjs.config.ts
+++ b/packages/procaptcha/vite.cjs.config.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/procaptcha/vite.esm.config.ts
+++ b/packages/procaptcha/vite.esm.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/api/admin/apiAdminRoutesProvider.ts
+++ b/packages/provider/src/api/admin/apiAdminRoutesProvider.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/api/admin/apiRegisterSiteKeyEndpoint.ts
+++ b/packages/provider/src/api/admin/apiRegisterSiteKeyEndpoint.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/api/admin/apiRemoveDetectorKeyEndpoint.ts
+++ b/packages/provider/src/api/admin/apiRemoveDetectorKeyEndpoint.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/api/admin/apiToggleMaintenanceModeEndpoint.ts
+++ b/packages/provider/src/api/admin/apiToggleMaintenanceModeEndpoint.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/api/admin/apiUpdateDetectorKeyEndpoint.ts
+++ b/packages/provider/src/api/admin/apiUpdateDetectorKeyEndpoint.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/api/admin/createApiAdminRoutesProvider.ts
+++ b/packages/provider/src/api/admin/createApiAdminRoutesProvider.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/api/blacklistRequestInspector.ts
+++ b/packages/provider/src/api/blacklistRequestInspector.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/api/block.ts
+++ b/packages/provider/src/api/block.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/api/captcha.ts
+++ b/packages/provider/src/api/captcha.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/api/captcha/contextAwareValidation.ts
+++ b/packages/provider/src/api/captcha/contextAwareValidation.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/api/captcha/getFrictionlessCaptchaChallenge.ts
+++ b/packages/provider/src/api/captcha/getFrictionlessCaptchaChallenge.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/api/captcha/getImageCaptchaChallenge.ts
+++ b/packages/provider/src/api/captcha/getImageCaptchaChallenge.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/api/captcha/getPoWCaptchaChallenge.ts
+++ b/packages/provider/src/api/captcha/getPoWCaptchaChallenge.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/api/captcha/submitImageCaptchaSolution.ts
+++ b/packages/provider/src/api/captcha/submitImageCaptchaSolution.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/api/captcha/submitPoWCaptchaSolution.ts
+++ b/packages/provider/src/api/captcha/submitPoWCaptchaSolution.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/api/domainMiddleware.ts
+++ b/packages/provider/src/api/domainMiddleware.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/api/headerCheckMiddleware.ts
+++ b/packages/provider/src/api/headerCheckMiddleware.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/api/ignoreMiddleware.ts
+++ b/packages/provider/src/api/ignoreMiddleware.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/api/ja4Middleware.ts
+++ b/packages/provider/src/api/ja4Middleware.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/api/public.ts
+++ b/packages/provider/src/api/public.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/api/robotsMiddleware.ts
+++ b/packages/provider/src/api/robotsMiddleware.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/api/validateAddress.ts
+++ b/packages/provider/src/api/validateAddress.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/api/verify.ts
+++ b/packages/provider/src/api/verify.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/compositeIpAddress.ts
+++ b/packages/provider/src/compositeIpAddress.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/express.d.ts
+++ b/packages/provider/src/express.d.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/index.ts
+++ b/packages/provider/src/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/pairs.ts
+++ b/packages/provider/src/pairs.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/rules/lang.ts
+++ b/packages/provider/src/rules/lang.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/schedulers/captchaScheduler.ts
+++ b/packages/provider/src/schedulers/captchaScheduler.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/schedulers/getClientList.ts
+++ b/packages/provider/src/schedulers/getClientList.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/schedulers/setClientEntropy.ts
+++ b/packages/provider/src/schedulers/setClientEntropy.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/services/ipComparison.ts
+++ b/packages/provider/src/services/ipComparison.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/services/ipInfo.ts
+++ b/packages/provider/src/services/ipInfo.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/tasks/captchaManager.ts
+++ b/packages/provider/src/tasks/captchaManager.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/tasks/client/clientTasks.ts
+++ b/packages/provider/src/tasks/client/clientTasks.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/tasks/dataset/datasetTasks.ts
+++ b/packages/provider/src/tasks/dataset/datasetTasks.ts
@@ -1,5 +1,5 @@
 import type { Logger } from "@prosopo/common";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/tasks/dataset/datasetTasksUtils.ts
+++ b/packages/provider/src/tasks/dataset/datasetTasksUtils.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/tasks/detection/decodePayload.js
+++ b/packages/provider/src/tasks/detection/decodePayload.js
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/tasks/detection/getBotScore.ts
+++ b/packages/provider/src/tasks/detection/getBotScore.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/tasks/frictionless/frictionlessTasks.ts
+++ b/packages/provider/src/tasks/frictionless/frictionlessTasks.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/tasks/frictionless/frictionlessTasksUtils.ts
+++ b/packages/provider/src/tasks/frictionless/frictionlessTasksUtils.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/tasks/imgCaptcha/imgCaptchaTasks.ts
+++ b/packages/provider/src/tasks/imgCaptcha/imgCaptchaTasks.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/tasks/imgCaptcha/imgCaptchaTasksUtils.ts
+++ b/packages/provider/src/tasks/imgCaptcha/imgCaptchaTasksUtils.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/tasks/index.ts
+++ b/packages/provider/src/tasks/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/tasks/powCaptcha/powTasks.ts
+++ b/packages/provider/src/tasks/powCaptcha/powTasks.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/tasks/powCaptcha/powTasksUtils.ts
+++ b/packages/provider/src/tasks/powCaptcha/powTasksUtils.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/tasks/tasks.ts
+++ b/packages/provider/src/tasks/tasks.ts
@@ -5,7 +5,7 @@ import {
 	parseLogLevel,
 } from "@prosopo/common";
 import type { KeyringPair } from "@prosopo/types";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/tests/index.ts
+++ b/packages/provider/src/tests/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/tests/integration/api/admin/apiRegisterSiteKeyEndpoint.integration.test.ts
+++ b/packages/provider/src/tests/integration/api/admin/apiRegisterSiteKeyEndpoint.integration.test.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/tests/integration/api/blacklistRequestInspector.integration.test.ts
+++ b/packages/provider/src/tests/integration/api/blacklistRequestInspector.integration.test.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/tests/integration/imgCaptcha.integration.test.ts
+++ b/packages/provider/src/tests/integration/imgCaptcha.integration.test.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/tests/integration/ipValidation.integration.test.ts
+++ b/packages/provider/src/tests/integration/ipValidation.integration.test.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/tests/integration/mocks/solvedTestCaptchas.ts
+++ b/packages/provider/src/tests/integration/mocks/solvedTestCaptchas.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/tests/integration/powCaptcha.integration.test.ts
+++ b/packages/provider/src/tests/integration/powCaptcha.integration.test.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/tests/integration/registerSitekey.ts
+++ b/packages/provider/src/tests/integration/registerSitekey.ts
@@ -1,6 +1,6 @@
 import { ProviderApi } from "@prosopo/api";
 import { loadBalancer } from "@prosopo/load-balancer";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/tests/integration/userAccessPolicy.ts
+++ b/packages/provider/src/tests/integration/userAccessPolicy.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/tests/unit/api/blacklistRequestInspector.unit.test.ts
+++ b/packages/provider/src/tests/unit/api/blacklistRequestInspector.unit.test.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/tests/unit/api/contextAwareValidation.unit.test.ts
+++ b/packages/provider/src/tests/unit/api/contextAwareValidation.unit.test.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/tests/unit/api/getFrictionlessCaptchaChallenge.unit.test.ts
+++ b/packages/provider/src/tests/unit/api/getFrictionlessCaptchaChallenge.unit.test.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/tests/unit/api/ignoreMiddleware.unit.test.ts
+++ b/packages/provider/src/tests/unit/api/ignoreMiddleware.unit.test.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/tests/unit/api/ja4Middleware.unit.test.ts
+++ b/packages/provider/src/tests/unit/api/ja4Middleware.unit.test.ts
@@ -1,5 +1,5 @@
 import { type Logger, getLogger } from "@prosopo/common";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/tests/unit/compositeIpAddress.unit.test.ts
+++ b/packages/provider/src/tests/unit/compositeIpAddress.unit.test.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/tests/unit/pairs.unit.test.ts
+++ b/packages/provider/src/tests/unit/pairs.unit.test.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/tests/unit/schedulers/captchaScheduler.unit.test.ts
+++ b/packages/provider/src/tests/unit/schedulers/captchaScheduler.unit.test.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/tests/unit/services/ipComparison.unit.test.ts
+++ b/packages/provider/src/tests/unit/services/ipComparison.unit.test.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/tests/unit/services/ipInfo.unit.test.ts
+++ b/packages/provider/src/tests/unit/services/ipInfo.unit.test.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/tests/unit/tasks/captchaManager.unit.test.ts
+++ b/packages/provider/src/tests/unit/tasks/captchaManager.unit.test.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/tests/unit/tasks/client/clientTasks.unit.test.ts
+++ b/packages/provider/src/tests/unit/tasks/client/clientTasks.unit.test.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/tests/unit/tasks/dataset/datasetTasks.unit.test.ts
+++ b/packages/provider/src/tests/unit/tasks/dataset/datasetTasks.unit.test.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/tests/unit/tasks/dataset/datasetTasksUtils.unit.test.ts
+++ b/packages/provider/src/tests/unit/tasks/dataset/datasetTasksUtils.unit.test.ts
@@ -1,7 +1,7 @@
 import { ProsopoEnvError } from "@prosopo/common";
 import { buildDataset } from "@prosopo/datasets";
 import type { DatasetRaw } from "@prosopo/types";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/tests/unit/tasks/frictionless/decryptPayload.unit.test.ts
+++ b/packages/provider/src/tests/unit/tasks/frictionless/decryptPayload.unit.test.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/tests/unit/tasks/frictionless/frictionlessTasks.unit.test.ts
+++ b/packages/provider/src/tests/unit/tasks/frictionless/frictionlessTasks.unit.test.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/tests/unit/tasks/frictionless/frictionlessTasksUtils.unit.test.ts
+++ b/packages/provider/src/tests/unit/tasks/frictionless/frictionlessTasksUtils.unit.test.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/tests/unit/tasks/imgCaptcha/imgCaptchaTasks.unit.test.ts
+++ b/packages/provider/src/tests/unit/tasks/imgCaptcha/imgCaptchaTasks.unit.test.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/tests/unit/tasks/imgCaptcha/imgCaptchaTasksUtils.unit.test.ts
+++ b/packages/provider/src/tests/unit/tasks/imgCaptcha/imgCaptchaTasksUtils.unit.test.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/tests/unit/tasks/powCaptcha/powTasks.unit.test.ts
+++ b/packages/provider/src/tests/unit/tasks/powCaptcha/powTasks.unit.test.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/tests/unit/tasks/powCaptcha/powTasksUtils.unit.test.ts
+++ b/packages/provider/src/tests/unit/tasks/powCaptcha/powTasksUtils.unit.test.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/tests/unit/util.evaluateIpValidationRules.unit.test.ts
+++ b/packages/provider/src/tests/unit/util.evaluateIpValidationRules.unit.test.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/tests/unit/util.ipDistance.unit.test.ts
+++ b/packages/provider/src/tests/unit/util.ipDistance.unit.test.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/tests/unit/util.unit.test.ts
+++ b/packages/provider/src/tests/unit/util.unit.test.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/util.ts
+++ b/packages/provider/src/util.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/utils/hashUserAgent.ts
+++ b/packages/provider/src/utils/hashUserAgent.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/src/utils/hashUserIp.ts
+++ b/packages/provider/src/utils/hashUserIp.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/vite.cjs.config.ts
+++ b/packages/provider/vite.cjs.config.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/vite.esm.config.ts
+++ b/packages/provider/vite.esm.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/vite.test.config.ts
+++ b/packages/provider/vite.test.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/provider/vite.threads.test.config.ts
+++ b/packages/provider/vite.threads.test.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/redis-client/src/index.ts
+++ b/packages/redis-client/src/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/redis-client/src/redisClient.ts
+++ b/packages/redis-client/src/redisClient.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/redis-client/src/redisIndex.ts
+++ b/packages/redis-client/src/redisIndex.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/redis-client/src/tests/redisIndex.integration.test.ts
+++ b/packages/redis-client/src/tests/redisIndex.integration.test.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/redis-client/src/tests/testRedisConnection.ts
+++ b/packages/redis-client/src/tests/testRedisConnection.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/redis-client/vite.cjs.config.ts
+++ b/packages/redis-client/vite.cjs.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/redis-client/vite.esm.config.ts
+++ b/packages/redis-client/vite.esm.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/redis-client/vite.test.config.ts
+++ b/packages/redis-client/vite.test.config.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/server/vite.cjs.config.ts
+++ b/packages/server/vite.cjs.config.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/server/vite.esm.config.ts
+++ b/packages/server/vite.esm.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/testpkg2/src/index.ts
+++ b/packages/testpkg2/src/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/testpkg2/vite.cjs.config.ts
+++ b/packages/testpkg2/vite.cjs.config.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/testpkg2/vite.esm.config.ts
+++ b/packages/testpkg2/vite.esm.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/types-database/src/index.ts
+++ b/packages/types-database/src/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/types-database/src/provider/pendingCaptchaRequest.ts
+++ b/packages/types-database/src/provider/pendingCaptchaRequest.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/types-database/src/types/captcha.ts
+++ b/packages/types-database/src/types/captcha.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/types-database/src/types/client.ts
+++ b/packages/types-database/src/types/client.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/types-database/src/types/index.ts
+++ b/packages/types-database/src/types/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/types-database/src/types/mongo.ts
+++ b/packages/types-database/src/types/mongo.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/types-database/src/types/provider.ts
+++ b/packages/types-database/src/types/provider.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/types-database/src/types/userAgent.ts
+++ b/packages/types-database/src/types/userAgent.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/types-database/vite.cjs.config.ts
+++ b/packages/types-database/vite.cjs.config.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/types-database/vite.esm.config.ts
+++ b/packages/types-database/vite.esm.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/types-env/src/env.ts
+++ b/packages/types-env/src/env.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/types-env/src/index.ts
+++ b/packages/types-env/src/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/types-env/src/provider.ts
+++ b/packages/types-env/src/provider.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/types-env/vite.cjs.config.ts
+++ b/packages/types-env/vite.cjs.config.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/types-env/vite.esm.config.ts
+++ b/packages/types-env/vite.esm.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/types/src/api/api.ts
+++ b/packages/types/src/api/api.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/types/src/api/index.ts
+++ b/packages/types/src/api/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/types/src/api/ipapi.ts
+++ b/packages/types/src/api/ipapi.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/types/src/api/params.ts
+++ b/packages/types/src/api/params.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/types/src/client/captchaType/captchaType.ts
+++ b/packages/types/src/client/captchaType/captchaType.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/types/src/client/captchaType/captchaTypeSpec.ts
+++ b/packages/types/src/client/captchaType/captchaTypeSpec.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/types/src/client/index.ts
+++ b/packages/types/src/client/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/types/src/client/settings.ts
+++ b/packages/types/src/client/settings.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/types/src/client/user.ts
+++ b/packages/types/src/client/user.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/types/src/config/config.ts
+++ b/packages/types/src/config/config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/types/src/config/enumMap.ts
+++ b/packages/types/src/config/enumMap.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/types/src/config/frictionless.ts
+++ b/packages/types/src/config/frictionless.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/types/src/config/index.ts
+++ b/packages/types/src/config/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/types/src/config/network.ts
+++ b/packages/types/src/config/network.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/types/src/config/timeouts.ts
+++ b/packages/types/src/config/timeouts.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/types/src/datasets/assets.ts
+++ b/packages/types/src/datasets/assets.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/types/src/datasets/captcha.ts
+++ b/packages/types/src/datasets/captcha.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/types/src/datasets/dataset.ts
+++ b/packages/types/src/datasets/dataset.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/types/src/datasets/index.ts
+++ b/packages/types/src/datasets/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/types/src/datasets/merkle.ts
+++ b/packages/types/src/datasets/merkle.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/types/src/keyring/index.ts
+++ b/packages/types/src/keyring/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/types/src/procaptcha-bundle/index.ts
+++ b/packages/types/src/procaptcha-bundle/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/types/src/procaptcha-frictionless/index.ts
+++ b/packages/types/src/procaptcha-frictionless/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/types/src/procaptcha-frictionless/props.ts
+++ b/packages/types/src/procaptcha-frictionless/props.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/types/src/procaptcha/api.ts
+++ b/packages/types/src/procaptcha/api.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/types/src/procaptcha/client.ts
+++ b/packages/types/src/procaptcha/client.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/types/src/procaptcha/collector.ts
+++ b/packages/types/src/procaptcha/collector.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/types/src/procaptcha/index.ts
+++ b/packages/types/src/procaptcha/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/types/src/procaptcha/manager.ts
+++ b/packages/types/src/procaptcha/manager.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/types/src/procaptcha/props.ts
+++ b/packages/types/src/procaptcha/props.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/types/src/procaptcha/token.ts
+++ b/packages/types/src/procaptcha/token.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/types/src/procaptcha/utils.ts
+++ b/packages/types/src/procaptcha/utils.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/types/src/provider/accounts.ts
+++ b/packages/types/src/provider/accounts.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/types/src/provider/api.ts
+++ b/packages/types/src/provider/api.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/types/src/provider/detection.ts
+++ b/packages/types/src/provider/detection.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/types/src/provider/index.ts
+++ b/packages/types/src/provider/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/types/src/provider/scheduler.ts
+++ b/packages/types/src/provider/scheduler.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/types/vite.cjs.config.ts
+++ b/packages/types/vite.cjs.config.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/types/vite.esm.config.ts
+++ b/packages/types/vite.esm.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/user-access-policy/entries.ts
+++ b/packages/user-access-policy/entries.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/user-access-policy/src/.export.ts
+++ b/packages/user-access-policy/src/.export.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/user-access-policy/src/api/.export.ts
+++ b/packages/user-access-policy/src/api/.export.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/user-access-policy/src/api/accessRulesApiClient.ts
+++ b/packages/user-access-policy/src/api/accessRulesApiClient.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/user-access-policy/src/api/delete/.export.ts
+++ b/packages/user-access-policy/src/api/delete/.export.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/user-access-policy/src/api/delete/deleteAllRules.ts
+++ b/packages/user-access-policy/src/api/delete/deleteAllRules.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/user-access-policy/src/api/delete/deleteRuleGroups.ts
+++ b/packages/user-access-policy/src/api/delete/deleteRuleGroups.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/user-access-policy/src/api/delete/deleteRules.ts
+++ b/packages/user-access-policy/src/api/delete/deleteRules.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/user-access-policy/src/api/read/.export.ts
+++ b/packages/user-access-policy/src/api/read/.export.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/user-access-policy/src/api/read/fetchRules.ts
+++ b/packages/user-access-policy/src/api/read/fetchRules.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/user-access-policy/src/api/read/findRuleIds.ts
+++ b/packages/user-access-policy/src/api/read/findRuleIds.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/user-access-policy/src/api/read/getMissingIds.ts
+++ b/packages/user-access-policy/src/api/read/getMissingIds.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/user-access-policy/src/api/ruleApiRoutes.ts
+++ b/packages/user-access-policy/src/api/ruleApiRoutes.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/user-access-policy/src/api/rulesApiClient.ts
+++ b/packages/user-access-policy/src/api/rulesApiClient.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/user-access-policy/src/api/write/.export.ts
+++ b/packages/user-access-policy/src/api/write/.export.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/user-access-policy/src/api/write/insertRules.ts
+++ b/packages/user-access-policy/src/api/write/insertRules.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/user-access-policy/src/api/write/rehashRules.ts
+++ b/packages/user-access-policy/src/api/write/rehashRules.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/user-access-policy/src/mongoose/.export.ts
+++ b/packages/user-access-policy/src/mongoose/.export.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/user-access-policy/src/mongoose/mongooseRuleSchema.ts
+++ b/packages/user-access-policy/src/mongoose/mongooseRuleSchema.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/user-access-policy/src/redis/.export.ts
+++ b/packages/user-access-policy/src/redis/.export.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/user-access-policy/src/redis/reader/redisAggregate.ts
+++ b/packages/user-access-policy/src/redis/reader/redisAggregate.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/user-access-policy/src/redis/reader/redisRulesQuery.ts
+++ b/packages/user-access-policy/src/redis/reader/redisRulesQuery.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/user-access-policy/src/redis/reader/redisRulesReader.ts
+++ b/packages/user-access-policy/src/redis/reader/redisRulesReader.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/user-access-policy/src/redis/redisClient.ts
+++ b/packages/user-access-policy/src/redis/redisClient.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/user-access-policy/src/redis/redisRuleIndex.ts
+++ b/packages/user-access-policy/src/redis/redisRuleIndex.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/user-access-policy/src/redis/redisRulesStorage.ts
+++ b/packages/user-access-policy/src/redis/redisRulesStorage.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/user-access-policy/src/redis/redisRulesWriter.ts
+++ b/packages/user-access-policy/src/redis/redisRulesWriter.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/user-access-policy/src/rule.ts
+++ b/packages/user-access-policy/src/rule.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/user-access-policy/src/ruleInput/.export.ts
+++ b/packages/user-access-policy/src/ruleInput/.export.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/user-access-policy/src/ruleInput/policyInput.ts
+++ b/packages/user-access-policy/src/ruleInput/policyInput.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/user-access-policy/src/ruleInput/ruleInput.ts
+++ b/packages/user-access-policy/src/ruleInput/ruleInput.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/user-access-policy/src/ruleInput/userScopeInput.ts
+++ b/packages/user-access-policy/src/ruleInput/userScopeInput.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/user-access-policy/src/ruleRecord.ts
+++ b/packages/user-access-policy/src/ruleRecord.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/user-access-policy/src/rulesStorage.ts
+++ b/packages/user-access-policy/src/rulesStorage.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/user-access-policy/src/tests/policyInput.unit.test.ts
+++ b/packages/user-access-policy/src/tests/policyInput.unit.test.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/user-access-policy/src/tests/redis/reader/redisRulesQuery.unit.test.ts
+++ b/packages/user-access-policy/src/tests/redis/reader/redisRulesQuery.unit.test.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/user-access-policy/src/tests/redis/redisRulesStorage.integration.test.ts
+++ b/packages/user-access-policy/src/tests/redis/redisRulesStorage.integration.test.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/user-access-policy/src/tests/testLogger.ts
+++ b/packages/user-access-policy/src/tests/testLogger.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/user-access-policy/src/tests/transformRule.unit.test.ts
+++ b/packages/user-access-policy/src/tests/transformRule.unit.test.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/user-access-policy/src/transformRule.ts
+++ b/packages/user-access-policy/src/transformRule.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/user-access-policy/vite.cjs.config.ts
+++ b/packages/user-access-policy/vite.cjs.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/user-access-policy/vite.esm.config.ts
+++ b/packages/user-access-policy/vite.esm.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/user-access-policy/vite.test.config.ts
+++ b/packages/user-access-policy/vite.test.config.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/util-crypto/src/address/index.ts
+++ b/packages/util-crypto/src/address/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/util-crypto/src/hash.ts
+++ b/packages/util-crypto/src/hash.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/util-crypto/src/index.ts
+++ b/packages/util-crypto/src/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/util-crypto/src/networks.ts
+++ b/packages/util-crypto/src/networks.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/util-crypto/src/secp256k1/index.ts
+++ b/packages/util-crypto/src/secp256k1/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/util-crypto/vite.cjs.config.ts
+++ b/packages/util-crypto/vite.cjs.config.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/util-crypto/vite.esm.config.ts
+++ b/packages/util-crypto/vite.esm.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/util-crypto/vite.test.config.ts
+++ b/packages/util-crypto/vite.test.config.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/util/src/asyncConstructor.ts
+++ b/packages/util/src/asyncConstructor.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/util/src/at.ts
+++ b/packages/util/src/at.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/util/src/binaryString.ts
+++ b/packages/util/src/binaryString.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/util/src/checks.ts
+++ b/packages/util/src/checks.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/util/src/choice.ts
+++ b/packages/util/src/choice.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/util/src/date.ts
+++ b/packages/util/src/date.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/util/src/fetchWithEtag.ts
+++ b/packages/util/src/fetchWithEtag.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/util/src/get.ts
+++ b/packages/util/src/get.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/util/src/hammingDistance.ts
+++ b/packages/util/src/hammingDistance.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/util/src/hex.ts
+++ b/packages/util/src/hex.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/util/src/index.ts
+++ b/packages/util/src/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/util/src/ip.ts
+++ b/packages/util/src/ip.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/util/src/isMain.ts
+++ b/packages/util/src/isMain.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/util/src/lodash.ts
+++ b/packages/util/src/lodash.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/util/src/merge.ts
+++ b/packages/util/src/merge.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/util/src/ofLen.ts
+++ b/packages/util/src/ofLen.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/util/src/permutations.ts
+++ b/packages/util/src/permutations.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/util/src/solverService.ts
+++ b/packages/util/src/solverService.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/util/src/table.ts
+++ b/packages/util/src/table.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/util/src/tests/asyncConstructor.unit.test.ts
+++ b/packages/util/src/tests/asyncConstructor.unit.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/util/src/tests/at.unit.test.ts
+++ b/packages/util/src/tests/at.unit.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/util/src/tests/binaryString.unit.test.ts
+++ b/packages/util/src/tests/binaryString.unit.test.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/util/src/tests/get.unit.test.ts
+++ b/packages/util/src/tests/get.unit.test.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/util/src/tests/hammingDistance.unit.test.ts
+++ b/packages/util/src/tests/hammingDistance.unit.test.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/util/src/tests/hex.unit.test.ts
+++ b/packages/util/src/tests/hex.unit.test.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/util/src/tests/lodash.unit.test.ts
+++ b/packages/util/src/tests/lodash.unit.test.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/util/src/tests/merge.unit.test.ts
+++ b/packages/util/src/tests/merge.unit.test.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/util/src/tests/permutations.unit.test.ts
+++ b/packages/util/src/tests/permutations.unit.test.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/util/src/tests/url.unit.test.ts
+++ b/packages/util/src/tests/url.unit.test.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/util/src/tests/util.unit.test.ts
+++ b/packages/util/src/tests/util.unit.test.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/util/src/url.ts
+++ b/packages/util/src/url.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/util/src/util.ts
+++ b/packages/util/src/util.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/util/src/verifyRecency.ts
+++ b/packages/util/src/verifyRecency.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/util/src/version.ts
+++ b/packages/util/src/version.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/util/vite.cjs.config.ts
+++ b/packages/util/vite.cjs.config.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/util/vite.esm.config.ts
+++ b/packages/util/vite.esm.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/util/vite.test.config.ts
+++ b/packages/util/vite.test.config.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/widget-skeleton/src/constants.ts
+++ b/packages/widget-skeleton/src/constants.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/widget-skeleton/src/elements/checkbox.ts
+++ b/packages/widget-skeleton/src/elements/checkbox.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/widget-skeleton/src/elements/logo.ts
+++ b/packages/widget-skeleton/src/elements/logo.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/widget-skeleton/src/elements/skeleton.ts
+++ b/packages/widget-skeleton/src/elements/skeleton.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/widget-skeleton/src/index.ts
+++ b/packages/widget-skeleton/src/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/widget-skeleton/src/theme.ts
+++ b/packages/widget-skeleton/src/theme.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/widget-skeleton/src/webComponent/createWebComponent.ts
+++ b/packages/widget-skeleton/src/webComponent/createWebComponent.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/widget-skeleton/src/webComponent/createWidget.ts
+++ b/packages/widget-skeleton/src/webComponent/createWidget.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/widget-skeleton/vite.cjs.config.ts
+++ b/packages/widget-skeleton/vite.cjs.config.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/widget-skeleton/vite.esm.config.ts
+++ b/packages/widget-skeleton/vite.esm.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Prosopo (UK) Ltd.
+// Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
- Update all license headers from 2021-2025 to 2021-2026
- Remove duplicate license header in demos/client-bundle-example/src/index.ts
- Fix all linting errors at root workspace level
