### PR TITLE
fix(database): replace $or+$expr unstored-records sweep with pendingStage sentinel

### DIFF
--- a/.changeset/pending-stage-sentinel.md
+++ b/.changeset/pending-stage-sentinel.md
@@ -1,0 +1,47 @@
+---
+"@prosopo/types": patch
+"@prosopo/types-database": patch
+"@prosopo/database": patch
+"@prosopo/provider": patch
+---
+
+fix: replace `$or + $expr` unstored-records sweep with a `pendingStage` sentinel
+
+The `StoreCommitmentsExternal` background job fetches "records that still
+need to be shipped to the central DB" via
+`{ $or: [ { storedAtTimestamp: { $exists: false } }, { $expr: { $lt: [$storedAtTimestamp, $lastUpdatedTimestamp] } } ] }`.
+`$expr` is unindexable (per-doc computation) and combined with `$or`
+defeats the planner entirely — production was running this every sweep
+as a `IXSCAN { _id: 1 }` collection scan, examining ~673K powcaptcha
+docs, ~240K usercommitments docs, and ~60K sessions docs per pass. On
+the worst-affected nodes this thrashed the WiredTiger cache (10h of
+cumulative app-thread blocking on disk reads in 43h of uptime) and made
+every other Mongo lookup (including the frictionless session dedup
+queries) slow by eviction — manifesting as traffic-correlated provider
+latency starting 2026-05-26.
+
+Replace the query semantics with a `pendingStage: true` sentinel:
+
+- New optional `pendingStage` field on `StoredCaptcha` and `Session`
+  (Zod + TS + Mongoose schemas).
+- New tiny partial index per collection:
+  `{ pendingStage: 1 }` with `partialFilterExpression: { pendingStage: true }`.
+  Indexes only the rows that need staging — typically a tiny rolling set,
+  ~20 KB for a 700K-row collection with 100 pending rows in local tests.
+- Write paths (`storeXxx`, `updateXxx`, `markXxxChecked`, approve /
+  disapprove, `checkAndRemoveSession`, `recordSessionSimdReadingsIfAbsent`,
+  `storePendingImageCommitment`) set `pendingStage: true` alongside the
+  existing `lastUpdatedTimestamp` bump.
+- `markXxxStored` and the per-record streamer mark-stored callbacks
+  `$unset: { pendingStage: 1 }` alongside the `storedAtTimestamp` write,
+  guarded by `lastUpdatedTimestamp: { $lte: ts }` so an in-flight update
+  doesn't get its pending flag cleared by an older stage completion.
+- `markXxxStored` bulk methods accept an `asOfTimestamp` argument; the
+  sweep passes the time it fetched the batch so the guard is correct
+  across the full ship-then-mark round trip.
+- `getUnstoredXxx` queries become `{ pendingStage: true }` sorted by
+  `_id` — uses the new partial index, examines only pending docs.
+
+Local verification on a 700,100-doc test collection: old query ~549 ms
+examining 700,100 docs; new query 0 ms examining 100 docs. Index storage
+~20 KB.

--- a/packages/database/src/databases/provider.ts
+++ b/packages/database/src/databases/provider.ts
@@ -762,6 +762,7 @@ export class ProviderDatabase
 			providerSignature,
 			userSignature,
 			lastUpdatedTimestamp: new Date(),
+			pendingStage: true,
 			sessionId,
 			ipInfo,
 		};
@@ -780,8 +781,18 @@ export class ProviderDatabase
 			this.centralStreamer?.streamPowRecord(
 				powCaptchaRecord as PoWCaptchaRecord,
 				(ts) =>
+					// Guard with `lastUpdatedTimestamp: { $lte: ts }` so a concurrent
+					// update (newer lastUpdatedTimestamp) doesn't get its pendingStage
+					// flag cleared by this older stage completion. Mismatched docs
+					// leave pendingStage set so the next sweep picks them up.
 					this.tables.powcaptcha
-						.updateOne({ challenge }, { $set: { storedAtTimestamp: ts } })
+						.updateOne(
+							{ challenge, lastUpdatedTimestamp: { $lte: ts } },
+							{
+								$set: { storedAtTimestamp: ts },
+								$unset: { pendingStage: 1 },
+							},
+						)
 						.then(() => {}),
 			);
 		} catch (error) {
@@ -896,12 +907,14 @@ export class ProviderDatabase
 			| "userSignature"
 			| "lastUpdatedTimestamp"
 			| "coords"
+			| "pendingStage"
 		> = {
 			result,
 			serverChecked,
 			userSubmitted,
 			userSignature,
 			lastUpdatedTimestamp: timestamp,
+			pendingStage: true,
 			...(coords && { coords }),
 		};
 		try {
@@ -936,7 +949,13 @@ export class ProviderDatabase
 				() => this.getPowCaptchaRecordByChallenge(challenge),
 				(ts) =>
 					this.tables.powcaptcha
-						.updateOne({ challenge }, { $set: { storedAtTimestamp: ts } })
+						.updateOne(
+							{ challenge, lastUpdatedTimestamp: { $lte: ts } },
+							{
+								$set: { storedAtTimestamp: ts },
+								$unset: { pendingStage: 1 },
+							},
+						)
 						.then(() => {}),
 			);
 		} catch (error) {
@@ -963,14 +982,20 @@ export class ProviderDatabase
 		const tables = this.getTables();
 		await tables.powcaptcha.updateOne(
 			{ challenge },
-			{ $set: updates },
+			{ $set: { ...updates, pendingStage: true } },
 			{ upsert: false },
 		);
 		this.centralStreamer?.streamPowUpdate(
 			() => this.getPowCaptchaRecordByChallenge(challenge),
 			(ts) =>
 				this.tables.powcaptcha
-					.updateOne({ challenge }, { $set: { storedAtTimestamp: ts } })
+					.updateOne(
+						{ challenge, lastUpdatedTimestamp: { $lte: ts } },
+						{
+							$set: { storedAtTimestamp: ts },
+							$unset: { pendingStage: 1 },
+						},
+					)
 					.then(() => {}),
 		);
 	}
@@ -1010,6 +1035,7 @@ export class ProviderDatabase
 			tolerance,
 			providerSignature,
 			lastUpdatedTimestamp: new Date(),
+			pendingStage: true,
 			sessionId,
 			ipInfo,
 		};
@@ -1143,12 +1169,14 @@ export class ProviderDatabase
 			| "userSignature"
 			| "lastUpdatedTimestamp"
 			| "coords"
+			| "pendingStage"
 		> = {
 			result,
 			serverChecked,
 			userSubmitted,
 			userSignature,
 			lastUpdatedTimestamp: timestamp,
+			pendingStage: true,
 			...(coords && { coords }),
 		};
 		try {
@@ -1203,7 +1231,7 @@ export class ProviderDatabase
 		const tables = this.getTables();
 		await tables.puzzlecaptcha.updateOne(
 			{ challenge },
-			{ $set: updates },
+			{ $set: { ...updates, pendingStage: true } },
 			{ upsert: false },
 		);
 	}
@@ -1221,52 +1249,50 @@ export class ProviderDatabase
 	}
 
 	/** @description Get Dapp User captcha commitments from the commitments table that have not been counted towards the
-	 * client's total
+	 * client's total.
+	 *
+	 * Served by the `pendingStage_partial` index. Records have
+	 * `pendingStage: true` set on insert and on every mutation (see
+	 * `updateDappUserCommitment`, `markDappUserCommitmentsChecked`,
+	 * `approveDappUserCommitment`, `disapproveDappUserCommitment`,
+	 * `storePendingImageCommitment`). `markDappUserCommitmentsStored` clears
+	 * the flag after a successful stage, guarded by `lastUpdatedTimestamp`
+	 * so an in-flight update isn't lost.
 	 */
 	async getUnstoredDappUserCommitments(
 		limit = 1000,
 		skip = 0,
 	): Promise<UserCommitmentRecord[]> {
-		const filterNoStoredTimestamp: {
-			[key in keyof Pick<PoWCaptchaRecord, "storedAtTimestamp">]: {
-				$exists: boolean;
-			};
-		} = { storedAtTimestamp: { $exists: false } };
-		const docs = await this.tables?.commitment.aggregate<UserCommitmentRecord>([
-			{
-				$match: {
-					$or: [
-						filterNoStoredTimestamp,
-						{
-							$expr: {
-								$lt: ["$storedAtTimestamp", "$lastUpdatedTimestamp"],
-							},
-						},
-					],
-				},
-			},
-			{
-				$sort: { _id: 1 },
-			},
-			{
-				$skip: skip,
-			},
-			{
-				$limit: limit,
-			},
-		]);
+		const docs = await this.tables?.commitment
+			.find({ pendingStage: true })
+			.sort({ _id: 1 })
+			.skip(skip)
+			.limit(limit)
+			.lean<UserCommitmentRecord[]>();
 		return docs || [];
 	}
 
-	/** @description Mark a list of captcha commits as stored
+	/** @description Mark a list of captcha commits as stored.
+	 *
+	 * `asOfTimestamp` defaults to "now" but the sweep should pass the time
+	 * at which it fetched the batch. The lastUpdatedTimestamp guard prevents
+	 * us from clearing pendingStage on a record that was mutated between
+	 * fetch and mark-stored — those records will leave pendingStage set so
+	 * the next sweep picks them up.
 	 */
-	async markDappUserCommitmentsStored(commitmentIds: Hash[]): Promise<void> {
-		const updateDoc: Pick<StoredCaptcha, "storedAtTimestamp"> = {
-			storedAtTimestamp: new Date(),
-		};
+	async markDappUserCommitmentsStored(
+		commitmentIds: Hash[],
+		asOfTimestamp: Date = new Date(),
+	): Promise<void> {
 		await this.tables?.commitment.updateMany(
-			{ id: { $in: commitmentIds } },
-			{ $set: updateDoc },
+			{
+				id: { $in: commitmentIds },
+				lastUpdatedTimestamp: { $lte: asOfTimestamp },
+			},
+			{
+				$set: { storedAtTimestamp: new Date() },
+				$unset: { pendingStage: 1 },
+			},
 			{ upsert: false },
 		);
 	}
@@ -1276,10 +1302,11 @@ export class ProviderDatabase
 	async markDappUserCommitmentsChecked(commitmentIds: Hash[]): Promise<void> {
 		const updateDoc: Pick<
 			StoredCaptcha,
-			"serverChecked" | "lastUpdatedTimestamp"
+			"serverChecked" | "lastUpdatedTimestamp" | "pendingStage"
 		> = {
 			[StoredStatusNames.serverChecked]: true,
 			lastUpdatedTimestamp: new Date(),
+			pendingStage: true,
 		};
 
 		await this.tables?.commitment.updateMany(
@@ -1299,6 +1326,7 @@ export class ProviderDatabase
 		await this.tables?.commitment.updateOne(filter, {
 			...updates,
 			lastUpdatedAtTimestamp: new Date(),
+			pendingStage: true,
 		});
 	}
 
@@ -1312,60 +1340,36 @@ export class ProviderDatabase
 		limit = 1000,
 		skip = 0,
 	): Promise<PoWCaptchaRecord[]> {
-		const filterNoStoredTimestamp: {
-			[key in keyof Pick<PoWCaptchaRecord, "storedAtTimestamp">]: {
-				$exists: boolean;
-			};
-		} = { storedAtTimestamp: { $exists: false } };
-		const docs = await this.tables?.powcaptcha.aggregate<PoWCaptchaRecord>([
-			{
-				$match: {
-					$or: [
-						filterNoStoredTimestamp,
-						{
-							$expr: {
-								$lt: [
-									{
-										$convert: {
-											input: "$storedAtTimestamp",
-											to: "date",
-										},
-									},
-									{
-										$convert: {
-											input: "$lastUpdatedTimestamp",
-											to: "date",
-										},
-									},
-								],
-							},
-						},
-					],
-				},
-			},
-			{
-				$sort: { _id: 1 },
-			},
-			{
-				$skip: skip,
-			},
-			{
-				$limit: limit,
-			},
-		]);
+		// Served by the `pendingStage_partial` index — see
+		// `getUnstoredDappUserCommitments` for the lifecycle of the flag.
+		const docs = await this.tables?.powcaptcha
+			.find({ pendingStage: true })
+			.sort({ _id: 1 })
+			.skip(skip)
+			.limit(limit)
+			.lean<PoWCaptchaRecord[]>();
 		return docs || [];
 	}
 
-	/** @description Mark a list of PoW captcha commits as stored
+	/** @description Mark a list of PoW captcha commits as stored.
+	 *
+	 * `asOfTimestamp` defaults to "now" but the sweep should pass the time
+	 * at which it fetched the batch. See markDappUserCommitmentsStored for
+	 * the guard rationale.
 	 */
-	async markDappUserPoWCommitmentsStored(challenges: string[]): Promise<void> {
-		const updateDoc: Pick<StoredCaptcha, "storedAtTimestamp"> = {
-			storedAtTimestamp: new Date(),
-		};
-
+	async markDappUserPoWCommitmentsStored(
+		challenges: string[],
+		asOfTimestamp: Date = new Date(),
+	): Promise<void> {
 		await this.tables?.powcaptcha.updateMany(
-			{ challenge: { $in: challenges } },
-			{ $set: updateDoc },
+			{
+				challenge: { $in: challenges },
+				lastUpdatedTimestamp: { $lte: asOfTimestamp },
+			},
+			{
+				$set: { storedAtTimestamp: new Date() },
+				$unset: { pendingStage: 1 },
+			},
 			{ upsert: false },
 		);
 	}
@@ -1375,10 +1379,11 @@ export class ProviderDatabase
 	async markDappUserPoWCommitmentsChecked(challenges: string[]): Promise<void> {
 		const updateDoc: Pick<
 			StoredCaptcha,
-			"serverChecked" | "lastUpdatedTimestamp"
+			"serverChecked" | "lastUpdatedTimestamp" | "pendingStage"
 		> = {
 			[StoredStatusNames.serverChecked]: true,
 			lastUpdatedTimestamp: new Date(),
+			pendingStage: true,
 		};
 		await this.tables?.powcaptcha.updateMany(
 			{ challenge: { $in: challenges } },
@@ -1397,14 +1402,31 @@ export class ProviderDatabase
 			this.logger.debug(() => ({
 				data: { action: "storing", sessionRecord },
 			}));
-			await this.tables.session.create(sessionRecord);
+			// Stamp lastUpdatedTimestamp at insert so the markStored guard
+			// (`lastUpdatedTimestamp <= ts`) has something to compare against
+			// after the streamer succeeds. Without it, a successful first
+			// stage couldn't unset pendingStage and the sweep would re-stage
+			// the record on every pass until the first update happened.
+			const recordWithFlag: Session = {
+				...sessionRecord,
+				lastUpdatedTimestamp:
+					sessionRecord.lastUpdatedTimestamp ?? sessionRecord.createdAt,
+				pendingStage: true,
+			};
+			await this.tables.session.create(recordWithFlag);
 			this.centralStreamer?.streamSessionRecord(
-				sessionRecord as unknown as StoredSession,
+				recordWithFlag as unknown as StoredSession,
 				(ts) =>
 					this.tables.session
 						.updateOne(
-							{ sessionId: sessionRecord.sessionId },
-							{ $set: { storedAtTimestamp: ts } },
+							{
+								sessionId: sessionRecord.sessionId,
+								lastUpdatedTimestamp: { $lte: ts },
+							},
+							{
+								$set: { storedAtTimestamp: ts },
+								$unset: { pendingStage: 1 },
+							},
 						)
 						.then(() => {}),
 			);
@@ -1469,6 +1491,7 @@ export class ProviderDatabase
 				.findOneAndUpdate<SessionRecord>(filter, {
 					deleted: true,
 					lastUpdatedTimestamp: new Date(),
+					pendingStage: true,
 				})
 				.lean<SessionRecord>();
 			return session || undefined;
@@ -1494,13 +1517,25 @@ export class ProviderDatabase
 		try {
 			await this.tables.session.updateOne(
 				{ sessionId },
-				{ $set: { ...updates, lastUpdatedTimestamp: new Date() } },
+				{
+					$set: {
+						...updates,
+						lastUpdatedTimestamp: new Date(),
+						pendingStage: true,
+					},
+				},
 			);
 			if (streamToCentral && this.centralStreamer) {
 				const streamer = this.centralStreamer;
 				const markStored = (ts: Date) =>
 					this.tables.session
-						.updateOne({ sessionId }, { $set: { storedAtTimestamp: ts } })
+						.updateOne(
+							{ sessionId, lastUpdatedTimestamp: { $lte: ts } },
+							{
+								$set: { storedAtTimestamp: ts },
+								$unset: { pendingStage: 1 },
+							},
+						)
 						.then(() => {});
 				this.tables.session
 					.findOne({ sessionId })
@@ -1539,6 +1574,7 @@ export class ProviderDatabase
 						simdReadings: { $ifNull: ["$simdReadings", readings] },
 						simdReadingsStage: { $ifNull: ["$simdReadingsStage", stage] },
 						lastUpdatedTimestamp: new Date(),
+						pendingStage: true,
 					},
 				},
 			]);
@@ -1583,64 +1619,47 @@ export class ProviderDatabase
 	}
 
 	/** Get unstored session records
-	 * @description Get session records that have not been stored yet
+	 * @description Get session records that have not been stored yet.
+	 *
+	 * Served by the `pendingStage_partial` index — see
+	 * `getUnstoredDappUserCommitments` for the lifecycle of the flag.
+	 * `checkAndRemoveSession` also flips the flag so consumed sessions
+	 * propagate to the central DB via the next sweep.
 	 * @param limit
 	 * @param skip
 	 */
 	getUnstoredSessionRecords(limit = 1000, skip = 0): Promise<SessionRecord[]> {
-		const filterNoStoredTimestamp: {
-			[key in keyof Pick<SessionRecord, "storedAtTimestamp">]: {
-				$exists: boolean;
-			};
-		} = { storedAtTimestamp: { $exists: false } };
-		return this.tables?.session
-			.aggregate<SessionRecord>([
-				{
-					$match: {
-						$or: [
-							filterNoStoredTimestamp,
-							{
-								$expr: {
-									$lt: [
-										{
-											$convert: {
-												input: "$storedAtTimestamp",
-												to: "date",
-											},
-										},
-										{
-											$convert: {
-												input: "$lastUpdatedTimestamp",
-												to: "date",
-											},
-										},
-									],
-								},
-							},
-						],
-					},
-				},
-				{
-					$sort: { _id: 1 },
-				},
-				{
-					$skip: skip,
-				},
-				{
-					$limit: limit,
-				},
-			])
+		return Promise.resolve(this.tables?.session)
+			.then((tbl) =>
+				tbl
+					?.find({ pendingStage: true })
+					.sort({ _id: 1 })
+					.skip(skip)
+					.limit(limit)
+					.lean<SessionRecord[]>(),
+			)
 			.then((docs) => docs || []);
 	}
 
-	/** Mark a list of session records as stored */
-	async markSessionRecordsStored(sessionIds: string[]): Promise<void> {
-		const updateDoc: Pick<SessionRecord, "storedAtTimestamp"> = {
-			storedAtTimestamp: new Date(),
-		};
+	/** Mark a list of session records as stored.
+	 *
+	 * `asOfTimestamp` defaults to "now" but the sweep should pass the time
+	 * at which it fetched the batch. See markDappUserCommitmentsStored for
+	 * the guard rationale.
+	 */
+	async markSessionRecordsStored(
+		sessionIds: string[],
+		asOfTimestamp: Date = new Date(),
+	): Promise<void> {
 		await this.tables?.session.updateMany(
-			{ sessionId: { $in: sessionIds } },
-			{ $set: updateDoc },
+			{
+				sessionId: { $in: sessionIds },
+				lastUpdatedTimestamp: { $lte: asOfTimestamp },
+			},
+			{
+				$set: { storedAtTimestamp: new Date() },
+				$unset: { pendingStage: 1 },
+			},
 			{ upsert: false },
 		);
 	}
@@ -1678,6 +1697,7 @@ export class ProviderDatabase
 			sessionId,
 			threshold,
 			ipInfo,
+			pendingStage: true,
 			// Placeholder fields required by schema but not needed for pending state
 			dappAccount: "",
 			providerAccount: "",
@@ -1977,10 +1997,11 @@ export class ProviderDatabase
 			const result: CaptchaResult = { status: CaptchaStatus.approved };
 			const updateDoc: Pick<
 				StoredCaptcha,
-				"result" | "lastUpdatedTimestamp" | "coords"
+				"result" | "lastUpdatedTimestamp" | "coords" | "pendingStage"
 			> = {
 				result,
 				lastUpdatedTimestamp: new Date(),
+				pendingStage: true,
 				...(coords ? { coords } : {}),
 			};
 			const filter: Pick<UserCommitmentRecord, "id"> = { id: commitmentId };
@@ -1995,8 +2016,11 @@ export class ProviderDatabase
 				(ts) =>
 					this.tables.commitment
 						.updateOne(
-							{ id: commitmentId },
-							{ $set: { storedAtTimestamp: ts } },
+							{ id: commitmentId, lastUpdatedTimestamp: { $lte: ts } },
+							{
+								$set: { storedAtTimestamp: ts },
+								$unset: { pendingStage: 1 },
+							},
 						)
 						.then(() => {}),
 			);
@@ -2021,10 +2045,11 @@ export class ProviderDatabase
 		try {
 			const updateDoc: Pick<
 				StoredCaptcha,
-				"result" | "lastUpdatedTimestamp" | "coords"
+				"result" | "lastUpdatedTimestamp" | "coords" | "pendingStage"
 			> = {
 				result: { status: CaptchaStatus.disapproved, reason },
 				lastUpdatedTimestamp: new Date(),
+				pendingStage: true,
 				...(coords ? { coords } : {}),
 			};
 
@@ -2040,8 +2065,11 @@ export class ProviderDatabase
 				(ts) =>
 					this.tables.commitment
 						.updateOne(
-							{ id: commitmentId },
-							{ $set: { storedAtTimestamp: ts } },
+							{ id: commitmentId, lastUpdatedTimestamp: { $lte: ts } },
+							{
+								$set: { storedAtTimestamp: ts },
+								$unset: { pendingStage: 1 },
+							},
 						)
 						.then(() => {}),
 			);

--- a/packages/provider/src/tasks/client/clientTasks.ts
+++ b/packages/provider/src/tasks/client/clientTasks.ts
@@ -109,6 +109,10 @@ export class ClientTaskManager {
 		try {
 			const BATCH_SIZE = 1000;
 			const captchaDB = this.getCaptchaDB(this.config.mongoCaptchaUri);
+			// Captured once at sweep start. Passed through to markXxxStored as
+			// the guard cutoff so any record mutated after this point keeps
+			// `pendingStage: true` and is picked up on the next sweep.
+			const sweepStartedAt = new Date();
 
 			// Process image commitments with cursor
 			let processedCommitments = 0;
@@ -128,6 +132,7 @@ export class ClientTaskManager {
 						await captchaDB.saveCaptchas([], filteredBatch, []);
 						await this.providerDB.markDappUserCommitmentsStored(
 							filteredBatch.map((commitment) => commitment.id),
+							sweepStartedAt,
 						);
 					}
 					processedCommitments += filteredBatch.length;
@@ -151,6 +156,7 @@ export class ClientTaskManager {
 						await captchaDB.saveCaptchas([], [], filteredBatch);
 						await this.providerDB.markDappUserPoWCommitmentsStored(
 							filteredBatch.map((record) => record.challenge),
+							sweepStartedAt,
 						);
 					}
 					processedPowRecords += filteredBatch.length;
@@ -171,6 +177,7 @@ export class ClientTaskManager {
 						await captchaDB.saveCaptchas(filteredBatch, [], []);
 						await this.providerDB.markSessionRecordsStored(
 							filteredBatch.map((record) => record.sessionId),
+							sweepStartedAt,
 						);
 					}
 					processedSessionRecords += filteredBatch.length;

--- a/packages/provider/src/tests/unit/tasks/client/clientTasks.unit.test.ts
+++ b/packages/provider/src/tests/unit/tasks/client/clientTasks.unit.test.ts
@@ -285,9 +285,11 @@ describe("ClientTaskManager", () => {
 
 		expect(providerDB.markDappUserCommitmentsStored).toHaveBeenCalledWith(
 			mockCommitments.map((c) => c.id),
+			expect.any(Date),
 		);
 		expect(providerDB.markDappUserPoWCommitmentsStored).toHaveBeenCalledWith(
 			mockPoWCommitments.map((c) => c.challenge),
+			expect.any(Date),
 		);
 	});
 
@@ -379,6 +381,7 @@ describe("ClientTaskManager", () => {
 		const expectedPoWChallenges = mockPoWCommitments.map((c) => c.challenge);
 		expect(providerDB.markDappUserPoWCommitmentsStored).toHaveBeenCalledWith(
 			expectedPoWChallenges,
+			expect.any(Date),
 		);
 		logger.info(() => ({
 			msg: "Test: Verified PoW commitments were marked as stored",

--- a/packages/types-database/src/types/provider.ts
+++ b/packages/types-database/src/types/provider.ts
@@ -177,6 +177,11 @@ export const PoWCaptchaRecordSchema = new Schema<PoWCaptchaRecord>({
 	userSubmitted: { type: Boolean, required: true },
 	serverChecked: { type: Boolean, required: true },
 	storedAtTimestamp: { type: Date, required: false, expires: ONE_MONTH },
+	// See `StoredCaptcha.pendingStage` — `true` while the record has
+	// unstaged changes. Indexed via a tiny partial index so the
+	// StoreCommitmentsExternal sweep scans only pending rows instead of
+	// the whole collection.
+	pendingStage: { type: Boolean, required: false },
 	// Full ipinfo payload. Replaces the flat `vpn`, `countryCode`,
 	// `geolocation` and other per-flag fields — consumers narrow on
 	// `ipInfo.isValid` and read whichever sub-field they need.
@@ -218,6 +223,17 @@ PoWCaptchaRecordSchema.index({ "ipInfo.isVPN": 1 });
 // `$not` isn't allowed inside `partialFilterExpression`.
 PoWCaptchaRecordSchema.index({ ipInfo: 1 });
 PoWCaptchaRecordSchema.index({ parsedUserAgentInfo: 1 });
+// Tiny partial index serving the StoreCommitmentsExternal sweep. Only
+// records with `pendingStage: true` are indexed — typically a small
+// rolling set — so the query examines only the pending rows instead of
+// scanning the whole powcaptchas collection.
+PoWCaptchaRecordSchema.index(
+	{ pendingStage: 1 },
+	{
+		name: "pendingStage_partial",
+		partialFilterExpression: { pendingStage: true },
+	},
+);
 
 export const PuzzleCaptchaRecordSchema = new Schema<PuzzleCaptchaRecord>({
 	challenge: { type: String, required: true },
@@ -263,6 +279,8 @@ export const PuzzleCaptchaRecordSchema = new Schema<PuzzleCaptchaRecord>({
 	userSubmitted: { type: Boolean, required: true },
 	serverChecked: { type: Boolean, required: true },
 	storedAtTimestamp: { type: Date, required: false, expires: ONE_MONTH },
+	// See `StoredCaptcha.pendingStage`.
+	pendingStage: { type: Boolean, required: false },
 	// Full ipinfo payload. Replaces the flat `vpn`, `countryCode`,
 	// `geolocation` and other per-flag fields — consumers narrow on
 	// `ipInfo.isValid` and read whichever sub-field they need.
@@ -298,6 +316,13 @@ PuzzleCaptchaRecordSchema.index({ "ipInfo.countryCode": 1 });
 PuzzleCaptchaRecordSchema.index({ "ipInfo.isVPN": 1 });
 PuzzleCaptchaRecordSchema.index({ ipInfo: 1 });
 PuzzleCaptchaRecordSchema.index({ parsedUserAgentInfo: 1 });
+PuzzleCaptchaRecordSchema.index(
+	{ pendingStage: 1 },
+	{
+		name: "pendingStage_partial",
+		partialFilterExpression: { pendingStage: true },
+	},
+);
 
 export const UserCommitmentRecordSchema = new Schema<UserCommitmentRecord>({
 	userAccount: { type: String, required: true },
@@ -327,6 +352,8 @@ export const UserCommitmentRecordSchema = new Schema<UserCommitmentRecord>({
 	storedAtTimestamp: { type: Date, required: false, expires: ONE_MONTH },
 	requestedAtTimestamp: { type: Date, required: true },
 	lastUpdatedTimestamp: { type: Date, required: false },
+	// See `StoredCaptcha.pendingStage`.
+	pendingStage: { type: Boolean, required: false },
 	// Full ipinfo payload. Replaces the flat `vpn`, `countryCode`,
 	// `geolocation` and other per-flag fields — consumers narrow on
 	// `ipInfo.isValid` and read whichever sub-field they need.
@@ -370,6 +397,13 @@ UserCommitmentRecordSchema.index({ requestHash: -1 });
 UserCommitmentRecordSchema.index({ pending: 1 });
 UserCommitmentRecordSchema.index({ ipInfo: 1 });
 UserCommitmentRecordSchema.index({ parsedUserAgentInfo: 1 });
+UserCommitmentRecordSchema.index(
+	{ pendingStage: 1 },
+	{
+		name: "pendingStage_partial",
+		partialFilterExpression: { pendingStage: true },
+	},
+);
 
 export const DatasetRecordSchema = new Schema<DatasetWithIds>({
 	contentTree: { type: [[String]], required: true },
@@ -474,6 +508,8 @@ export const SessionRecordSchema = new Schema<SessionRecord>({
 	powDifficulty: { type: Number, required: false },
 	storedAtTimestamp: { type: Date, required: false, expires: ONE_DAY },
 	lastUpdatedTimestamp: { type: Date, required: false },
+	// See `StoredCaptcha.pendingStage` — same semantics on Session records.
+	pendingStage: { type: Boolean, required: false },
 	deleted: { type: Boolean, required: false },
 	userSitekeyIpHash: { type: String, required: false },
 	webView: { type: Boolean, required: true, default: false },
@@ -533,6 +569,15 @@ SessionRecordSchema.index({ createdAt: 1, deleted: 1 });
 SessionRecordSchema.index(
 	{ "result.status": 1 },
 	{ background: true, sparse: true },
+);
+// See PoWCaptchaRecordSchema's pendingStage_partial — same purpose for
+// the unstored-session sweep.
+SessionRecordSchema.index(
+	{ pendingStage: 1 },
+	{
+		name: "pendingStage_partial",
+		partialFilterExpression: { pendingStage: true },
+	},
 );
 
 export type DetectorSchema = mongoose.Document & DetectorKey;
@@ -705,7 +750,10 @@ export interface IProviderDatabase extends IDatabase {
 		skip?: number,
 	): Promise<UserCommitmentRecord[]>;
 
-	markDappUserCommitmentsStored(commitmentIds: Hash[]): Promise<void>;
+	markDappUserCommitmentsStored(
+		commitmentIds: Hash[],
+		asOfTimestamp?: Date,
+	): Promise<void>;
 
 	markDappUserCommitmentsChecked(commitmentIds: Hash[]): Promise<void>;
 
@@ -721,7 +769,10 @@ export interface IProviderDatabase extends IDatabase {
 
 	markDappUserPoWCommitmentsChecked(challengeIds: string[]): Promise<void>;
 
-	markDappUserPoWCommitmentsStored(challengeIds: string[]): Promise<void>;
+	markDappUserPoWCommitmentsStored(
+		challengeIds: string[],
+		asOfTimestamp?: Date,
+	): Promise<void>;
 
 	flagProcessedDappUserSolutions(captchaIds: Hash[]): Promise<void>;
 
@@ -861,7 +912,10 @@ export interface IProviderDatabase extends IDatabase {
 		skip: number,
 	): Promise<SessionRecord[]>;
 
-	markSessionRecordsStored(sessionIds: string[]): Promise<void>;
+	markSessionRecordsStored(
+		sessionIds: string[],
+		asOfTimestamp?: Date,
+	): Promise<void>;
 
 	getUserAccessRulesStorage(): AccessRulesStorage;
 

--- a/packages/types/src/provider/database.ts
+++ b/packages/types/src/provider/database.ts
@@ -159,6 +159,13 @@ export interface StoredCaptcha {
 	parsedUserAgentInfo?: UserAgentInfo;
 	storedAtTimestamp?: Date;
 	lastUpdatedTimestamp?: Date;
+	// Sentinel for the central-DB sweep. `true` when the record has unstaged
+	// changes (never staged, or mutated after the last stage). Unset by
+	// `markXxxStored` after a successful stage (guarded so an in-flight update
+	// isn't accidentally cleared). Allows the sweep to scan a tiny partial
+	// index instead of $or'ing `{storedAtTimestamp:{$exists:false}}` with an
+	// unindexable $expr branch.
+	pendingStage?: boolean;
 	sessionId?: string;
 	coords?: [number, number][][];
 	// Legacy fields - kept for backward compatibility with existing data
@@ -223,6 +230,7 @@ export const UserCommitmentSchema = object({
 	storedAtTimestamp: date().optional(),
 	requestedAtTimestamp: date(),
 	lastUpdatedTimestamp: date().optional(),
+	pendingStage: boolean().optional(),
 	sessionId: string().optional(),
 	coords: array(array(tuple([number(), number()]))).optional(),
 	// Pending request fields for image captcha workflow
@@ -316,6 +324,7 @@ export const SessionSchema = object({
 	powDifficulty: number().optional(),
 	storedAtTimestamp: date().optional(),
 	lastUpdatedTimestamp: date().optional(),
+	pendingStage: boolean().optional(),
 	deleted: boolean().optional(),
 	userSitekeyIpHash: string().optional(),
 	webView: boolean(),
@@ -373,6 +382,8 @@ export type Session = {
 	powDifficulty?: number;
 	storedAtTimestamp?: Date;
 	lastUpdatedTimestamp?: Date;
+	// See StoredCaptcha.pendingStage — same semantics on Session records.
+	pendingStage?: boolean;
 	deleted?: boolean;
 	userSitekeyIpHash?: string;
 	webView: boolean;


### PR DESCRIPTION
## Summary

Replaces the $or+$expr query that the `StoreCommitmentsExternal` sweep uses to find records needing central-DB shipment, eliminating the per-sweep collection scan that's been thrashing the WiredTiger cache on busy provider nodes.

## Why

Production slow-query log on `production_provider_mongo` (12h window) showed the sweep's unstored-records query going via `IXSCAN { _id: 1 }`:

| ns | plan | count | avg_ms | total_s | avg_docs |
|---|---|---:|---:|---:|---:|
| `prosopo.powcaptchas` | `IXSCAN { _id: 1 }` | 3,312 | 27,298 | 90,411 | 673,141 |
| `prosopo.usercommitments` | `IXSCAN { id: -1 }` | 1,544 | 14,206 | 21,935 | 165,521 |
| `prosopo.usercommitments` | `IXSCAN { _id: 1 }` | 3,263 | 6,346 | 20,708 | 240,654 |
| `prosopo.sessions` | `IXSCAN { _id: 1 }` | 3,163 | 1,436 | 4,543 | 61,680 |

The query is `{ $or: [{ storedAtTimestamp: { $exists: false } }, { $expr: { $lt: [$storedAt, $lastUpdated] } }] }`. The `$expr` arm is unindexable (per-document computation), and combined with `$or` it forces the planner into a full collection scan via `_id`. On pronode7 / pronode10 this drove the WT cache to thrash — `application threads page read from disk to cache time` accumulated to ~10 hours in 43 hours of uptime — which evicted the indexes the per-request frictionless dedup queries depend on, manifesting as the traffic-correlated provider latency that started 2026-05-26.

## What changed

Sentinel `pendingStage?: boolean` field added to `StoredCaptcha` and `Session` (TS + Zod + Mongoose). Lifecycle:

- **Set `true`** on insert and on every record mutation (`storeXxx`, `updateXxx`, `markXxxChecked`, `approveDappUserCommitment`, `disapproveDappUserCommitment`, `checkAndRemoveSession`, `recordSessionSimdReadingsIfAbsent`, `storePendingImageCommitment`).
- **`$unset`** by `markXxxStored` after a successful stage, guarded by `lastUpdatedTimestamp: { $lte: ts }` so a concurrent update isn't accidentally cleared. Mismatched docs leave the flag set so the next sweep picks them up.
- Bulk `markXxxStored` accept an `asOfTimestamp` (captured at sweep start) so the guard is correct across the ship-then-mark round trip.

Tiny partial index per collection: `{ pendingStage: 1 }` with `partialFilterExpression: { pendingStage: true }` — only indexes the rows needing staging.

Sweep queries become `{ pendingStage: true }` sorted by `_id` — served by the partial index.

## Verification

Local mongod (`mongo:6.0.17`):

- **`$exists: false`** in `partialFilterExpression` rejected as expected (`"Expression not supported in partial index: $not"`) — confirms the historic ipInfo issue and that this design avoids it.
- **`{ pendingStage: true }`** in `partialFilterExpression` accepted.
- **100,050-doc test** (100K staged, 50 pending): query examines 50 docs in 0 ms via `IXSCAN (pendingStage_partial)`; index size 20 KB.
- **Guard scenario A** (no concurrent update): markStored matches, clears `pendingStage`, sets `storedAtTimestamp`.
- **Guard scenario B** (update lands between sweep-start and markStored): markStored matches 0 docs, `pendingStage: true` persists for the next sweep — no lost update.
- `@prosopo/database` + `@prosopo/provider` unit suites pass (731 provider tests, 21 database tests).

## Test plan

- [ ] Confirm partial indexes are created on next deploy (`db.<collection>.getIndexes()` shows `pendingStage_partial`)
- [ ] Monitor `production_provider_mongo` slow-query log — the `IXSCAN { _id: 1 }` lines for `powcaptchas` / `usercommitments` / `sessions` should disappear
- [ ] Confirm WT cache eviction settles on busy nodes (`wiredTiger.cache.application threads page read from disk to cache time` stops growing rapidly)
- [ ] Confirm provider response-time stops tracking traffic volume (caddy `avg(duration)` becomes flat with respect to request rate, matching pre-2026-05-26 baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)