### PR TITLE
feat(types): add optional internal ML labelling fields to captcha records

### DIFF
--- a/.changeset/captcha-record-labels.md
+++ b/.changeset/captcha-record-labels.md
@@ -1,0 +1,6 @@
+---
+"@prosopo/types": patch
+"@prosopo/types-database": patch
+---
+
+Add optional internal ML labelling fields (label/labelReason/labelledBy/labelledAt) to captcha records.

--- a/packages/database/src/tests/unit/captchaLabel.unit.test.ts
+++ b/packages/database/src/tests/unit/captchaLabel.unit.test.ts
@@ -1,0 +1,67 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { CaptchaLabel, CaptchaLabelSchema } from "@prosopo/types";
+import { PoWCaptchaStoredSchema, UserCommitmentSchema } from "@prosopo/types";
+import {
+	PoWCaptchaRecordSchema,
+	UserCommitmentRecordSchema,
+} from "@prosopo/types-database";
+import type { Schema } from "mongoose";
+import { describe, expect, it } from "vitest";
+
+const recordSchemas: Schema[] = [
+	PoWCaptchaRecordSchema,
+	UserCommitmentRecordSchema,
+];
+
+describe("captcha labelling schema fields", () => {
+	it("CaptchaLabelSchema accepts every CaptchaLabel value", () => {
+		for (const value of Object.values(CaptchaLabel)) {
+			expect(CaptchaLabelSchema.parse(value)).toBe(value);
+		}
+	});
+
+	it("CaptchaLabelSchema rejects unknown labels", () => {
+		expect(() => CaptchaLabelSchema.parse("definitely-not-a-label")).toThrow();
+	});
+
+	it("Zod record schemas expose the optional label fields", () => {
+		for (const schema of [PoWCaptchaStoredSchema, UserCommitmentSchema]) {
+			expect(schema.shape.label.isOptional()).toBe(true);
+			expect(schema.shape.labelReason.isOptional()).toBe(true);
+			expect(schema.shape.labelledBy.isOptional()).toBe(true);
+			expect(schema.shape.labelledAt.isOptional()).toBe(true);
+		}
+	});
+
+	it("Mongoose record schemas declare the label paths with correct types", () => {
+		for (const schema of recordSchemas) {
+			expect(schema.path("label").instance).toBe("String");
+			expect(schema.path("labelReason").instance).toBe("String");
+			expect(schema.path("labelledBy").instance).toBe("String");
+			expect(schema.path("labelledAt").instance).toBe("Date");
+		}
+	});
+
+	it("Mongoose label path is constrained to the CaptchaLabel enum", () => {
+		for (const schema of recordSchemas) {
+			const enumValues: string[] | undefined =
+				schema.path("label").options.enum;
+			expect(enumValues).toEqual(
+				expect.arrayContaining(Object.values(CaptchaLabel)),
+			);
+		}
+	});
+});

--- a/packages/types-database/src/types/provider.ts
+++ b/packages/types-database/src/types/provider.ts
@@ -15,6 +15,7 @@
 import type { AllKeys } from "@prosopo/common";
 import { type TranslationKey, TranslationKeysSchema } from "@prosopo/locale";
 import {
+	CaptchaLabel,
 	CaptchaType,
 	type ClientContextEntropy,
 	type CompositeIpAddress,
@@ -215,10 +216,17 @@ export const PoWCaptchaRecordSchema = new Schema<PoWCaptchaRecord>({
 		required: false,
 	},
 	providerSignature: { type: String, required: true },
+	// Internal ML labelling applied by superadmins via the audit page.
+	label: { type: String, enum: Object.values(CaptchaLabel), required: false },
+	labelReason: { type: String, required: false },
+	labelledBy: { type: String, required: false },
+	labelledAt: { type: Date, required: false },
 });
 
 // Set an index on the captchaId field, ascending
 PoWCaptchaRecordSchema.index({ challenge: 1 });
+// Supports the labelled-dataset export query (`{ label: { $exists: true } }`).
+PoWCaptchaRecordSchema.index({ label: 1, dappAccount: 1 });
 PoWCaptchaRecordSchema.index({ lastUpdatedTimestamp: 1 });
 PoWCaptchaRecordSchema.index({ dappAccount: 1, requestedAtTimestamp: 1 });
 PoWCaptchaRecordSchema.index({ "ipAddress.lower": 1 });
@@ -414,9 +422,16 @@ export const UserCommitmentRecordSchema = new Schema<UserCommitmentRecord>({
 		},
 		required: false,
 	},
+	// Internal ML labelling applied by superadmins via the audit page.
+	label: { type: String, enum: Object.values(CaptchaLabel), required: false },
+	labelReason: { type: String, required: false },
+	labelledBy: { type: String, required: false },
+	labelledAt: { type: Date, required: false },
 });
 // Set an index on the commitment id field, descending
 UserCommitmentRecordSchema.index({ id: -1 });
+// Supports the labelled-dataset export query (`{ label: { $exists: true } }`).
+UserCommitmentRecordSchema.index({ label: 1, dappAccount: 1 });
 UserCommitmentRecordSchema.index({
 	lastUpdatedTimestamp: 1,
 });

--- a/packages/types/src/provider/database.ts
+++ b/packages/types/src/provider/database.ts
@@ -151,6 +151,20 @@ export interface ClientMetaData {
 	hp?: string;
 }
 
+/**
+ * Internal classification labels applied by superadmins from the audit page to
+ * build supervised ML training sets. Stored directly on the captcha record
+ * (see {@link StoredCaptcha.label}); not part of the captcha verification flow.
+ */
+export enum CaptchaLabel {
+	human = "human",
+	bot = "bot",
+	suspicious = "suspicious",
+	unknown = "unknown",
+}
+
+export const CaptchaLabelSchema = nativeEnum(CaptchaLabel);
+
 export interface StoredCaptcha {
 	result: {
 		status: CaptchaStatus;
@@ -193,6 +207,13 @@ export interface StoredCaptcha {
 	// Current behavioral data storage format (packed)
 	deviceCapability?: string;
 	behavioralDataPacked?: BehavioralDataPacked;
+	// Internal ML labelling, written by superadmins via the audit page. Not part
+	// of the captcha verification flow; used to build supervised training sets.
+	// See `CaptchaLabel`.
+	label?: CaptchaLabel;
+	labelReason?: string;
+	labelledBy?: string;
+	labelledAt?: Date;
 }
 
 export interface UserCommitment extends StoredCaptcha {
@@ -270,6 +291,11 @@ export const UserCommitmentSchema = object({
 	// Behavioral data fields
 	deviceCapability: string().optional(),
 	behavioralDataPacked: BehavioralDataPackedSchema.optional(),
+	// Internal ML labelling (see StoredCaptcha.label)
+	label: CaptchaLabelSchema.optional(),
+	labelReason: string().optional(),
+	labelledBy: string().optional(),
+	labelledAt: date().optional(),
 }) satisfies ZodType<UserCommitment, ZodTypeDef, unknown>;
 
 // Zod schema for ScoreComponents
@@ -475,6 +501,11 @@ export const PoWCaptchaStoredSchema = object({
 	clickEvents: array(object({}).catchall(any())).optional(),
 	deviceCapability: string().optional(),
 	behavioralDataPacked: BehavioralDataPackedSchema.optional(),
+	// Internal ML labelling (see StoredCaptcha.label)
+	label: CaptchaLabelSchema.optional(),
+	labelReason: string().optional(),
+	labelledBy: string().optional(),
+	labelledAt: date().optional(),
 }) satisfies ZodType<PoWCaptchaStored, ZodTypeDef, unknown>;
 
 export type PendingImageCaptchaRequest = {


### PR DESCRIPTION
Adds optional `label`/`labelReason`/`labelledBy`/`labelledAt` fields (and a `CaptchaLabel` enum) to the PoW and Image captcha record schemas so superadmins can build supervised ML training sets from the audit page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)