### PR TITLE
fix(types-database): index ipInfo / parsedUserAgentInfo backfill queries

### DIFF
--- a/.changeset/ipinfo-backfill-indexes.md
+++ b/.changeset/ipinfo-backfill-indexes.md
@@ -1,0 +1,27 @@
+---
+"@prosopo/types-database": patch
+---
+
+fix(types-database): index the ipInfo / parsedUserAgentInfo backfill queries
+
+The CHECK_IP_INFO and PARSE_USER_AGENT jobs read records via
+`getCaptchas({ <field>: { $exists: false } })`, but no index covered
+either predicate on `PoWCaptchaRecordSchema`, `PuzzleCaptchaRecordSchema`,
+or `UserCommitmentRecordSchema`. The existing `ipInfo.countryCode` and
+`ipInfo.isVPN` indexes only contain rows where `ipInfo` already exists,
+so they actively can't help the "missing" query — both jobs were running
+COLLSCANs.
+
+Add partial indexes keyed on `_id` with
+`partialFilterExpression: { <field>: { $exists: false } }` to each of the
+three schemas (six new indexes total). Partial filters exactly matching
+the query predicate allow the planner to use the index. The index stays
+small because it only contains un-enriched rows, shrinks as the backfill
+progresses, and is essentially empty once the request-time middleware has
+populated every new row.
+
+Note: `CaptchaDatabase.ensureIndexes()` drops then recreates all indexes
+on each collection, so applying these in production will rebuild every
+existing index on `commitment`, `powcaptcha`, and `puzzlecaptcha` —
+schedule during a maintenance window or build only the new partial
+indexes directly via `createIndex` on the live cluster.

--- a/packages/types-database/src/types/provider.ts
+++ b/packages/types-database/src/types/provider.ts
@@ -210,6 +210,24 @@ PoWCaptchaRecordSchema.index({ "ipAddress.upper": 1 });
 PoWCaptchaRecordSchema.index({ "result.reason": 1 });
 PoWCaptchaRecordSchema.index({ "ipInfo.countryCode": 1 });
 PoWCaptchaRecordSchema.index({ "ipInfo.isVPN": 1 });
+// Supports the CHECK_IP_INFO / PARSE_USER_AGENT backfill queries
+// (`{ <field>: { $exists: false } }`). Partial filter keeps the index
+// limited to the un-enriched rows, so it shrinks as the backfill
+// progresses and is empty once the middleware has filled every row.
+PoWCaptchaRecordSchema.index(
+	{ _id: 1 },
+	{
+		name: "ipInfo_missing",
+		partialFilterExpression: { ipInfo: { $exists: false } },
+	},
+);
+PoWCaptchaRecordSchema.index(
+	{ _id: 1 },
+	{
+		name: "parsedUserAgentInfo_missing",
+		partialFilterExpression: { parsedUserAgentInfo: { $exists: false } },
+	},
+);
 
 export const PuzzleCaptchaRecordSchema = new Schema<PuzzleCaptchaRecord>({
 	challenge: { type: String, required: true },
@@ -288,6 +306,20 @@ PuzzleCaptchaRecordSchema.index({ "ipAddress.upper": 1 });
 PuzzleCaptchaRecordSchema.index({ "result.reason": 1 });
 PuzzleCaptchaRecordSchema.index({ "ipInfo.countryCode": 1 });
 PuzzleCaptchaRecordSchema.index({ "ipInfo.isVPN": 1 });
+PuzzleCaptchaRecordSchema.index(
+	{ _id: 1 },
+	{
+		name: "ipInfo_missing",
+		partialFilterExpression: { ipInfo: { $exists: false } },
+	},
+);
+PuzzleCaptchaRecordSchema.index(
+	{ _id: 1 },
+	{
+		name: "parsedUserAgentInfo_missing",
+		partialFilterExpression: { parsedUserAgentInfo: { $exists: false } },
+	},
+);
 
 export const UserCommitmentRecordSchema = new Schema<UserCommitmentRecord>({
 	userAccount: { type: String, required: true },
@@ -358,6 +390,20 @@ UserCommitmentRecordSchema.index({ "ipInfo.countryCode": 1 });
 UserCommitmentRecordSchema.index({ "ipInfo.isVPN": 1 });
 UserCommitmentRecordSchema.index({ requestHash: -1 });
 UserCommitmentRecordSchema.index({ pending: 1 });
+UserCommitmentRecordSchema.index(
+	{ _id: 1 },
+	{
+		name: "ipInfo_missing",
+		partialFilterExpression: { ipInfo: { $exists: false } },
+	},
+);
+UserCommitmentRecordSchema.index(
+	{ _id: 1 },
+	{
+		name: "parsedUserAgentInfo_missing",
+		partialFilterExpression: { parsedUserAgentInfo: { $exists: false } },
+	},
+);
 
 export const DatasetRecordSchema = new Schema<DatasetWithIds>({
 	contentTree: { type: [[String]], required: true },


### PR DESCRIPTION
## Summary

- The CHECK_IP_INFO and PARSE_USER_AGENT jobs read via `getCaptchas({ <field>: { $exists: false } })`, but no index covered either predicate — both jobs were running COLLSCANs on the `commitment`, `powcaptcha`, and `puzzlecaptcha` collections.
- The existing `ipInfo.countryCode` / `ipInfo.isVPN` sub-field indexes can't help: they only contain rows where `ipInfo` already exists.
- Add partial indexes keyed on `_id` with `partialFilterExpression` exactly matching each query predicate on all three schemas (6 new indexes). The planner uses them; they stay small (only un-enriched rows), shrink as the backfill progresses, and are empty once the request-time middleware has filled every row.

## Operational note

`CaptchaDatabase.ensureIndexes()` does `dropIndexes()` before recreating, so running it in production rebuilds every index on these three collections (not just the new ones). Schedule during a maintenance window, or build only the new partial indexes directly via `db.<coll>.createIndex(...)` on the live cluster — both options are documented in the changeset.

## Test plan

- [x] Schema edits only — no behavior change at the application layer
- [x] `npx biome check` clean on changed files
- [ ] On rollout: verify the planner picks `ipInfo_missing` / `parsedUserAgentInfo_missing` (e.g. `db.commitment.find({ ipInfo: { $exists: false } }).explain()` should show `IXSCAN`, not `COLLSCAN`)
- [ ] Pairs with prosopo/captcha-private#3386 (the job-runner-side fan-out cap); merge order doesn't matter

🤖 Generated with [Claude Code](https://claude.com/claude-code)