### PR TITLE
ci(publish_release): drop --provenance for now

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -100,11 +100,14 @@ jobs:
         # token. No NPM_TOKEN secret required. Each workspace package must
         # be registered as a trusted publisher on npmjs.com pointing at
         # this workflow file.
-        # --provenance attaches a signed build attestation linking the
-        # tarball back to this exact workflow run.
+        # `--provenance` is intentionally omitted: provenance attestation
+        # demands `repository.url` on every published manifest and most
+        # of our workspace packages don't carry one. Re-add once each
+        # package.json declares the repo (or once we strip the private
+        # dev/* packages from the publish set).
         run: |
           echo "Publishing all packages to npm via trusted publishing"
-          npm --workspaces publish --access=public --provenance
+          npm --workspaces publish --access=public
 
       - name: Publish production image to Docker Hub
         run: |


### PR DESCRIPTION
Provenance verification rejected v3.6.30 because most workspace packages lack `repository.url`. Drop the flag so the publish completes; re-add after each package.json declares its repo.