### PR TITLE
fix(logger): use conventional log level numbering (trace=0, fatal=5)

### DIFF
--- a/.changeset/log-level-convention.md
+++ b/.changeset/log-level-convention.md
@@ -1,0 +1,5 @@
+---
+"@prosopo/logger": patch
+---
+
+Fix log level numeric ordering to use conventional ascending severity (trace=0, fatal=5) matching Winston, Pino, and Log4j. Also fixes the emitted level field which was recording the threshold instead of the message level.

--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -69,12 +69,12 @@ export type LevelMap = {
 };
 
 const logLevelMap: LevelMap = {
-	[TraceLevel]: 5,
-	[DebugLevel]: 4,
-	[InfoLevel]: 3,
-	[WarnLevel]: 2,
-	[ErrorLevel]: 1,
-	[FatalLevel]: 0,
+	[TraceLevel]: 0,
+	[DebugLevel]: 1,
+	[InfoLevel]: 2,
+	[WarnLevel]: 3,
+	[ErrorLevel]: 4,
+	[FatalLevel]: 5,
 };
 
 export function parseLogLevel(
@@ -237,8 +237,8 @@ export class NativeLogger implements Logger {
 		fn: LogRecordFn,
 		level: LogLevel,
 	): void {
-		if (this.levelMap[level] > this.levelNum) {
-			return; // skip logging if the level is higher than the current log level
+		if (this.levelMap[level] < this.levelNum) {
+			return; // skip logging if the level is below the current log level threshold
 		}
 		const ts = new Date().toISOString();
 		// populate the log fields using the fn
@@ -268,7 +268,7 @@ export class NativeLogger implements Logger {
 			msg?: string;
 			err?: string;
 			errData?: LogRecord;
-		} = { scope: this.scope, ts, level: this.level };
+		} = { scope: this.scope, ts, level };
 		if (data) {
 			baseRecord.data = data;
 		}


### PR DESCRIPTION
## Summary

- Flips `logLevelMap` to the conventional ordering used by every major logging library (Winston, Pino, Log4j, Python logging): `trace=0, debug=1, info=2, warn=3, error=4, fatal=5`
- Updates the filter guard accordingly: `< this.levelNum` instead of `> this.levelNum`
- Fixes a secondary bug where the `level` field in the emitted log record was recording `this.level` (the configured threshold) instead of the actual level of the message being printed

## Test plan

- [ ] Set log level to `info` and verify `trace`/`debug` messages are suppressed
- [ ] Set log level to `info` and verify `warn`/`error`/`fatal` messages appear
- [ ] Confirm the `level` field in JSON output matches the method called (e.g. calling `logger.warn(...)` emits `"level":"warn"`)