### PR TITLE
fix/2556 reload button in image captcha mode loads a new challenge

### DIFF
--- a/.changeset/reload-image-captcha-fetches-new-challenge.md
+++ b/.changeset/reload-image-captcha-fetches-new-challenge.md
@@ -1,0 +1,15 @@
+---
+"@prosopo/procaptcha": patch
+---
+
+fix/2556 reload button in image captcha mode now loads a fresh challenge
+in place instead of closing the modal.
+
+Previously `Manager.reload` called `resetState(frictionlessState?.restart)`,
+which unmounted the underlying widget via the frictionless `key`-driven
+restart hook (bundle path) and synchronously set `showModal: false` on the
+direct path. In both cases the visible result was the same: the modal
+disappeared and the user was bounced back to the checkbox. `reload` now
+fires the `onReload` event, clears the challenge timeout, ensures
+`loading` is false so `start()` won't no-op, and calls `start()` to fetch
+a new image captcha against the existing frictionless session (if any).

--- a/package-lock.json
+++ b/package-lock.json
@@ -36445,11 +36445,13 @@
 			},
 			"devDependencies": {
 				"@prosopo/config": "3.3.1",
+				"@types/jsdom": "21.1.7",
 				"@types/node": "22.10.2",
 				"@vitest/coverage-v8": "3.2.4",
 				"concurrently": "9.0.1",
 				"del-cli": "6.0.0",
 				"dotenv": "16.4.5",
+				"jsdom": "25.0.0",
 				"npm-run-all": "4.1.5",
 				"tslib": "2.7.0",
 				"tsx": "4.20.3",
@@ -36473,9 +36475,6 @@
 				"@prosopo/locale": "3.2.1",
 				"@prosopo/procaptcha-common": "2.10.5",
 				"@prosopo/procaptcha-frictionless": "2.8.62",
-				"@prosopo/procaptcha-pow": "2.8.55",
-				"@prosopo/procaptcha-puzzle": "2.8.45",
-				"@prosopo/procaptcha-react": "2.9.54",
 				"@prosopo/types": "3.16.1",
 				"@prosopo/util": "3.2.11",
 				"@prosopo/widget-skeleton": "2.8.1",
@@ -36984,6 +36983,90 @@
 			},
 			"funding": {
 				"url": "https://dotenvx.com"
+			}
+		},
+		"packages/procaptcha/node_modules/jsdom": {
+			"version": "25.0.0",
+			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.0.tgz",
+			"integrity": "sha512-OhoFVT59T7aEq75TVw9xxEfkXgacpqAhQaYgP9y/fDqWQCMB/b1H66RfmPm/MaeaAIU9nDwMOVTlPN51+ao6CQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"cssstyle": "^4.0.1",
+				"data-urls": "^5.0.0",
+				"decimal.js": "^10.4.3",
+				"form-data": "^4.0.0",
+				"html-encoding-sniffer": "^4.0.0",
+				"http-proxy-agent": "^7.0.2",
+				"https-proxy-agent": "^7.0.5",
+				"is-potential-custom-element-name": "^1.0.1",
+				"nwsapi": "^2.2.12",
+				"parse5": "^7.1.2",
+				"rrweb-cssom": "^0.7.1",
+				"saxes": "^6.0.0",
+				"symbol-tree": "^3.2.4",
+				"tough-cookie": "^4.1.4",
+				"w3c-xmlserializer": "^5.0.0",
+				"webidl-conversions": "^7.0.0",
+				"whatwg-encoding": "^3.1.1",
+				"whatwg-mimetype": "^4.0.0",
+				"whatwg-url": "^14.0.0",
+				"ws": "^8.18.0",
+				"xml-name-validator": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"canvas": "^2.11.2"
+			},
+			"peerDependenciesMeta": {
+				"canvas": {
+					"optional": true
+				}
+			}
+		},
+		"packages/procaptcha/node_modules/punycode": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+			"integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"packages/procaptcha/node_modules/rrweb-cssom": {
+			"version": "0.7.1",
+			"resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+			"integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"packages/procaptcha/node_modules/tough-cookie": {
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+			"integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"psl": "^1.1.33",
+				"punycode": "^2.1.1",
+				"universalify": "^0.2.0",
+				"url-parse": "^1.5.3"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"packages/procaptcha/node_modules/universalify": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+			"integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4.0.0"
 			}
 		},
 		"packages/provider": {

--- a/packages/procaptcha/package.json
+++ b/packages/procaptcha/package.json
@@ -16,7 +16,9 @@
 		"build:cross-env": "vite build --config vite.esm.config.ts",
 		"build:tsc": "tsc --build --verbose",
 		"build:cjs": "NODE_ENV=${NODE_ENV:-development}; vite build --config vite.cjs.config.ts --mode $NODE_ENV",
-		"typecheck": "tsc --project tsconfig.types.json"
+		"typecheck": "tsc --project tsconfig.types.json",
+		"test": "NODE_ENV=${NODE_ENV:-test}; npx vitest run --config ./vite.test.config.ts",
+		"test:watch": "NODE_ENV=${NODE_ENV:-test}; npx vitest --config ./vite.test.config.ts"
 	},
 	"exports": {
 		".": {
@@ -43,11 +45,13 @@
 	},
 	"devDependencies": {
 		"@prosopo/config": "3.3.1",
+		"@types/jsdom": "21.1.7",
 		"@types/node": "22.10.2",
 		"@vitest/coverage-v8": "3.2.4",
 		"concurrently": "9.0.1",
 		"del-cli": "6.0.0",
 		"dotenv": "16.4.5",
+		"jsdom": "25.0.0",
 		"npm-run-all": "4.1.5",
 		"tslib": "2.7.0",
 		"tsx": "4.20.3",

--- a/packages/procaptcha/src/modules/Manager.ts
+++ b/packages/procaptcha/src/modules/Manager.ts
@@ -380,14 +380,12 @@ export function Manager(
 	const reload = async () => {
 		// disable the time limit
 		clearTimeout();
-		// trigger the onClose event
+		// trigger the onReload event
 		events.onReload();
-		// abandon the captcha process and restart frictionless, if it exists
-		resetState(frictionlessState?.restart);
-		if (!frictionlessState?.restart) {
-			// start the captcha process again unless we need a new session
-			await start();
-		}
+		// ensure start() will proceed and load a fresh challenge in place,
+		// keeping the modal open and the frictionless session (if any) intact
+		updateState({ loading: false });
+		await start();
 	};
 
 	/**

--- a/packages/procaptcha/src/tests/Manager.test.ts
+++ b/packages/procaptcha/src/tests/Manager.test.ts
@@ -1,0 +1,223 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type {
+	Account,
+	CaptchaResponseBody,
+	FrictionlessState,
+	ProcaptchaClientConfigOutput,
+	ProcaptchaState,
+	RandomProvider,
+} from "@prosopo/types";
+import { EnvironmentTypesSchema } from "@prosopo/types";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// providerRetry is responsible for invoking `currentFn` (the async body of start())
+// and handling its retry semantics. The reload bug under test is about *whether*
+// start is invoked at all, not about start's own internal behavior, so we replace
+// providerRetry with a passthrough that simply records the call.
+const providerRetryMock = vi.fn(
+	async (currentFn: () => Promise<void>) => {
+		// swallow currentFn errors so unmocked network code doesn't crash the test
+		try {
+			await currentFn();
+		} catch {
+			// intentionally ignored - we only assert that start() was triggered
+		}
+	},
+);
+
+vi.mock("@prosopo/procaptcha-common", async () => {
+	const actual =
+		await vi.importActual<typeof import("@prosopo/procaptcha-common")>(
+			"@prosopo/procaptcha-common",
+		);
+	return {
+		...actual,
+		providerRetry: providerRetryMock,
+	};
+});
+
+const buildConfig = (): ProcaptchaClientConfigOutput =>
+	({
+		account: { address: "test-dapp-address" },
+		userAccountAddress: "",
+		web2: true,
+		defaultEnvironment: EnvironmentTypesSchema.enum.development,
+		captchas: {
+			image: { challengeTimeout: 60_000, solutionTimeout: 60_000 },
+		},
+		theme: "light",
+		mode: "default",
+	}) as unknown as ProcaptchaClientConfigOutput;
+
+const mockChallenge = (): CaptchaResponseBody =>
+	({
+		captchas: [
+			{
+				captchaId: "cap-1",
+				captchaContentId: "content-1",
+				datasetId: "dataset-1",
+				items: [],
+				target: "select all",
+				timeLimitMs: 60_000,
+			},
+		],
+		requestHash: "req-hash",
+		timestamp: `${Date.now()}`,
+		signature: { provider: { requestHash: "req-hash-sig" } },
+	}) as unknown as CaptchaResponseBody;
+
+const buildInitialState = (
+	overrides: Partial<ProcaptchaState> = {},
+): ProcaptchaState => ({
+	isHuman: false,
+	index: 0,
+	solutions: [],
+	captchaApi: undefined,
+	showModal: true,
+	challenge: mockChallenge(),
+	loading: false,
+	account: undefined,
+	dappAccount: undefined,
+	submission: undefined,
+	timeout: undefined,
+	successfullChallengeTimeout: undefined,
+	sendData: false,
+	attemptCount: 1,
+	error: undefined,
+	sessionId: undefined,
+	...overrides,
+});
+
+const buildFrictionlessState = (): FrictionlessState => ({
+	provider: {
+		provider: { url: "https://provider.test" },
+	} as unknown as RandomProvider,
+	userAccount: {
+		account: { address: "frictionless-user", meta: { source: "" } },
+	} as unknown as Account,
+	restart: vi.fn(),
+	sessionId: "session-123",
+});
+
+describe("Manager.reload", () => {
+	beforeEach(() => {
+		providerRetryMock.mockClear();
+	});
+
+	it("fires the onReload event", async () => {
+		const { Manager } = await import("../modules/Manager.js");
+		const onReload = vi.fn();
+
+		const manager = Manager(
+			buildConfig(),
+			buildInitialState(),
+			vi.fn(),
+			{ onReload },
+		);
+
+		await manager.reload();
+
+		expect(onReload).toHaveBeenCalledTimes(1);
+	});
+
+	it("invokes start() to load a new challenge", async () => {
+		const { Manager } = await import("../modules/Manager.js");
+		const onOpen = vi.fn();
+
+		const manager = Manager(
+			buildConfig(),
+			buildInitialState(),
+			vi.fn(),
+			{ onOpen },
+		);
+
+		await manager.reload();
+
+		// start() fires onOpen before delegating to providerRetry
+		expect(onOpen).toHaveBeenCalledTimes(1);
+		// providerRetry was invoked, i.e. start() proceeded past its loading guard
+		expect(providerRetryMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("does NOT invoke frictionlessState.restart (keeps the modal open)", async () => {
+		const { Manager } = await import("../modules/Manager.js");
+		const frictionlessState = buildFrictionlessState();
+
+		const manager = Manager(
+			buildConfig(),
+			buildInitialState(),
+			vi.fn(),
+			{},
+			frictionlessState,
+		);
+
+		await manager.reload();
+
+		expect(frictionlessState.restart).not.toHaveBeenCalled();
+	});
+
+	it("does not close the modal during reload (showModal stays true)", async () => {
+		const { Manager } = await import("../modules/Manager.js");
+		const onStateUpdate = vi.fn();
+		const state = buildInitialState({ showModal: true });
+
+		const manager = Manager(buildConfig(), state, onStateUpdate, {});
+
+		await manager.reload();
+
+		// no update should explicitly set showModal to false during reload itself
+		const closingUpdate = onStateUpdate.mock.calls.find(
+			([next]) => next.showModal === false,
+		);
+		expect(closingUpdate).toBeUndefined();
+	});
+
+	it("clears the active challenge timeout", async () => {
+		const { Manager } = await import("../modules/Manager.js");
+		const clearTimeoutSpy = vi.spyOn(window, "clearTimeout");
+		const existingTimeout = setTimeout(() => {}, 999_999);
+		const state = buildInitialState({ timeout: existingTimeout });
+
+		const manager = Manager(buildConfig(), state, vi.fn(), {});
+
+		await manager.reload();
+
+		expect(clearTimeoutSpy).toHaveBeenCalled();
+
+		clearTimeoutSpy.mockRestore();
+		clearTimeout(existingTimeout);
+	});
+
+	it("ensures loading is reset so start() proceeds even if previously loading", async () => {
+		const { Manager } = await import("../modules/Manager.js");
+		const onOpen = vi.fn();
+		const onStateUpdate = vi.fn();
+		const state = buildInitialState({ loading: true });
+
+		const manager = Manager(buildConfig(), state, onStateUpdate, { onOpen });
+
+		await manager.reload();
+
+		// loading was reset to false before start() was triggered
+		const loadingResetCall = onStateUpdate.mock.calls.find(
+			([next]) => next.loading === false,
+		);
+		expect(loadingResetCall).toBeDefined();
+		// start() proceeded past the loading guard
+		expect(onOpen).toHaveBeenCalledTimes(1);
+		expect(providerRetryMock).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/procaptcha/vite.test.config.ts
+++ b/packages/procaptcha/vite.test.config.ts
@@ -1,0 +1,39 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import fs from "node:fs";
+import path from "node:path";
+import { ViteTestConfig } from "@prosopo/config";
+import dotenv from "dotenv";
+process.env.NODE_ENV = "test";
+// if .env.test exists at this level, use it, otherwise use the one at the root
+const envFile = `.env.${process.env.NODE_ENV || "development"}`;
+let envPath = envFile;
+if (fs.existsSync(envFile)) {
+	envPath = path.resolve(envFile);
+} else if (fs.existsSync(`../../${envFile}`)) {
+	envPath = path.resolve(`../../${envFile}`);
+} else {
+	throw new Error(`No ${envFile} file found`);
+}
+
+dotenv.config({ path: envPath });
+
+export default function () {
+	const config = ViteTestConfig();
+	config.test = config.test || {};
+	config.test.environment = "jsdom";
+	config.test.globals = true;
+	return config;
+}


### PR DESCRIPTION
## Summary
Fixes #2556 — the reload button in image captcha mode used to bounce the user back to the checkbox: the modal closed and never reopened with a fresh challenge.

`Manager.reload` called `resetState(frictionlessState?.restart)`, which on the bundle path restarts the entire frictionless flow by re-keying the `ProcaptchaFrictionless` wrapper, unmounting the image captcha widget. On the direct path it synchronously set `showModal: false`. Either way the modal disappeared.

`reload` now clears the active timeout, fires `onReload`, resets the loading flag so `start()` won't no-op against a stale `loading: true`, and calls `start()` to request a fresh challenge using the existing frictionless session (if any). The modal stays open through the transition.

- packages/procaptcha/src/modules/Manager.ts — new `reload` body
- packages/procaptcha — vitest infrastructure + Manager.reload tests
- .changeset — patch bump for `@prosopo/procaptcha`

## Test plan
- [x] `npm run -w @prosopo/procaptcha test` — 6/6 pass
- [x] `npm run -w @prosopo/procaptcha build:tsc`
- [x] `npm run -w @prosopo/procaptcha-react build:tsc`
- [x] `npm run -w @prosopo/procaptcha-frictionless build:tsc`
- [x] `npm run -w @prosopo/procaptcha-bundle build:tsc`
- [x] `npm run -w @prosopo/procaptcha-common test`
- [x] `npm run -w @prosopo/procaptcha-frictionless test`
- [ ] Manual smoke: click "I'm not a robot" → solve modal opens → click reload → new challenge appears in the same modal (no checkbox flash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)