### PR TITLE
fix(provider): silence per-request error when decision machine has no route export

### DIFF
--- a/.changeset/decision-machine-route-optional.md
+++ b/.changeset/decision-machine-route-optional.md
@@ -1,0 +1,17 @@
+---
+"@prosopo/provider": patch
+---
+
+Stop logging an error per request when a decision machine has no `route` export.
+
+PR #2543 added a routing pre-phase that calls `route()` on whichever decision
+machine is selected for the dapp. The runner's export lookup only treats
+`module.exports = fn` as a default for `decide`/`default`, so decide-only
+machines (the in-prod shape: a bare default function) caused `route()` to
+throw `Decision machine must export one of: route` on every verify request.
+
+Behaviour was already correct — the caller catches and falls back to the
+baseline — but the per-request error log was noisy. Pass `optional: true`
+when looking up the `route` export so a missing one returns `undefined`
+silently, matching how `requiredCounters` is already handled. Schema
+validation failures, throws, and timeouts continue to log an error.

--- a/packages/provider/src/tasks/decisionMachine/decisionMachineRunner.ts
+++ b/packages/provider/src/tasks/decisionMachine/decisionMachineRunner.ts
@@ -154,9 +154,10 @@ export class DecisionMachineRunner {
 
 	/**
 	 * Routing phase: ask the configured machine which concrete captcha type to
-	 * serve. Returns undefined when no machine is configured, the machine throws
-	 * or times out, or the output fails schema validation — caller should fall
-	 * back to its baseline in any of these cases.
+	 * serve. Returns undefined when no machine is configured, the machine has
+	 * no route export, the machine throws or times out, or the output fails
+	 * schema validation — caller should fall back to its baseline in any of
+	 * these cases.
 	 */
 	async route(
 		input: RoutingMachineInput,
@@ -175,7 +176,7 @@ export class DecisionMachineRunner {
 			return await this.runArtifactExport(
 				artifact,
 				["route"],
-				{ input },
+				{ input, optional: true },
 				RoutingMachineOutputSchema,
 			);
 		} catch (error) {

--- a/packages/provider/src/tests/unit/tasks/decisionMachine/decisionMachineRunner.unit.test.ts
+++ b/packages/provider/src/tests/unit/tasks/decisionMachine/decisionMachineRunner.unit.test.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import type { Logger } from "@prosopo/common";
 import {
 	CaptchaType,
 	type DecisionMachineArtifact,
@@ -25,6 +26,30 @@ import {
 import type { IProviderDatabase } from "@prosopo/types-database";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { DecisionMachineRunner } from "../../../../tasks/decisionMachine/decisionMachineRunner.js";
+
+const stubLogger = (): Logger => {
+	const noop = (): void => {};
+	const logger: Partial<Logger> = {
+		setLogLevel: noop,
+		getLogLevel: () => "info",
+		getScope: () => "test",
+		info: vi.fn(),
+		debug: vi.fn(),
+		trace: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+		fatal: vi.fn(),
+		log: vi.fn(),
+		getPretty: () => false,
+		setPretty: noop,
+		getPrintStack: () => false,
+		setPrintStack: noop,
+		getFormat: () => "json",
+		setFormat: noop,
+	};
+	logger.with = () => logger as Logger;
+	return logger as Logger;
+};
 
 const baseRouteInput = (
 	overrides: Partial<RoutingMachineInputBase> = {},
@@ -273,6 +298,25 @@ describe("DecisionMachineRunner", () => {
 
 			const result = await runner.route(routeInput());
 			expect(result).toBeUndefined();
+		});
+
+		it("returns undefined without logging an error for a decide-only artifact", async () => {
+			// Mirrors the in-prod shape: a bare default function intended for
+			// decide(). route() should silently fall back to baseline rather
+			// than log "Decision machine must export one of: route" per request.
+			const artifact = buildArtifact(
+				'module.exports = () => ({ decision: "allow" });',
+				DecisionMachineScope.Global,
+			);
+			(db.getDecisionMachineArtifact as unknown as ReturnType<typeof vi.fn>)
+				.mockResolvedValueOnce(undefined)
+				.mockResolvedValueOnce(artifact);
+
+			const logger = stubLogger();
+			const result = await runner.route(routeInput(), logger);
+			expect(result).toBeUndefined();
+			expect(logger.error).not.toHaveBeenCalled();
+			expect(logger.warn).not.toHaveBeenCalled();
 		});
 
 		it("returns undefined on invalid output", async () => {


### PR DESCRIPTION
## Summary

- PR #2543 (v3.6.20, *Interactive Puzzle Routing*) added a routing pre-phase that calls `route()` on whichever decision machine is selected for the dapp.
- The runner's export lookup in `findExport` (`decisionMachineRunner.ts:366`) only treats `module.exports = fn` as a default export when one of the requested names is `"default"` or `"decide"`. The routing call passes only `["route"]`, so the in-prod **decide-only** machines (bare default function) cause `runArtifactExport` to throw `Decision machine must export one of: route` on every verify request.
- Behaviour was already correct — `route()`'s catch logs and `applyRouter` falls back to the baseline — but the per-request error log was noisy in production after the v3.6.22 rollout.
- Fix: pass `optional: true` to the `route` lookup so a missing export returns `undefined` silently, mirroring how `getRequiredCounters` is already handled (`decisionMachineRunner.ts:207`). Schema validation failures, sandbox throws and timeouts continue to log an error.

## Test plan

- [x] `npm run -w @prosopo/provider build:tsc` (clean)
- [x] `npx vitest run packages/provider/src/tests/unit/tasks/decisionMachine/decisionMachineRunner.unit.test.ts` — all 21 tests pass, including a new regression test asserting `logger.error` is **not** called when `route()` runs against a decide-only artifact
- [ ] Post-merge: confirm "Routing machine failed, falling back to baseline — Decision machine must export one of: route" no longer appears in provider logs for dapps without a custom router

🤖 Generated with [Claude Code](https://claude.com/claude-code)