### PR TITLE
ci(publish_release): switch to npm trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -14,6 +14,10 @@ on:
 permissions:
   contents: write
   packages: write
+  # Required so npm CLI can mint an OIDC token for trusted publishing.
+  # Without this, `npm publish` falls back to legacy NPM_TOKEN auth.
+  # See https://docs.npmjs.com/trusted-publishers
+  id-token: write
 
 defaults:
   run:
@@ -45,13 +49,6 @@ jobs:
         with:
           node-version: '24'
           cache: 'npm'
-
-      - name: Setup npm registry
-        run: |
-          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> ~/.npmrc
-
-      - name: Verify npm registry auth
-        run: npm whoami --registry https://registry.npmjs.org/
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
@@ -98,9 +95,16 @@ jobs:
           echo "✅ Build verification passed"
 
       - name: Publish to npm
+        # Trusted publishing: npm CLI auto-exchanges the GitHub OIDC token
+        # (granted via `id-token: write` above) for a short-lived registry
+        # token. No NPM_TOKEN secret required. Each workspace package must
+        # be registered as a trusted publisher on npmjs.com pointing at
+        # this workflow file.
+        # --provenance attaches a signed build attestation linking the
+        # tarball back to this exact workflow run.
         run: |
-          echo "Publishing all packages to npm"
-          npm --workspaces publish --access=public
+          echo "Publishing all packages to npm via trusted publishing"
+          npm --workspaces publish --access=public --provenance
 
       - name: Publish production image to Docker Hub
         run: |


### PR DESCRIPTION
## Summary
- Removes NPM_TOKEN usage from `publish_release.yml`; uses npm trusted publishing instead (GitHub Actions OIDC → short-lived registry token).
- Adds `id-token: write` permission and `--provenance` flag.

## Why
v3.6.30's `publish_release` run failed at `npm whoami` with HTTP 401 — the long-lived `NPM_TOKEN` had expired/been revoked. Trusted publishing eliminates the rotation problem entirely. Trusted publisher config has been registered on the npmjs side per the user.

## Test plan
- [ ] Merge → re-run `publish_release` workflow against tag `v3.6.30` → packages land on npm with provenance attestations.