### PR TITLE
Reduce provider latency with parallel lookups, caching, and connection tuning

### DIFF
--- a/.changeset/silly-impalas-dream.md
+++ b/.changeset/silly-impalas-dream.md
@@ -1,0 +1,8 @@
+---
+"@prosopo/load-balancer": minor
+"@prosopo/database": minor
+"@prosopo/provider": minor
+---
+
+Provider speed ups
+  

--- a/architecture.mmd
+++ b/architecture.mmd
@@ -1,0 +1,174 @@
+---
+title: Prosopo Procaptcha System Architecture
+---
+
+graph TB
+    %% ===== ACTORS =====
+    Developer["Website Developer<br/>(integrates Procaptcha)"]
+    EndUser["End User<br/>(website visitor)"]
+
+    %% ===== CLIENT SIDE =====
+    subgraph Browser["End User Browser"]
+        direction TB
+        Widget["Procaptcha Widget<br/>procaptcha-react / procaptcha-bundle"]
+        Manager["Manager<br/>(procaptcha)"]
+        LB["Load Balancer<br/>(load-balancer)"]
+
+        subgraph Detection["Bot Detection"]
+            Detector["Detector<br/>(detector)"]
+            Fingerprint["Fingerprint<br/>(fingerprint)"]
+            Behavioral["Behavioral Collectors<br/>mouse / touch / keyboard"]
+        end
+
+        subgraph CaptchaFlows["Challenge Flows"]
+            Frictionless["Frictionless<br/>(procaptcha-frictionless)"]
+            ImageCaptcha["Image Captcha<br/>select matching images"]
+            PoW["Proof of Work<br/>compute hash puzzle"]
+        end
+    end
+
+    %% ===== PROVIDER =====
+    subgraph Provider["Prosopo Provider"]
+        direction TB
+        subgraph PublicAPI["Public API"]
+            Healthz["GET /healthz"]
+            Details["GET .../public/details"]
+        end
+
+        subgraph ClientAPI["Client API (requires Site Key header)"]
+            direction TB
+            FrictionlessEP["POST .../client/captcha/frictionless"]
+            ImageChallengeEP["POST .../client/captcha/image"]
+            ImageSolutionEP["POST .../client/solution"]
+            PowChallengeEP["POST .../client/captcha/pow"]
+            PowSolutionEP["POST .../client/pow/solution"]
+            ImageVerifyEP["POST .../client/image/dapp/verify"]
+            PowVerifyEP["POST .../client/pow/verify"]
+            SpamEmailEP["POST .../client/spam/email"]
+        end
+
+        subgraph AdminAPI["Admin API (requires JWT)"]
+            SiteKeyMgmt["Site Key Management<br/>register / remove"]
+            DetectorMgmt["Detector Key Management<br/>update / remove"]
+            DecisionMachineMgmt["Decision Machine Management<br/>create / get / remove"]
+            MaintenanceToggle["Maintenance Mode Toggle"]
+        end
+
+        subgraph UapAPI["User Access Policy API (requires JWT)"]
+            RulesCRUD["Access Rules CRUD<br/>insert / fetch / delete / rehash"]
+        end
+
+        subgraph ProviderLogic["Provider Logic"]
+            ImgTasks["Image Captcha Manager"]
+            PowTasks["PoW Captcha Manager"]
+            FrictionlessTasks["Frictionless Manager"]
+            SolutionVerifier["Solution Verifier<br/>Merkle tree + salt embedding"]
+            DecisionMachine["Decision Machine<br/>pluggable scoring"]
+            AccessRules["Access Rules Engine<br/>spam / traffic / geo filters"]
+        end
+
+        subgraph Storage["Storage"]
+            MongoDB[(MongoDB<br/>captchas, commitments,<br/>clients, sessions)]
+            Redis[(Redis<br/>session cache,<br/>write queue)]
+            Dataset[(Dataset<br/>labelled + unlabelled<br/>captcha images)]
+        end
+    end
+
+    %% ===== WEBSITE BACKEND =====
+    subgraph DappBackend["Website Backend"]
+        ServerPkg["ProsopoServer<br/>(@prosopo/server)"]
+    end
+
+    %% ===== EXTERNAL =====
+    ProviderList["Provider List<br/>provider-list.prosopo.io"]
+
+    %% ===== DEVELOPER FLOW =====
+    Developer -->|"1. Sign up at prosopo.io<br/>get site key + secret"| DappBackend
+    Developer -->|"2. Add widget to frontend<br/>with site key"| Widget
+
+    %% ===== USER FLOW =====
+    EndUser -->|visits website| Widget
+    Widget --> Manager
+    Manager -->|fetch provider list| LB
+    LB -->|weighted random selection| ProviderList
+    ProviderList -->|provider URLs + weights| LB
+
+    %% ===== FRICTIONLESS FLOW =====
+    Manager -->|default: frictionless| Frictionless
+    Frictionless -->|parallel| Detector
+    Frictionless -->|parallel| Fingerprint
+    Frictionless -->|parallel| Behavioral
+    Frictionless -->|request session| FrictionlessEP
+
+    FrictionlessEP --> FrictionlessTasks
+    FrictionlessTasks --> Redis
+    FrictionlessTasks -->|human detected| Manager
+    FrictionlessTasks -->|bot suspected| ImageCaptcha
+    FrictionlessTasks -->|bot suspected| PoW
+
+    %% ===== IMAGE CAPTCHA FLOW =====
+    Manager -->|fallback: image| ImageCaptcha
+    ImageCaptcha -->|get challenge| ImageChallengeEP
+    ImageChallengeEP --> ImgTasks
+    ImgTasks -->|random captchas + salt| Dataset
+    ImgTasks -->|signed challenge| ImageCaptcha
+    ImageCaptcha -->|user selects images| ImageSolutionEP
+    ImageSolutionEP --> SolutionVerifier
+    SolutionVerifier -->|compare solutions| Dataset
+    SolutionVerifier -->|build commitment| MongoDB
+    SolutionVerifier -->|optional scoring| DecisionMachine
+    SolutionVerifier -->|check rules| AccessRules
+    SolutionVerifier -->|signed token| Manager
+
+    %% ===== POW FLOW =====
+    Manager -->|fallback: pow| PoW
+    PoW -->|get challenge| PowChallengeEP
+    PowChallengeEP --> PowTasks
+    PowTasks -->|challenge + difficulty| PoW
+    PoW -->|computed proof| PowSolutionEP
+    PowSolutionEP --> PowTasks
+    PowTasks -->|verify proof| MongoDB
+    PowTasks -->|signed token| Manager
+
+    %% ===== TOKEN TO BACKEND =====
+    Manager -->|"ProcaptchaToken<br/>(hex-encoded)"| EndUser
+    EndUser -->|"submit form + token"| DappBackend
+
+    %% ===== SERVER VERIFICATION =====
+    DappBackend --> ServerPkg
+    ServerPkg -->|verify image token| ImageVerifyEP
+    ServerPkg -->|verify pow token| PowVerifyEP
+    ImageVerifyEP -->|decode token, check commitment| MongoDB
+    PowVerifyEP -->|decode token, check proof| MongoDB
+    ImageVerifyEP -->|"verified: true/false"| ServerPkg
+    PowVerifyEP -->|"verified: true/false"| ServerPkg
+    ServerPkg -->|grant or deny access| DappBackend
+
+    %% ===== ADMIN =====
+    Developer -.->|"manage via portal<br/>or admin API"| AdminAPI
+    AdminAPI --> MongoDB
+
+    %% ===== STORAGE CONNECTIONS =====
+    ImgTasks --> MongoDB
+    PowTasks --> MongoDB
+    FrictionlessTasks --> MongoDB
+    AccessRules --> MongoDB
+    DecisionMachine --> MongoDB
+    ImgTasks --> Redis
+    PowTasks --> Redis
+
+    %% ===== STYLES =====
+    classDef actor fill:#e1f5fe,stroke:#0288d1,color:#000
+    classDef browser fill:#fff3e0,stroke:#f57c00,color:#000
+    classDef provider fill:#e8f5e9,stroke:#388e3c,color:#000
+    classDef storage fill:#fce4ec,stroke:#c62828,color:#000
+    classDef backend fill:#f3e5f5,stroke:#7b1fa2,color:#000
+    classDef external fill:#eceff1,stroke:#546e6a,color:#000
+
+    class Developer,EndUser actor
+    class Widget,Manager,LB,Detector,Fingerprint,Behavioral,Frictionless,ImageCaptcha,PoW browser
+    class Healthz,Details,FrictionlessEP,ImageChallengeEP,ImageSolutionEP,PowChallengeEP,PowSolutionEP,ImageVerifyEP,PowVerifyEP,SpamEmailEP,SiteKeyMgmt,DetectorMgmt,DecisionMachineMgmt,MaintenanceToggle,RulesCRUD provider
+    class ImgTasks,PowTasks,FrictionlessTasks,SolutionVerifier,DecisionMachine,AccessRules provider
+    class MongoDB,Redis,Dataset storage
+    class ServerPkg,DappBackend backend
+    class ProviderList external

--- a/packages/database/src/base/mongo.ts
+++ b/packages/database/src/base/mongo.ts
@@ -102,6 +102,8 @@ export class MongoDatabase implements IDatabase {
 				const connection = mongoose.createConnection(this.url, {
 					dbName: this.dbname,
 					serverApi: ServerApiVersion.v1,
+					maxPoolSize: 50,
+					minPoolSize: 5,
 				});
 
 				const onConnected = () => {

--- a/packages/load-balancer/src/providers.ts
+++ b/packages/load-balancer/src/providers.ts
@@ -17,6 +17,22 @@ import { type HardcodedProvider, loadBalancer } from "./index.js";
 
 let cachedProviders: HardcodedProvider[] = [];
 
+/** Optional custom loader for server-side caching (e.g. cacheFile with ETag). */
+let customProviderLoader:
+	| ((env: EnvironmentTypes) => Promise<HardcodedProvider[]>)
+	| null = null;
+
+/**
+ * Set a custom provider loader that replaces the default HTTP fetch.
+ * Use this on the server side to inject cacheFile-based loading with
+ * ETag/Last-Modified support for disk persistence across restarts.
+ */
+export function setProviderLoader(
+	loader: (env: EnvironmentTypes) => Promise<HardcodedProvider[]>,
+): void {
+	customProviderLoader = loader;
+}
+
 export function _resetCache() {
 	cachedProviders = [];
 }
@@ -59,6 +75,16 @@ export function selectWeightedProvider(
 	return selectedProvider;
 }
 
+/** Load providers using the custom loader if set, otherwise the default fetch. */
+const loadProviders = async (
+	env: EnvironmentTypes,
+): Promise<HardcodedProvider[]> => {
+	if (customProviderLoader) {
+		return customProviderLoader(env);
+	}
+	return loadBalancer(env);
+};
+
 /**
  * Pre-warms the provider cache for a given environment without requiring entropy.
  * Call this as early as possible to avoid a cold-cache delay when getRandomActiveProvider is first used.
@@ -67,7 +93,7 @@ export const prefetchProviders = async (
 	env: EnvironmentTypes,
 ): Promise<void> => {
 	if (cachedProviders.length === 0) {
-		cachedProviders = await loadBalancer(env);
+		cachedProviders = await loadProviders(env);
 	}
 };
 
@@ -76,8 +102,7 @@ export const getRandomActiveProvider = async (
 	entropy: number,
 ): Promise<RandomProvider> => {
 	if (cachedProviders.length === 0) {
-		// only get the providers JSON once
-		cachedProviders = await loadBalancer(env);
+		cachedProviders = await loadProviders(env);
 	}
 
 	const randomProviderObj = selectWeightedProvider(cachedProviders, entropy);

--- a/packages/provider/src/api/captcha/getFrictionlessCaptchaChallenge.ts
+++ b/packages/provider/src/api/captcha/getFrictionlessCaptchaChallenge.ts
@@ -128,48 +128,56 @@ export default (
 			// Calculate the hash upfront so both checks can run in parallel
 			const userSitekeyIpHash = hashUserIp(user, normalizedIp, dapp);
 
-			// Run token-reuse check and session deduplication in parallel.
-			// These are independent lookups that previously ran sequentially.
-			const sessionDedupPromise = (async (): Promise<{
+			// Fire token-reuse check, Redis session lookup, and MongoDB session
+			// lookup all at once.  Redis and MongoDB race for the session dedup:
+			// if Redis has a cached hit we use it immediately without waiting for
+			// MongoDB; if Redis misses, the MongoDB query is already in-flight so
+			// we pay no extra latency for the Redis attempt.
+			const redisSessionPromise: Promise<string | null> = tasks.writeQueue
+				? tasks.writeQueue.getCachedSessionByHash(userSitekeyIpHash)
+				: Promise.resolve(null);
+			const mongoSessionPromise =
+				tasks.db.getSessionByuserSitekeyIpHash(userSitekeyIpHash);
+
+			const [existingToken, redisSessionId] = await Promise.all([
+				tasks.db.getSessionRecordByToken(token),
+				redisSessionPromise,
+			]);
+
+			// Resolve session dedup: prefer Redis hit, fall back to
+			// already-in-flight MongoDB query.
+			type SessionDedupResult = {
 				source: "redis" | "mongo";
 				sessionId: string;
 				captchaType: string;
 				session?: import("@prosopo/types").Session;
-			} | null> => {
-				// Check Redis cache first
-				if (tasks.writeQueue) {
-					const cachedSessionId =
-						await tasks.writeQueue.getCachedSessionByHash(userSitekeyIpHash);
-					if (cachedSessionId) {
-						const cachedData =
-							await tasks.writeQueue.getCachedSession(cachedSessionId);
-						if (cachedData?.captchaType && !cachedData.deleted) {
-							return {
-								source: "redis",
-								sessionId: cachedSessionId,
-								captchaType: cachedData.captchaType as string,
-							};
-						}
-					}
+			};
+			let sessionDedup: SessionDedupResult | null = null;
+
+			if (redisSessionId && tasks.writeQueue) {
+				const cachedData =
+					await tasks.writeQueue.getCachedSession(redisSessionId);
+				if (cachedData?.captchaType && !cachedData.deleted) {
+					sessionDedup = {
+						source: "redis",
+						sessionId: redisSessionId,
+						captchaType: cachedData.captchaType as string,
+					};
 				}
-				// Fall back to MongoDB
-				const existingSession =
-					await tasks.db.getSessionByuserSitekeyIpHash(userSitekeyIpHash);
+			}
+
+			if (!sessionDedup) {
+				// MongoDB query was started in parallel — just await its result
+				const existingSession = await mongoSessionPromise;
 				if (existingSession) {
-					return {
+					sessionDedup = {
 						source: "mongo",
 						sessionId: existingSession.sessionId,
 						captchaType: existingSession.captchaType,
 						session: existingSession,
 					};
 				}
-				return null;
-			})();
-
-			const [existingToken, sessionDedup] = await Promise.all([
-				tasks.db.getSessionRecordByToken(token),
-				sessionDedupPromise,
-			]);
+			}
 
 			if (existingToken) {
 				req.logger.info(() => ({

--- a/packages/provider/src/api/captcha/getFrictionlessCaptchaChallenge.ts
+++ b/packages/provider/src/api/captcha/getFrictionlessCaptchaChallenge.ts
@@ -125,8 +125,51 @@ export default (
 				);
 			}
 
-			// Check if the token has already been used
-			const existingToken = await tasks.db.getSessionRecordByToken(token);
+			// Calculate the hash upfront so both checks can run in parallel
+			const userSitekeyIpHash = hashUserIp(user, normalizedIp, dapp);
+
+			// Run token-reuse check and session deduplication in parallel.
+			// These are independent lookups that previously ran sequentially.
+			const sessionDedupPromise = (async (): Promise<{
+				source: "redis" | "mongo";
+				sessionId: string;
+				captchaType: string;
+				session?: import("@prosopo/types").Session;
+			} | null> => {
+				// Check Redis cache first
+				if (tasks.writeQueue) {
+					const cachedSessionId =
+						await tasks.writeQueue.getCachedSessionByHash(userSitekeyIpHash);
+					if (cachedSessionId) {
+						const cachedData =
+							await tasks.writeQueue.getCachedSession(cachedSessionId);
+						if (cachedData?.captchaType && !cachedData.deleted) {
+							return {
+								source: "redis",
+								sessionId: cachedSessionId,
+								captchaType: cachedData.captchaType as string,
+							};
+						}
+					}
+				}
+				// Fall back to MongoDB
+				const existingSession =
+					await tasks.db.getSessionByuserSitekeyIpHash(userSitekeyIpHash);
+				if (existingSession) {
+					return {
+						source: "mongo",
+						sessionId: existingSession.sessionId,
+						captchaType: existingSession.captchaType,
+						session: existingSession,
+					};
+				}
+				return null;
+			})();
+
+			const [existingToken, sessionDedup] = await Promise.all([
+				tasks.db.getSessionRecordByToken(token),
+				sessionDedupPromise,
+			]);
 
 			if (existingToken) {
 				req.logger.info(() => ({
@@ -146,75 +189,52 @@ export default (
 				);
 			}
 
-			// Calculate the hash for this user-IP-sitekey combination
-			const userSitekeyIpHash = hashUserIp(user, normalizedIp, dapp);
+			if (sessionDedup) {
+				if (sessionDedup.source === "redis") {
+					req.logger.info(() => ({
+						msg: "Reusing existing session from Redis cache",
+						data: {
+							userSitekeyIpHash,
+							sessionId: sessionDedup.sessionId,
+							captchaType: sessionDedup.captchaType,
+						},
+					}));
+				} else {
+					req.logger.info(() => ({
+						msg: "Reusing existing session for user-IP-sitekey combination",
+						data: {
+							userSitekeyIpHash,
+							sessionId: sessionDedup.sessionId,
+							captchaType: sessionDedup.captchaType,
+						},
+					}));
+					req.logger.info(() => ({
+						msg: "Frictionless decision",
+						data: {
+							requestId: req.requestId,
+							decision: "reuse_session",
+							captchaType: sessionDedup.captchaType,
+							sessionId: sessionDedup.sessionId,
+						},
+					}));
 
-			// Check Redis cache first for session deduplication (avoids MongoDB query).
-			// Falls back to MongoDB if Redis is unavailable or cache miss.
-			let existingSessionId: string | null = null;
-			if (tasks.writeQueue) {
-				existingSessionId =
-					await tasks.writeQueue.getCachedSessionByHash(userSitekeyIpHash);
-				if (existingSessionId) {
-					// Verify the cached session still exists and get its details
-					const cachedData =
-						await tasks.writeQueue.getCachedSession(existingSessionId);
-					if (cachedData?.captchaType && !cachedData.deleted) {
-						req.logger.info(() => ({
-							msg: "Reusing existing session from Redis cache",
-							data: {
-								userSitekeyIpHash,
-								sessionId: existingSessionId,
-								captchaType: cachedData.captchaType,
-							},
-						}));
-						return res.json({
-							[ApiParams.captchaType]: cachedData.captchaType as string,
-							[ApiParams.sessionId]: existingSessionId,
-							[ApiParams.status]: "ok",
-						});
+					// Populate Redis cache for future requests
+					if (tasks.writeQueue && sessionDedup.session) {
+						tasks.writeQueue
+							.cacheSessionByHash(userSitekeyIpHash, sessionDedup.sessionId)
+							.catch(() => {});
+						tasks.writeQueue
+							.cacheSession(
+								sessionDedup.sessionId,
+								sessionDedup.session as unknown as Record<string, unknown>,
+							)
+							.catch(() => {});
 					}
-				}
-			}
-
-			const existingSession =
-				await tasks.db.getSessionByuserSitekeyIpHash(userSitekeyIpHash);
-
-			if (existingSession) {
-				req.logger.info(() => ({
-					msg: "Reusing existing session for user-IP-sitekey combination",
-					data: {
-						userSitekeyIpHash,
-						sessionId: existingSession.sessionId,
-						captchaType: existingSession.captchaType,
-					},
-				}));
-				req.logger.info(() => ({
-					msg: "Frictionless decision",
-					data: {
-						requestId: req.requestId,
-						decision: "reuse_session",
-						captchaType: existingSession.captchaType,
-						sessionId: existingSession.sessionId,
-					},
-				}));
-
-				// Populate Redis cache for future requests
-				if (tasks.writeQueue) {
-					tasks.writeQueue
-						.cacheSessionByHash(userSitekeyIpHash, existingSession.sessionId)
-						.catch(() => {});
-					tasks.writeQueue
-						.cacheSession(
-							existingSession.sessionId,
-							existingSession as unknown as Record<string, unknown>,
-						)
-						.catch(() => {});
 				}
 
 				return res.json({
-					[ApiParams.captchaType]: existingSession.captchaType,
-					[ApiParams.sessionId]: existingSession.sessionId,
+					[ApiParams.captchaType]: sessionDedup.captchaType,
+					[ApiParams.sessionId]: sessionDedup.sessionId,
 					[ApiParams.status]: "ok",
 				});
 			}

--- a/packages/provider/src/api/captcha/getImageCaptchaChallenge.ts
+++ b/packages/provider/src/api/captcha/getImageCaptchaChallenge.ts
@@ -116,6 +116,7 @@ export default (
 				reason,
 				sessionId: validSessionId,
 				solvedImagesCount,
+				countryCode: sessionCountryCode,
 			} = await tasks.imgCaptchaManager.isValidRequest(
 				clientRecord,
 				CaptchaType.image,
@@ -155,17 +156,9 @@ export default (
 				},
 			};
 
-			// Get countryCode from session if available, otherwise from geolocation
-			let countryCodeToStore: string | undefined;
-			if (validSessionId) {
-				const sessionRecord =
-					await tasks.db.getSessionRecordBySessionId(validSessionId);
-				countryCodeToStore = sessionRecord?.countryCode;
-			}
-			// If not available from session, use the one we got for access policy
-			if (!countryCodeToStore) {
-				countryCodeToStore = countryCode;
-			}
+			// Use countryCode from session (already fetched in isValidRequest) or fall back to geolocation
+			const countryCodeToStore: string | undefined =
+				sessionCountryCode || countryCode;
 
 			const taskData =
 				await tasks.imgCaptchaManager.getRandomCaptchasAndRequestHash(

--- a/packages/provider/src/api/startProviderApi.ts
+++ b/packages/provider/src/api/startProviderApi.ts
@@ -25,6 +25,11 @@ import {
 } from "@prosopo/api-express-router";
 import { parseLogLevel } from "@prosopo/common";
 import type { ProviderEnvironment } from "@prosopo/env";
+import {
+	convertHostedProvider,
+	getLoadBalancerUrl,
+	setProviderLoader,
+} from "@prosopo/load-balancer";
 import { i18nMiddleware } from "@prosopo/locale";
 import {
 	AdminApiPaths,
@@ -36,6 +41,7 @@ import {
 	getExpressApiRuleRateLimits,
 } from "@prosopo/user-access-policy/api";
 import type { JWT } from "@prosopo/util-crypto";
+import { cacheFile } from "@prosopo/util/node";
 import cors from "cors";
 import express from "express";
 import type { Request } from "express";
@@ -138,6 +144,32 @@ export async function startProviderApi(
 	port?: number,
 ): Promise<Server> {
 	env.logger.info(() => ({ msg: "Starting Prosopo API" }));
+
+	// Wire up cacheFile-based provider list loading for disk persistence
+	// with ETag/Last-Modified support. This avoids cold-start fetches after
+	// process restarts and provides a disk fallback if the remote is down.
+	const providerCacheDir = path.resolve("./provider-list-cache");
+	setProviderLoader(async (environment) => {
+		if (environment === "development") {
+			// Development uses hardcoded providers, no caching needed
+			const { loadBalancer } = await import("@prosopo/load-balancer");
+			return loadBalancer(environment);
+		}
+		const url = getLoadBalancerUrl(environment);
+		const filePath = await cacheFile(
+			providerCacheDir,
+			url,
+			env.logger,
+			"provider-list-",
+			".json",
+		);
+		const text = fs.readFileSync(filePath, "utf-8");
+		const providers: Record<string, unknown> = JSON.parse(text) as Record<
+			string,
+			unknown
+		>;
+		return convertHostedProvider(providers);
+	});
 
 	const apiApp = express();
 	const apiPort = port || env.config.server?.port;

--- a/packages/provider/src/tasks/captchaManager.ts
+++ b/packages/provider/src/tasks/captchaManager.ts
@@ -104,6 +104,7 @@ export class CaptchaManager {
 		type: CaptchaType;
 		powDifficulty?: number;
 		solvedImagesCount?: number;
+		countryCode?: string;
 	}> {
 		this.logger.debug(() => ({
 			msg: "Validating request",
@@ -201,6 +202,7 @@ export class CaptchaManager {
 					...(sessionRecord.solvedImagesCount && {
 						solvedImagesCount: sessionRecord.solvedImagesCount,
 					}),
+					countryCode: sessionRecord.countryCode,
 				};
 			}
 

--- a/packages/provider/src/tasks/decisionMachine/decisionMachineRunner.ts
+++ b/packages/provider/src/tasks/decisionMachine/decisionMachineRunner.ts
@@ -33,12 +33,64 @@ const EXEC_TIMEOUT_MS =
 	Number.parseInt(process.env.DECISION_MACHINE_EXEC_TIMEOUT_MS ?? "", 10) ||
 	2000;
 
+/** How long cached artifacts are considered fresh (ms). */
+const ARTIFACT_CACHE_TTL_MS =
+	Number.parseInt(
+		process.env.DECISION_MACHINE_ARTIFACT_CACHE_TTL_MS ?? "",
+		10,
+	) || 5 * 60 * 1000; // 5 minutes
+
 const DEFAULT_DECISION: DecisionMachineOutput = {
 	decision: DecisionMachineDecision.Allow,
 };
 
+interface CachedArtifact {
+	artifact: DecisionMachineArtifact | undefined;
+	cachedAt: number;
+}
+
 export class DecisionMachineRunner {
+	private readonly artifactCache = new Map<string, CachedArtifact>();
+
 	constructor(private readonly db: IProviderDatabase) {}
+
+	/** Build a cache key for a given scope + dappAccount pair. */
+	private static cacheKey(
+		scope: DecisionMachineScope,
+		dappAccount?: string,
+	): string {
+		return `${scope}:${dappAccount ?? ""}`;
+	}
+
+	/** Return a cached artifact if still fresh, or undefined. */
+	private getCachedArtifact(
+		scope: DecisionMachineScope,
+		dappAccount?: string,
+	): DecisionMachineArtifact | undefined | null {
+		const entry = this.artifactCache.get(
+			DecisionMachineRunner.cacheKey(scope, dappAccount),
+		);
+		if (!entry) return null; // cache miss
+		if (Date.now() - entry.cachedAt > ARTIFACT_CACHE_TTL_MS) {
+			this.artifactCache.delete(
+				DecisionMachineRunner.cacheKey(scope, dappAccount),
+			);
+			return null; // expired
+		}
+		return entry.artifact; // may be undefined (negative cache)
+	}
+
+	/** Store an artifact (or undefined for negative cache) in the cache. */
+	private setCachedArtifact(
+		scope: DecisionMachineScope,
+		dappAccount: string | undefined,
+		artifact: DecisionMachineArtifact | undefined,
+	): void {
+		this.artifactCache.set(DecisionMachineRunner.cacheKey(scope, dappAccount), {
+			artifact,
+			cachedAt: Date.now(),
+		});
+	}
 
 	/**
 	 * Evaluates a single decision machine artifact and returns a decision.
@@ -99,19 +151,56 @@ export class DecisionMachineRunner {
 		dappAccount: string,
 		captchaType?: CaptchaType.image | CaptchaType.pow | undefined,
 	): Promise<DecisionMachineArtifact | undefined> {
-		// Check for dapp-specific artifact first (highest priority)
-		const dappArtifact = await this.db.getDecisionMachineArtifact(
+		// Try cache first for both scopes
+		const cachedDapp = this.getCachedArtifact(
 			DecisionMachineScope.Dapp,
 			dappAccount,
 		);
+		const cachedGlobal = this.getCachedArtifact(DecisionMachineScope.Global);
+
+		// Both cached (including negative cache) — use priority logic without DB calls
+		if (cachedDapp !== null && cachedGlobal !== null) {
+			if (cachedDapp && this.matchesCaptchaType(cachedDapp, captchaType)) {
+				return cachedDapp;
+			}
+			if (cachedGlobal && this.matchesCaptchaType(cachedGlobal, captchaType)) {
+				return cachedGlobal;
+			}
+			return undefined;
+		}
+
+		// Fetch both scopes in parallel when cache misses
+		const [dappArtifact, globalArtifact] = await Promise.all([
+			cachedDapp !== null
+				? Promise.resolve(cachedDapp)
+				: this.db
+						.getDecisionMachineArtifact(DecisionMachineScope.Dapp, dappAccount)
+						.then((a) => {
+							this.setCachedArtifact(
+								DecisionMachineScope.Dapp,
+								dappAccount,
+								a ?? undefined,
+							);
+							return a ?? undefined;
+						}),
+			cachedGlobal !== null
+				? Promise.resolve(cachedGlobal)
+				: this.db
+						.getDecisionMachineArtifact(DecisionMachineScope.Global)
+						.then((a) => {
+							this.setCachedArtifact(
+								DecisionMachineScope.Global,
+								undefined,
+								a ?? undefined,
+							);
+							return a ?? undefined;
+						}),
+		]);
+
+		// Apply priority: dapp-specific first, then global
 		if (dappArtifact && this.matchesCaptchaType(dappArtifact, captchaType)) {
 			return dappArtifact;
 		}
-
-		// Fall back to global artifact (lower priority)
-		const globalArtifact = await this.db.getDecisionMachineArtifact(
-			DecisionMachineScope.Global,
-		);
 		if (
 			globalArtifact &&
 			this.matchesCaptchaType(globalArtifact, captchaType)

--- a/packages/provider/src/util/redisCache.ts
+++ b/packages/provider/src/util/redisCache.ts
@@ -47,6 +47,7 @@ export class RedisWriteQueue {
 	private flushTimer: ReturnType<typeof setInterval> | null = null;
 	private flushCallback: ((queue: RedisWriteQueue) => Promise<void>) | null =
 		null;
+	private earlyFlushThreshold: number | undefined;
 
 	constructor(connection: RedisConnection, logger: Logger) {
 		this.connection = connection;
@@ -225,6 +226,9 @@ export class RedisWriteQueue {
 				EX: ttlSeconds,
 			});
 
+			// Fire-and-forget: trigger an early flush if the queue is large
+			this.triggerEarlyFlushIfNeeded();
+
 			return true;
 		} catch (error) {
 			this.logger.warn(() => ({
@@ -283,13 +287,19 @@ export class RedisWriteQueue {
 	/**
 	 * Start periodic background flush of queued records.
 	 * The callback receives this queue instance and should drain + bulk-write records.
+	 *
+	 * When the queue depth exceeds `earlyFlushThreshold`, an early flush is
+	 * triggered on the next `queueSessionRecord` call without waiting for
+	 * the regular interval.
 	 */
 	startPeriodicFlush(
 		callback: (queue: RedisWriteQueue) => Promise<void>,
 		intervalMs = 10000,
+		earlyFlushThreshold = 50,
 	): void {
 		this.stopPeriodicFlush();
 		this.flushCallback = callback;
+		this.earlyFlushThreshold = earlyFlushThreshold;
 		this.flushTimer = setInterval(() => {
 			this.flushCallback?.(this).catch((error) => {
 				this.logger.error(() => ({
@@ -301,6 +311,38 @@ export class RedisWriteQueue {
 	}
 
 	/**
+	 * Trigger an early flush if the pending queue exceeds the threshold.
+	 * Called automatically after queueing a record. This avoids large
+	 * batch build-ups between regular interval flushes.
+	 */
+	private triggerEarlyFlushIfNeeded(): void {
+		if (!this.flushCallback || !this.earlyFlushThreshold) return;
+		this.getPendingCount()
+			.then((count): Promise<void> | void => {
+				if (count >= (this.earlyFlushThreshold ?? 50)) {
+					return this.flushCallback?.(this);
+				}
+			})
+			.catch((error) => {
+				this.logger.error(() => ({
+					msg: "Early flush failed",
+					err: error,
+				}));
+			});
+	}
+
+	/** Get the number of pending session records awaiting flush. */
+	private async getPendingCount(): Promise<number> {
+		const client = await this.getClient();
+		if (!client) return 0;
+		try {
+			return await client.sCard("writeq:session:pending");
+		} catch {
+			return 0;
+		}
+	}
+
+	/**
 	 * Stop the periodic flush timer.
 	 */
 	stopPeriodicFlush(): void {
@@ -309,6 +351,7 @@ export class RedisWriteQueue {
 			this.flushTimer = null;
 		}
 		this.flushCallback = null;
+		this.earlyFlushThreshold = undefined;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- **Provider list caching**: Use `cacheFile` with ETag/Last-Modified for disk persistence across restarts, with automatic fallback if remote is unavailable
- **Parallel frictionless checks**: Run token-reuse and session-dedup lookups concurrently via `Promise.all` instead of sequentially
- **Eliminate redundant session fetch**: Return `countryCode` from `isValidRequest` (session already fetched), removing a second `getSessionRecordBySessionId` call in the image challenge flow
- **Decision machine artifact caching**: In-memory TTL cache (5 min, configurable) with negative caching and parallel dapp+global lookups
- **MongoDB connection pool**: Set `maxPoolSize: 50`, `minPoolSize: 5` (up from default 10)
- **Adaptive write queue flush**: Trigger early Redis→MongoDB flush when queue depth exceeds threshold (default 50 pending records)

## Test plan

- [ ] Verify frictionless flow returns correct session/captcha type for repeat and fresh requests
- [ ] Verify image challenge still returns correct countryCode in commitment records
- [ ] Verify decision machine deny/allow decisions still work correctly
- [ ] Confirm provider list loads from disk cache on restart (check `./provider-list-cache/` directory)
- [ ] Load test to confirm improved latency under concurrent requests
- [ ] Confirm Redis write queue flushes promptly under high write volume

🤖 Generated with [Claude Code](https://claude.com/claude-code)