### PR TITLE
fix/frictionless: invalidate hash cache on consume + use solved count for configured-image

### DIFF
--- a/.changeset/puzzle-hash-cache-and-image-shortcircuit.md
+++ b/.changeset/puzzle-hash-cache-and-image-shortcircuit.md
@@ -1,0 +1,19 @@
+---
+"@prosopo/provider": patch
+---
+
+Fix `/captcha/{type}` endpoints looping with "No session found" after a
+session has been consumed: the hash → sessionId mapping
+(`cache:session:hash:{userSitekeyIpHash}`) is now invalidated alongside
+the sessionId cache, and both invalidations are awaited so a concurrent
+`patchCachedSession` (e.g. puzzle solution submission) can no longer
+re-populate the cache between consume and response. Previously the
+hash mapping outlived the session for up to its 1-hour TTL, so
+`/frictionless` kept handing the dead sessionId back to the client.
+
+Fix the configured-image short-circuit in `/frictionless` to use the
+normal solved count capped by `imageMaxRounds`, matching every other
+image branch in the file. Previously it used `imageMaxRounds`
+(default 32) as the count rather than as a cap, so any site key
+configured with `captchaType: image` punished every visitor with 32
+rounds regardless of bot signals.

--- a/packages/provider/src/api/captcha/getFrictionlessCaptchaChallenge.ts
+++ b/packages/provider/src/api/captcha/getFrictionlessCaptchaChallenge.ts
@@ -329,7 +329,10 @@ export default (
 						return res.json(
 							await tasks.frictionlessManager.sendImageCaptcha({
 								...shortCircuitParams,
-								solvedImagesCount: clientRecord.settings.imageMaxRounds,
+								solvedImagesCount: Math.min(
+									env.config.captchas.solved.count,
+									clientRecord.settings.imageMaxRounds,
+								),
 							}),
 						);
 					case CaptchaType.pow:

--- a/packages/provider/src/tasks/captchaManager.ts
+++ b/packages/provider/src/tasks/captchaManager.ts
@@ -282,6 +282,13 @@ export class CaptchaManager {
 		// runs the decision machine; image/pow/puzzle short-circuit). We trust
 		// the session record's captchaType as the source of truth.
 		if (sessionId) {
+			// Look up the cache record before consuming the session so we
+			// can invalidate the hash → sessionId mapping even when the DB
+			// record is already gone. Without this, the failure path leaks
+			// the hash mapping for the remainder of its 1-hour TTL.
+			const cachedBeforeRemove = this.writeQueue
+				? await this.writeQueue.getCachedSession(sessionId)
+				: null;
 			const sessionRecord = await this.db.checkAndRemoveSession(sessionId);
 			if (!sessionRecord) {
 				this.logger.warn(() => ({
@@ -297,7 +304,16 @@ export class CaptchaManager {
 				// and /frictionless keeps "Reusing existing session" →
 				// /captcha/* keeps failing in an infinite loop.
 				if (this.writeQueue) {
-					this.writeQueue.invalidateCachedSession(sessionId).catch(() => {});
+					const cachedHash =
+						typeof cachedBeforeRemove?.userSitekeyIpHash === "string"
+							? cachedBeforeRemove.userSitekeyIpHash
+							: undefined;
+					await Promise.all([
+						this.writeQueue.invalidateCachedSession(sessionId),
+						cachedHash
+							? this.writeQueue.invalidateCachedSessionByHash(cachedHash)
+							: Promise.resolve(),
+					]);
 				}
 				return {
 					valid: false,
@@ -308,9 +324,19 @@ export class CaptchaManager {
 
 			// Invalidate the Redis session cache so that subsequent
 			// requests do not receive this now-deleted sessionId from
-			// the stale cache.
+			// the stale cache. Both the sessionId cache and the
+			// hash → sessionId mapping must be invalidated, awaited so
+			// no concurrent write (e.g. solution-submit `patchCachedSession`)
+			// can re-populate the entry between consume and response.
 			if (this.writeQueue) {
-				this.writeQueue.invalidateCachedSession(sessionId).catch(() => {});
+				await Promise.all([
+					this.writeQueue.invalidateCachedSession(sessionId),
+					sessionRecord.userSitekeyIpHash
+						? this.writeQueue.invalidateCachedSessionByHash(
+								sessionRecord.userSitekeyIpHash,
+							)
+						: Promise.resolve(),
+				]);
 			}
 
 			// Validate IP address if currentIP is provided

--- a/packages/provider/src/tests/unit/tasks/captchaManager.unit.test.ts
+++ b/packages/provider/src/tests/unit/tasks/captchaManager.unit.test.ts
@@ -99,6 +99,8 @@ describe("CaptchaManager", () => {
 
 		mockWriteQueue = {
 			invalidateCachedSession: vi.fn().mockResolvedValue(undefined),
+			invalidateCachedSessionByHash: vi.fn().mockResolvedValue(undefined),
+			getCachedSession: vi.fn().mockResolvedValue(null),
 		} as unknown as RedisWriteQueue;
 
 		captchaManager = new CaptchaManager(
@@ -227,7 +229,8 @@ describe("CaptchaManager", () => {
 			(db.checkAndRemoveSession as any).mockResolvedValue({
 				sessionId: "sessionId",
 				captchaType: CaptchaType.pow,
-			} as Pick<Session, "sessionId" | "captchaType">);
+				userSitekeyIpHash: "hash-xyz",
+			} as Pick<Session, "sessionId" | "captchaType" | "userSitekeyIpHash">);
 
 			await captchaManager.isValidRequest(
 				{
@@ -248,13 +251,17 @@ describe("CaptchaManager", () => {
 			expect(mockWriteQueue.invalidateCachedSession).toHaveBeenCalledWith(
 				"sessionId",
 			);
+			expect(mockWriteQueue.invalidateCachedSessionByHash).toHaveBeenCalledWith(
+				"hash-xyz",
+			);
 		});
 		it("should invalidate the Redis session cache after consuming a frictionless image session", async () => {
 			// biome-ignore lint/suspicious/noExplicitAny: tests
 			(db.checkAndRemoveSession as any).mockResolvedValue({
 				sessionId: "sessionId",
 				captchaType: CaptchaType.image,
-			} as Pick<Session, "sessionId" | "captchaType">);
+				userSitekeyIpHash: "hash-xyz",
+			} as Pick<Session, "sessionId" | "captchaType" | "userSitekeyIpHash">);
 
 			await captchaManager.isValidRequest(
 				{
@@ -275,10 +282,23 @@ describe("CaptchaManager", () => {
 			expect(mockWriteQueue.invalidateCachedSession).toHaveBeenCalledWith(
 				"sessionId",
 			);
+			expect(mockWriteQueue.invalidateCachedSessionByHash).toHaveBeenCalledWith(
+				"hash-xyz",
+			);
 		});
 		it("should invalidate Redis cache when session is not found, to break stale-cache loops", async () => {
 			// biome-ignore lint/suspicious/noExplicitAny: tests
 			(db.checkAndRemoveSession as any).mockResolvedValue(undefined);
+			// Simulate the drifted-cache state: DB record is gone, but the
+			// Redis sessionId cache still holds the original entry which
+			// carries the userSitekeyIpHash needed to invalidate the hash
+			// mapping.
+
+			// biome-ignore lint/suspicious/noExplicitAny: tests
+			(mockWriteQueue.getCachedSession as any).mockResolvedValueOnce({
+				sessionId: "sessionId",
+				userSitekeyIpHash: "hash-xyz",
+			});
 
 			await captchaManager.isValidRequest(
 				{
@@ -294,12 +314,16 @@ describe("CaptchaManager", () => {
 				"sessionId",
 			);
 
-			// When DB has no record but Redis cache does, the cache must be
-			// invalidated; otherwise the user-IP-hash mapping keeps resolving
-			// to the dead sessionId and /frictionless keeps "Reusing existing
-			// session" while /captcha/{type} keeps 400-ing in a loop.
+			// When DB has no record but Redis cache does, BOTH the sessionId
+			// cache and the hash → sessionId mapping must be invalidated;
+			// otherwise the hash mapping keeps resolving to the dead
+			// sessionId and /frictionless keeps "Reusing existing session"
+			// while /captcha/{type} keeps 400-ing in a loop.
 			expect(mockWriteQueue.invalidateCachedSession).toHaveBeenCalledWith(
 				"sessionId",
+			);
+			expect(mockWriteQueue.invalidateCachedSessionByHash).toHaveBeenCalledWith(
+				"hash-xyz",
 			);
 		});
 		it("should not throw when writeQueue is null and session is consumed", async () => {

--- a/packages/provider/src/util/redisCache.ts
+++ b/packages/provider/src/util/redisCache.ts
@@ -193,6 +193,31 @@ export class RedisWriteQueue {
 		}
 	}
 
+	/**
+	 * Invalidate the hash → sessionId mapping used by /frictionless for
+	 * dedup. Must be called alongside `invalidateCachedSession` when a
+	 * session is consumed, otherwise the hash mapping keeps resolving to
+	 * a dead sessionId for the remainder of its 1-hour TTL.
+	 */
+	async invalidateCachedSessionByHash(
+		userSitekeyIpHash: string,
+	): Promise<void> {
+		const client = await this.getClient();
+		if (!client) {
+			return;
+		}
+
+		try {
+			await client.del(`cache:session:hash:${userSitekeyIpHash}`);
+		} catch (error) {
+			this.logger.warn(() => ({
+				msg: "Failed to invalidate cached session hash in Redis",
+				err: error,
+				userSitekeyIpHash,
+			}));
+		}
+	}
+
 	// ── Frictionless session deduplication cache ────────────────────────
 
 	/**


### PR DESCRIPTION
## Summary
Two fixes in `/frictionless` and the captcha-type endpoints, both surfaced from a staging investigation on `pronode3` / `pronode4`:

### 1. "No session found" loop on `/captcha/{type}`
- The hash → sessionId mapping (`cache:session:hash:{userSitekeyIpHash}`) was never invalidated when a session was consumed. It outlived the session for up to its 1-hour TTL, so `/frictionless` kept handing the dead sessionId back to the client and `/captcha/{type}` kept failing with `CAPTCHA.NO_SESSION_FOUND` in a loop.
- The fire-and-forget invalidation of the sessionId cache also raced with concurrent `patchCachedSession` writes (e.g. puzzle solution submission, which calls `updateSessionRecordWithCache`) — the cache could be re-populated between consume and response, with `deleted: undefined` because the cached copy never carried the Mongo-side `deleted: true` flag.

**Fix:** new `invalidateCachedSessionByHash()` is called alongside `invalidateCachedSession()` from `CaptchaManager.isValidRequest`, awaited together in `Promise.all` on both the success and failure paths. The failure path reads the cache **before** `checkAndRemoveSession` so the `userSitekeyIpHash` is available even when the DB record is already gone.

### 2. Configured-image short-circuit used `imageMaxRounds` as the count
- In `getFrictionlessCaptchaChallenge.ts`, when a site key has `settings.captchaType: image` the short-circuit was setting `solvedImagesCount: clientRecord.settings.imageMaxRounds` (default **32**).
- `imageMaxRounds` is named and used everywhere else as a **cap** (`Math.min(someCount, imageMaxRounds)`). Using it as the count meant any site key configured for image captcha punished every visitor with 32 rounds regardless of bot signals — a UX choice ("always show image") got treated as a maximum penalty.

**Fix:** use `Math.min(env.config.captchas.solved.count, clientRecord.settings.imageMaxRounds)`, matching the `BOT_SCORE_ABOVE_THRESHOLD` branch.

## Test plan
- [x] `npm run -w @prosopo/provider test:unit -- src/tests/unit/tasks/captchaManager.unit.test.ts` — 34/34 pass
- [x] `npm run -w @prosopo/provider test:unit -- src/tests/unit/tasks/frictionless/` — 44/44 pass
- [x] `npm run -w @prosopo/provider test:unit -- src/tests/unit/util/redisCache.unit.test.ts` — 27/27 pass
- [x] `npm run -w @prosopo/provider build:tsc` clean
- [x] `npx biome check` clean on changed files
- [ ] Reproduce the "No session found" loop on staging-pronode3 against the new build and confirm `/frictionless` falls through to a fresh session instead of resurrecting the dead one
- [ ] Confirm a site key configured with `captchaType: image` issues `solved.count` rounds (2 by default) rather than 32

🤖 Generated with [Claude Code](https://claude.com/claude-code)