### PR TITLE
fix(database/provider): don't flag image-captcha placeholders as pendingStage

### DIFF
--- a/.changeset/skip-placeholder-pending-stage.md
+++ b/.changeset/skip-placeholder-pending-stage.md
@@ -1,0 +1,41 @@
+---
+"@prosopo/database": patch
+"@prosopo/provider": patch
+---
+
+fix(database/provider): don't flag image-captcha placeholder records as `pendingStage`
+
+#2596 set `pendingStage: true` on every commitment write, including
+`storePendingImageCommitment` which inserts placeholder records with
+`id: ""` while waiting for the user to submit a solution. The sweep
+then picked those up via `pendingStage_partial` (fast) and called
+`markDappUserCommitmentsStored(["", "", ...], ts)` (slow) — Mongo
+dedupes the `$in` array to a single empty-string bound and the
+`IXSCAN { id: -1 }` walks every empty-id document on the node (~102K
+on production). On pronode11 that meant 2–8 s per sweep cycle of
+unnecessary index scan on `usercommitments`, replacing the old
+WT-cache-thrash with a different one.
+
+Two-part fix:
+
+- `storePendingImageCommitment` no longer sets `pendingStage`. The
+  real commitment record only gets the flag once `approve` /
+  `disapprove` runs, at which point `id` is populated and staging is
+  meaningful.
+- `storeCommitmentsExternal` defensively skips any batch entry whose
+  `id` is empty before calling `markDappUserCommitmentsStored`, so a
+  stray placeholder slipping into the partial index can never
+  re-introduce the bug.
+
+For nodes already running #2596, the existing flagged placeholders
+need clearing once (otherwise they sit at `pendingStage: true`
+forever, since `markDappUserCommitmentsStored`'s
+`lastUpdatedTimestamp <= ts` guard never matches them after their
+last update). One-shot per node:
+
+```js
+db.usercommitments.updateMany(
+  { pendingStage: true, id: "" },
+  { $unset: { pendingStage: 1 } }
+);
+```

--- a/packages/database/src/databases/provider.ts
+++ b/packages/database/src/databases/provider.ts
@@ -1697,7 +1697,16 @@ export class ProviderDatabase
 			sessionId,
 			threshold,
 			ipInfo,
-			pendingStage: true,
+			// Deliberately NOT setting pendingStage here. Placeholder
+			// records have id: "" until the user submits a solution; if we
+			// flag them, the sweep picks them up via the partial index but
+			// then `markDappUserCommitmentsStored` runs
+			// `{ id: { $in: ["", ...] } }` which collapses to a single ""
+			// bound and scans every empty-id row via the `id_-1` index —
+			// turning a cheap sweep into a fresh cache evictor. The real
+			// commitment only gets `pendingStage: true` once `id` is
+			// populated by approve/disapprove, at which point staging it is
+			// meaningful.
 			// Placeholder fields required by schema but not needed for pending state
 			dappAccount: "",
 			providerAccount: "",

--- a/packages/provider/src/tasks/client/clientTasks.ts
+++ b/packages/provider/src/tasks/client/clientTasks.ts
@@ -124,9 +124,19 @@ export class ClientTaskManager {
 						skip,
 					),
 				async (batch) => {
-					const filteredBatch = lastTask?.updated
-						? batch.filter((commitment) => this.isRecordUpdated(commitment))
-						: batch;
+					const filteredBatch = (
+						lastTask?.updated
+							? batch.filter((commitment) => this.isRecordUpdated(commitment))
+							: batch
+					).filter((commitment) => commitment.id !== "");
+					// Skip placeholder records — `storePendingImageCommitment`
+					// inserts with `id: ""` until the user submits a solution.
+					// Defense in depth: even if a stray placeholder slips into
+					// the partial index, never pass `id: ""` to
+					// markDappUserCommitmentsStored — Mongo collapses
+					// `{ id: { $in: ["", "", ...] } }` to a single empty-string
+					// bound and the IXSCAN on `id_-1` then walks every
+					// empty-id document on the node (~100K rows).
 
 					if (filteredBatch.length > 0) {
 						await captchaDB.saveCaptchas([], filteredBatch, []);


### PR DESCRIPTION
## Summary

Follow-up to #2596. v3.6.25 is deployed and the new `pendingStage_partial` sweep query *is* fast, but `markDappUserCommitmentsStored` now produces 2–8 s `IXSCAN { id: -1 }` ops examining ~102K rows per sweep cycle.

Root cause: #2596 added `pendingStage: true` to `storePendingImageCommitment`, which creates placeholder records with `id: ""` while waiting for user solution submission. Sweep picks these up (cheap), passes their empty ids to `markDappUserCommitmentsStored`, Mongo dedupes the `\$in` array to a single `""` bound, and the IXSCAN on `id_-1` walks every empty-id document on the node.

## Production evidence (pronode11, this morning)

```
usercommitments total:                187,258
  records with id="":                 102,748
  pendingStage=true:                      128
  pendingStage=true AND id="":            128   ← all of them
  pendingStage=true AND id<>"":             0
```

Slow-query log (live, post-deploy):
```
dur=8205ms docs=5819   plan=IXSCAN { dappAccount: 1, requestedAtTimestamp: 1 }
dur=5367ms docs=102717 plan=IXSCAN { id: -1 }
dur=5061ms docs=102719 plan=IXSCAN { id: -1 }
dur=2206ms docs=102720 plan=IXSCAN { id: -1 }
```

The `id:-1` ops have `q: { id: { \$in: ["", "", ..., ""] }, lastUpdatedTimestamp: { \$lte: ... } }`. Same WT cache pressure profile as the old `\$or+\$expr` sweep, just a different query shape.

## Fix

- `storePendingImageCommitment` no longer sets `pendingStage`. Placeholder records have no business in the central DB until the real commitment is created (via `approve` / `disapprove`, which already set the flag).
- `storeCommitmentsExternal` defensively filters `id === ""` out of the sweep batch before calling `markDappUserCommitmentsStored` — covers any future code path that might accidentally flag a placeholder.

## Cleanup for already-deployed nodes

The 128 stranded placeholders need clearing once per node — `markDappUserCommitmentsStored`'s `lastUpdatedTimestamp <= ts` guard will never match them after their last update, so they stay flagged forever:

```js
db.usercommitments.updateMany(
  { pendingStage: true, id: "" },
  { \$unset: { pendingStage: 1 } }
);
```

## Test plan

- [ ] After deploy, confirm `db.usercommitments.countDocuments({ pendingStage: true, id: "" })` stays at 0 on each node.
- [ ] Confirm the `IXSCAN { id: -1 }` slow ops disappear from `production_provider_mongo` for the `usercommitments` collection.
- [ ] Confirm sweep still ships real (resolved) commitments — count of \`pendingStage=true AND id<>""\` should be small (transient).

🤖 Generated with [Claude Code](https://claude.com/claude-code)