### PR TITLE
chore(deps): bump mongo 7.0.0 -> 8.2.3 (CVE-2025-14847)

### DIFF
--- a/docker/docker-compose.client-example-server.yml
+++ b/docker/docker-compose.client-example-server.yml
@@ -65,11 +65,11 @@ services:
             - 208.67.222.222
     database1:
         container_name: database1
-        image: mongo:7.0.0
+        image: mongo:8.2.3
         volumes:
             - /data/client-example-server:/data/db
         ports:
-            - '127.0.0.1:27018:27017'
+            - '27018:27017'
         env_file:
             - ../.env.${NODE_ENV}
         networks:


### PR DESCRIPTION
## Summary

- Bump `database1` image from `mongo:7.0.0` to `mongo:8.2.3` to patch [CVE-2025-14847 ("MongoBleed")](https://www.akamai.com/blog/security-research/cve-2025-14847-all-you-need-to-know-about-mongobleed), an **unauthenticated** info-disclosure vulnerability affecting all 7.0.x prior to 7.0.28 (and 8.2.x prior to 8.2.3).
- Restore the host port mapping to the public interface (`27018:27017`) so external consumers (AWS staging Lambdas via `MONGO_CLIENT_DB`) can reach mongo behind auth. The localhost-only bind that was put in place as a stopgap blocked them.

## Why mongo 8.2.3 (and not 7.0.34)?

8.2.3 is the first patched release on the 8.2 line. Going forward we'd rather be on the current major than stay pinned to 7.0.x.

The staging instance was migrated via dump + restore (not in-place ladder), so FCV constraints don't apply here.

## Reviewer note: port exposure

This compose file is labelled with both `production` and `staging` profiles. Removing the `127.0.0.1:` bind makes mongo reachable on the public interface for **any** deployment using this file — not just staging. Mongo enforces SCRAM auth via the env-driven root user, so this isn't unauthenticated exposure, but if there are other deployments where mongo should remain localhost-only, consider parameterising the bind via env var instead (e.g. `'${MONGO_BIND_HOST:-127.0.0.1:}27018:27017'`). Happy to switch to that if preferred.

## Test plan

- [x] Upgraded the staging-db host (195.179.230.185) in-place: dump 7.0.0 -> restore into fresh 8.2.3 instance
- [x] Verified document counts match v7 (captchacounts 462897, accounts 6046, spamemaildomains 5197, anomalydetectors 5, systemusers 1, client.users 71, jobdefinitions 16)
- [x] Local `server1` reconnects to `database1` on the internal docker network with no code/env changes
- [x] External auth handshake from outside the host succeeds against `195.179.230.185:27018`
- [ ] AWS staging Lambdas reconnect (will confirm post-merge once the deploy picks up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)