### PR TITLE
chore(client-bundle-example): register invisible-puzzle pages as Vite entries

### DIFF
--- a/.changeset/invisible-puzzle-bundle-demo-entries.md
+++ b/.changeset/invisible-puzzle-bundle-demo-entries.md
@@ -1,0 +1,5 @@
+---
+"@prosopo/client-bundle-example": patch
+---
+
+chore(client-bundle-example): register invisible-puzzle explicit/implicit pages as Vite build entries so they are emitted in `dist` and reachable from the demo navigation.

--- a/demos/client-bundle-example/vite.config.ts
+++ b/demos/client-bundle-example/vite.config.ts
@@ -206,6 +206,14 @@ export default defineConfig(({ command, mode }) => {
 						__dirname,
 						"src/puzzle-explicit.html",
 					),
+					"invisible-puzzle-implicit": path.resolve(
+						__dirname,
+						"src/invisible-puzzle-implicit.html",
+					),
+					"invisible-puzzle-explicit": path.resolve(
+						__dirname,
+						"src/invisible-puzzle-explicit.html",
+					),
 				},
 			},
 		},


### PR DESCRIPTION
## Summary
- `invisible-puzzle-explicit.html` and `invisible-puzzle-implicit.html` already existed and are listed in the navigation injector, but they were missing from `vite.config.ts` `rollupOptions.input` so they weren't built into `dist`.
- Adds both as Vite build entries alongside `puzzle-implicit` / `puzzle-explicit`, following the existing invisible-* pattern.

## Test plan
- [ ] CI green
- [ ] `npm run -w @prosopo/client-bundle-example build` emits both `invisible-puzzle-*.html` files in `dist`

🤖 Generated with [Claude Code](https://claude.com/claude-code)