### PR TITLE
fix(util): restore Vite define substitution for package version

### DIFF
--- a/.changeset/fix-version-vite-define.md
+++ b/.changeset/fix-version-vite-define.md
@@ -1,0 +1,16 @@
+---
+"@prosopo/util": patch
+---
+
+Restore Vite build-time substitution of the package version.
+
+The `process` guard added in #2551 introduced optional chaining
+(`process.env?.PROSOPO_PACKAGE_VERSION`), which Vite's `define` plugin
+no longer matches because the AST node becomes an OptionalMemberExpression
+instead of a plain MemberExpression. As a result the build-time version
+was never inlined and bundled servers reported `version: "dev"` from the
+`/v1/prosopo/provider/public/details` endpoint.
+
+Drop the `?.` while keeping the `typeof process !== "undefined"` guard
+so the guard still protects browser runtimes and Vite's define
+substitution works again.

--- a/packages/util/src/version.ts
+++ b/packages/util/src/version.ts
@@ -12,9 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // Guarded to remain loadable in browser runtimes (e.g. vite dev/preview)
-// where `process` isn't defined.
+// where `process` isn't defined. Note: the inner access must be
+// `process.env.PROSOPO_PACKAGE_VERSION` (no optional chaining) so that Vite's
+// `define` AST replacement matches and substitutes the build-time version.
 const envVersion =
 	typeof process !== "undefined"
-		? process.env?.PROSOPO_PACKAGE_VERSION
+		? process.env.PROSOPO_PACKAGE_VERSION
 		: undefined;
 export const version = envVersion || "dev";


### PR DESCRIPTION
## Summary
- The `/v1/prosopo/provider/public/details` endpoint on `pronode4.prosopo.io` is reporting `version: "dev"` even though the container is `prosopo/provider:3.6.22`.
- Root cause: #2551 added a `typeof process !== "undefined"` guard to `packages/util/src/version.ts` and, in the process, switched the access to `process.env?.PROSOPO_PACKAGE_VERSION`. The optional chaining turns the node into an `OptionalMemberExpression`, which Vite's `define` plugin does not pattern-match, so the build-time version is never inlined. At runtime the env var isn't actually set in the container, so it falls back to `"dev"`.
- Fix: keep the `typeof process` guard but drop the `?.` so the inner access is once again `process.env.PROSOPO_PACKAGE_VERSION` — the literal expression Vite's `define` rewrites. Browser runtimes are still protected by the outer guard.

## Test plan
- [ ] Rebuild the provider image and confirm `/v1/prosopo/provider/public/details` returns the package version (e.g. `3.6.22`) instead of `dev`.
- [ ] Smoke-test in a browser context (vite dev/preview) to confirm the `typeof process` guard still prevents a ReferenceError.

🤖 Generated with [Claude Code](https://claude.com/claude-code)