### PR TITLE
perf/frictionless: defer SIMD benchmark until after the POST

### DIFF
--- a/.changeset/defer-simd-until-after-frictionless.md
+++ b/.changeset/defer-simd-until-after-frictionless.md
@@ -1,0 +1,16 @@
+---
+"@prosopo/procaptcha-frictionless": patch
+---
+
+Defer the SIMD benchmark trigger to after the frictionless POST is in
+flight, and stop attaching SIMD readings to the frictionless request
+body. The previous `await detectionResult.getSimdReadings(0)` still
+waited a microtask cycle and the full RSA-OAEP + AES-GCM encryption
+(10–30ms) even when `timeoutMs` was `0`, and the benchmark itself —
+a CPU-bound WASM loop — was running concurrently with the BotScore
+worker, contending for cores on small VMs. Stretches like 344ms →
+1167ms on staging were attributable to the contention.
+
+The first-hop-wins semantics on the provider mean we just lose the
+frictionless-hop attach, not the signal — readings still attach on the
+captcha challenge GET and on solution submit.

--- a/packages/procaptcha-frictionless/src/customDetectBot.ts
+++ b/packages/procaptcha-frictionless/src/customDetectBot.ts
@@ -101,26 +101,26 @@ const customDetectBot: BotDetectionFunction = async (
 		config.account.address,
 	);
 
-	// Non-blocking SIMD-readings check: only attach if the catcher's
-	// prefetched WASM benchmark has already resolved. If not ready by this
-	// initial frictionless hop, it'll be re-attempted on the captcha
-	// challenge GET and again on solution submit.
-	const simdReadingsOnFrictionless = detectionResult.getSimdReadings
-		? await detectionResult.getSimdReadings(0)
-		: undefined;
-
-	// Get frictionless captcha with timeout
-	const captcha = await withTimeout(
-		providerApi.getFrictionlessCaptcha(
-			detectionResult.token,
-			detectionResult.encryptHeadHash,
-			config.account.address,
-			userAccount.account.address,
-			config.mode,
-			simdReadingsOnFrictionless,
-		),
-		10000, // 10 second timeout
+	// SIMD readings deliberately omitted from the frictionless hop. The WASM
+	// benchmark is a CPU-bound loop that contends with BotScoreWorker if it
+	// runs during detection; deferring it until after the POST is in flight
+	// lets it complete in the worker thread while the network round-trip
+	// burns. Readings still attach on the challenge GET and on solution
+	// submit (first-hop-wins server-side).
+	const captchaPromise = providerApi.getFrictionlessCaptcha(
+		detectionResult.token,
+		detectionResult.encryptHeadHash,
+		config.account.address,
+		userAccount.account.address,
+		config.mode,
+		undefined,
 	);
+	if (detectionResult.getSimdReadings) {
+		// Fire-and-forget: triggers the memoised prefetch inside the catcher
+		// so the next hop sees a hot benchmark. We never await the result here.
+		void detectionResult.getSimdReadings(60_000).catch(() => undefined);
+	}
+	const captcha = await withTimeout(captchaPromise, 10000);
 
 	return {
 		captchaType: captcha.captchaType,

--- a/packages/procaptcha-frictionless/src/tests/customDetectBotSimd.test.ts
+++ b/packages/procaptcha-frictionless/src/tests/customDetectBotSimd.test.ts
@@ -59,11 +59,16 @@ const baseConfig = {
 	mode: "frictionless" as const,
 } as unknown as Parameters<typeof customDetectBot>[0];
 
-const makeDetectionResult = (getSimdReadings?: (timeoutMs: number) => Promise<string | undefined>) => ({
+const makeDetectionResult = (
+	getSimdReadings?: (timeoutMs: number) => Promise<string | undefined>,
+) => ({
 	token: "TOKEN",
 	encryptHeadHash: "HASH",
 	userAccount: { account: { address: "5FakeUserAccountAddress" } },
-	provider: { provider: { url: "https://provider.test" }, providerAccount: "5Provider" },
+	provider: {
+		provider: { url: "https://provider.test" },
+		providerAccount: "5Provider",
+	},
 	getSimdReadings,
 	mouseTracker: undefined,
 	touchTracker: undefined,
@@ -121,9 +126,10 @@ describe("customDetectBot SIMD deferral", () => {
 
 	it("does not block the frictionless POST on a slow getSimdReadings", async () => {
 		let simdResolve!: (v: string) => void;
-		const getSimdReadings = vi.fn().mockImplementation(
-			() => new Promise<string>((r) => (simdResolve = r)),
-		);
+		const simdPromise = new Promise<string>((resolve) => {
+			simdResolve = resolve;
+		});
+		const getSimdReadings = vi.fn().mockReturnValue(simdPromise);
 		mocks.detect.mockResolvedValue(makeDetectionResult(getSimdReadings));
 
 		// If the POST awaited getSimdReadings, this would hang forever.

--- a/packages/procaptcha-frictionless/src/tests/customDetectBotSimd.test.ts
+++ b/packages/procaptcha-frictionless/src/tests/customDetectBotSimd.test.ts
@@ -1,0 +1,153 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// `vi.mock` is hoisted; share state via `vi.hoisted` so the factories can
+// reference the same spies the tests assert against.
+const mocks = vi.hoisted(() => ({
+	getFrictionlessCaptcha: vi.fn(),
+	getRandomActiveProvider: vi.fn(),
+	prefetchProviders: vi.fn(async () => undefined),
+	detect: vi.fn(),
+}));
+
+vi.mock("@prosopo/api", () => ({
+	ProviderApi: vi.fn(() => ({
+		getFrictionlessCaptcha: mocks.getFrictionlessCaptcha,
+	})),
+}));
+
+vi.mock("@prosopo/load-balancer", () => ({
+	getRandomActiveProvider: mocks.getRandomActiveProvider,
+	prefetchProviders: mocks.prefetchProviders,
+}));
+
+vi.mock("@prosopo/procaptcha-common", () => ({
+	ExtensionLoader: vi.fn(async () => {
+		return class FakeExtension {
+			getAccount() {
+				return Promise.resolve({
+					account: { address: "5FakeUserAccountAddress" },
+				});
+			}
+		};
+	}),
+}));
+
+vi.mock("../detectorLoader.js", () => ({
+	DetectorLoader: vi.fn(async () => mocks.detect),
+}));
+
+import customDetectBot from "../customDetectBot.js";
+
+const baseConfig = {
+	account: { address: "5FakeSiteKey" },
+	defaultEnvironment: "production" as const,
+	web2: true,
+	mode: "frictionless" as const,
+} as unknown as Parameters<typeof customDetectBot>[0];
+
+const makeDetectionResult = (getSimdReadings?: (timeoutMs: number) => Promise<string | undefined>) => ({
+	token: "TOKEN",
+	encryptHeadHash: "HASH",
+	userAccount: { account: { address: "5FakeUserAccountAddress" } },
+	provider: { provider: { url: "https://provider.test" }, providerAccount: "5Provider" },
+	getSimdReadings,
+	mouseTracker: undefined,
+	touchTracker: undefined,
+	clickTracker: undefined,
+});
+
+const captchaResponse = {
+	captchaType: "pow",
+	sessionId: "SID",
+	status: "ok",
+};
+
+beforeEach(() => {
+	mocks.getFrictionlessCaptcha.mockReset();
+	mocks.getRandomActiveProvider.mockReset();
+	mocks.prefetchProviders.mockReset();
+	mocks.detect.mockReset();
+	mocks.prefetchProviders.mockResolvedValue(undefined);
+	mocks.getFrictionlessCaptcha.mockResolvedValue(captchaResponse);
+});
+
+describe("customDetectBot SIMD deferral", () => {
+	it("passes simdReadings as undefined to the frictionless POST even when getSimdReadings would return a value", async () => {
+		const getSimdReadings = vi.fn().mockResolvedValue("ENCODED_SIMD");
+		mocks.detect.mockResolvedValue(makeDetectionResult(getSimdReadings));
+
+		await customDetectBot(baseConfig, undefined, () => undefined);
+
+		expect(mocks.getFrictionlessCaptcha).toHaveBeenCalledTimes(1);
+		const args = mocks.getFrictionlessCaptcha.mock.calls[0];
+		// args: token, headHash, dappAccount, userAccount, mode, simdReadings
+		expect(args?.[5]).toBeUndefined();
+	});
+
+	it("fires getSimdReadings after the frictionless POST is initiated (fire-and-forget)", async () => {
+		const callOrder: string[] = [];
+		mocks.getFrictionlessCaptcha.mockImplementation(() => {
+			callOrder.push("captcha-call");
+			return Promise.resolve(captchaResponse);
+		});
+		const getSimdReadings = vi.fn().mockImplementation(() => {
+			callOrder.push("simd-call");
+			return Promise.resolve("ENCODED_SIMD");
+		});
+		mocks.detect.mockResolvedValue(makeDetectionResult(getSimdReadings));
+
+		await customDetectBot(baseConfig, undefined, () => undefined);
+
+		expect(getSimdReadings).toHaveBeenCalledTimes(1);
+		// SIMD trigger must come AFTER the frictionless POST is initiated.
+		expect(callOrder.indexOf("captcha-call")).toBeLessThan(
+			callOrder.indexOf("simd-call"),
+		);
+	});
+
+	it("does not block the frictionless POST on a slow getSimdReadings", async () => {
+		let simdResolve!: (v: string) => void;
+		const getSimdReadings = vi.fn().mockImplementation(
+			() => new Promise<string>((r) => (simdResolve = r)),
+		);
+		mocks.detect.mockResolvedValue(makeDetectionResult(getSimdReadings));
+
+		// If the POST awaited getSimdReadings, this would hang forever.
+		const result = await customDetectBot(
+			baseConfig,
+			undefined,
+			() => undefined,
+		);
+
+		expect(result.sessionId).toBe("SID");
+		// Resolve afterwards so the unhandled promise doesn't leak.
+		simdResolve("ENCODED_SIMD");
+	});
+
+	it("skips the SIMD trigger when the detector doesn't expose getSimdReadings", async () => {
+		mocks.detect.mockResolvedValue(makeDetectionResult(undefined));
+
+		const result = await customDetectBot(
+			baseConfig,
+			undefined,
+			() => undefined,
+		);
+
+		expect(result.sessionId).toBe("SID");
+		expect(mocks.getFrictionlessCaptcha).toHaveBeenCalledTimes(1);
+	});
+});


### PR DESCRIPTION
## Summary
The previous flow attached SIMD readings to the frictionless POST and gated the request on a synchronous-feeling RSA-OAEP + AES-GCM encrypt (10–30ms) even though the call signature looked non-blocking. The SIMD benchmark itself is a CPU-bound WASM loop in its own worker — on constrained VMs (staging) it was running concurrently with BotScoreWorker and stretching that worker from ~340ms (local) to ~1170ms.

This PR:

1. **Stops attaching `simdReadings` to the frictionless POST body.** The field always sends as `undefined` on the initial hop.
2. **Kicks off `getSimdReadings(60_000)` fire-and-forget after the POST is initiated.** The benchmark completes in the worker thread during the network round-trip and the encoded readings are cached for the next hop.
3. **First-hop-wins server persistence** means we lose the frictionless-hop attach but the signal still flows — readings attach on the captcha challenge GET and on the solution submit, and the provider records the earliest hop where readings arrived.

Companion PR in captcha-private (the catcher source) removes the `prefetchSimdBenchmark()` call from `detector.ts` module-init and memoises the encoded SIMD result so later hops don't re-encrypt.

## Test plan
- [x] `npm run -w @prosopo/procaptcha-frictionless test` (8 tests pass; 4 new in `customDetectBotSimd.test.ts`)
- [x] `npm run -w @prosopo/procaptcha-frictionless build:tsc`
- [x] CI on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)