### PR TITLE
chore/fingerprint: bump @prosopo/fingerprintjs to 5.2.0

### DIFF
--- a/.changeset/account-worker-js-suffix.md
+++ b/.changeset/account-worker-js-suffix.md
@@ -1,0 +1,12 @@
+---
+"@prosopo/account": patch
+---
+
+Fix `CryptoWorkerManager` import path so downstream Vite bundles resolve
+the inlined worker. The import was `./cryptoWorker.ts?worker&inline`,
+which kept the `.ts` extension through TypeScript compilation; the
+emitted `dist/workers/CryptoWorkerManager.js` then referenced a
+non-existent `.ts` file when consumed by `procaptcha-bundle`'s Rollup
+build, breaking the cypress workflow with
+`Could not resolve "./cryptoWorker.ts?worker&inline"`. Aligning with
+the catcher pattern (`*.js?worker&inline`).

--- a/.changeset/fpjs-version-bump.md
+++ b/.changeset/fpjs-version-bump.md
@@ -1,0 +1,9 @@
+---
+"@prosopo/fingerprint": patch
+"@prosopo/fingerprintjs": minor
+---
+
+Bump `@prosopo/fingerprintjs` to 5.2.0 to mirror the upstream v5.2.0
+release brought into the fork by the earlier upstream merge. Also
+aligns the fork's `@prosopo/config` devDependency with the workspace
+pin (3.3.0 → 3.3.1).

--- a/package-lock.json
+++ b/package-lock.json
@@ -22187,6 +22187,7 @@
 			"resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.6.0.tgz",
 			"integrity": "sha512-iwaY4wzbe48AfKLZ/Cc8k0L+FKG6oSNRaZ8x5A/T/IVDGyXcbHncM9TdDa93wn0FsSm82FhTKW7f3vS61thXAw==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@types/html-minifier-terser": "^6.0.0",
 				"html-minifier-terser": "^6.0.2",
@@ -36098,7 +36099,7 @@
 			"version": "5.2.0",
 			"license": "MIT",
 			"devDependencies": {
-				"@prosopo/config": "3.3.0",
+				"@prosopo/config": "3.3.1",
 				"@types/node": "22.10.2",
 				"@vitest/coverage-v8": "3.2.4",
 				"concurrently": "9.0.1",
@@ -36111,33 +36112,6 @@
 				"typescript": "5.6.2",
 				"vite": "6.4.1",
 				"vitest": "3.2.4"
-			},
-			"engines": {
-				"node": "^24",
-				"npm": "^11"
-			}
-		},
-		"packages/fingerprintjs/node_modules/@prosopo/config": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/@prosopo/config/-/config-3.3.0.tgz",
-			"integrity": "sha512-GXbnXTsDVLifGDFDaPzUlT4hIXvzFvvjmU1iXuCRSWwZktzzwUBSKozT758l41H36rTKDQ7FZVQnH6oXDbhS2Q==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@rollup/plugin-node-resolve": "16.0.3",
-				"@rollup/plugin-typescript": "11.1.6",
-				"@rollup/plugin-wasm": "6.2.2",
-				"@vitejs/plugin-react": "5.1.0",
-				"esbuild": "0.25.9",
-				"fast-glob": "3.3.2",
-				"html-webpack-plugin": "5.6.0",
-				"mini-css-extract-plugin": "2.9.1",
-				"node-polyfill-webpack-plugin": "4.1.0",
-				"rollup": "4.52.5",
-				"rollup-plugin-import-css": "4.1.1",
-				"terser-webpack-plugin": "5.3.14",
-				"vite-plugin-no-bundle": "4.0.0",
-				"vite-tsconfig-paths": "5.1.4"
 			},
 			"engines": {
 				"node": "^24",

--- a/package-lock.json
+++ b/package-lock.json
@@ -36062,7 +36062,7 @@
 			"version": "2.6.29",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@prosopo/fingerprintjs": "5.1.0"
+				"@prosopo/fingerprintjs": "5.2.0"
 			},
 			"devDependencies": {
 				"@prosopo/config": "3.3.1",
@@ -36095,7 +36095,7 @@
 		},
 		"packages/fingerprintjs": {
 			"name": "@prosopo/fingerprintjs",
-			"version": "5.1.0",
+			"version": "5.2.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@prosopo/config": "3.3.0",

--- a/packages/account/src/workers/CryptoWorkerManager.ts
+++ b/packages/account/src/workers/CryptoWorkerManager.ts
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Imports remain correct, assuming the declaration file is set up
-import CryptoWorkerConstructor from "./cryptoWorker.ts?worker&inline";
+import CryptoWorkerConstructor from "./cryptoWorker.js?worker&inline";
 
 interface CryptoWorkerMessage {
 	taskId: string;

--- a/packages/fingerprint/package.json
+++ b/packages/fingerprint/package.json
@@ -35,7 +35,7 @@
 	},
 	"homepage": "https://github.com/prosopo/captcha#readme",
 	"dependencies": {
-		"@prosopo/fingerprintjs": "5.1.0"
+		"@prosopo/fingerprintjs": "5.2.0"
 	},
 	"devDependencies": {
 		"@prosopo/config": "3.3.1",


### PR DESCRIPTION
## Summary
Reinstates the @prosopo/fingerprintjs version label at 5.2.0 across the workspace, matching the upstream v5.2.0 merge brought into the fork.

- `packages/fingerprintjs` submodule pointer → `e09c6ba` (workspace package.json + agent.ts both report 5.2.0).
- `packages/fingerprint/package.json` dep → `5.2.0`.
- `package-lock.json` regenerated to reflect 5.2.0 throughout.

The earlier perf PR (#2551) kept this at 5.1.0 to stay aligned with the protect submodule's pinned dep. Protect is being bumped to 5.2.0 in parallel via https://github.com/prosopo/Protect/pull-new/feat/fpjs-5.2.0 — once that lands and the captcha-private side picks it up, the workspace is consistent at 5.2.0 again.

## Test plan
- [x] `npm run -w @prosopo/fingerprint build:tsc` clean
- [x] CI on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)