### PR TITLE
fix(provider): defer Tasks construction in domainMiddleware to fix maintenance-mode crash loop

### DIFF
--- a/.changeset/domain-middleware-maintenance-mode.md
+++ b/.changeset/domain-middleware-maintenance-mode.md
@@ -1,0 +1,18 @@
+---
+"@prosopo/provider": patch
+---
+
+Fix provider crash-loop on startup in maintenance mode.
+
+`domainMiddleware` constructed `new Tasks(env)` eagerly at wire-up time, which
+calls `env.getDb()`. In `MAINTENANCE_MODE=true` the DB is intentionally never
+connected (`isReady()` skips the connect), so `getDb()` throws
+`"db not setup! Please call isReady() first"`. That error was unguarded and
+propagated out of `startProviderApi`, crashing the process on every boot and
+leaving the provider in a Docker restart loop.
+
+`Tasks` is now resolved lazily on the first request that actually needs domain
+validation — i.e. only once maintenance mode is off — mirroring the existing
+lazy pattern in `blockMiddleware`. The request handler already short-circuits
+on `getMaintenanceMode()` before touching the DB, so no request path depends on
+the eager construction.

--- a/packages/provider/src/api/domainMiddleware.ts
+++ b/packages/provider/src/api/domainMiddleware.ts
@@ -42,7 +42,10 @@ export const domainMiddleware = (env: ProviderEnvironment) => {
 				return;
 			}
 
-			const tasks = (cachedTasks ??= new Tasks(env));
+			if (!cachedTasks) {
+				cachedTasks = new Tasks(env);
+			}
+			const tasks = cachedTasks;
 
 			const siteKey = req.headers["prosopo-site-key"] as string;
 			if (!siteKey)

--- a/packages/provider/src/api/domainMiddleware.ts
+++ b/packages/provider/src/api/domainMiddleware.ts
@@ -25,7 +25,11 @@ import { Tasks } from "../tasks/index.js";
 import { getMaintenanceMode } from "./admin/apiToggleMaintenanceModeEndpoint.js";
 
 export const domainMiddleware = (env: ProviderEnvironment) => {
-	const tasks = new Tasks(env);
+	// Resolve Tasks (and its DB handle) lazily. In maintenance-mode startup the
+	// DB isn't initialised, so constructing Tasks eagerly here would call
+	// env.getDb() and crash boot. Build it on the first request that actually
+	// needs domain validation (i.e. once maintenance mode is off).
+	let cachedTasks: Tasks | undefined;
 
 	return async (req: Request, res: Response, next: NextFunction) => {
 		try {
@@ -37,6 +41,8 @@ export const domainMiddleware = (env: ProviderEnvironment) => {
 				next();
 				return;
 			}
+
+			const tasks = (cachedTasks ??= new Tasks(env));
 
 			const siteKey = req.headers["prosopo-site-key"] as string;
 			if (!siteKey)


### PR DESCRIPTION
## Problem

On staging (`staging-pronode2`), both `provider1` and `provider2` containers (`prosopo/provider:3.6.27-staging`) were stuck in a Docker restart loop while **maintenance mode** was active.

Boot logs showed the DB being intentionally skipped, several routes handling that gracefully, then an unhandled throw crashing the process:

```
MAINTENANCE_MODE=true — skipping DB import on startup
Skipping startup cleanup — DB not connected
Starting Prosopo API
db not setup! ...  → "Skipping admin/access-rule routes; DB unavailable"   ✅ handled
db not setup! ...  → "verify endpoints will skip access-policy checks"      ✅ handled
Enabling admin auth middleware
db not setup! ...  → (CLI scope) err: "db not setup!..."                     💥 crash → restart
```

## Root cause

In `MAINTENANCE_MODE=true`, `Environment.isReady()` deliberately skips the DB connect, so `env.db` stays `undefined` and `env.getDb()` throws `"db not setup! Please call isReady() first"`.

The startup path was hardened for this almost everywhere — `startProviderApi` try/catches the admin/access-rule wiring, `blockMiddleware` resolves the DB lazily, and the captcha/verify routers swallow the error. **`domainMiddleware` was missed:**

```ts
export const domainMiddleware = (env: ProviderEnvironment) => {
	const tasks = new Tasks(env);   // ← eager: Tasks constructor calls env.getDb()
	...
```

`new Tasks(env)` runs at wire-up time when `startProviderApi` calls `apiApp.use("/v1/prosopo/provider/client/", domainMiddleware(env))`, and `Tasks`' constructor does `this.db = env.getDb()` unconditionally. The throw propagates out of `startProviderApi` to the top-level CLI handler → process exits → restart loop. (This is also why the captcha router's "captcha endpoints will skip access-policy checks" message never printed — the crash happened just before it was wired.)

The irony: the middleware's request handler already short-circuits on `getMaintenanceMode()` before touching the DB — it just never got the chance, because construction crashed before any request arrived.

## Fix

Resolve `Tasks` lazily on the first request that actually needs domain validation (only once maintenance mode is off), mirroring the existing lazy pattern in `blockMiddleware`. No request path depends on the eager construction.

## Testing

- `npm run -w @prosopo/provider build:tsc` passes.
- The handler's existing `getMaintenanceMode()` short-circuit means `Tasks` is never constructed while maintenance mode is on, so boot no longer calls `env.getDb()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)