### PR TITLE
fix(types-database): persist autoBanScoreThreshold on client settings

### DIFF
--- a/.changeset/auto-ban-score-threshold-db-schema.md
+++ b/.changeset/auto-ban-score-threshold-db-schema.md
@@ -1,0 +1,16 @@
+---
+"@prosopo/types-database": patch
+---
+
+fix(types-database): persist `autoBanScoreThreshold` on client settings
+
+`autoBanScoreThreshold` was added to the zod `ClientSettingsSchema` and the
+frictionless decision machine in #2592, but the Mongoose `UserSettingsSchema`
+was never updated. Mongoose's strict mode silently dropped the field on every
+`$set`, so neither the portal account collection nor the provider
+`ClientRecord` collection ever persisted the value — meaning a system user
+could set the threshold in the portal, the API would accept it, but the
+provider would never actually enforce it.
+
+Adds the field to the Mongoose schema (`Number`, `min: 0`, `required: false`,
+no default) so the property is preserved on write.

--- a/packages/types-database/src/types/client.ts
+++ b/packages/types-database/src/types/client.ts
@@ -160,6 +160,11 @@ export const UserSettingsSchema = new Schema({
 		default: false,
 		required: false,
 	},
+	autoBanScoreThreshold: {
+		type: Number,
+		min: 0,
+		required: false,
+	},
 	spamFilter: {
 		enabled: { type: Boolean, default: false },
 		emailRules: {


### PR DESCRIPTION
## Summary

- Adds `autoBanScoreThreshold` to the Mongoose `UserSettingsSchema` in `packages/types-database/src/types/client.ts`.
- Bug: the field was added to the zod `ClientSettingsSchema` and the frictionless decision machine in #2592, but the Mongoose schema was never updated. Mongoose strict mode silently strips undeclared fields on `$set`, so neither the account collection (writes from the portal `/sites/update` handler) nor the provider `ClientRecord` collection (writes from `/admin/sitekey/register`) ever persisted the value.
- Net effect: a system user could set the threshold in the portal, the API accepted it, but the provider never enforced it.

## Test plan

- [ ] `npm run -w @prosopo/types-database build:tsc` — passes locally.
- [ ] Covered end-to-end by the new Playwright spec in the captcha-private companion PR (portal save → assert provider Mongo doc).
- [ ] Manually verify against a dev provider: POST `/admin/sitekey/register` with `settings.autoBanScoreThreshold: 1` and confirm the value appears in the provider's `clientrecords` collection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)