### PR TITLE
refactor(logger): move stringifyBigInts to @prosopo/util

### DIFF
--- a/.changeset/stringify-bigints-to-util.md
+++ b/.changeset/stringify-bigints-to-util.md
@@ -1,0 +1,6 @@
+---
+"@prosopo/logger": patch
+"@prosopo/util": patch
+---
+
+Move stringifyBigInts to @prosopo/util where generic utilities belong. Re-exported from @prosopo/logger for backward compatibility.

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -28,6 +28,7 @@
 	"author": "Prosopo Limited",
 	"license": "Apache-2.0",
 	"dependencies": {
+		"@prosopo/util": "3.2.14",
 		"zod": "3.23.8"
 	},
 	"devDependencies": {

--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -15,7 +15,7 @@
 import { stringifyBigInts } from "@prosopo/util";
 import { z } from "zod";
 
-export { stringifyBigInts } from "@prosopo/util";
+export { stringifyBigInts };
 
 export type LogObject = object;
 export type LogRecord = {

--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -12,7 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { stringifyBigInts } from "@prosopo/util";
 import { z } from "zod";
+
+export { stringifyBigInts } from "@prosopo/util";
 
 export type LogObject = object;
 export type LogRecord = {
@@ -348,35 +351,3 @@ export class NativeLogger implements Logger {
 		}
 	}
 }
-
-/**
- * Recursively converts BigInt values to strings throughout an object, array, or primitive value.
- *
- * BigInts must be cast to strings before applying JSON.stringify(), as it cannot serialize BigInt values and will
- * throw "TypeError: Do not know how to serialize a BigInt".
- *
- * @param value - The value to process (can be a primitive, object, or array)
- * @returns The same value with all BigInt instances converted to strings
- */
-export const stringifyBigInts = (value: unknown): unknown => {
-	if ("bigint" === typeof value) {
-		return value.toString();
-	}
-
-	if (isObject(value)) {
-		for (const key of Object.keys(value)) {
-			value[key] = stringifyBigInts(value[key]);
-		}
-	}
-
-	if (Array.isArray(value)) {
-		for (let i = 0; i < value.length; i++) {
-			value[i] = stringifyBigInts(value[i]);
-		}
-	}
-
-	return value;
-};
-
-const isObject = (value: unknown): value is Record<string, unknown> =>
-	Object === value?.constructor;

--- a/packages/logger/tsconfig.cjs.json
+++ b/packages/logger/tsconfig.cjs.json
@@ -13,6 +13,9 @@
 	"references": [
 		{
 			"path": "../../dev/config/tsconfig.cjs.json"
+		},
+		{
+			"path": "../util/tsconfig.cjs.json"
 		}
 	]
 }

--- a/packages/logger/tsconfig.json
+++ b/packages/logger/tsconfig.json
@@ -15,6 +15,9 @@
 	"references": [
 		{
 			"path": "../../dev/config/tsconfig.json"
+		},
+		{
+			"path": "../util"
 		}
 	]
 }

--- a/packages/provider/src/tests/unit/api/public.unit.test.ts
+++ b/packages/provider/src/tests/unit/api/public.unit.test.ts
@@ -24,9 +24,13 @@ vi.mock("@prosopo/api-express-router", () => ({
 	handleErrors: vi.fn(),
 }));
 
-vi.mock("@prosopo/util", () => ({
-	version: "1.0.0-test",
-}));
+vi.mock("@prosopo/util", async (importActual) => {
+	const actual = await importActual<typeof import("@prosopo/util")>();
+	return {
+		...actual,
+		version: "1.0.0-test",
+	};
+});
 
 describe("publicRouter", () => {
 	let mockEnv: ProviderEnvironment;

--- a/packages/provider/src/tests/unit/tasks/spam/checkSpamEmail.unit.test.ts
+++ b/packages/provider/src/tests/unit/tasks/spam/checkSpamEmail.unit.test.ts
@@ -19,10 +19,14 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { checkSpamEmail } from "../../../../tasks/spam/checkSpamEmail.js";
 
 // Mock @prosopo/util module
-vi.mock("@prosopo/util", () => ({
-	validateDomainForOutboundRequest: vi.fn(),
-	extractDomainFromEmail: vi.fn(),
-}));
+vi.mock("@prosopo/util", async (importActual) => {
+	const actual = await importActual<typeof import("@prosopo/util")>();
+	return {
+		...actual,
+		validateDomainForOutboundRequest: vi.fn(),
+		extractDomainFromEmail: vi.fn(),
+	};
+});
 
 // Mock the local dns utils module
 vi.mock("../../../../utils/dns.js", () => ({

--- a/packages/util/src/bigint.ts
+++ b/packages/util/src/bigint.ts
@@ -21,8 +21,10 @@ const isObject = (value: unknown): value is Record<string, unknown> =>
  * BigInts must be cast to strings before applying JSON.stringify(), as it cannot serialize BigInt values and will
  * throw "TypeError: Do not know how to serialize a BigInt".
  *
+ * Mutates objects and arrays in-place — do not pass a value you need to preserve unchanged.
+ *
  * @param value - The value to process (can be a primitive, object, or array)
- * @returns The same value with all BigInt instances converted to strings
+ * @returns The same (mutated) value with all BigInt instances converted to strings
  */
 export const stringifyBigInts = (value: unknown): unknown => {
 	if ("bigint" === typeof value) {

--- a/packages/util/src/bigint.ts
+++ b/packages/util/src/bigint.ts
@@ -1,0 +1,45 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const isObject = (value: unknown): value is Record<string, unknown> =>
+	Object === value?.constructor;
+
+/**
+ * Recursively converts BigInt values to strings throughout an object, array, or primitive value.
+ *
+ * BigInts must be cast to strings before applying JSON.stringify(), as it cannot serialize BigInt values and will
+ * throw "TypeError: Do not know how to serialize a BigInt".
+ *
+ * @param value - The value to process (can be a primitive, object, or array)
+ * @returns The same value with all BigInt instances converted to strings
+ */
+export const stringifyBigInts = (value: unknown): unknown => {
+	if ("bigint" === typeof value) {
+		return value.toString();
+	}
+
+	if (isObject(value)) {
+		for (const key of Object.keys(value)) {
+			value[key] = stringifyBigInts(value[key]);
+		}
+	}
+
+	if (Array.isArray(value)) {
+		for (let i = 0; i < value.length; i++) {
+			value[i] = stringifyBigInts(value[i]);
+		}
+	}
+
+	return value;
+};

--- a/packages/util/src/index.ts
+++ b/packages/util/src/index.ts
@@ -34,3 +34,4 @@ export * from "./binaryString.js";
 export * from "./date.js";
 export * from "./email.js";
 export * from "./domainValidation.js";
+export * from "./bigint.js";

--- a/packages/util/src/tests/bigint.unit.test.ts
+++ b/packages/util/src/tests/bigint.unit.test.ts
@@ -44,5 +44,4 @@ describe("stringifyBigInts", () => {
 		stringifyBigInts(nested);
 		expect(nested).toEqual({ inner: { val: "99" } });
 	});
-
 });

--- a/packages/util/src/tests/bigint.unit.test.ts
+++ b/packages/util/src/tests/bigint.unit.test.ts
@@ -1,0 +1,48 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import { describe, expect, test } from "vitest";
+import { stringifyBigInts } from "../bigint.js";
+
+describe("stringifyBigInts", () => {
+	test("converts a top-level bigint to string", () => {
+		expect(stringifyBigInts(42n)).toBe("42");
+	});
+
+	test("leaves non-bigint primitives unchanged", () => {
+		expect(stringifyBigInts(42)).toBe(42);
+		expect(stringifyBigInts("hello")).toBe("hello");
+		expect(stringifyBigInts(true)).toBe(true);
+		expect(stringifyBigInts(null)).toBe(null);
+		expect(stringifyBigInts(undefined)).toBe(undefined);
+	});
+
+	test("converts bigint fields inside an object", () => {
+		const obj: Record<string, unknown> = { a: 1n, b: "x" };
+		stringifyBigInts(obj);
+		expect(obj).toEqual({ a: "1", b: "x" });
+	});
+
+	test("converts bigint elements inside an array", () => {
+		const arr: unknown[] = [1n, 2, "y"];
+		stringifyBigInts(arr);
+		expect(arr).toEqual(["1", 2, "y"]);
+	});
+
+	test("recursively converts nested bigints", () => {
+		const nested: Record<string, unknown> = { inner: { val: 99n } };
+		stringifyBigInts(nested);
+		expect(nested).toEqual({ inner: { val: "99" } });
+	});
+
+});


### PR DESCRIPTION
## Summary

- Moves `stringifyBigInts` (and its `isObject` helper) from `@prosopo/logger` into `@prosopo/util` where generic utilities belong
- Adds `@prosopo/util` as a dependency of `@prosopo/logger`
- Re-exports `stringifyBigInts` from `@prosopo/logger` so existing consumers have no breaking change
- Existing logger tests continue to import from `../logger.js` and pass unchanged

## Test plan

- [ ] Existing `stringifyBigInts` unit tests in `packages/logger/src/tests/logger.unit.test.ts` still pass
- [ ] `@prosopo/util` exports `stringifyBigInts` and can be imported directly