### PR TITLE
fix(types-database): replace broken partial indexes with regular non-sparse indexes

### DIFF
--- a/.changeset/ipinfo-backfill-indexes.md
+++ b/.changeset/ipinfo-backfill-indexes.md
@@ -2,30 +2,13 @@
 "@prosopo/types-database": patch
 ---
 
-fix(types-database): index the ipInfo / parsedUserAgentInfo backfill queries
+fix(types-database): replace broken partial indexes with regular non-sparse indexes for CHECK_IP_INFO / PARSE_USER_AGENT backfill queries
 
-The CHECK_IP_INFO and PARSE_USER_AGENT jobs read records via
-`getCaptchas({ <field>: { $exists: false } })`, but no index covered
-either predicate on `PoWCaptchaRecordSchema`, `PuzzleCaptchaRecordSchema`,
-or `UserCommitmentRecordSchema`. The existing `ipInfo.countryCode` and
-`ipInfo.isVPN` indexes only contain rows where `ipInfo` already exists,
-so they actively can't help the "missing" query — both jobs were running
-COLLSCANs.
+The original partial-index approach (#2587, then #2589) couldn't work in MongoDB:
 
-Add partial indexes keyed on `requestedAtTimestamp` with
-`partialFilterExpression: { <field>: { $exists: false } }` to each of the
-three schemas (six new indexes total). Partial filters exactly matching
-the query predicate allow the planner to use the index. The index stays
-small because it only contains un-enriched rows, shrinks as the backfill
-progresses, and is essentially empty once the request-time middleware has
-populated every new row.
+- `partialFilterExpression` isn't allowed on `_id` indexes (caught by #2589).
+- More fundamentally, `{ $exists: false }` is rewritten internally as `$not: { $exists: true }`, and `$not` isn't on the partial-filter operator allowlist either. So no key field could rescue the partial-index design.
 
-MongoDB rejects `partialFilterExpression` on `_id` indexes, so the key
-field is `requestedAtTimestamp` — present on every record-bearing schema
-as `required: true`.
+Replace the six broken partial-index definitions on `PoWCaptchaRecordSchema`, `PuzzleCaptchaRecordSchema`, and `UserCommitmentRecordSchema` with regular non-sparse indexes on the fields themselves (`{ ipInfo: 1 }` and `{ parsedUserAgentInfo: 1 }`). Non-sparse indexes include entries for missing-field documents (stored as null), which the planner can use to satisfy `{ <field>: { $exists: false } }` via `IXSCAN`.
 
-Note: `CaptchaDatabase.ensureIndexes()` drops then recreates all indexes
-on each collection, so applying these in production will rebuild every
-existing index on `commitment`, `powcaptcha`, and `puzzlecaptcha` —
-schedule during a maintenance window or build only the new partial
-indexes directly via `createIndex` on the live cluster.
+Note: both layers that swallowed the original `createIndex` failures (`CaptchaDatabase.ensureIndexes()` `.catch` warning, and Mongoose `autoIndex`'s un-listened `'index'` event) are still silent — worth a follow-up so the next bad schema change doesn't ship unnoticed.

--- a/packages/types-database/src/types/provider.ts
+++ b/packages/types-database/src/types/provider.ts
@@ -211,23 +211,13 @@ PoWCaptchaRecordSchema.index({ "result.reason": 1 });
 PoWCaptchaRecordSchema.index({ "ipInfo.countryCode": 1 });
 PoWCaptchaRecordSchema.index({ "ipInfo.isVPN": 1 });
 // Supports the CHECK_IP_INFO / PARSE_USER_AGENT backfill queries
-// (`{ <field>: { $exists: false } }`). Partial filter keeps the index
-// limited to the un-enriched rows, so it shrinks as the backfill
-// progresses and is empty once the middleware has filled every row.
-PoWCaptchaRecordSchema.index(
-	{ requestedAtTimestamp: 1 },
-	{
-		name: "ipInfo_missing",
-		partialFilterExpression: { ipInfo: { $exists: false } },
-	},
-);
-PoWCaptchaRecordSchema.index(
-	{ requestedAtTimestamp: 1 },
-	{
-		name: "parsedUserAgentInfo_missing",
-		partialFilterExpression: { parsedUserAgentInfo: { $exists: false } },
-	},
-);
+// (`{ <field>: { $exists: false } }`). Regular (non-sparse) indexes
+// include entries for documents missing the field, which is what the
+// planner needs for `$exists: false`. A partial filter can't help here:
+// MongoDB rewrites `$exists: false` to `$not: { $exists: true }`, and
+// `$not` isn't allowed inside `partialFilterExpression`.
+PoWCaptchaRecordSchema.index({ ipInfo: 1 });
+PoWCaptchaRecordSchema.index({ parsedUserAgentInfo: 1 });
 
 export const PuzzleCaptchaRecordSchema = new Schema<PuzzleCaptchaRecord>({
 	challenge: { type: String, required: true },
@@ -306,20 +296,8 @@ PuzzleCaptchaRecordSchema.index({ "ipAddress.upper": 1 });
 PuzzleCaptchaRecordSchema.index({ "result.reason": 1 });
 PuzzleCaptchaRecordSchema.index({ "ipInfo.countryCode": 1 });
 PuzzleCaptchaRecordSchema.index({ "ipInfo.isVPN": 1 });
-PuzzleCaptchaRecordSchema.index(
-	{ requestedAtTimestamp: 1 },
-	{
-		name: "ipInfo_missing",
-		partialFilterExpression: { ipInfo: { $exists: false } },
-	},
-);
-PuzzleCaptchaRecordSchema.index(
-	{ requestedAtTimestamp: 1 },
-	{
-		name: "parsedUserAgentInfo_missing",
-		partialFilterExpression: { parsedUserAgentInfo: { $exists: false } },
-	},
-);
+PuzzleCaptchaRecordSchema.index({ ipInfo: 1 });
+PuzzleCaptchaRecordSchema.index({ parsedUserAgentInfo: 1 });
 
 export const UserCommitmentRecordSchema = new Schema<UserCommitmentRecord>({
 	userAccount: { type: String, required: true },
@@ -390,20 +368,8 @@ UserCommitmentRecordSchema.index({ "ipInfo.countryCode": 1 });
 UserCommitmentRecordSchema.index({ "ipInfo.isVPN": 1 });
 UserCommitmentRecordSchema.index({ requestHash: -1 });
 UserCommitmentRecordSchema.index({ pending: 1 });
-UserCommitmentRecordSchema.index(
-	{ requestedAtTimestamp: 1 },
-	{
-		name: "ipInfo_missing",
-		partialFilterExpression: { ipInfo: { $exists: false } },
-	},
-);
-UserCommitmentRecordSchema.index(
-	{ requestedAtTimestamp: 1 },
-	{
-		name: "parsedUserAgentInfo_missing",
-		partialFilterExpression: { parsedUserAgentInfo: { $exists: false } },
-	},
-);
+UserCommitmentRecordSchema.index({ ipInfo: 1 });
+UserCommitmentRecordSchema.index({ parsedUserAgentInfo: 1 });
 
 export const DatasetRecordSchema = new Schema<DatasetWithIds>({
 	contentTree: { type: [[String]], required: true },


### PR DESCRIPTION
## Summary

The partial-index approach from #2587 + #2589 couldn't have worked: MongoDB rejects `$not` (and so `$exists: false`) inside `partialFilterExpression`:

```
MongoServerError: Expression not supported in partial index: $not -- ipInfo exists
```

So all six indexes (`ipInfo_missing` / `parsedUserAgentInfo_missing` on each of `PoWCaptcha`, `PuzzleCaptcha`, `UserCommitment`) failed to build in production. The `createIndex` rejection was swallowed by two silent layers (`CaptchaDatabase.ensureIndexes()` `.catch`, and Mongoose `autoIndex`'s un-listened `'index'` event), which is why nothing escalated.

This PR replaces the broken partial indexes with regular non-sparse indexes on the fields themselves: `{ ipInfo: 1 }` and `{ parsedUserAgentInfo: 1 }` on all three schemas. Non-sparse indexes include entries for missing-field docs (stored as null), so the planner can use them to satisfy `{ <field>: { $exists: false } }` via `IXSCAN`.

## Verified in prod

Indexes already created manually on `mongo1` (`powcaptchas`, `usercommitments`) and confirmed via `explain()`:

```
== powcaptchas . ipInfo ==              LIMIT → FETCH → IXSCAN [ipInfo_1]
== powcaptchas . parsedUserAgentInfo == LIMIT → FETCH → IXSCAN [parsedUserAgentInfo_full]
== usercommitments . ipInfo ==          LIMIT → FETCH → IXSCAN [ipInfo_1]
== usercommitments . parsedUserAgentInfo == LIMIT → FETCH → IXSCAN [parsedUserAgentInfo_1]
```

(The `parsedUserAgentInfo_full` vs `parsedUserAgentInfo_1` name asymmetry on `powcaptchas` is because an orphan sparse `parsedUserAgentInfo_1` from a previous schema was still on the live cluster. The new non-sparse index was built under a different name to avoid an `IndexOptionsConflict`. Worth tidying separately.)

## Follow-up worth doing

Both silent-failure layers for `createIndex` should fail loud — otherwise the next bad schema change will ship unnoticed. Not in this PR.

## Test plan

- [ ] CI green
- [ ] After merge + parent-repo submodule bump + runner image rebuild, Mongoose `autoIndex` should find the indexes already present on the live collections (no-op).

🤖 Generated with [Claude Code](https://claude.com/claude-code)