### PR TITLE
feat(provider): allow Google Translate proxy domains through domain check

### DIFF
--- a/.changeset/allow-google-translate-domains.md
+++ b/.changeset/allow-google-translate-domains.md
@@ -1,0 +1,18 @@
+---
+"@prosopo/util": patch
+"@prosopo/provider": patch
+---
+
+feat(provider): allow Google Translate proxy domains through the domain check middleware
+
+Google Translate proxies a site under `<encoded>.translate.goog` (e.g.
+`prosopo-io.translate.goog`), encoding `.` as `-` and `-` as `--`. With the
+previous implementation the proxied host never matched a site's allowed
+domains and the captcha widget broke on translated pages.
+
+Add `decodeGoogleTranslateHost` to `@prosopo/util` which reverses the
+encoding, and update the provider's `domainMiddleware` so that when the
+request origin is a `*.translate.goog` URL it also tries the decoded
+origin against the site's allowed domains.
+
+Closes #2585.

--- a/packages/provider/src/api/domainMiddleware.ts
+++ b/packages/provider/src/api/domainMiddleware.ts
@@ -15,6 +15,7 @@
 import { handleErrors } from "@prosopo/api-express-router";
 import { type Logger, ProsopoApiError } from "@prosopo/common";
 import type { ProviderEnvironment } from "@prosopo/types-env";
+import { decodeGoogleTranslateHost, parseUrl } from "@prosopo/util";
 import { validateAddress } from "@prosopo/util-crypto";
 import type { NextFunction, Request, Response } from "express";
 import type { TFunction } from "i18next";
@@ -67,10 +68,14 @@ export const domainMiddleware = (env: ProviderEnvironment) => {
 			if (!origin)
 				throw unauthorizedOriginError(req.i18n, undefined, req.logger);
 
-			for (const domain of allowedDomains) {
-				if (tasks.clientTaskManager.domainPatternMatcher(origin, domain)) {
-					next();
-					return;
+			const candidateOrigins = [origin, ...googleTranslateOrigins(origin)];
+
+			for (const candidate of candidateOrigins) {
+				for (const domain of allowedDomains) {
+					if (tasks.clientTaskManager.domainPatternMatcher(candidate, domain)) {
+						next();
+						return;
+					}
 				}
 			}
 
@@ -88,6 +93,19 @@ export const domainMiddleware = (env: ProviderEnvironment) => {
 			}
 		}
 	};
+};
+
+// If the origin is a Google Translate proxy URL, return the decoded original
+// origin(s) so the domain check can still match the site's allowed domains.
+const googleTranslateOrigins = (origin: string): string[] => {
+	try {
+		const url = parseUrl(origin);
+		const decodedHost = decodeGoogleTranslateHost(url.hostname);
+		if (!decodedHost) return [];
+		return [`${url.protocol}//${decodedHost}`];
+	} catch {
+		return [];
+	}
 };
 
 const siteKeyNotRegisteredError = (

--- a/packages/util/src/tests/url.unit.test.ts
+++ b/packages/util/src/tests/url.unit.test.ts
@@ -12,7 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import { describe, expect, it } from "vitest";
-import { buildDomainSuffixCandidates, validateDomain } from "../url.js";
+import {
+	buildDomainSuffixCandidates,
+	decodeGoogleTranslateHost,
+	validateDomain,
+} from "../url.js";
 
 describe("url", () => {
 	it("validates valid domains", () => {
@@ -129,5 +133,53 @@ describe("buildDomainSuffixCandidates", () => {
 		const result = buildDomainSuffixCandidates("sub.domain.tld");
 		expect(result[0]).toBe("sub.domain.tld");
 		expect(result[result.length - 1]).toBe("domain.tld");
+	});
+});
+
+describe("decodeGoogleTranslateHost", () => {
+	it("decodes a simple two-label domain", () => {
+		expect(decodeGoogleTranslateHost("prosopo-io.translate.goog")).toBe(
+			"prosopo.io",
+		);
+	});
+
+	it("decodes a domain with subdomains", () => {
+		expect(decodeGoogleTranslateHost("www-example-com.translate.goog")).toBe(
+			"www.example.com",
+		);
+	});
+
+	it("decodes a domain containing a dash (double-dash encoding)", () => {
+		expect(decodeGoogleTranslateHost("my--site-com.translate.goog")).toBe(
+			"my-site.com",
+		);
+	});
+
+	it("decodes a domain with mixed dashes and subdomains", () => {
+		expect(decodeGoogleTranslateHost("foo-my--site-co-uk.translate.goog")).toBe(
+			"foo.my-site.co.uk",
+		);
+	});
+
+	it("is case-insensitive on the suffix", () => {
+		expect(decodeGoogleTranslateHost("Prosopo-IO.Translate.Goog")).toBe(
+			"prosopo.io",
+		);
+	});
+
+	it("ignores a trailing dot on the FQDN", () => {
+		expect(decodeGoogleTranslateHost("prosopo-io.translate.goog.")).toBe(
+			"prosopo.io",
+		);
+	});
+
+	it("returns null for non-translate.goog hosts", () => {
+		expect(decodeGoogleTranslateHost("prosopo.io")).toBeNull();
+		expect(decodeGoogleTranslateHost("translate.google.com")).toBeNull();
+		expect(decodeGoogleTranslateHost("translate.goog")).toBeNull();
+	});
+
+	it("returns null for an empty encoded subdomain", () => {
+		expect(decodeGoogleTranslateHost(".translate.goog")).toBeNull();
 	});
 });

--- a/packages/util/src/url.ts
+++ b/packages/util/src/url.ts
@@ -74,6 +74,29 @@ export const validateDomain = (domain: string): boolean => {
 	return true;
 };
 
+/**
+ * @description Decodes a Google Translate proxy hostname back to the original host.
+ * Google Translate proxies a site under `<encoded>.translate.goog`, where the original
+ * hostname is encoded by replacing dots with single dashes and dashes with double dashes.
+ * For example:
+ *   - "prosopo.io"     → "prosopo-io.translate.goog"
+ *   - "www.example.com" → "www-example-com.translate.goog"
+ *   - "my-site.com"     → "my--site-com.translate.goog"
+ * Returns the decoded original hostname, or null if the input is not a translate.goog host.
+ */
+export const decodeGoogleTranslateHost = (hostname: string): string | null => {
+	const suffix = ".translate.goog";
+	const host = hostname.toLowerCase().replace(/\.$/, "");
+	if (!host.endsWith(suffix)) return null;
+	const encoded = host.slice(0, -suffix.length);
+	if (!encoded) return null;
+	const placeholder = "\x00";
+	return encoded
+		.replace(/--/g, placeholder)
+		.replace(/-/g, ".")
+		.replace(new RegExp(placeholder, "g"), "-");
+};
+
 export const domainIsLocalhost = (domain: string) => {
 	try {
 		const url = new URL(`http://${domain}`);


### PR DESCRIPTION
## Summary
- Add `decodeGoogleTranslateHost` to `@prosopo/util` that reverses Google Translate's host encoding (`.` → `-`, `-` → `--`) so e.g. `prosopo-io.translate.goog` decodes back to `prosopo.io`.
- Update the provider's `domainMiddleware` so that when an origin is a `*.translate.goog` URL it also tries the decoded origin against the site's allowed domains — the captcha widget now works on Google-translated pages.
- 10 new unit tests covering simple, subdomain, dashed, mixed, case, trailing-dot, and null cases.

Closes #2585.

## Test plan
- [x] `npm run -w @prosopo/util build:tsc`
- [x] `npm run -w @prosopo/provider build:tsc`
- [x] `vitest run packages/util/src/tests/url.unit.test.ts` (28/28 pass)
- [x] `vitest run packages/provider/src/tests/unit/tasks/client/clientTasks.unit.test.ts` (18/18 pass, no regression)
- [x] `npm run lint`
- [ ] Verify in staging that loading a site via `https://<site>.translate.goog/?_x_tr_sl=...` lets the widget through

🤖 Generated with [Claude Code](https://claude.com/claude-code)