### PR TITLE
fix(types-database): switch ipInfo backfill index key from _id to requestedAtTimestamp

### DIFF
--- a/.changeset/ipinfo-backfill-indexes.md
+++ b/.changeset/ipinfo-backfill-indexes.md
@@ -12,13 +12,17 @@ or `UserCommitmentRecordSchema`. The existing `ipInfo.countryCode` and
 so they actively can't help the "missing" query — both jobs were running
 COLLSCANs.
 
-Add partial indexes keyed on `_id` with
+Add partial indexes keyed on `requestedAtTimestamp` with
 `partialFilterExpression: { <field>: { $exists: false } }` to each of the
 three schemas (six new indexes total). Partial filters exactly matching
 the query predicate allow the planner to use the index. The index stays
 small because it only contains un-enriched rows, shrinks as the backfill
 progresses, and is essentially empty once the request-time middleware has
 populated every new row.
+
+MongoDB rejects `partialFilterExpression` on `_id` indexes, so the key
+field is `requestedAtTimestamp` — present on every record-bearing schema
+as `required: true`.
 
 Note: `CaptchaDatabase.ensureIndexes()` drops then recreates all indexes
 on each collection, so applying these in production will rebuild every

--- a/packages/types-database/src/types/provider.ts
+++ b/packages/types-database/src/types/provider.ts
@@ -215,14 +215,14 @@ PoWCaptchaRecordSchema.index({ "ipInfo.isVPN": 1 });
 // limited to the un-enriched rows, so it shrinks as the backfill
 // progresses and is empty once the middleware has filled every row.
 PoWCaptchaRecordSchema.index(
-	{ _id: 1 },
+	{ requestedAtTimestamp: 1 },
 	{
 		name: "ipInfo_missing",
 		partialFilterExpression: { ipInfo: { $exists: false } },
 	},
 );
 PoWCaptchaRecordSchema.index(
-	{ _id: 1 },
+	{ requestedAtTimestamp: 1 },
 	{
 		name: "parsedUserAgentInfo_missing",
 		partialFilterExpression: { parsedUserAgentInfo: { $exists: false } },
@@ -307,14 +307,14 @@ PuzzleCaptchaRecordSchema.index({ "result.reason": 1 });
 PuzzleCaptchaRecordSchema.index({ "ipInfo.countryCode": 1 });
 PuzzleCaptchaRecordSchema.index({ "ipInfo.isVPN": 1 });
 PuzzleCaptchaRecordSchema.index(
-	{ _id: 1 },
+	{ requestedAtTimestamp: 1 },
 	{
 		name: "ipInfo_missing",
 		partialFilterExpression: { ipInfo: { $exists: false } },
 	},
 );
 PuzzleCaptchaRecordSchema.index(
-	{ _id: 1 },
+	{ requestedAtTimestamp: 1 },
 	{
 		name: "parsedUserAgentInfo_missing",
 		partialFilterExpression: { parsedUserAgentInfo: { $exists: false } },
@@ -391,14 +391,14 @@ UserCommitmentRecordSchema.index({ "ipInfo.isVPN": 1 });
 UserCommitmentRecordSchema.index({ requestHash: -1 });
 UserCommitmentRecordSchema.index({ pending: 1 });
 UserCommitmentRecordSchema.index(
-	{ _id: 1 },
+	{ requestedAtTimestamp: 1 },
 	{
 		name: "ipInfo_missing",
 		partialFilterExpression: { ipInfo: { $exists: false } },
 	},
 );
 UserCommitmentRecordSchema.index(
-	{ _id: 1 },
+	{ requestedAtTimestamp: 1 },
 	{
 		name: "parsedUserAgentInfo_missing",
 		partialFilterExpression: { parsedUserAgentInfo: { $exists: false } },


### PR DESCRIPTION
## Summary

- Switches the six partial indexes from #2587 to key on `requestedAtTimestamp` (was `_id`) — MongoDB rejects `partialFilterExpression` on `_id` indexes with `MongoServerError: The field 'partialFilterExpression' is not valid for an _id index specification`, so the indexes from #2587 never actually got built in production.
- The CHECK_IP_INFO job was therefore still running COLLSCANs (saturating the captcha collection scan, then timing out into MongoDB socket errors).
- `requestedAtTimestamp` is `required: true` on `PoWCaptchaRecordSchema`, `PuzzleCaptchaRecordSchema`, and `UserCommitmentRecordSchema`, so the index always covers the rows the partial filter selects.

Also updates the changeset body to describe the corrected key and why `_id` isn't valid.

## Why this slipped through

Two silent-failure layers stacked:
1. `CaptchaDatabase.ensureIndexes()` (`packages/database/src/databases/captcha.ts:91`) wraps `tables[c].ensureIndexes()` in `.catch` that only warn-logs.
2. Mongoose's `autoIndex` emits index errors through an `'index'` event listener that nothing in our code subscribes to.

So the broken `createIndex` calls just disappeared. Worth a follow-up to fail loud (or surface in healthcheck) — separate from this PR.

## Test plan

- [ ] CI green
- [ ] After merge + bump in `captcha-private` parent repo + runner image rebuild, verify `ipInfo_missing` and `parsedUserAgentInfo_missing` indexes appear on `powcaptchas`, `usercommitments`, and `puzzlecaptchas` via `db.<coll>.getIndexes()` on mongo1
- [ ] Re-run CHECK_IP_INFO; confirm it completes without the `Socket 'secureConnect' timed out` failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)