### PR TITLE
feat: detect insecure HTTP context and surface clear Procaptcha message (#3183)

### DIFF
--- a/.changeset/detect-insecure-http-context.md
+++ b/.changeset/detect-insecure-http-context.md
@@ -1,0 +1,13 @@
+---
+"@prosopo/procaptcha-frictionless": patch
+"@prosopo/procaptcha-common": patch
+"@prosopo/locale": patch
+---
+
+Detect when the widget is served over plain HTTP (an insecure browser context)
+and show a clear "Procaptcha requires a secure (HTTPS) connection" message
+instead of failing later with a cryptic `Provider Selection Failed` error.
+Procaptcha depends on secure-context-only browser APIs (e.g. SubtleCrypto), so
+the frictionless widget now short-circuits before the provider-selection retry
+loop when `window.isSecureContext` is false. Adds the `WIDGET.INSECURE_CONTEXT`
+translation key across all locales and an `isSecureBrowserContext` helper.

--- a/packages/locale/src/locales/ar/translation.json
+++ b/packages/locale/src/locales/ar/translation.json
@@ -373,7 +373,8 @@
 		"I_AM_HUMAN": "أنا إنسان",
 		"NO_ACCOUNTS_FOUND": "لم يتم العثور على حسابات",
 		"ACCOUNT_NOT_FOUND": "حساب غير موجود",
-		"NO_EXTENSION_FOUND": "لم يتم العثور على امتداد"
+		"NO_EXTENSION_FOUND": "لم يتم العثور على امتداد",
+		"INSECURE_CONTEXT": "يتطلب Procaptcha اتصالاً آمنًا (HTTPS)"
 	},
 	"CONTRACT": {
 		"INVALID_ADDRESS": "فشل في ترميز عنوان غير صالح",

--- a/packages/locale/src/locales/az/translation.json
+++ b/packages/locale/src/locales/az/translation.json
@@ -373,7 +373,8 @@
 		"I_AM_HUMAN": "Mən insanam",
 		"NO_ACCOUNTS_FOUND": "Hesab tapılmadı",
 		"ACCOUNT_NOT_FOUND": "Hesab tapılmadı",
-		"NO_EXTENSION_FOUND": "Tətbiq tapılmadı"
+		"NO_EXTENSION_FOUND": "Tətbiq tapılmadı",
+		"INSECURE_CONTEXT": "Procaptcha təhlükəsiz (HTTPS) bağlantı tələb edir"
 	},
 	"CONTRACT": {
 		"INVALID_ADDRESS": "Geçərsiz ünvan kodlanmadı",

--- a/packages/locale/src/locales/cs/translation.json
+++ b/packages/locale/src/locales/cs/translation.json
@@ -373,7 +373,8 @@
 		"I_AM_HUMAN": "Jsem člověk",
 		"NO_ACCOUNTS_FOUND": "Nebyly nalezeny žádné účty",
 		"ACCOUNT_NOT_FOUND": "Účet nenalezen",
-		"NO_EXTENSION_FOUND": "Nenalezeno žádné rozšíření"
+		"NO_EXTENSION_FOUND": "Nenalezeno žádné rozšíření",
+		"INSECURE_CONTEXT": "Procaptcha vyžaduje zabezpečené připojení (HTTPS)"
 	},
 	"CONTRACT": {
 		"INVALID_ADDRESS": "Nepodařilo se zakódovat neplatnou adresu",

--- a/packages/locale/src/locales/de/translation.json
+++ b/packages/locale/src/locales/de/translation.json
@@ -74,7 +74,8 @@
 		"I_AM_HUMAN": "Ich bin ein Mensch",
 		"NO_ACCOUNTS_FOUND": "Keine Konten gefunden",
 		"ACCOUNT_NOT_FOUND": "Konto nicht gefunden",
-		"NO_EXTENSION_FOUND": "Keine Erweiterung gefunden"
+		"NO_EXTENSION_FOUND": "Keine Erweiterung gefunden",
+		"INSECURE_CONTEXT": "Procaptcha erfordert eine sichere (HTTPS-)Verbindung"
 	},
 	"CONTRACT": {
 		"INVALID_ADDRESS": "Ungültige Adresse konnte nicht codiert werden",

--- a/packages/locale/src/locales/el/translation.json
+++ b/packages/locale/src/locales/el/translation.json
@@ -373,7 +373,8 @@
 		"I_AM_HUMAN": "Είμαι άνθρωπος",
 		"NO_ACCOUNTS_FOUND": "Δεν βρέθηκαν λογαριασμοί",
 		"ACCOUNT_NOT_FOUND": "Δεν βρέθηκε λογαριασμός",
-		"NO_EXTENSION_FOUND": "Δε βρέθηκε επέκταση"
+		"NO_EXTENSION_FOUND": "Δε βρέθηκε επέκταση",
+		"INSECURE_CONTEXT": "Το Procaptcha απαιτεί ασφαλή σύνδεση (HTTPS)"
 	},
 	"CONTRACT": {
 		"INVALID_ADDRESS": "Αποτυχία κωδικοποίησης μη έγκυρης διεύθυνσης",

--- a/packages/locale/src/locales/en/translation.json
+++ b/packages/locale/src/locales/en/translation.json
@@ -11,7 +11,8 @@
 		"I_AM_HUMAN": "I am human",
 		"NO_ACCOUNTS_FOUND": "No accounts found",
 		"ACCOUNT_NOT_FOUND": "Account not found",
-		"NO_EXTENSION_FOUND": "No extension found"
+		"NO_EXTENSION_FOUND": "No extension found",
+		"INSECURE_CONTEXT": "Procaptcha requires a secure (HTTPS) connection"
 	},
 	"GENERAL": {
 		"JSON_LOAD_FAILED": "Failed to load JSON file",

--- a/packages/locale/src/locales/es/translation.json
+++ b/packages/locale/src/locales/es/translation.json
@@ -74,7 +74,8 @@
 		"I_AM_HUMAN": "Soy humano",
 		"NO_ACCOUNTS_FOUND": "No se encontraron cuentas",
 		"ACCOUNT_NOT_FOUND": "Cuenta no encontrada",
-		"NO_EXTENSION_FOUND": "Extensión no encontrada"
+		"NO_EXTENSION_FOUND": "Extensión no encontrada",
+		"INSECURE_CONTEXT": "Procaptcha requiere una conexión segura (HTTPS)"
 	},
 	"CONTRACT": {
 		"INVALID_ADDRESS": "Error al codificar dirección inválida",

--- a/packages/locale/src/locales/fi/translation.json
+++ b/packages/locale/src/locales/fi/translation.json
@@ -407,7 +407,8 @@
 		"I_AM_HUMAN": "Olen ihminen",
 		"NO_ACCOUNTS_FOUND": "Ei tilejä löytynyt",
 		"ACCOUNT_NOT_FOUND": "Tiliä ei löytynyt",
-		"NO_EXTENSION_FOUND": "Laajennusta ei löytynyt"
+		"NO_EXTENSION_FOUND": "Laajennusta ei löytynyt",
+		"INSECURE_CONTEXT": "Procaptcha vaatii suojatun (HTTPS) yhteyden"
 	},
 	"CONTRACT": {
 		"INVALID_ADDRESS": "Epäonnistui koodata virheellinen osoite",

--- a/packages/locale/src/locales/fr/translation.json
+++ b/packages/locale/src/locales/fr/translation.json
@@ -74,7 +74,8 @@
 		"I_AM_HUMAN": "Je suis humain",
 		"NO_ACCOUNTS_FOUND": "Aucun compte trouvé",
 		"ACCOUNT_NOT_FOUND": "Compte non trouvé",
-		"NO_EXTENSION_FOUND": "Aucune extension trouvée"
+		"NO_EXTENSION_FOUND": "Aucune extension trouvée",
+		"INSECURE_CONTEXT": "Procaptcha nécessite une connexion sécurisée (HTTPS)"
 	},
 	"CONTRACT": {
 		"INVALID_ADDRESS": "Échec de l'encodage de l'adresse invalide",

--- a/packages/locale/src/locales/hi/translation.json
+++ b/packages/locale/src/locales/hi/translation.json
@@ -373,7 +373,8 @@
 		"I_AM_HUMAN": "म मनषय ह",
 		"NO_ACCOUNTS_FOUND": "कई खत नह मल",
 		"ACCOUNT_NOT_FOUND": "खत नह मल",
-		"NO_EXTENSION_FOUND": "कई एकसटशन नह मल"
+		"NO_EXTENSION_FOUND": "कई एकसटशन नह मल",
+		"INSECURE_CONTEXT": "Procaptcha के लिए सुरक्षित (HTTPS) कनेक्शन आवश्यक है"
 	},
 	"CONTRACT": {
 		"INVALID_ADDRESS": "अवध पत क एनकड करन म वफल रह",

--- a/packages/locale/src/locales/hu/translation.json
+++ b/packages/locale/src/locales/hu/translation.json
@@ -373,7 +373,8 @@
 		"I_AM_HUMAN": "Ember vagyok",
 		"NO_ACCOUNTS_FOUND": "Nem található felhasználó",
 		"ACCOUNT_NOT_FOUND": "Felhasználó nem található",
-		"NO_EXTENSION_FOUND": "Nincs kiterjesztés található"
+		"NO_EXTENSION_FOUND": "Nincs kiterjesztés található",
+		"INSECURE_CONTEXT": "A Procaptcha biztonságos (HTTPS) kapcsolatot igényel"
 	},
 	"CONTRACT": {
 		"INVALID_ADDRESS": "Nem sikerült kódolni az érvénytelen címet",

--- a/packages/locale/src/locales/id/translation.json
+++ b/packages/locale/src/locales/id/translation.json
@@ -373,7 +373,8 @@
 		"I_AM_HUMAN": "Saya manusia",
 		"NO_ACCOUNTS_FOUND": "Tidak ada akun ditemukan",
 		"ACCOUNT_NOT_FOUND": "Akun tidak ditemukan",
-		"NO_EXTENSION_FOUND": "Tidak ada ekstensi ditemukan"
+		"NO_EXTENSION_FOUND": "Tidak ada ekstensi ditemukan",
+		"INSECURE_CONTEXT": "Procaptcha memerlukan koneksi aman (HTTPS)"
 	},
 	"CONTRACT": {
 		"INVALID_ADDRESS": "Gagal mengkodekan alamat yang tidak valid",

--- a/packages/locale/src/locales/it/translation.json
+++ b/packages/locale/src/locales/it/translation.json
@@ -74,7 +74,8 @@
 		"I_AM_HUMAN": "Sono umano",
 		"NO_ACCOUNTS_FOUND": "Nessun account trovato",
 		"ACCOUNT_NOT_FOUND": "Account non trovato",
-		"NO_EXTENSION_FOUND": "Nessuna estensione trovata"
+		"NO_EXTENSION_FOUND": "Nessuna estensione trovata",
+		"INSECURE_CONTEXT": "Procaptcha richiede una connessione sicura (HTTPS)"
 	},
 	"CONTRACT": {
 		"INVALID_ADDRESS": "Impossibile codificare l'indirizzo non valido",

--- a/packages/locale/src/locales/ja/translation.json
+++ b/packages/locale/src/locales/ja/translation.json
@@ -373,7 +373,8 @@
 		"I_AM_HUMAN": "私は人間です",
 		"NO_ACCOUNTS_FOUND": "アカウントが見つかりません",
 		"ACCOUNT_NOT_FOUND": "アカウントが見つかりません",
-		"NO_EXTENSION_FOUND": "拡張機能が見つかりません"
+		"NO_EXTENSION_FOUND": "拡張機能が見つかりません",
+		"INSECURE_CONTEXT": "Procaptcha には安全な (HTTPS) 接続が必要です"
 	},
 	"CONTRACT": {
 		"INVALID_ADDRESS": "無効なアドレスをエンコードできませんでした",

--- a/packages/locale/src/locales/jv/translation.json
+++ b/packages/locale/src/locales/jv/translation.json
@@ -373,7 +373,8 @@
 		"I_AM_HUMAN": "Saya manusia",
 		"NO_ACCOUNTS_FOUND": "Tidak ada akun ditemukan",
 		"ACCOUNT_NOT_FOUND": "Akun tidak ditemukan",
-		"NO_EXTENSION_FOUND": "Tidak ada ekstensi ditemukan"
+		"NO_EXTENSION_FOUND": "Tidak ada ekstensi ditemukan",
+		"INSECURE_CONTEXT": "Procaptcha mbutuhake sambungan sing aman (HTTPS)"
 	},
 	"CONTRACT": {
 		"INVALID_ADDRESS": "Gagal mengkodekan alamat yang tidak valid",

--- a/packages/locale/src/locales/ko/translation.json
+++ b/packages/locale/src/locales/ko/translation.json
@@ -373,7 +373,8 @@
 		"I_AM_HUMAN": "인간입니다",
 		"NO_ACCOUNTS_FOUND": "계정을 찾을 수 없음",
 		"ACCOUNT_NOT_FOUND": "계정을 찾을 수 없음",
-		"NO_EXTENSION_FOUND": "확장 프로그램을 찾을 수 없음"
+		"NO_EXTENSION_FOUND": "확장 프로그램을 찾을 수 없음",
+		"INSECURE_CONTEXT": "Procaptcha에는 보안 연결(HTTPS)이 필요합니다"
 	},
 	"CONTRACT": {
 		"INVALID_ADDRESS": "유효하지 않은 주소를 인코딩하는 데 실패함",

--- a/packages/locale/src/locales/ml/translation.json
+++ b/packages/locale/src/locales/ml/translation.json
@@ -373,7 +373,8 @@
 		"I_AM_HUMAN": "Ako tawo",
 		"NO_ACCOUNTS_FOUND": "Walay makitang mga account",
 		"ACCOUNT_NOT_FOUND": "Account dili makita",
-		"NO_EXTENSION_FOUND": "Walay nakitang extension"
+		"NO_EXTENSION_FOUND": "Walay nakitang extension",
+		"INSECURE_CONTEXT": "Procaptcha-യ്ക്ക് സുരക്ഷിതമായ (HTTPS) കണക്ഷൻ ആവശ്യമാണ്"
 	},
 	"CONTRACT": {
 		"INVALID_ADDRESS": "Nahimong pakyas ang pag-encode sa dili balido nga address",

--- a/packages/locale/src/locales/ms/translation.json
+++ b/packages/locale/src/locales/ms/translation.json
@@ -373,7 +373,8 @@
 		"I_AM_HUMAN": "I am human",
 		"NO_ACCOUNTS_FOUND": "No accounts found",
 		"ACCOUNT_NOT_FOUND": "Account not found",
-		"NO_EXTENSION_FOUND": "No extension found"
+		"NO_EXTENSION_FOUND": "No extension found",
+		"INSECURE_CONTEXT": "Procaptcha memerlukan sambungan selamat (HTTPS)"
 	},
 	"CONTRACT": {
 		"INVALID_ADDRESS": "Failed to encode invalid address",

--- a/packages/locale/src/locales/nl/translation.json
+++ b/packages/locale/src/locales/nl/translation.json
@@ -373,7 +373,8 @@
 		"I_AM_HUMAN": "Ik ben een mens",
 		"NO_ACCOUNTS_FOUND": "Geen accounts gevonden",
 		"ACCOUNT_NOT_FOUND": "Account niet gevonden",
-		"NO_EXTENSION_FOUND": "Geen extensie gevonden"
+		"NO_EXTENSION_FOUND": "Geen extensie gevonden",
+		"INSECURE_CONTEXT": "Procaptcha vereist een beveiligde (HTTPS-)verbinding"
 	},
 	"CONTRACT": {
 		"INVALID_ADDRESS": "Mislukt om ongeldig adres te coderen",

--- a/packages/locale/src/locales/no/translation.json
+++ b/packages/locale/src/locales/no/translation.json
@@ -373,7 +373,8 @@
 		"I_AM_HUMAN": "Jeg er menneske",
 		"NO_ACCOUNTS_FOUND": "Ingen kontoer funnet",
 		"ACCOUNT_NOT_FOUND": "Konto ikke funnet",
-		"NO_EXTENSION_FOUND": "Ingen tilleggsprogram funnet"
+		"NO_EXTENSION_FOUND": "Ingen tilleggsprogram funnet",
+		"INSECURE_CONTEXT": "Procaptcha krever en sikker (HTTPS) tilkobling"
 	},
 	"CONTRACT": {
 		"INVALID_ADDRESS": "Klarte ikke å kryptere ugyldig adresse",

--- a/packages/locale/src/locales/pl/translation.json
+++ b/packages/locale/src/locales/pl/translation.json
@@ -373,7 +373,8 @@
 		"I_AM_HUMAN": "Jestem człowiekiem",
 		"NO_ACCOUNTS_FOUND": "Nie znaleziono kont",
 		"ACCOUNT_NOT_FOUND": "Nie znaleziono konta",
-		"NO_EXTENSION_FOUND": "Nie znaleziono rozszerzenia"
+		"NO_EXTENSION_FOUND": "Nie znaleziono rozszerzenia",
+		"INSECURE_CONTEXT": "Procaptcha wymaga bezpiecznego połączenia (HTTPS)"
 	},
 	"CONTRACT": {
 		"INVALID_ADDRESS": "Nie udało się zakodować nieprawidłowego adresu",

--- a/packages/locale/src/locales/pt-BR/translation.json
+++ b/packages/locale/src/locales/pt-BR/translation.json
@@ -74,7 +74,8 @@
 		"I_AM_HUMAN": "Eu sou um humano",
 		"NO_ACCOUNTS_FOUND": "Nenhuma conta encontrada",
 		"ACCOUNT_NOT_FOUND": "Conta não encontrada",
-		"NO_EXTENSION_FOUND": "Nenhuma extensão encontrada"
+		"NO_EXTENSION_FOUND": "Nenhuma extensão encontrada",
+		"INSECURE_CONTEXT": "O Procaptcha requer uma conexão segura (HTTPS)"
 	},
 	"CONTRACT": {
 		"INVALID_ADDRESS": "Falha ao codificar endereço inválido",

--- a/packages/locale/src/locales/pt/translation.json
+++ b/packages/locale/src/locales/pt/translation.json
@@ -74,7 +74,8 @@
 		"I_AM_HUMAN": "Eu sou humano",
 		"NO_ACCOUNTS_FOUND": "Nenhuma conta encontrada",
 		"ACCOUNT_NOT_FOUND": "Conta não encontrada",
-		"NO_EXTENSION_FOUND": "Nenhuma extensão encontrada"
+		"NO_EXTENSION_FOUND": "Nenhuma extensão encontrada",
+		"INSECURE_CONTEXT": "O Procaptcha requer uma ligação segura (HTTPS)"
 	},
 	"CONTRACT": {
 		"INVALID_ADDRESS": "Falha ao codificar endereço inválido",

--- a/packages/locale/src/locales/ro/translation.json
+++ b/packages/locale/src/locales/ro/translation.json
@@ -373,7 +373,8 @@
 		"I_AM_HUMAN": "Sunt om",
 		"NO_ACCOUNTS_FOUND": "Niciun cont gasit",
 		"ACCOUNT_NOT_FOUND": "Contul nu a fost gasit",
-		"NO_EXTENSION_FOUND": "Nicio extensie gasita"
+		"NO_EXTENSION_FOUND": "Nicio extensie gasita",
+		"INSECURE_CONTEXT": "Procaptcha necesită o conexiune securizată (HTTPS)"
 	},
 	"CONTRACT": {
 		"INVALID_ADDRESS": "Eroare la codificarea adresei invalide",

--- a/packages/locale/src/locales/ru/translation.json
+++ b/packages/locale/src/locales/ru/translation.json
@@ -373,7 +373,8 @@
 		"I_AM_HUMAN": "Я человек",
 		"NO_ACCOUNTS_FOUND": "Учетные записи не найдены",
 		"ACCOUNT_NOT_FOUND": "Учетная запись не найдена",
-		"NO_EXTENSION_FOUND": "Расширение не найдено"
+		"NO_EXTENSION_FOUND": "Расширение не найдено",
+		"INSECURE_CONTEXT": "Procaptcha требует безопасного соединения (HTTPS)"
 	},
 	"CONTRACT": {
 		"INVALID_ADDRESS": "Не удалось закодировать неверный адрес",

--- a/packages/locale/src/locales/sr/translation.json
+++ b/packages/locale/src/locales/sr/translation.json
@@ -373,7 +373,8 @@
 		"I_AM_HUMAN": "Ја сам човек",
 		"NO_ACCOUNTS_FOUND": "Нису пронађени налози",
 		"ACCOUNT_NOT_FOUND": "Н��лог није пронађен",
-		"NO_EXTENSION_FOUND": "Нису пронађене екстензије"
+		"NO_EXTENSION_FOUND": "Нису пронађене екстензије",
+		"INSECURE_CONTEXT": "Procaptcha захтева безбедну (HTTPS) везу"
 	},
 	"CONTRACT": {
 		"INVALID_ADDRESS": "Немогуће кодирање неважеће адресе",

--- a/packages/locale/src/locales/sv/translation.json
+++ b/packages/locale/src/locales/sv/translation.json
@@ -373,7 +373,8 @@
 		"I_AM_HUMAN": "Jag är en människa",
 		"NO_ACCOUNTS_FOUND": "Inga konton hittades",
 		"ACCOUNT_NOT_FOUND": "Konto hittades inte",
-		"NO_EXTENSION_FOUND": "Ingen förlängning hittades"
+		"NO_EXTENSION_FOUND": "Ingen förlängning hittades",
+		"INSECURE_CONTEXT": "Procaptcha kräver en säker (HTTPS) anslutning"
 	},
 	"CONTRACT": {
 		"INVALID_ADDRESS": "Misslyckades att koda ogiltig adress",

--- a/packages/locale/src/locales/th/translation.json
+++ b/packages/locale/src/locales/th/translation.json
@@ -373,7 +373,8 @@
 		"I_AM_HUMAN": "ฉันเป็นมนุษย์",
 		"NO_ACCOUNTS_FOUND": "ไม่พบบัญชี",
 		"ACCOUNT_NOT_FOUND": "ไม่พบบัญชี",
-		"NO_EXTENSION_FOUND": "ไม่พบส่วนขยาย"
+		"NO_EXTENSION_FOUND": "ไม่พบส่วนขยาย",
+		"INSECURE_CONTEXT": "Procaptcha ต้องใช้การเชื่อมต่อที่ปลอดภัย (HTTPS)"
 	},
 	"CONTRACT": {
 		"INVALID_ADDRESS": "ล้มเหลวในการเข้ารหัสที่อยู่ไม่ถูกต้อง",

--- a/packages/locale/src/locales/tr/translation.json
+++ b/packages/locale/src/locales/tr/translation.json
@@ -373,7 +373,8 @@
 		"I_AM_HUMAN": "Ben bir insanım",
 		"NO_ACCOUNTS_FOUND": "Hesap bulunamadı",
 		"ACCOUNT_NOT_FOUND": "Hesap bulunamadı",
-		"NO_EXTENSION_FOUND": "Eklenti bulunamadı"
+		"NO_EXTENSION_FOUND": "Eklenti bulunamadı",
+		"INSECURE_CONTEXT": "Procaptcha güvenli bir (HTTPS) bağlantı gerektirir"
 	},
 	"CONTRACT": {
 		"INVALID_ADDRESS": "Geçersiz adresi kodlama başarısız oldu",

--- a/packages/locale/src/locales/uk/translation.json
+++ b/packages/locale/src/locales/uk/translation.json
@@ -373,7 +373,8 @@
 		"I_AM_HUMAN": "I am human",
 		"NO_ACCOUNTS_FOUND": "No accounts found",
 		"ACCOUNT_NOT_FOUND": "Account not found",
-		"NO_EXTENSION_FOUND": "No extension found"
+		"NO_EXTENSION_FOUND": "No extension found",
+		"INSECURE_CONTEXT": "Procaptcha потребує безпечного з'єднання (HTTPS)"
 	},
 	"CONTRACT": {
 		"INVALID_ADDRESS": "Failed to encode invalid address",

--- a/packages/locale/src/locales/vi/translation.json
+++ b/packages/locale/src/locales/vi/translation.json
@@ -373,7 +373,8 @@
 		"I_AM_HUMAN": "Tôi là con người",
 		"NO_ACCOUNTS_FOUND": "Không tìm thấy tài khoản",
 		"ACCOUNT_NOT_FOUND": "Không tìm thấy tài khoản",
-		"NO_EXTENSION_FOUND": "Không tìm thấy tiện ích"
+		"NO_EXTENSION_FOUND": "Không tìm thấy tiện ích",
+		"INSECURE_CONTEXT": "Procaptcha yêu cầu kết nối an toàn (HTTPS)"
 	},
 	"CONTRACT": {
 		"INVALID_ADDRESS": "Không thể mã hóa địa chỉ không hợp lệ",

--- a/packages/locale/src/locales/zh-CN/translation.json
+++ b/packages/locale/src/locales/zh-CN/translation.json
@@ -373,7 +373,8 @@
 		"I_AM_HUMAN": "我是人类",
 		"NO_ACCOUNTS_FOUND": "找不到帐户",
 		"ACCOUNT_NOT_FOUND": "找不到帐户",
-		"NO_EXTENSION_FOUND": "找不到扩展"
+		"NO_EXTENSION_FOUND": "找不到扩展",
+		"INSECURE_CONTEXT": "Procaptcha 需要安全连接 (HTTPS)"
 	},
 	"CONTRACT": {
 		"INVALID_ADDRESS": "无法编码无效地址",

--- a/packages/procaptcha-common/src/elements/window.ts
+++ b/packages/procaptcha-common/src/elements/window.ts
@@ -22,3 +22,18 @@ export const getWindowCallback = (callbackName: string) => {
 	}
 	return fn;
 };
+
+/**
+ * Procaptcha depends on secure-context-only browser APIs (e.g. SubtleCrypto)
+ * to run a challenge. These are unavailable when the widget is served over
+ * plain HTTP, which otherwise surfaces as a cryptic provider-selection
+ * failure. The browser already treats HTTPS and localhost as secure contexts,
+ * so this only flags genuine HTTP origins. Non-browser (SSR) environments are
+ * treated as secure since the HTTP restriction does not apply there.
+ */
+export const isSecureBrowserContext = (): boolean => {
+	if (typeof window === "undefined") {
+		return true;
+	}
+	return window.isSecureContext === true;
+};

--- a/packages/procaptcha-common/src/tests/window.test.ts
+++ b/packages/procaptcha-common/src/tests/window.test.ts
@@ -13,7 +13,10 @@
 // limitations under the License.
 
 import { afterEach, describe, expect, it } from "vitest";
-import { getWindowCallback } from "../elements/window.js";
+import {
+	getWindowCallback,
+	isSecureBrowserContext,
+} from "../elements/window.js";
 
 describe("elements/window", () => {
 	describe("getWindowCallback", () => {
@@ -101,6 +104,34 @@ describe("elements/window", () => {
 			const result = getWindowCallback("testRegularCallback");
 			expect(result).toBe(regularFn);
 			expect(result(5)).toBe(10);
+		});
+	});
+
+	describe("isSecureBrowserContext", () => {
+		const originalIsSecureContext = window.isSecureContext;
+
+		const setIsSecureContext = (value: boolean): void => {
+			Object.defineProperty(window, "isSecureContext", {
+				value,
+				configurable: true,
+				writable: true,
+			});
+		};
+
+		afterEach(() => {
+			setIsSecureContext(originalIsSecureContext);
+		});
+
+		it("should return true in a secure context (HTTPS/localhost)", () => {
+			setIsSecureContext(true);
+
+			expect(isSecureBrowserContext()).toBe(true);
+		});
+
+		it("should return false in an insecure context (plain HTTP)", () => {
+			setIsSecureContext(false);
+
+			expect(isSecureBrowserContext()).toBe(false);
 		});
 	});
 });

--- a/packages/procaptcha-frictionless/src/ProcaptchaFrictionless.tsx
+++ b/packages/procaptcha-frictionless/src/ProcaptchaFrictionless.tsx
@@ -16,6 +16,7 @@ import { loadI18next } from "@prosopo/locale";
 import {
 	Checkbox,
 	getDefaultEvents,
+	isSecureBrowserContext,
 	providerRetry,
 } from "@prosopo/procaptcha-common";
 import {
@@ -150,6 +151,18 @@ export const ProcaptchaFrictionless = ({
 	};
 
 	const start = async () => {
+		// Procaptcha cannot run over plain HTTP (no SubtleCrypto etc.), which
+		// would otherwise fail later with a cryptic provider-selection error.
+		// Surface a clear, non-retrying message instead.
+		if (!isSecureBrowserContext()) {
+			const errorMessage = i18n.isInitialized
+				? i18n.t("WIDGET.INSECURE_CONTEXT")
+				: "Procaptcha requires a secure (HTTPS) connection";
+			events.onError(new Error(errorMessage));
+			fallOverWithStyle(errorMessage, "WIDGET.INSECURE_CONTEXT");
+			return;
+		}
+
 		await providerRetry(
 			async () => {
 				stateRef.current.attemptCount += 1;


### PR DESCRIPTION
Detect when the widget is served over plain HTTP and show a clear "Procaptcha requires a secure (HTTPS) connection" message instead of the cryptic `Provider Selection Failed` error.

Closes #3183

🤖 Generated with [Claude Code](https://claude.com/claude-code)