### PR TITLE
chore: remove obsolete captchaType render option from bundle demos

### DIFF
--- a/.changeset/remove-demo-captchatype-prop.md
+++ b/.changeset/remove-demo-captchatype-prop.md
@@ -1,0 +1,6 @@
+---
+"@prosopo/client-bundle-example": patch
+---
+
+Remove the obsolete `captchaType` render option from the client-bundle-example
+demos; captcha type is now server-driven per site key, so the prop was a no-op.

--- a/demos/client-bundle-example/src/frictionless-explicit-web3.html
+++ b/demos/client-bundle-example/src/frictionless-explicit-web3.html
@@ -234,7 +234,6 @@
             // Render the CAPTCHA
             const widgetId = render(captchaContainer, {
                 siteKey: import.meta.env.PROSOPO_SITE_KEY_FRICTIONLESS,
-                captchaType: "frictionless",
                 callback: onCaptchaVerified,
                 "failed-callback": function () {
                     console.log('Challenge failed');

--- a/demos/client-bundle-example/src/frictionless-explicit.html
+++ b/demos/client-bundle-example/src/frictionless-explicit.html
@@ -196,7 +196,6 @@
     // Render the CAPTCHA
     const widgetId = render(captchaContainer, {
         siteKey: import.meta.env.PROSOPO_SITE_KEY_FRICTIONLESS,
-        captchaType: "frictionless",
         callback: onCaptchaVerified,
         "failed-callback": function () {
             console.log('Challenge failed');

--- a/demos/client-bundle-example/src/frictionless-implicit.html
+++ b/demos/client-bundle-example/src/frictionless-implicit.html
@@ -203,7 +203,6 @@
         // Render the CAPTCHA
         const widgetId = render(captchaContainer, {
             siteKey: import.meta.env.PROSOPO_SITE_KEY_FRICTIONLESS,
-            captchaType: "frictionless",
             callback: onCaptchaVerified,
             "failed-callback": function () {
                 console.log('Challenge failed');

--- a/demos/client-bundle-example/src/image-explicit-web3.html
+++ b/demos/client-bundle-example/src/image-explicit-web3.html
@@ -175,7 +175,6 @@
 
             const widgetId = render(document.getElementById('procaptcha-container'), {
                 siteKey: import.meta.env.PROSOPO_SITE_KEY_IMAGE,
-                captchaType: "image",
                 callback: handleCaptchaResponse,
                 "failed-callback": handleCaptchaFailed,
                 web3:true,

--- a/demos/client-bundle-example/src/image-explicit.html
+++ b/demos/client-bundle-example/src/image-explicit.html
@@ -137,7 +137,6 @@
             // Render the CAPTCHA
             const widgetId = render(document.getElementById('procaptcha-container'), {
                 siteKey: import.meta.env.PROSOPO_SITE_KEY_IMAGE,
-                captchaType: "image",
                 callback: handleCaptchaResponse,
                 "failed-callback": handleCaptchaFailed
             });

--- a/demos/client-bundle-example/src/invisible-frictionless-explicit.html
+++ b/demos/client-bundle-example/src/invisible-frictionless-explicit.html
@@ -108,7 +108,6 @@
             // Render the CAPTCHA
             const widgetId = render(document.getElementById('procaptcha-container'), {
                 siteKey: import.meta.env.PROSOPO_SITE_KEY_FRICTIONLESS,
-                captchaType: "frictionless",
                 callback: handleCaptchaResponse,
                 "failed-callback": handleCaptchaFailed,
                 size: "invisible"

--- a/demos/client-bundle-example/src/invisible-image-explicit.html
+++ b/demos/client-bundle-example/src/invisible-image-explicit.html
@@ -138,7 +138,6 @@
             // Render the CAPTCHA
             const widgetId = render(document.getElementById('procaptcha-container'), {
                 siteKey: import.meta.env.PROSOPO_SITE_KEY_IMAGE,
-                captchaType: "image",
                 callback: handleCaptchaResponse,
                 "failed-callback": handleCaptchaFailed,
                 size: "invisible"

--- a/demos/client-bundle-example/src/invisible-pow-explicit.html
+++ b/demos/client-bundle-example/src/invisible-pow-explicit.html
@@ -138,7 +138,6 @@
             // Render the CAPTCHA
             const widgetId = render(document.getElementById('procaptcha-container'), {
                 siteKey: import.meta.env.PROSOPO_SITE_KEY_POW,
-                captchaType: "pow",
                 callback: handleCaptchaResponse,
                 "failed-callback": handleCaptchaFailed,
                 size: "invisible"

--- a/demos/client-bundle-example/src/invisible-puzzle-explicit.html
+++ b/demos/client-bundle-example/src/invisible-puzzle-explicit.html
@@ -137,7 +137,6 @@
             // Render the CAPTCHA
             const widgetId = render(document.getElementById('procaptcha-container'), {
                 siteKey: import.meta.env.PROSOPO_SITE_KEY_PUZZLE,
-                captchaType: "puzzle",
                 callback: handleCaptchaResponse,
                 "failed-callback": handleCaptchaFailed,
                 size: "invisible"

--- a/demos/client-bundle-example/src/pow-explicit-web3.html
+++ b/demos/client-bundle-example/src/pow-explicit-web3.html
@@ -172,7 +172,6 @@
             window.updateCaptchaStatus(`Rendering the CAPTCHA for account ${account}`, 'info');
             const widgetId = render(document.getElementById('procaptcha-container'), {
                 siteKey: import.meta.env.PROSOPO_SITE_KEY_POW,
-                captchaType: "pow",
                 callback: handleCaptchaResponse,
                 "failed-callback": handleCaptchaFailed,
                 web3:true,

--- a/demos/client-bundle-example/src/pow-explicit.html
+++ b/demos/client-bundle-example/src/pow-explicit.html
@@ -137,7 +137,6 @@
             // Render the CAPTCHA
             const widgetId = render(document.getElementById('procaptcha-container'), {
                 siteKey: import.meta.env.PROSOPO_SITE_KEY_POW,
-                captchaType: "pow",
                 callback: handleCaptchaResponse,
                 "failed-callback": handleCaptchaFailed
             });

--- a/demos/client-bundle-example/src/puzzle-explicit.html
+++ b/demos/client-bundle-example/src/puzzle-explicit.html
@@ -137,7 +137,6 @@
             // Render the CAPTCHA
             const widgetId = render(document.getElementById('procaptcha-container'), {
                 siteKey: import.meta.env.PROSOPO_SITE_KEY_PUZZLE,
-                captchaType: "puzzle",
                 callback: handleCaptchaResponse,
                 "failed-callback": handleCaptchaFailed
             });


### PR DESCRIPTION
Removes the no-op `captchaType` render option from the client-bundle-example demos, since captcha type is now server-driven per site key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)