### PR TITLE
fix(puzzle): invalidate cache on no-session-found + add invisible mode

### DIFF
--- a/.changeset/puzzle-session-cache-and-invisible.md
+++ b/.changeset/puzzle-session-cache-and-invisible.md
@@ -1,0 +1,20 @@
+---
+"@prosopo/provider": patch
+"@prosopo/procaptcha-puzzle": minor
+"@prosopo/client-bundle-example": patch
+---
+
+Fix `/captcha/{type}` endpoints looping with "No session found" when the
+Redis session cache and Mongo diverge: on a session lookup miss the cache
+entry is now invalidated, so the next `/frictionless` falls through and
+creates a fresh session instead of resurrecting the dead one.
+
+Add invisible-mode support to the puzzle captcha widget: the
+execute-event handler now drives the full phase transition
+(`start` → `setChallengeData` → `dragging`), and the puzzle overlay is
+rendered in invisible mode so the user can still solve the (inherently
+interactive) drag challenge — only the checkbox UI is hidden.
+
+Add `invisible-puzzle-implicit.html` / `invisible-puzzle-explicit.html`
+demo pages, and surface both standard and invisible puzzle entries in
+the client-bundle-example navbar.

--- a/demos/client-bundle-example/src/invisible-puzzle-explicit.html
+++ b/demos/client-bundle-example/src/invisible-puzzle-explicit.html
@@ -112,12 +112,11 @@
             const name = document.getElementById('name').value;
             const email = document.getElementById('email').value;
 
-            // Display result
+            // Display result. textContent (not innerHTML) — user-typed values
+            // must not be interpreted as HTML; whitespace preserved via CSS.
             const resultElement = document.getElementById('result');
-            resultElement.innerHTML = `<strong>Form submitted with:</strong><br>
-- Name: ${name}<br>
-- Email: ${email}<br>
-- Procaptcha verified: Yes`;
+            resultElement.textContent = `Form submitted with:\n- Name: ${name}\n- Email: ${email}\n- Procaptcha verified: Yes`;
+            resultElement.style.whiteSpace = 'pre-wrap';
             resultElement.style.display = 'block';
 
             window.updateCaptchaStatus('Form submission completed', 'success');

--- a/demos/client-bundle-example/src/invisible-puzzle-explicit.html
+++ b/demos/client-bundle-example/src/invisible-puzzle-explicit.html
@@ -1,0 +1,162 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <link href="https://cdn.muicss.com/mui-0.10.3/css/mui.min.css" rel="stylesheet" type="text/css"/>
+    <link href="styles/field.css" rel="stylesheet" type="text/css"/>
+
+    <script src="index.js"></script>
+    <title>Procaptcha Invisible Puzzle Mode - Explicit Rendering</title>
+<link href="styles/captcha.css" rel="stylesheet" type="text/css"/>
+    <script type="module">
+        // Function to update CAPTCHA status display is now provided by status-log-injector
+
+        document.addEventListener('DOMContentLoaded', function() {
+
+            updateCaptchaStatus('Page loaded - Initializing CAPTCHA system', 'info');
+
+            // Monitor DOM for CAPTCHA initialization
+            const observer = new MutationObserver((mutations) => {
+                mutations.forEach((mutation) => {
+                    if (mutation.addedNodes.length) {
+                        for (let i = 0; i < mutation.addedNodes.length; i++) {
+                            const node = mutation.addedNodes[i];
+                            if (node.classList && (node.classList.contains('procaptcha') ||
+                                  node.querySelector && node.querySelector('.procaptcha'))) {
+                                updateCaptchaStatus('CAPTCHA DOM elements initialized', 'info');
+                                observer.disconnect();
+                                break;
+                            }
+                        }
+                    }
+                });
+            });
+
+            observer.observe(document.body, { childList: true, subtree: true });
+        });
+
+        // updateCaptchaStatus is now provided by status-log-injector
+    </script>
+</head>
+<body>
+    <div class="mui-container">
+        <h1>Procaptcha Invisible Puzzle Mode - Explicit Rendering</h1>
+        <p>This example demonstrates how to use Procaptcha in invisible Puzzle mode with explicit rendering. The puzzle overlay appears after the form is submitted.</p>
+
+        <!-- CAPTCHA Status Display will be injected by the status-log-injector plugin -->
+
+        <form id="demo-form" class="mui-form">
+            <h2>Example Form</h2>
+
+            <div class="mui-textfield mui-textfield--float-label">
+                <label for="name">Name</label>
+                <input type="text" id="name" name="name" required />
+            </div>
+
+            <div class="mui-textfield mui-textfield--float-label">
+                <label for="email">Email</label>
+                <input type="email" id="email" name="email" required />
+            </div>
+
+            <!-- The container for the CAPTCHA -->
+            <div id="procaptcha-container"></div>
+
+            <button type="submit" class="mui-btn mui-btn--raised">Submit</button>
+
+            <div id="error"></div>
+        </form>
+
+        <div id="result" class="info-box" style="display: none;"></div>
+
+        <!-- Console output display area -->
+        <div id="console-output" class="console-output" style="display: none;"></div>
+
+        <!-- Explanation will be injected by the explanation-injector plugin -->
+    </div>
+
+    <script type="module">
+        import { render, execute } from "%VITE_BUNDLE_URL%"
+
+        // Form validation function
+        function validateForm() {
+            const nameInput = document.getElementById('name');
+            const emailInput = document.getElementById('email');
+            const errorDisplay = document.getElementById('error');
+
+            if (!nameInput.value || !emailInput.value) {
+                errorDisplay.textContent = 'Please fill out all fields';
+                errorDisplay.style.display = 'block';
+                window.updateCaptchaStatus('Form validation failed: Empty fields', 'error');
+                return false;
+            }
+
+            // Basic email validation
+            const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+            if (!emailPattern.test(emailInput.value)) {
+                errorDisplay.textContent = 'Please enter a valid email address';
+                errorDisplay.style.display = 'block';
+                window.updateCaptchaStatus('Form validation failed: Invalid email format', 'error');
+                return false;
+            }
+
+            errorDisplay.style.display = 'none';
+            window.updateCaptchaStatus('Form validation passed', 'info');
+            return true;
+        }
+
+        // Callback for successful CAPTCHA verification
+        function handleCaptchaResponse(token) {
+            console.log('Procaptcha verified, token:', token);
+            window.updateCaptchaStatus('Challenge passed successfully!', 'success');
+            window.updateCaptchaStatus(`Token generated: ${token.substring(0, 15)}...`, 'success');
+
+            const name = document.getElementById('name').value;
+            const email = document.getElementById('email').value;
+
+            // Display result
+            const resultElement = document.getElementById('result');
+            resultElement.innerHTML = `<strong>Form submitted with:</strong><br>
+- Name: ${name}<br>
+- Email: ${email}<br>
+- Procaptcha verified: Yes`;
+            resultElement.style.display = 'block';
+
+            window.updateCaptchaStatus('Form submission completed', 'success');
+        }
+
+        // Callback for failed CAPTCHA verification
+        function handleCaptchaFailed() {
+            console.log('Captcha verification failed');
+            window.updateCaptchaStatus('Challenge failed - CAPTCHA verification could not be completed', 'error');
+            document.getElementById('error').textContent = 'CAPTCHA verification failed. Please try again.';
+            document.getElementById('error').style.display = 'block';
+        }
+
+        // Wait for DOM content to be loaded
+        document.addEventListener('DOMContentLoaded', function() {
+            window.updateCaptchaStatus('Initializing CAPTCHA with explicit render call', 'info');
+
+            // Render the CAPTCHA
+            const widgetId = render(document.getElementById('procaptcha-container'), {
+                siteKey: import.meta.env.PROSOPO_SITE_KEY_PUZZLE,
+                captchaType: "puzzle",
+                callback: handleCaptchaResponse,
+                "failed-callback": handleCaptchaFailed,
+                size: "invisible"
+            });
+
+            window.updateCaptchaStatus('CAPTCHA render function called with widget ID: ' + widgetId, 'info');
+
+            // Add form submit handler
+            document.getElementById('demo-form').addEventListener('submit', function(e) {
+                e.preventDefault();
+                window.updateCaptchaStatus('Form submission attempted', 'info');
+                if (validateForm()) {
+                    // Form is valid, CAPTCHA verification will be handled by the callback
+                    window.updateCaptchaStatus('Waiting for CAPTCHA verification', 'info');
+                    execute();
+                }
+            });
+        });
+    </script>
+</body>
+</html>

--- a/demos/client-bundle-example/src/invisible-puzzle-implicit.html
+++ b/demos/client-bundle-example/src/invisible-puzzle-implicit.html
@@ -50,10 +50,10 @@
 
             const resultElement = document.getElementById('result');
             if (resultElement) {
-                resultElement.innerHTML = `<strong>Form submitted with:</strong><br>
-- Name: ${name}<br>
-- Email: ${email}<br>
-- Procaptcha verified: Yes`;
+                // textContent (not innerHTML) — user-typed values must not be
+                // interpreted as HTML; whitespace preserved via CSS below.
+                resultElement.textContent = `Form submitted with:\n- Name: ${name}\n- Email: ${email}\n- Procaptcha verified: Yes`;
+                resultElement.style.whiteSpace = 'pre-wrap';
                 resultElement.style.display = 'block';
             }
 

--- a/demos/client-bundle-example/src/invisible-puzzle-implicit.html
+++ b/demos/client-bundle-example/src/invisible-puzzle-implicit.html
@@ -1,0 +1,106 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <link href="https://cdn.muicss.com/mui-0.10.3/css/mui.min.css" rel="stylesheet" type="text/css"/>
+    <link href="styles/field.css" rel="stylesheet" type="text/css"/>
+
+    <script src="index.js"></script>
+    <title>Procaptcha Invisible Puzzle Mode - Implicit Rendering</title>
+<link href="styles/captcha.css" rel="stylesheet" type="text/css"/>
+    <script type="module">
+        // Function to update CAPTCHA status display is now provided by status-log-injector
+
+        document.addEventListener('DOMContentLoaded', function() {
+            updateCaptchaStatus('Page loaded - Initializing CAPTCHA system', 'info');
+
+            // Monitor DOM for CAPTCHA initialization
+            const observer = new MutationObserver((mutations) => {
+                mutations.forEach((mutation) => {
+                    if (mutation.addedNodes.length) {
+                        for (let i = 0; i < mutation.addedNodes.length; i++) {
+                            const node = mutation.addedNodes[i];
+                            if (node.classList && (node.classList.contains('procaptcha') ||
+                                  node.querySelector && node.querySelector('.procaptcha'))) {
+                                updateCaptchaStatus('CAPTCHA DOM elements initialized', 'info');
+                                observer.disconnect();
+                                break;
+                            }
+                        }
+                    }
+                });
+            });
+
+            observer.observe(document.body, { childList: true, subtree: true });
+        });
+
+        // Create a method to show CAPTCHA execution events
+        document.addEventListener('procaptcha:execute', function(e) {
+            updateCaptchaStatus(`CAPTCHA execution started: type=puzzle, mode=invisible`, 'info');
+            updateCaptchaStatus(`Container: ${e.detail.containerId}, timestamp: ${new Date(e.detail.timestamp).toLocaleTimeString()}`, 'info');
+        });
+
+        window.onSubmit = function(token) {
+            console.log('Procaptcha verified, token: ' + token);
+            updateCaptchaStatus('Challenge passed successfully!', 'success');
+            updateCaptchaStatus(`Token generated: ${token.substring(0, 15)}...`, 'success');
+
+            // Get form values
+            const name = document.getElementById('name').value;
+            const email = document.getElementById('email').value;
+
+            const resultElement = document.getElementById('result');
+            if (resultElement) {
+                resultElement.innerHTML = `<strong>Form submitted with:</strong><br>
+- Name: ${name}<br>
+- Email: ${email}<br>
+- Procaptcha verified: Yes`;
+                resultElement.style.display = 'block';
+            }
+
+            updateCaptchaStatus('Form submission completed', 'success');
+
+            // Prevent actual form submission
+            return false;
+        }
+    </script>
+    <!-- Load the Procaptcha script -->
+    <script type="module" src="%VITE_BUNDLE_URL%" async defer></script>
+</head>
+<body>
+    <div class="mui-container">
+        <h1>Invisible Puzzle CAPTCHA - Implicit Rendering</h1>
+        <p>This example demonstrates how to use Procaptcha in invisible Puzzle mode with implicit rendering directly on a button. The puzzle overlay appears when the button is clicked.</p>
+
+        <!-- CAPTCHA Status Display will be injected by the status-log-injector plugin -->
+
+        <form id="demo-form" action="javascript:void(0);" method="POST" class="mui-form">
+            <h2>Example Form</h2>
+            <div class="mui-textfield mui-textfield--float-label">
+                <label for="name">Name</label>
+                <input type="text" id="name" name="name" required />
+            </div>
+
+            <div class="mui-textfield mui-textfield--float-label">
+                <label for="email">Email</label>
+                <input type="email" id="email" name="email" required />
+            </div>
+
+            <!-- Submit button with Procaptcha attributes -->
+            <button
+                class="mui-btn mui-btn--raised procaptcha"
+                data-sitekey="%PROSOPO_SITE_KEY_PUZZLE%"
+                data-callback="onSubmit"
+                data-size="invisible">
+                Submit
+            </button>
+        </form>
+
+        <div id="result" class="info-box" style="display: none;"></div>
+
+        <!-- Console output display area -->
+        <div id="console-output" class="console-output" style="display: none;"></div>
+
+        <!-- Explanation will be injected by the explanation-injector plugin -->
+    </div>
+</body>
+</html>

--- a/demos/client-bundle-example/src/plugins/navigation-injector.ts
+++ b/demos/client-bundle-example/src/plugins/navigation-injector.ts
@@ -48,9 +48,10 @@ export default function navigationInjector(): Plugin {
 				implicit: { path: "frictionless-implicit.html", exists: true },
 				explicit: { path: "frictionless-explicit.html", exists: true },
 			},
-			// puzzle pages exist (puzzle-implicit.html, puzzle-explicit.html) and
-			// are reachable via direct URL, but intentionally hidden from the
-			// navbar while the puzzle captcha is in beta.
+			puzzle: {
+				implicit: { path: "puzzle-implicit.html", exists: true },
+				explicit: { path: "puzzle-explicit.html", exists: true },
+			},
 		},
 		invisible: {
 			image: {
@@ -70,6 +71,10 @@ export default function navigationInjector(): Plugin {
 					path: "invisible-frictionless-explicit.html",
 					exists: true,
 				},
+			},
+			puzzle: {
+				implicit: { path: "invisible-puzzle-implicit.html", exists: true },
+				explicit: { path: "invisible-puzzle-explicit.html", exists: true },
 			},
 		},
 	};

--- a/packages/procaptcha-puzzle/src/components/ProcaptchaWidget.tsx
+++ b/packages/procaptcha-puzzle/src/components/ProcaptchaWidget.tsx
@@ -84,15 +84,27 @@ const Procaptcha = (props: ProcaptchaProps) => {
 	useEffect(() => {
 		// Only set up event listener if in invisible mode
 		if (config.mode === ModeEnum.invisible) {
-			// Event handler for when execute() is called
-			const handleExecuteEvent = () => {
-				// Directly start the verification process without showing any UI
+			// Event handler for when execute() is called: fetch a challenge
+			// then drive the puzzle UI through the same phase transitions as
+			// the visible checkbox flow.
+			const handleExecuteEvent = async () => {
+				if (loading) {
+					return;
+				}
+				setLoading(true);
+				setShowRetry(false);
 				try {
-					manager.current.start();
+					const challenge = await manager.current.start();
+					if (challenge) {
+						setChallengeData(challenge);
+						setPuzzlePhase("dragging");
+					}
 				} catch (error) {
 					callbacks.onError?.(
 						error instanceof Error ? error : new Error(String(error)),
 					);
+				} finally {
+					setLoading(false);
 				}
 			};
 
@@ -109,7 +121,7 @@ const Procaptcha = (props: ProcaptchaProps) => {
 
 		// Return empty cleanup function when not in invisible mode
 		return () => {};
-	}, [config.mode, callbacks.onError]);
+	}, [config.mode, callbacks.onError, loading]);
 
 	const handlePuzzleComplete = useCallback(
 		async (finalX: number, finalY: number, puzzleEvents: PuzzleEvent[]) => {
@@ -159,52 +171,56 @@ const Procaptcha = (props: ProcaptchaProps) => {
 		[callbacks.onError],
 	);
 
-	if (config.mode === ModeEnum.invisible) {
-		// Return null for invisible mode - no UI needed
-		return null;
-	}
+	const isInvisible = config.mode === ModeEnum.invisible;
+	const showPuzzleOverlay =
+		(puzzlePhase === "dragging" || puzzlePhase === "submitting") &&
+		challengeData;
 
 	return (
 		<>
-			{/* Puzzle overlay — rendered outside the shadow DOM flow via fixed positioning */}
-			{(puzzlePhase === "dragging" || puzzlePhase === "submitting") &&
-				challengeData && (
-					<PuzzleCanvas
-						originX={challengeData.originX}
-						originY={challengeData.originY}
-						targetX={challengeData.targetX}
-						targetY={challengeData.targetY}
-						onComplete={handlePuzzleComplete}
-						showRetry={showRetry}
-						submitting={puzzlePhase === "submitting"}
-					/>
-				)}
+			{/* Puzzle overlay — rendered outside the shadow DOM flow via fixed
+			    positioning. Shown in both visible and invisible modes once a
+			    challenge has been fetched; puzzle is inherently interactive. */}
+			{showPuzzleOverlay && (
+				<PuzzleCanvas
+					originX={challengeData.originX}
+					originY={challengeData.originY}
+					targetX={challengeData.targetX}
+					targetY={challengeData.targetY}
+					onComplete={handlePuzzleComplete}
+					showRetry={showRetry}
+					submitting={puzzlePhase === "submitting"}
+				/>
+			)}
 
-			{/* Checkbox — always rendered so transitions are smooth */}
-			<Checkbox
-				checked={state.isHuman}
-				theme={theme}
-				onChange={async (_event: React.MouseEvent | React.TouchEvent) => {
-					if (loading) {
-						return;
-					}
-					setLoading(true);
-					setShowRetry(false);
+			{/* Checkbox — only in visible mode. Invisible mode is driven by
+			    the host page's execute() call (e.g. on form submit). */}
+			{!isInvisible && (
+				<Checkbox
+					checked={state.isHuman}
+					theme={theme}
+					onChange={async (_event: React.MouseEvent | React.TouchEvent) => {
+						if (loading) {
+							return;
+						}
+						setLoading(true);
+						setShowRetry(false);
 
-					const challenge = await manager.current.start();
+						const challenge = await manager.current.start();
 
-					if (challenge) {
-						setChallengeData(challenge);
-						setPuzzlePhase("dragging");
-					}
+						if (challenge) {
+							setChallengeData(challenge);
+							setPuzzlePhase("dragging");
+						}
 
-					setLoading(false);
-				}}
-				labelText={isTranslationReady ? t("WIDGET.I_AM_HUMAN") : ""}
-				error={state.error?.message}
-				aria-label="human checkbox"
-				loading={loading || puzzlePhase === "submitting"}
-			/>
+						setLoading(false);
+					}}
+					labelText={isTranslationReady ? t("WIDGET.I_AM_HUMAN") : ""}
+					error={state.error?.message}
+					aria-label="human checkbox"
+					loading={loading || puzzlePhase === "submitting"}
+				/>
+			)}
 		</>
 	);
 };

--- a/packages/provider/src/tasks/captchaManager.ts
+++ b/packages/provider/src/tasks/captchaManager.ts
@@ -148,6 +148,14 @@ export class CaptchaManager {
 						sessionId: sessionId,
 					},
 				}));
+				// DB and cache have drifted (e.g. cache outlived the DB
+				// record, or Mongo was dropped while Redis kept the entry).
+				// Without this, the hash → sessionId mapping keeps resolving
+				// and /frictionless keeps "Reusing existing session" →
+				// /captcha/* keeps failing in an infinite loop.
+				if (this.writeQueue) {
+					this.writeQueue.invalidateCachedSession(sessionId).catch(() => {});
+				}
 				return {
 					valid: false,
 					reason: "CAPTCHA.NO_SESSION_FOUND",

--- a/packages/provider/src/tests/unit/tasks/captchaManager.unit.test.ts
+++ b/packages/provider/src/tests/unit/tasks/captchaManager.unit.test.ts
@@ -232,7 +232,7 @@ describe("CaptchaManager", () => {
 				"sessionId",
 			);
 		});
-		it("should not invalidate Redis cache when session is not found", async () => {
+		it("should invalidate Redis cache when session is not found, to break stale-cache loops", async () => {
 			// biome-ignore lint/suspicious/noExplicitAny: tests
 			(db.checkAndRemoveSession as any).mockResolvedValue(undefined);
 
@@ -250,7 +250,13 @@ describe("CaptchaManager", () => {
 				"sessionId",
 			);
 
-			expect(mockWriteQueue.invalidateCachedSession).not.toHaveBeenCalled();
+			// When DB has no record but Redis cache does, the cache must be
+			// invalidated; otherwise the user-IP-hash mapping keeps resolving
+			// to the dead sessionId and /frictionless keeps "Reusing existing
+			// session" while /captcha/{type} keeps 400-ing in a loop.
+			expect(mockWriteQueue.invalidateCachedSession).toHaveBeenCalledWith(
+				"sessionId",
+			);
 		});
 		it("should not throw when writeQueue is null and session is consumed", async () => {
 			const managerWithoutRedis = new CaptchaManager(


### PR DESCRIPTION
## Summary

- **Fix session-cache divergence loop.** When `/captcha/{type}` fails to find a session in Mongo it now invalidates the matching Redis `cache:session:{id}` entry. Without this, the `userSitekeyIpHash → sessionId` mapping kept resurrecting the dead session on every `/frictionless` call, causing repeated 400 "No session found" responses. Spotted because the puzzle widget surfaced it most visibly — the cache and DB had drifted (e.g. Mongo dropped while Redis persisted), and the widget got stuck in a `/frictionless` → reuse → `/puzzle` → 400 → restart loop.

- **Invisible-mode support for the puzzle widget.** The execute-event handler now drives the full phase transition (`start` → `setChallengeData` → `dragging`) instead of firing `start()` and dropping the result. The widget no longer returns `null` for invisible mode — the `PuzzleCanvas` overlay still renders when a challenge is set (the drag is inherently interactive), only the checkbox UI is hidden.

- **Demo + navbar.** New `invisible-puzzle-{implicit,explicit}.html`. Surface the existing `puzzle-{implicit,explicit}.html` pages in the standard nav (they previously existed but were hidden behind a "beta" comment) and add the new invisible variants too.

## Test plan

- [ ] Local: drop Mongo while Redis is up, reload `puzzle-explicit.html` — should self-heal on first request instead of looping
- [ ] `npm run -w @prosopo/provider test:unit`
- [ ] `npm run -w @prosopo/provider test:integration` (passes session-cache existing scenarios)
- [ ] Manually exercise `invisible-puzzle-implicit.html` and `invisible-puzzle-explicit.html` — clicking Submit reveals the puzzle overlay

🤖 Generated with [Claude Code](https://claude.com/claude-code)