### PR TITLE
ci(release): fail loudly on npm publish errors

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -50,6 +50,9 @@ jobs:
         run: |
           echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> ~/.npmrc
 
+      - name: Verify npm registry auth
+        run: npm whoami --registry https://registry.npmjs.org/
+
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -97,7 +100,7 @@ jobs:
       - name: Publish to npm
         run: |
           echo "Publishing all packages to npm"
-          npm --workspaces publish --access=public || true
+          npm --workspaces publish --access=public
 
       - name: Publish production image to Docker Hub
         run: |


### PR DESCRIPTION
## Summary

- Drop `|| true` from the npm publish step in `publish_release.yml` so publish failures fail the job instead of being silently swallowed.
- Add an `npm whoami` verification step after the registry auth setup so token problems surface immediately with a clear error, before tarballs are built.

## Why

Every `@prosopo/*` package's most recent npm publish is timestamped within a few seconds of each other on 2026-01-14 (e.g. `@prosopo/config@3.3.0`, `@prosopo/flux@2.6.39`, `@prosopo/scripts@3.1.44`, `@prosopo/server@2.9.52`, `@prosopo/types@3.8.0`). Since then, every release tag (v3.5.20 → v3.6.29, ~26 releases) has reported "success" in `publish_release`, but nothing has actually reached npm. The failing run linked below shows the underlying error has been there the whole time:

```
npm error 404 Not Found - PUT https://registry.npmjs.org/@***%2fconfig - Not found
npm error 404  The requested resource '@***/config@3.3.1' could not be found or you do not have permission to access it.
```

`@prosopo/config@3.3.0` is on npm and the maintainers list is intact, so the scope is fine — npm returns 404 here when a token lacks publish permission for the scope (it hides "no permission" as "not found" for security). The CI never noticed because of `|| true`.

**Follow-up needed (out of scope for this PR):** the `NPM_TOKEN` repository secret needs to be rotated / re-granted publish rights on the `@prosopo` scope. Once that's done, this workflow change will let the next release tag actually publish and fail loudly if anything else is wrong.

Example failing run: https://github.com/prosopo/captcha/actions/runs/26892649940/job/79324604691

## Test plan

- [ ] After NPM_TOKEN is rotated, cut a patch release tag and confirm the `Verify npm registry auth` step prints the expected npm user and the `Publish to npm` step publishes all bumped workspaces.
- [ ] If NPM_TOKEN is still bad, confirm the workflow fails at the `Verify npm registry auth` step rather than silently passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)