### PR TITLE
feat(widget): honeypot baits AI responses via labelled empty input portaled to form

### DIFF
--- a/.changeset/honeypot-portal-form.md
+++ b/.changeset/honeypot-portal-form.md
@@ -1,0 +1,17 @@
+---
+"@prosopo/procaptcha-common": patch
+"@prosopo/procaptcha-react": patch
+"@prosopo/procaptcha-pow": patch
+"@prosopo/procaptcha-puzzle": patch
+"@prosopo/procaptcha-bundle": patch
+---
+
+feat(widget): bait AI responses with empty input + decoded label, portaled into the dapp's form
+
+Redesigns the honeypot so it can actually catch AI agents instead of being inert:
+
+- Empty input + decoded label: the encoded morse/semaphore question moves from `input.value` to an offscreen `<label>` (base64-decoded at render). Naive form-fillers and humans leave the empty input alone; agents that read the DOM as a prompt write into the empty field, captured as `clientMetaData.hp` on submit.
+- Portaled to light DOM, inside the dapp's `<form>`: widget stays in shadow DOM, but the honeypot portals via `react-dom/createPortal` into the enclosing form (`document.body` fallback). Bots no longer have to traverse `.shadowRoot` to reach it (which was tripping `@prosopo/catcher`'s shadow-DOM guard and wiping the bot's value), and the bait sits where bots actually look — `form.querySelectorAll('input')`.
+- `form="<useId>-d"`: opaque per-instance non-existent form id disassociates the input from native form submission while keeping it DOM-discoverable. Dapp backends don't receive a stray `email_confirm=` field.
+- Shared `<Honeypot />` extracted to `@prosopo/procaptcha-common`.
+- `procaptcha-bundle` Vite config now routes the Honeypot module into a per-build opaque chunk (`c<random8hex>-<hash>.js`) so the URL doesn't identify the component or stay stable across builds for static blocklisting.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@prosopo/captcha",
-	"version": "3.6.27",
+	"version": "3.6.28",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@prosopo/captcha",
-			"version": "3.6.27",
+			"version": "3.6.28",
 			"license": "Apache-2.0",
 			"workspaces": [
 				"dev/*",
@@ -923,6 +923,7 @@
 			"integrity": "sha512-uzcxnSDVjAopEUjljkWh8EIrg6tlzrjFUfMcR1EVsRDGwf/ccef0qQPRyOrROwhrTDaApueq+ja+KLPlzR/zdg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.25.0",
 				"fdir": "^6.5.0",
@@ -1015,6 +1016,7 @@
 			"integrity": "sha512-l3xF/fXfJAl/UrNnH9Ufkr79myjMgXdHq1mmmph2UnpeqilRB1b8lC9sLBV9MipQHVn3dwocxMIvtrcryfOaXw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@babel/core": "7.28.3",
 				"@jridgewell/sourcemap-codec": "^1.4.14",
@@ -1048,6 +1050,7 @@
 			"integrity": "sha512-yDBHV9kQNcr2/sUr9jghVyz9C3Y5G2zUM2H2lo+9mKv4sFgbA8s8Z9t8D1jiTkGoO/NoIfKMyKWr4s6CN23ZwQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@ampproject/remapping": "^2.2.0",
 				"@babel/code-frame": "^7.27.1",
@@ -1239,6 +1242,7 @@
 			"integrity": "sha512-Xxr6BBRCAOQixvonOye19wnzyDiUtTeqldOOmj3CkeblonbccA12PFwlufvRdrpjXxqnmUaeiU5EOA+7s5diUQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"undici-types": "~6.20.0"
 			}
@@ -1380,7 +1384,8 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"dev": true,
-			"license": "0BSD"
+			"license": "0BSD",
+			"peer": true
 		},
 		"integration/frameworks/angular/angular-procaptcha-integration-demo/node_modules/typescript": {
 			"version": "5.8.3",
@@ -1388,6 +1393,7 @@
 			"integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -1402,6 +1408,7 @@
 			"integrity": "sha512-gX/dMkRQc7QOMzgTe6KsYFM7DxeIONQSui1s0n/0xht36HvrgbxtM1xBlgx596NbpHuQU8P7QpKwrZYwUX48nw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@types/eslint-scope": "^3.7.7",
 				"@types/estree": "^1.0.8",
@@ -1519,6 +1526,7 @@
 			"integrity": "sha512-Fe7MIg2NWXoK+M4GtclxaYNoTdZX2U8f/Fd3N8zxtEMcRsvliJOnJ4oQtpx5kqMAuZVO4zY3wuIY1wAGXYCUbQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@babel/core": "7.28.3",
 				"@jridgewell/sourcemap-codec": "^1.4.14",
@@ -2368,6 +2376,7 @@
 			"resolved": "https://registry.npmjs.org/@angular/common/-/common-20.3.16.tgz",
 			"integrity": "sha512-GRAziNlntwdnJy3F+8zCOvDdy7id0gITjDnM6P9+n2lXvtDuBLGJKU3DWBbvxcCjtD6JK/g/rEX5fbCxbUHkQQ==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.3.0"
 			},
@@ -2398,6 +2407,7 @@
 			"resolved": "https://registry.npmjs.org/@angular/core/-/core-20.3.16.tgz",
 			"integrity": "sha512-KSFPKvOmWWLCJBbEO+CuRUXfecX2FRuO0jNi9c54ptXMOPHlK1lIojUnyXmMNzjdHgRug8ci9qDuftvC2B7MKg==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.3.0"
 			},
@@ -2423,6 +2433,7 @@
 			"resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-20.3.16.tgz",
 			"integrity": "sha512-YsrLS6vyS77i4pVHg4gdSBW74qvzHjpQRTVQ5Lv/OxIjJdYYYkMmjNalCNgy1ZuyY6CaLIB11ccxhrNnxfKGOQ==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.3.0"
 			},
@@ -2505,6 +2516,7 @@
 			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
 			"integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.29.0",
 				"@babel/generator": "^7.29.0",
@@ -5044,6 +5056,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			},
@@ -5066,6 +5079,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -5275,6 +5289,7 @@
 			"resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.11.1.tgz",
 			"integrity": "sha512-5mlW1DquU5HaxjLkfkGN1GA/fvVGdyHURRiX/0FHl2cfIfRxSOfmxEH5YS43edp0OldZrZ+dkBKbngxcNCdZvA==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@babel/runtime": "^7.18.3",
 				"@emotion/babel-plugin": "^11.11.0",
@@ -6462,6 +6477,7 @@
 			"integrity": "sha512-nqhDw2ZcAUrKNPwhjinJny903bRhI0rQhiDz1LksjeRxqa36i3l75+4iXbOy0rlDpLJGxqtgoPavQjmmyS5UJw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@inquirer/checkbox": "^4.2.1",
 				"@inquirer/confirm": "^5.1.14",
@@ -7706,6 +7722,7 @@
 			"integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"accepts": "^2.0.0",
 				"body-parser": "^2.2.1",
@@ -7970,6 +7987,7 @@
 			"integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
 			}
@@ -8931,6 +8949,7 @@
 			"resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.2.tgz",
 			"integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@octokit/auth-token": "^4.0.0",
 				"@octokit/graphql": "^7.1.0",
@@ -9543,6 +9562,7 @@
 			"integrity": "sha512-MljrPobN0ZWTpn++da9vOvt+Ex+NlqTlr/XT7zi9sqPtDJiQcYl+d29hFAgpaeTqbeQKZwz3WDE9xcEfLE8c5A==",
 			"devOptional": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@polkadot-api/json-rpc-provider": "0.0.1",
 				"@polkadot-api/utils": "0.1.0"
@@ -9560,6 +9580,7 @@
 			"resolved": "https://registry.npmjs.org/@polkadot/api/-/api-16.5.4.tgz",
 			"integrity": "sha512-mX1fwtXCBAHXEyZLSnSrMDGP+jfU2rr7GfDVQBz0cBY1nmY8N34RqPWGrZWj8o4DxVu1DQ91sGncOmlBwEl0Qg==",
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"@polkadot/api-augment": "16.5.4",
 				"@polkadot/api-base": "16.5.4",
@@ -9835,6 +9856,7 @@
 			"resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.1.tgz",
 			"integrity": "sha512-764HhxkPV3x5rM0/p6QdynC2dw26n+SaE+jisjx556ViCd4E28Ke4xSPef6C0Spy4aoXf2gt0PuLEcBvd6fVZg==",
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"@polkadot/x-bigint": "14.0.1",
 				"@polkadot/x-global": "14.0.1",
@@ -9980,6 +10002,7 @@
 			"resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.1.tgz",
 			"integrity": "sha512-764HhxkPV3x5rM0/p6QdynC2dw26n+SaE+jisjx556ViCd4E28Ke4xSPef6C0Spy4aoXf2gt0PuLEcBvd6fVZg==",
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"@polkadot/x-bigint": "14.0.1",
 				"@polkadot/x-global": "14.0.1",
@@ -10142,6 +10165,7 @@
 			"resolved": "https://registry.npmjs.org/@polkadot/util/-/util-13.5.9.tgz",
 			"integrity": "sha512-pIK3XYXo7DKeFRkEBNYhf3GbCHg6dKQisSvdzZwuyzA6m7YxQq4DFw4IE464ve4Z7WsJFt3a6C9uII36hl9EWw==",
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"@polkadot/x-bigint": "13.5.9",
 				"@polkadot/x-global": "13.5.9",
@@ -10345,6 +10369,7 @@
 			"resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.1.tgz",
 			"integrity": "sha512-764HhxkPV3x5rM0/p6QdynC2dw26n+SaE+jisjx556ViCd4E28Ke4xSPef6C0Spy4aoXf2gt0PuLEcBvd6fVZg==",
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"@polkadot/x-bigint": "14.0.1",
 				"@polkadot/x-global": "14.0.1",
@@ -10556,6 +10581,7 @@
 			"resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.1.tgz",
 			"integrity": "sha512-764HhxkPV3x5rM0/p6QdynC2dw26n+SaE+jisjx556ViCd4E28Ke4xSPef6C0Spy4aoXf2gt0PuLEcBvd6fVZg==",
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"@polkadot/x-bigint": "14.0.1",
 				"@polkadot/x-global": "14.0.1",
@@ -10910,6 +10936,7 @@
 			"resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.1.tgz",
 			"integrity": "sha512-764HhxkPV3x5rM0/p6QdynC2dw26n+SaE+jisjx556ViCd4E28Ke4xSPef6C0Spy4aoXf2gt0PuLEcBvd6fVZg==",
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"@polkadot/x-bigint": "14.0.1",
 				"@polkadot/x-global": "14.0.1",
@@ -11027,6 +11054,7 @@
 			"resolved": "https://registry.npmjs.org/@polkadot/types/-/types-16.5.4.tgz",
 			"integrity": "sha512-8Oo1QWaL0DkIc/n2wKBIozPWug/0b2dPVhL+XrXHxJX7rIqS0x8sXDRbM9r166sI0nTqJiUho7pRIkt2PR/DMQ==",
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"@polkadot/keyring": "^14.0.1",
 				"@polkadot/types-augment": "16.5.4",
@@ -11509,6 +11537,7 @@
 			"resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.1.tgz",
 			"integrity": "sha512-764HhxkPV3x5rM0/p6QdynC2dw26n+SaE+jisjx556ViCd4E28Ke4xSPef6C0Spy4aoXf2gt0PuLEcBvd6fVZg==",
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"@polkadot/x-bigint": "14.0.1",
 				"@polkadot/x-global": "14.0.1",
@@ -11668,6 +11697,7 @@
 			"resolved": "https://registry.npmjs.org/@polkadot/util/-/util-13.5.9.tgz",
 			"integrity": "sha512-pIK3XYXo7DKeFRkEBNYhf3GbCHg6dKQisSvdzZwuyzA6m7YxQq4DFw4IE464ve4Z7WsJFt3a6C9uII36hl9EWw==",
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"@polkadot/x-bigint": "13.5.9",
 				"@polkadot/x-global": "13.5.9",
@@ -12036,6 +12066,7 @@
 			"resolved": "https://registry.npmjs.org/@polkadot/wasm-util/-/wasm-util-7.5.4.tgz",
 			"integrity": "sha512-hqPpfhCpRAqCIn/CYbBluhh0TXmwkJnDRjxrU9Bnqtw9nMNa97D8JuOjdd2pi0rxm+eeLQ/f1rQMp71RMM9t4w==",
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.7.0"
 			},
@@ -12120,6 +12151,7 @@
 			"resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-13.5.7.tgz",
 			"integrity": "sha512-NEElpdu+Wqlr6USoh3abQfe0MaWlFlynPiqkA0/SJjK+0V0UOw0CyPwPgGrGa71/ju+1bsnu/ySshXqCR8HXTw==",
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"@polkadot/x-global": "13.5.7",
 				"tslib": "^2.8.0"
@@ -13567,6 +13599,7 @@
 			"integrity": "sha512-Y1Cs7hhTc+a5E9Va/xwKlAJoariQyHY+5zBgCZg4PFWNYQ1nMN9sjK1zhw1gK69DuqVP++sht/1GZg1aRwmAXQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@sveltejs/vite-plugin-svelte-inspector": "^4.0.1",
 				"debug": "^4.4.1",
@@ -14052,6 +14085,7 @@
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.5.tgz",
 			"integrity": "sha512-Xjs4y5UPO/CLdzpgR6GirZJx36yScjh73+2NlLlkFRSoQN8B0DpfXPdZGnvVmLRLOsqDpOfTNv7D9trgGhmOIA==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"undici-types": "~6.19.2"
 			}
@@ -15049,6 +15083,7 @@
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
 			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -15138,6 +15173,7 @@
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
 			"integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
 				"fast-uri": "^3.0.1",
@@ -16600,6 +16636,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"baseline-browser-mapping": "^2.9.0",
 				"caniuse-lite": "^1.0.30001759",
@@ -17004,6 +17041,7 @@
 			"integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
 			"devOptional": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"readdirp": "^4.0.1"
 			},
@@ -18262,6 +18300,7 @@
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@cypress/request": "^3.0.1",
 				"@cypress/xvfb": "^1.2.4",
@@ -20089,6 +20128,7 @@
 			"integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"ansi-colors": "^4.1.1",
 				"strip-ansi": "^6.0.1"
@@ -20709,6 +20749,7 @@
 			"resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
 			"integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"accepts": "~1.3.8",
 				"array-flatten": "1.1.1",
@@ -22022,6 +22063,7 @@
 			"integrity": "sha512-Eaw2YTGM6WOxA6CXbckaEvslr2Ne4NFsKrvc0v97JD5awbmeBLO5w9Ho9L9kmKonrwF9RJlW6BxT1PVv/agBHQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=16.9.0"
 			}
@@ -22174,6 +22216,7 @@
 			"resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.6.0.tgz",
 			"integrity": "sha512-iwaY4wzbe48AfKLZ/Cc8k0L+FKG6oSNRaZ8x5A/T/IVDGyXcbHncM9TdDa93wn0FsSm82FhTKW7f3vS61thXAw==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@types/html-minifier-terser": "^6.0.0",
 				"html-minifier-terser": "^6.0.2",
@@ -22410,6 +22453,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@babel/runtime": "^7.23.2"
 			},
@@ -23684,7 +23728,8 @@
 			"resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-5.6.0.tgz",
 			"integrity": "sha512-niVlkeYVRwKFpmfWg6suo6H9CrNnydfBLEqefM5UjibYS+UoTjZdmvPJSiuyrRLGnFj1eYRhFd/ch+5hSlsFVA==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/jest-diff": {
 			"version": "29.7.0",
@@ -23732,6 +23777,7 @@
 			"integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
 			"devOptional": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"jiti": "bin/jiti.js"
 			}
@@ -24007,6 +24053,7 @@
 			"integrity": "sha512-LrtUxbdvt1gOpo3gxG+VAJlJAEMhbWlM4YrFQgql98FwF7+K8K12LYO4hnDdUkNjeztYrOXEMqgTajSWgmtI/w==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@colors/colors": "1.5.0",
 				"body-parser": "^1.19.0",
@@ -24450,6 +24497,7 @@
 			"integrity": "sha512-kdTwsyRuncDfjEs0DlRILWNvxhDG/Zij4YLO4TMJgDLW+8OzpfkdPnRgrsRuY1o+oaxJGWsps5f/RVBgGmmN0w==",
 			"devOptional": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"copy-anything": "^2.0.1",
 				"parse-node-version": "^1.0.1",
@@ -24589,6 +24637,7 @@
 			"integrity": "sha512-SL0JY3DaxylDuo/MecFeiC+7pedM0zia33zl0vcjgwcq1q1FWWF1To9EIauPbl8GbMCU0R2e0uJ8bZunhYKD2g==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"cli-truncate": "^4.0.0",
 				"colorette": "^2.0.20",
@@ -25834,6 +25883,7 @@
 			"resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.13.0.tgz",
 			"integrity": "sha512-e/iYV1mPeOkg+SWAMHzt3t42/EZyER3OB1H2pjP9C3vQ+Qb5DMeV9Kb+YCUycKgScA3fbwL7dKG4EpinGlg21g==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"bson": "^6.10.3",
 				"kareem": "2.6.3",
@@ -28278,6 +28328,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"nanoid": "^3.3.11",
 				"picocolors": "^1.1.1",
@@ -28929,6 +28980,7 @@
 			"resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
 			"integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0"
 			},
@@ -29783,6 +29835,7 @@
 			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.5.tgz",
 			"integrity": "sha512-3GuObel8h7Kqdjt0gxkEzaifHTqLVW56Y/bjN7PSQtkKr0w3V/QYSdt6QWYtd7A1xUtYQigtdUfgj1RvWVtorw==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@types/estree": "1.0.8"
 			},
@@ -30368,6 +30421,7 @@
 			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
 			"integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.1.0"
 			}
@@ -30481,6 +30535,7 @@
 			"integrity": "sha512-9GUyuksjw70uNpb1MTYWsH9MQHOHY6kwfnkafC24+7aOMZn9+rVMBxRbLvw756mrBFbIsFg6Xw9IkR2Fnn3k+Q==",
 			"devOptional": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"chokidar": "^4.0.0",
 				"immutable": "^5.0.2",
@@ -31207,6 +31262,7 @@
 			"integrity": "sha512-F+qYmH4z2s2FK+CxGj8moYcd1ekSIKH8ywkdqlOz88Dat35iB1DIYL11aILN46YSGMzQW/lbJNS307zBSDN5Ig==",
 			"devOptional": true,
 			"license": "GPL-3.0-or-later WITH Classpath-exception-2.0",
+			"peer": true,
 			"dependencies": {
 				"ws": "^8.8.1"
 			}
@@ -31372,6 +31428,7 @@
 			"integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
 			"devOptional": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"ip-address": "^10.0.1",
 				"smart-buffer": "^4.2.0"
@@ -31836,6 +31893,7 @@
 			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -32180,6 +32238,7 @@
 			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.51.2.tgz",
 			"integrity": "sha512-AqApqNOxVS97V4Ko9UHTHeSuDJrwauJhZpLDs1gYD8Jk48ntCSWD7NxKje+fnGn5Ja1O3u2FzQZHPdifQjXe3w==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@jridgewell/remapping": "^2.3.4",
 				"@jridgewell/sourcemap-codec": "^1.5.0",
@@ -32345,6 +32404,7 @@
 			"resolved": "https://registry.npmjs.org/terser/-/terser-5.43.1.tgz",
 			"integrity": "sha512-+6erLbBm0+LROX2sPXlUYx/ux5PyE9K/a92Wrt6oA+WDAoFTdpHE5tCYCI5PNzq2y8df4rA+QgHLJuR4jNymsg==",
 			"license": "BSD-2-Clause",
+			"peer": true,
 			"dependencies": {
 				"@jridgewell/source-map": "^0.3.3",
 				"acorn": "^8.14.0",
@@ -33027,7 +33087,8 @@
 			"version": "2.7.0",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
 			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
-			"license": "0BSD"
+			"license": "0BSD",
+			"peer": true
 		},
 		"node_modules/tsx": {
 			"version": "4.20.3",
@@ -33333,6 +33394,7 @@
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.2.tgz",
 			"integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
 			"license": "Apache-2.0",
+			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -33719,6 +33781,7 @@
 			"resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
 			"integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.25.0",
 				"fdir": "^6.4.4",
@@ -34031,6 +34094,7 @@
 			"integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@types/chai": "^5.2.2",
 				"@vitest/expect": "3.2.4",
@@ -34422,6 +34486,7 @@
 			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.102.1.tgz",
 			"integrity": "sha512-7h/weGm9d/ywQ6qzJ+Xy+r9n/3qgp/thalBbpOi5i223dPXKi04IBtqPN9nTd+jBc7QKfvDbaBnFipYp4sJAUQ==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@types/eslint-scope": "^3.7.7",
 				"@types/estree": "^1.0.8",
@@ -34582,6 +34647,7 @@
 			"integrity": "sha512-QcQ72gh8a+7JO63TAx/6XZf/CWhgMzu5m0QirvPfGvptOusAxG12w2+aua1Jkjr7hzaWDnJ2n6JFeexMHI+Zjg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@types/bonjour": "^3.5.13",
 				"@types/connect-history-api-fallback": "^1.5.4",
@@ -36667,13 +36733,15 @@
 				"@prosopo/load-balancer": "2.9.9",
 				"@prosopo/types": "4.2.1",
 				"@prosopo/widget-skeleton": "2.8.3",
-				"react": "18.3.1"
+				"react": "18.3.1",
+				"react-dom": "18.3.1"
 			},
 			"devDependencies": {
 				"@prosopo/config": "3.3.1",
 				"@types/jsdom": "21.1.7",
 				"@types/node": "22.10.2",
 				"@types/react": "18.3.1",
+				"@types/react-dom": "18.3.1",
 				"@vitest/coverage-v8": "3.2.4",
 				"concurrently": "9.0.1",
 				"del-cli": "6.0.0",
@@ -37494,6 +37562,7 @@
 			"resolved": "https://registry.npmjs.org/@polkadot/util/-/util-13.5.9.tgz",
 			"integrity": "sha512-pIK3XYXo7DKeFRkEBNYhf3GbCHg6dKQisSvdzZwuyzA6m7YxQq4DFw4IE464ve4Z7WsJFt3a6C9uII36hl9EWw==",
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"@polkadot/x-bigint": "13.5.9",
 				"@polkadot/x-global": "13.5.9",

--- a/packages/procaptcha-bundle/vite.config.ts
+++ b/packages/procaptcha-bundle/vite.config.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { randomBytes } from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import {
@@ -22,6 +23,12 @@ import { loadEnv } from "@prosopo/dotenv";
 import { at, flatten } from "@prosopo/util";
 import fg from "fast-glob";
 import { defineConfig } from "vite";
+
+// Per-build opaque chunk name for the honeypot module. Re-rolled on every
+// build so the emitted URL (e.g. `c8f2a1b0-<hash>.js`) doesn't leak the
+// component's purpose and can't be fingerprinted by scrapers that maintain
+// static URL blocklists.
+const honeypotChunkName = `c${randomBytes(4).toString("hex")}`;
 
 // load env using our util because vite loadEnv is not working for .env.development
 loadEnv();
@@ -92,6 +99,13 @@ export default defineConfig(async ({ command, mode }) => {
 				output: {
 					...frontendConfig.build?.rollupOptions?.output,
 					manualChunks(id: string) {
+						if (
+							id.includes(
+								"packages/procaptcha-common/dist/reactComponents/Honeypot",
+							)
+						) {
+							return honeypotChunkName;
+						}
 						if (id.includes("wasm-crypto-wasm")) {
 							return "web3Chunk";
 						}

--- a/packages/procaptcha-common/package.json
+++ b/packages/procaptcha-common/package.json
@@ -38,13 +38,15 @@
 		"@prosopo/load-balancer": "2.9.9",
 		"@prosopo/types": "4.2.1",
 		"@prosopo/widget-skeleton": "2.8.3",
-		"react": "18.3.1"
+		"react": "18.3.1",
+		"react-dom": "18.3.1"
 	},
 	"devDependencies": {
 		"@prosopo/config": "3.3.1",
 		"@types/jsdom": "21.1.7",
 		"@types/node": "22.10.2",
 		"@types/react": "18.3.1",
+		"@types/react-dom": "18.3.1",
 		"@vitest/coverage-v8": "3.2.4",
 		"concurrently": "9.0.1",
 		"del-cli": "6.0.0",

--- a/packages/procaptcha-common/src/index.ts
+++ b/packages/procaptcha-common/src/index.ts
@@ -20,4 +20,5 @@ export * from "./extensionLoader.js";
 export * from "./elements/window.js";
 export * from "./reactComponents/Reload.js";
 export * from "./reactComponents/Checkbox.js";
+export * from "./reactComponents/Honeypot.js";
 export * from "./reactComponents/TestModeBanner.js";

--- a/packages/procaptcha-common/src/reactComponents/Honeypot.tsx
+++ b/packages/procaptcha-common/src/reactComponents/Honeypot.tsx
@@ -105,20 +105,25 @@ export const Honeypot = forwardRef<HTMLInputElement, HoneypotProps>(
 			);
 		}
 
+		// Input is nested inside the label (implicit association) instead of
+		// htmlFor-linked — biome's noLabelWithoutControl rule only recognises
+		// the descendant form of association at static-analysis time.
 		return createPortal(
 			<div aria-hidden="true" style={offscreenStyle}>
-				<label htmlFor={id}>{question}</label>
-				<input
-					ref={ref}
-					id={id}
-					form={detachedFormId}
-					type="text"
-					name="email_confirm"
-					defaultValue=""
-					tabIndex={-1}
-					autoComplete="off"
-					aria-hidden="true"
-				/>
+				<label>
+					{question}
+					<input
+						ref={ref}
+						id={id}
+						form={detachedFormId}
+						type="text"
+						name="email_confirm"
+						defaultValue=""
+						tabIndex={-1}
+						autoComplete="off"
+						aria-hidden="true"
+					/>
+				</label>
 			</div>,
 			portalTarget,
 		);

--- a/packages/procaptcha-common/src/reactComponents/Honeypot.tsx
+++ b/packages/procaptcha-common/src/reactComponents/Honeypot.tsx
@@ -12,7 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { type CSSProperties, forwardRef, useId, useMemo } from "react";
+import {
+	type CSSProperties,
+	forwardRef,
+	useEffect,
+	useId,
+	useMemo,
+	useRef,
+	useState,
+} from "react";
+import { createPortal } from "react-dom";
 
 interface HoneypotProps {
 	encodedQuestion: string;
@@ -37,24 +46,72 @@ const decodeBase64Utf8 = (b64: string): string => {
 	return new TextDecoder().decode(bytes);
 };
 
-// The decoded question is rendered as the input's <label>, not as the input's
-// value. Naive form-fillers leave the empty input alone — no signal, no false
+// Locate the dapp's enclosing <form> by stepping out of the widget's shadow
+// root into light DOM, then walking up via closest(). Returns null when the
+// widget isn't embedded inside a form.
+const findAncestorForm = (anchor: Element): HTMLFormElement | null => {
+	const root = anchor.getRootNode();
+	const lightDomEntry = root instanceof ShadowRoot ? root.host : anchor;
+	return lightDomEntry instanceof Element
+		? lightDomEntry.closest("form")
+		: null;
+};
+
+// Honeypot must live in light DOM, not in the widget's shadow root: if it
+// rendered there a bot would have to traverse `.shadowRoot` to reach it, and
+// @prosopo/catcher patches that getter to detect (and restart on) automated
+// access — wiping the value the bot just wrote before it can submit.
+//
+// Within light DOM we prefer the enclosing <form> so bots scraping
+// `form.querySelectorAll('input')` discover the bait naturally; document.body
+// is the fallback for widgets mounted outside any form.
+//
+// The decoded question is rendered as the input's <label>, not as its value.
+// Naive form-fillers leave the empty input alone — no signal, no false
 // positives. Agents that read the DOM as a prompt may decode the label and
-// write an answer into the empty field; that response is what we capture and
-// persist via clientMetaData.hp.
+// write an answer into the empty field; that response rides up as
+// clientMetaData.hp.
 export const Honeypot = forwardRef<HTMLInputElement, HoneypotProps>(
 	({ encodedQuestion }, ref) => {
 		const id = useId();
+		// Opaque non-existent form id. Setting `form="..."` on an input with a
+		// value that doesn't match any form's id disassociates the input from
+		// every form: the browser excludes it from the parent form's submission
+		// set and from `form.elements`, while leaving it discoverable via
+		// `form.querySelectorAll('input')`. Built from useId so it's unique per
+		// Honeypot instance and guaranteed not to collide with the input's own id.
+		const detachedFormId = `${id}-d`;
 		const question = useMemo(
 			() => decodeBase64Utf8(encodedQuestion),
 			[encodedQuestion],
 		);
-		return (
+		const anchorRef = useRef<HTMLSpanElement>(null);
+		const [portalTarget, setPortalTarget] = useState<HTMLElement | null>(null);
+
+		useEffect(() => {
+			const anchor = anchorRef.current;
+			if (!anchor) return;
+			setPortalTarget(findAncestorForm(anchor) ?? document.body);
+		}, []);
+
+		if (typeof document === "undefined") return null;
+
+		// Transient anchor while we resolve the portal target. Sits in the React
+		// tree (inside the shadow root) just long enough for the effect above to
+		// walk out to light DOM and find the form.
+		if (!portalTarget) {
+			return (
+				<span ref={anchorRef} aria-hidden="true" style={{ display: "none" }} />
+			);
+		}
+
+		return createPortal(
 			<div aria-hidden="true" style={offscreenStyle}>
 				<label htmlFor={id}>{question}</label>
 				<input
 					ref={ref}
 					id={id}
+					form={detachedFormId}
 					type="text"
 					name="email_confirm"
 					defaultValue=""
@@ -62,7 +119,8 @@ export const Honeypot = forwardRef<HTMLInputElement, HoneypotProps>(
 					autoComplete="off"
 					aria-hidden="true"
 				/>
-			</div>
+			</div>,
+			portalTarget,
 		);
 	},
 );

--- a/packages/procaptcha-common/src/reactComponents/Honeypot.tsx
+++ b/packages/procaptcha-common/src/reactComponents/Honeypot.tsx
@@ -1,0 +1,70 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { type CSSProperties, forwardRef, useId, useMemo } from "react";
+
+interface HoneypotProps {
+	encodedQuestion: string;
+}
+
+const offscreenStyle: CSSProperties = {
+	position: "absolute",
+	left: "-9999px",
+	top: "-9999px",
+	width: "1px",
+	height: "1px",
+	overflow: "hidden",
+	opacity: 0,
+};
+
+// Server wraps morse/semaphore in base64 (utf-8) for the wire. Strip the
+// base64 layer here so the rendered label is the raw morse/semaphore an agent
+// can recognise and engage with.
+const decodeBase64Utf8 = (b64: string): string => {
+	const binary = atob(b64);
+	const bytes = Uint8Array.from(binary, (c) => c.charCodeAt(0));
+	return new TextDecoder().decode(bytes);
+};
+
+// The decoded question is rendered as the input's <label>, not as the input's
+// value. Naive form-fillers leave the empty input alone — no signal, no false
+// positives. Agents that read the DOM as a prompt may decode the label and
+// write an answer into the empty field; that response is what we capture and
+// persist via clientMetaData.hp.
+export const Honeypot = forwardRef<HTMLInputElement, HoneypotProps>(
+	({ encodedQuestion }, ref) => {
+		const id = useId();
+		const question = useMemo(
+			() => decodeBase64Utf8(encodedQuestion),
+			[encodedQuestion],
+		);
+		return (
+			<div aria-hidden="true" style={offscreenStyle}>
+				<label htmlFor={id}>{question}</label>
+				<input
+					ref={ref}
+					id={id}
+					type="text"
+					name="email_confirm"
+					defaultValue=""
+					tabIndex={-1}
+					autoComplete="off"
+					aria-hidden="true"
+				/>
+			</div>
+		);
+	},
+);
+
+Honeypot.displayName = "Honeypot";

--- a/packages/procaptcha-pow/src/components/ProcaptchaWidget.tsx
+++ b/packages/procaptcha-pow/src/components/ProcaptchaWidget.tsx
@@ -14,7 +14,7 @@
 
 import { loadI18next, useTranslation } from "@prosopo/locale";
 import { buildUpdateState, useProcaptcha } from "@prosopo/procaptcha-common";
-import { Checkbox } from "@prosopo/procaptcha-common";
+import { Checkbox, Honeypot } from "@prosopo/procaptcha-common";
 import { ModeEnum, type ProcaptchaProps } from "@prosopo/types";
 import { darkTheme, lightTheme } from "@prosopo/widget-skeleton";
 import { useEffect, useRef, useState } from "react";
@@ -104,22 +104,7 @@ const Procaptcha = (props: ProcaptchaProps) => {
 	}, [config.mode]);
 
 	const honeypot = frictionlessState?.hp ? (
-		<input
-			ref={hpRef}
-			type="text"
-			name="email_confirm"
-			defaultValue={frictionlessState.hp}
-			tabIndex={-1}
-			autoComplete="off"
-			aria-hidden="true"
-			style={{
-				position: "absolute",
-				left: "-9999px",
-				width: "1px",
-				height: "1px",
-				opacity: 0,
-			}}
-		/>
+		<Honeypot ref={hpRef} encodedQuestion={frictionlessState.hp} />
 	) : null;
 
 	if (config.mode === ModeEnum.invisible) {

--- a/packages/procaptcha-puzzle/src/components/ProcaptchaWidget.tsx
+++ b/packages/procaptcha-puzzle/src/components/ProcaptchaWidget.tsx
@@ -14,7 +14,7 @@
 
 import { loadI18next, useTranslation } from "@prosopo/locale";
 import { buildUpdateState, useProcaptcha } from "@prosopo/procaptcha-common";
-import { Checkbox } from "@prosopo/procaptcha-common";
+import { Checkbox, Honeypot } from "@prosopo/procaptcha-common";
 import {
 	type GetPuzzleCaptchaResponse,
 	ModeEnum,
@@ -187,22 +187,7 @@ const Procaptcha = (props: ProcaptchaProps) => {
 	return (
 		<>
 			{frictionlessState?.hp && (
-				<input
-					ref={hpRef}
-					type="text"
-					name="email_confirm"
-					defaultValue={frictionlessState.hp}
-					tabIndex={-1}
-					autoComplete="off"
-					aria-hidden="true"
-					style={{
-						position: "absolute",
-						left: "-9999px",
-						width: "1px",
-						height: "1px",
-						opacity: 0,
-					}}
-				/>
+				<Honeypot ref={hpRef} encodedQuestion={frictionlessState.hp} />
 			)}
 			{/* Puzzle overlay — rendered outside the shadow DOM flow via fixed
 			    positioning. Shown in both visible and invisible modes once a

--- a/packages/procaptcha-react/src/components/ProcaptchaWidget.tsx
+++ b/packages/procaptcha-react/src/components/ProcaptchaWidget.tsx
@@ -18,6 +18,7 @@ import { loadI18next, useTranslation } from "@prosopo/locale";
 import { Manager } from "@prosopo/procaptcha";
 import {
 	Checkbox,
+	Honeypot,
 	TestModeBanner,
 	useProcaptcha,
 } from "@prosopo/procaptcha-common";
@@ -107,22 +108,7 @@ const ProcaptchaWidget = (props: ProcaptchaProps) => {
 	}, [manager, state.challenge, updateState]); // Add dependencies
 
 	const honeypot = frictionlessState?.hp ? (
-		<input
-			ref={hpRef}
-			type="text"
-			name="email_confirm"
-			defaultValue={frictionlessState.hp}
-			tabIndex={-1}
-			autoComplete="off"
-			aria-hidden="true"
-			style={{
-				position: "absolute",
-				left: "-9999px",
-				width: "1px",
-				height: "1px",
-				opacity: 0,
-			}}
-		/>
+		<Honeypot ref={hpRef} encodedQuestion={frictionlessState.hp} />
 	) : null;
 
 	if (config.mode === "invisible") {


### PR DESCRIPTION
## Summary

Redesigns the honeypot so it can actually catch AI agents instead of being a silent no-op:

- **Empty input + decoded label** — the encoded morse/semaphore question moves from `input.value` to an offscreen `<label>`, base64-decoded at render. Naive form-fillers (and humans) leave the empty input alone → no signal, no false positives. Agents that read the DOM as a prompt write into the empty field → captured as `clientMetaData.hp` on submit.
- **Portaled to light DOM, inside the dapp's `<form>`** — the widget itself stays in shadow DOM, but the honeypot portals via `react-dom/createPortal` into the enclosing `<form>` (or `document.body` as fallback). This solves two problems: (1) bots no longer have to traverse `.shadowRoot` to reach it, which was tripping `@prosopo/catcher`'s anti-automation guard and wiping the bot's value before it could submit; (2) the bait sits where bots actually look — `form.querySelectorAll('input')`.
- **`form="<useId>-d"`** — opaque per-instance non-existent form id disassociates the input from native form submission while keeping it DOM-discoverable. Dapp backends don't receive a stray `email_confirm=` field.
- **Chunk-name masking** — `procaptcha-bundle/vite.config.ts` now routes `Honeypot.js` into a per-build opaque chunk (`c<random8hex>-<hash>.js`) so the URL doesn't identify the component or stay stable across builds for static blocklisting.
- **Extracted to `@prosopo/procaptcha-common`** — shared `<Honeypot />` consumed by procaptcha-react, procaptcha-pow, procaptcha-puzzle (previously ~17 lines inline x 3).

No backend changes — the existing `getHoneypotValue() → clientMetaData.hp` capture pipeline already does the right thing once the field is empty by default.

## Test plan

- [ ] `npm run -w @prosopo/procaptcha-common build:tsc` passes
- [ ] `npm run -w @prosopo/procaptcha-react build:tsc` passes
- [ ] `npm run -w @prosopo/procaptcha-pow build:tsc` passes
- [ ] `npm run -w @prosopo/procaptcha-puzzle build:tsc` passes
- [ ] `npm run -w @prosopo/procaptcha-bundle build` emits chunk `c<hex>-<hash>.js` (no `Honeypot-*.js` in dist)
- [ ] In a dapp embedding the widget with honeypot enabled: `document.querySelector('input[name=email_confirm]').value = 'test'` does not trigger widget restart, and the resulting captcha submit carries `clientMetaData.hp = "test"` (verified end-to-end during development)
- [ ] Native form submission of the parent form does NOT include `email_confirm` in the POST body
- [ ] Honeypot input appears as a descendant of the dapp's `<form>` element in DevTools (or `document.body` when no form ancestor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)