### PR TITLE
ci: declare repository.url everywhere; restore npm provenance

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -100,14 +100,14 @@ jobs:
         # token. No NPM_TOKEN secret required. Each workspace package must
         # be registered as a trusted publisher on npmjs.com pointing at
         # this workflow file.
-        # `--provenance` is intentionally omitted: provenance attestation
-        # demands `repository.url` on every published manifest and most
-        # of our workspace packages don't carry one. Re-add once each
-        # package.json declares the repo (or once we strip the private
-        # dev/* packages from the publish set).
+        # `--provenance` attaches a signed Sigstore attestation linking
+        # each tarball back to this workflow run. The registry verifies
+        # `repository.url` on every published manifest against the OIDC
+        # claim, so every workspace package.json must declare
+        # `repository: { url: git+https://github.com/prosopo/captcha.git, directory: <path> }`.
         run: |
           echo "Publishing all packages to npm via trusted publishing"
-          npm --workspaces publish --access=public
+          npm --workspaces publish --access=public --provenance
 
       - name: Publish production image to Docker Hub
         run: |

--- a/demos/client-bundle-example/package.json
+++ b/demos/client-bundle-example/package.json
@@ -43,5 +43,10 @@
 		"typescript": "5.6.2",
 		"vite": "6.4.1",
 		"vitest": "3.2.4"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/prosopo/captcha.git",
+		"directory": "demos/client-bundle-example"
 	}
 }

--- a/demos/client-example-server/package.json
+++ b/demos/client-example-server/package.json
@@ -29,7 +29,8 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/prosopo/client-example-server.git"
+		"url": "git+https://github.com/prosopo/captcha.git",
+		"directory": "demos/client-example-server"
 	},
 	"author": "PROSOPO LIMITED <info@prosopo.io>",
 	"license": "Apache-2.0",

--- a/demos/provider-mock/package.json
+++ b/demos/provider-mock/package.json
@@ -54,7 +54,8 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "git+ssh://git@github.com/prosopo/provider.git"
+		"url": "git+https://github.com/prosopo/captcha.git",
+		"directory": "demos/provider-mock"
 	},
 	"bugs": {
 		"url": "https://github.com/prosopo/captcha/issues"

--- a/dev/config/package.json
+++ b/dev/config/package.json
@@ -71,7 +71,8 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/prosopo/captcha.git"
+		"url": "git+https://github.com/prosopo/captcha.git",
+		"directory": "dev/config"
 	},
 	"bugs": {
 		"url": "https://github.com/prosopo/captcha/issues"

--- a/dev/flux/package.json
+++ b/dev/flux/package.json
@@ -57,5 +57,10 @@
 		"typescript": "5.6.2",
 		"vite": "6.4.1",
 		"vitest": "3.2.4"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/prosopo/captcha.git",
+		"directory": "dev/flux"
 	}
 }

--- a/dev/scripts/package.json
+++ b/dev/scripts/package.json
@@ -63,5 +63,10 @@
 		"typescript": "5.6.2",
 		"vite": "6.4.1",
 		"vitest": "3.2.4"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/prosopo/captcha.git",
+		"directory": "dev/scripts"
 	}
 }

--- a/dev/ts-brand/package.json
+++ b/dev/ts-brand/package.json
@@ -43,7 +43,8 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/prosopo/captcha.git"
+		"url": "git+https://github.com/prosopo/captcha.git",
+		"directory": "dev/ts-brand"
 	},
 	"bugs": {
 		"url": "https://github.com/prosopo/captcha/issues"

--- a/dev/vite-plugin-watch-workspace/package.json
+++ b/dev/vite-plugin-watch-workspace/package.json
@@ -42,7 +42,8 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/prosopo/captcha.git"
+		"url": "git+https://github.com/prosopo/captcha.git",
+		"directory": "dev/vite-plugin-watch-workspace"
 	},
 	"bugs": {
 		"url": "https://github.com/prosopo/captcha/issues"

--- a/dev/workspace/package.json
+++ b/dev/workspace/package.json
@@ -33,7 +33,8 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/prosopo/captcha.git"
+		"url": "git+https://github.com/prosopo/captcha.git",
+		"directory": "dev/workspace"
 	},
 	"bugs": {
 		"url": "https://github.com/prosopo/captcha/issues"

--- a/docker/images/caddy/package.json
+++ b/docker/images/caddy/package.json
@@ -23,5 +23,10 @@
 	},
 	"devDependencies": {
 		"@prosopo/config": "3.1.20"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/prosopo/captcha.git",
+		"directory": "docker/images/caddy"
 	}
 }

--- a/docker/images/client-example-server/package.json
+++ b/docker/images/client-example-server/package.json
@@ -26,5 +26,10 @@
 		"build": "npm run clean && cp -r src dist && docker buildx build --progress=plain --tag $(npm run --silent docker-tag) --platform linux/amd64 -f ./dist/Dockerfile ../../../",
 		"clean": "del-cli --verbose dist tsconfig.tsbuildinfo",
 		"publish:docker": "docker push $(npm run --silent docker-tag)"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/prosopo/captcha.git",
+		"directory": "docker/images/client-example-server"
 	}
 }

--- a/docker/images/provider-mock/package.json
+++ b/docker/images/provider-mock/package.json
@@ -26,5 +26,10 @@
 		"build": "npm run clean && cp -r src dist && docker buildx build --progress=plain --tag $(npm run --silent docker-tag) --platform linux/amd64 -f ./dist/Dockerfile ../../../",
 		"clean": "del-cli --verbose dist tsconfig.tsbuildinfo",
 		"publish:docker": "docker push $(npm run --silent docker-tag)"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/prosopo/captcha.git",
+		"directory": "docker/images/provider-mock"
 	}
 }

--- a/docker/images/provider/package.json
+++ b/docker/images/provider/package.json
@@ -27,5 +27,10 @@
 		"build": "npm run clean && cp -r src dist && NODE_ENV=$NODE_ENV docker buildx build --progress=plain --tag $(npm run --silent docker-tag) --platform linux/amd64 -f ./dist/Dockerfile ../../../",
 		"clean": "del-cli --verbose dist tsconfig.tsbuildinfo",
 		"publish:docker": "docker push $(NODE_ENV=$NODE_ENV npm run --silent docker-tag)"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/prosopo/captcha.git",
+		"directory": "docker/images/provider"
 	}
 }

--- a/docker/images/vector/package.json
+++ b/docker/images/vector/package.json
@@ -23,5 +23,10 @@
 	},
 	"devDependencies": {
 		"@prosopo/config": "3.1.20"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/prosopo/captcha.git",
+		"directory": "docker/images/vector"
 	}
 }

--- a/integration/frameworks/angular/angular-procaptcha-integration-demo/package.json
+++ b/integration/frameworks/angular/angular-procaptcha-integration-demo/package.json
@@ -46,5 +46,10 @@
 		"karma-jasmine": "~5.1.0",
 		"karma-jasmine-html-reporter": "~2.1.0",
 		"typescript": "~5.8.3"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/prosopo/captcha.git",
+		"directory": "integration/frameworks/angular/angular-procaptcha-integration-demo"
 	}
 }

--- a/integration/frameworks/angular/angular-procaptcha-wrapper/package.json
+++ b/integration/frameworks/angular/angular-procaptcha-wrapper/package.json
@@ -33,5 +33,10 @@
 		"url": "https://github.com/prosopo/captcha/issues"
 	},
 	"homepage": "https://github.com/prosopo/captcha#readme",
-	"sideEffects": false
+	"sideEffects": false,
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/prosopo/captcha.git",
+		"directory": "integration/frameworks/angular/angular-procaptcha-wrapper"
+	}
 }

--- a/integration/frameworks/react/react-procaptcha-integration-demo/package.json
+++ b/integration/frameworks/react/react-procaptcha-integration-demo/package.json
@@ -42,5 +42,10 @@
 		"url": "https://github.com/prosopo/captcha/issues"
 	},
 	"homepage": "https://github.com/prosopo/captcha#readme",
-	"sideEffects": false
+	"sideEffects": false,
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/prosopo/captcha.git",
+		"directory": "integration/frameworks/react/react-procaptcha-integration-demo"
+	}
 }

--- a/integration/frameworks/react/react-procaptcha-wrapper/package.json
+++ b/integration/frameworks/react/react-procaptcha-wrapper/package.json
@@ -42,5 +42,10 @@
 		"url": "https://github.com/prosopo/captcha/issues"
 	},
 	"homepage": "https://github.com/prosopo/captcha#readme",
-	"sideEffects": false
+	"sideEffects": false,
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/prosopo/captcha.git",
+		"directory": "integration/frameworks/react/react-procaptcha-wrapper"
+	}
 }

--- a/integration/frameworks/svelte/svelte-procaptcha-integration-demo/package.json
+++ b/integration/frameworks/svelte/svelte-procaptcha-integration-demo/package.json
@@ -42,5 +42,10 @@
 		"url": "https://github.com/prosopo/captcha/issues"
 	},
 	"homepage": "https://github.com/prosopo/captcha#readme",
-	"sideEffects": false
+	"sideEffects": false,
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/prosopo/captcha.git",
+		"directory": "integration/frameworks/svelte/svelte-procaptcha-integration-demo"
+	}
 }

--- a/integration/frameworks/svelte/svelte-procaptcha-wrapper/package.json
+++ b/integration/frameworks/svelte/svelte-procaptcha-wrapper/package.json
@@ -41,5 +41,10 @@
 		"url": "https://github.com/prosopo/captcha/issues"
 	},
 	"homepage": "https://github.com/prosopo/captcha#readme",
-	"sideEffects": false
+	"sideEffects": false,
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/prosopo/captcha.git",
+		"directory": "integration/frameworks/svelte/svelte-procaptcha-wrapper"
+	}
 }

--- a/integration/frameworks/vue/vue-procaptcha-integration-demo/package.json
+++ b/integration/frameworks/vue/vue-procaptcha-integration-demo/package.json
@@ -42,5 +42,10 @@
 		"url": "https://github.com/prosopo/captcha/issues"
 	},
 	"homepage": "https://github.com/prosopo/captcha#readme",
-	"sideEffects": false
+	"sideEffects": false,
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/prosopo/captcha.git",
+		"directory": "integration/frameworks/vue/vue-procaptcha-integration-demo"
+	}
 }

--- a/integration/frameworks/vue/vue-procaptcha-wrapper/package.json
+++ b/integration/frameworks/vue/vue-procaptcha-wrapper/package.json
@@ -41,5 +41,10 @@
 		"url": "https://github.com/prosopo/captcha/issues"
 	},
 	"homepage": "https://github.com/prosopo/captcha#readme",
-	"sideEffects": false
+	"sideEffects": false,
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/prosopo/captcha.git",
+		"directory": "integration/frameworks/vue/vue-procaptcha-wrapper"
+	}
 }

--- a/integration/procaptcha-integration-build-config/package.json
+++ b/integration/procaptcha-integration-build-config/package.json
@@ -39,5 +39,10 @@
 		"url": "https://github.com/prosopo/captcha/issues"
 	},
 	"homepage": "https://github.com/prosopo/captcha#readme",
-	"sideEffects": false
+	"sideEffects": false,
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/prosopo/captcha.git",
+		"directory": "integration/procaptcha-integration-build-config"
+	}
 }

--- a/packages/account/package.json
+++ b/packages/account/package.json
@@ -36,7 +36,8 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "git+ssh://git@github.com/prosopo/types.git"
+		"url": "git+https://github.com/prosopo/captcha.git",
+		"directory": "packages/account"
 	},
 	"author": "Prosopo Limited",
 	"license": "Apache-2.0",

--- a/packages/api-express-router/package.json
+++ b/packages/api-express-router/package.json
@@ -50,5 +50,10 @@
 		"url": "https://github.com/prosopo/captcha/issues"
 	},
 	"homepage": "https://github.com/prosopo/captcha#readme",
-	"sideEffects": false
+	"sideEffects": false,
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/prosopo/captcha.git",
+		"directory": "packages/api-express-router"
+	}
 }

--- a/packages/api-route/package.json
+++ b/packages/api-route/package.json
@@ -38,5 +38,10 @@
 		"url": "https://github.com/prosopo/captcha/issues"
 	},
 	"homepage": "https://github.com/prosopo/captcha#readme",
-	"sideEffects": false
+	"sideEffects": false,
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/prosopo/captcha.git",
+		"directory": "packages/api-route"
+	}
 }

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -26,7 +26,8 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/prosopo/captcha.git"
+		"url": "git+https://github.com/prosopo/captcha.git",
+		"directory": "packages/api"
 	},
 	"author": "PROSOPO LIMITED <info@prosopo.io>",
 	"license": "Apache-2.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -68,5 +68,10 @@
 	},
 	"author": "Prosopo",
 	"license": "Apache-2.0",
-	"sideEffects": false
+	"sideEffects": false,
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/prosopo/captcha.git",
+		"directory": "packages/cli"
+	}
 }

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -55,7 +55,8 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/prosopo/captcha.git"
+		"url": "git+https://github.com/prosopo/captcha.git",
+		"directory": "packages/common"
 	},
 	"bugs": {
 		"url": "https://github.com/prosopo/captcha/issues"

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -27,7 +27,8 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "git+ssh://git@github.com/prosopo/captcha.git"
+		"url": "git+https://github.com/prosopo/captcha.git",
+		"directory": "packages/database"
 	},
 	"author": "Prosopo Limited",
 	"license": "Apache-2.0",

--- a/packages/datasets-fs/package.json
+++ b/packages/datasets-fs/package.json
@@ -60,7 +60,8 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/prosopo/captcha.git"
+		"url": "git+https://github.com/prosopo/captcha.git",
+		"directory": "packages/datasets-fs"
 	},
 	"bugs": {
 		"url": "https://github.com/prosopo/captcha/issues"

--- a/packages/datasets/package.json
+++ b/packages/datasets/package.json
@@ -36,8 +36,12 @@
 	},
 	"typesVersions": {
 		"*": {
-			"types": ["dist/types"],
-			"captcha": ["dist/captcha"]
+			"types": [
+				"dist/types"
+			],
+			"captcha": [
+				"dist/captcha"
+			]
 		}
 	},
 	"dependencies": {
@@ -64,7 +68,8 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/prosopo/captcha.git"
+		"url": "git+https://github.com/prosopo/captcha.git",
+		"directory": "packages/datasets"
 	},
 	"bugs": {
 		"url": "https://github.com/prosopo/captcha/issues"

--- a/packages/detector/package.json
+++ b/packages/detector/package.json
@@ -39,5 +39,10 @@
 		"typescript": "5.6.2",
 		"vite": "6.4.1",
 		"vitest": "3.2.4"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/prosopo/captcha.git",
+		"directory": "packages/detector"
 	}
 }

--- a/packages/dotenv/package.json
+++ b/packages/dotenv/package.json
@@ -46,7 +46,8 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/prosopo/captcha.git"
+		"url": "git+https://github.com/prosopo/captcha.git",
+		"directory": "packages/dotenv"
 	},
 	"bugs": {
 		"url": "https://github.com/prosopo/captcha/issues"

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -50,5 +50,10 @@
 	},
 	"author": "Prosopo",
 	"license": "Apache-2.0",
-	"sideEffects": false
+	"sideEffects": false,
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/prosopo/captcha.git",
+		"directory": "packages/env"
+	}
 }

--- a/packages/file-server/package.json
+++ b/packages/file-server/package.json
@@ -46,5 +46,10 @@
 	},
 	"author": "Prosopo",
 	"license": "Apache-2.0",
-	"sideEffects": false
+	"sideEffects": false,
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/prosopo/captcha.git",
+		"directory": "packages/file-server"
+	}
 }

--- a/packages/fingerprint/package.json
+++ b/packages/fingerprint/package.json
@@ -26,7 +26,8 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "git+ssh://git@github.com/prosopo/captcha.git"
+		"url": "git+https://github.com/prosopo/captcha.git",
+		"directory": "packages/fingerprint"
 	},
 	"author": "Prosopo Limited",
 	"license": "Apache-2.0",

--- a/packages/http-blackhole/package.json
+++ b/packages/http-blackhole/package.json
@@ -24,5 +24,10 @@
 		"@types/node": "^24.0.13",
 		"tsx": "^4.20.3",
 		"typescript": "^5.8.3"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/prosopo/captcha.git",
+		"directory": "packages/http-blackhole"
 	}
 }

--- a/packages/ipinfo/package.json
+++ b/packages/ipinfo/package.json
@@ -39,5 +39,10 @@
 		"vite": "6.4.1",
 		"vitest": "3.2.4"
 	},
-	"license": "Apache-2.0"
+	"license": "Apache-2.0",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/prosopo/captcha.git",
+		"directory": "packages/ipinfo"
+	}
 }

--- a/packages/keyring/package.json
+++ b/packages/keyring/package.json
@@ -27,7 +27,8 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "git+ssh://git@github.com/prosopo/types.git"
+		"url": "git+https://github.com/prosopo/captcha.git",
+		"directory": "packages/keyring"
 	},
 	"author": "Prosopo Limited",
 	"license": "Apache-2.0",

--- a/packages/load-balancer/package.json
+++ b/packages/load-balancer/package.json
@@ -27,7 +27,8 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "git+ssh://git@github.com/prosopo/captcha.git"
+		"url": "git+https://github.com/prosopo/captcha.git",
+		"directory": "packages/load-balancer"
 	},
 	"author": "Prosopo Limited",
 	"license": "Apache-2.0",

--- a/packages/locale/package.json
+++ b/packages/locale/package.json
@@ -58,7 +58,8 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/prosopo/captcha.git"
+		"url": "git+https://github.com/prosopo/captcha.git",
+		"directory": "packages/locale"
 	},
 	"bugs": {
 		"url": "https://github.com/prosopo/captcha/issues"

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -47,7 +47,8 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/prosopo/captcha.git"
+		"url": "git+https://github.com/prosopo/captcha.git",
+		"directory": "packages/logger"
 	},
 	"bugs": {
 		"url": "https://github.com/prosopo/captcha/issues"

--- a/packages/procaptcha-bundle/package.json
+++ b/packages/procaptcha-bundle/package.json
@@ -37,7 +37,9 @@
 		"serve": "NODE_ENV=${NODE_ENV:-development}; vite serve --config vite.serve.config.ts --mode $NODE_ENV --host",
 		"test": "NODE_ENV=${NODE_ENV:-test}; npx vitest run --config ./vite.test.config.ts"
 	},
-	"browserslist": ["> 0.5%, last 2 versions, not dead"],
+	"browserslist": [
+		"> 0.5%, last 2 versions, not dead"
+	],
 	"dependencies": {
 		"@prosopo/dotenv": "3.0.43",
 		"@prosopo/locale": "3.2.4",
@@ -56,7 +58,8 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/prosopo/captcha.git"
+		"url": "git+https://github.com/prosopo/captcha.git",
+		"directory": "packages/procaptcha-bundle"
 	},
 	"bugs": {
 		"url": "https://github.com/prosopo/captcha/issues"

--- a/packages/procaptcha-common/package.json
+++ b/packages/procaptcha-common/package.json
@@ -30,7 +30,9 @@
 		"test:watch": "NODE_ENV=${NODE_ENV:-test}; npx vitest --config ./vite.test.config.ts",
 		"test:coverage": "NODE_ENV=${NODE_ENV:-test}; npx vitest run --coverage --config ./vite.test.config.ts"
 	},
-	"browserslist": ["> 0.5%, last 2 versions, not dead"],
+	"browserslist": [
+		"> 0.5%, last 2 versions, not dead"
+	],
 	"dependencies": {
 		"@emotion/react": "11.11.1",
 		"@emotion/styled": "11.11.0",
@@ -61,7 +63,8 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/prosopo/captcha.git"
+		"url": "git+https://github.com/prosopo/captcha.git",
+		"directory": "packages/procaptcha-common"
 	},
 	"bugs": {
 		"url": "https://github.com/prosopo/captcha/issues"

--- a/packages/procaptcha-frictionless/package.json
+++ b/packages/procaptcha-frictionless/package.json
@@ -28,7 +28,9 @@
 		"build:cjs": "NODE_ENV=${NODE_ENV:-development}; vite build --config vite.cjs.config.ts --mode $NODE_ENV",
 		"typecheck": "tsc --project tsconfig.types.json"
 	},
-	"browserslist": ["> 0.5%, last 2 versions, not dead"],
+	"browserslist": [
+		"> 0.5%, last 2 versions, not dead"
+	],
 	"dependencies": {
 		"@prosopo/api": "3.4.8",
 		"@prosopo/common": "3.1.38",
@@ -59,7 +61,8 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/prosopo/captcha.git"
+		"url": "git+https://github.com/prosopo/captcha.git",
+		"directory": "packages/procaptcha-frictionless"
 	},
 	"bugs": {
 		"url": "https://github.com/prosopo/captcha/issues"

--- a/packages/procaptcha-pow/package.json
+++ b/packages/procaptcha-pow/package.json
@@ -27,7 +27,9 @@
 		"build:cjs": "NODE_ENV=${NODE_ENV:-development}; vite build --config vite.cjs.config.ts --mode $NODE_ENV",
 		"typecheck": "tsc --project tsconfig.types.json"
 	},
-	"browserslist": ["> 0.5%, last 2 versions, not dead"],
+	"browserslist": [
+		"> 0.5%, last 2 versions, not dead"
+	],
 	"dependencies": {
 		"@polkadot/util": "13.5.7",
 		"@prosopo/api": "3.4.8",
@@ -57,7 +59,8 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/prosopo/captcha.git"
+		"url": "git+https://github.com/prosopo/captcha.git",
+		"directory": "packages/procaptcha-pow"
 	},
 	"bugs": {
 		"url": "https://github.com/prosopo/captcha/issues"

--- a/packages/procaptcha-puzzle/package.json
+++ b/packages/procaptcha-puzzle/package.json
@@ -27,7 +27,9 @@
 		"build:cjs": "NODE_ENV=${NODE_ENV:-development}; vite build --config vite.cjs.config.ts --mode $NODE_ENV",
 		"typecheck": "tsc --project tsconfig.types.json"
 	},
-	"browserslist": ["> 0.5%, last 2 versions, not dead"],
+	"browserslist": [
+		"> 0.5%, last 2 versions, not dead"
+	],
 	"dependencies": {
 		"@polkadot/util": "13.5.7",
 		"@prosopo/api": "3.4.8",
@@ -57,7 +59,8 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/prosopo/captcha.git"
+		"url": "git+https://github.com/prosopo/captcha.git",
+		"directory": "packages/procaptcha-puzzle"
 	},
 	"bugs": {
 		"url": "https://github.com/prosopo/captcha/issues"

--- a/packages/procaptcha-react/package.json
+++ b/packages/procaptcha-react/package.json
@@ -27,7 +27,9 @@
 		"build:cjs": "NODE_ENV=${NODE_ENV:-development}; vite build --config vite.cjs.config.ts --mode $NODE_ENV",
 		"typecheck": "tsc --project tsconfig.types.json"
 	},
-	"browserslist": ["> 0.5%, last 2 versions, not dead"],
+	"browserslist": [
+		"> 0.5%, last 2 versions, not dead"
+	],
 	"dependencies": {
 		"@prosopo/common": "3.1.38",
 		"@prosopo/locale": "3.2.4",
@@ -57,7 +59,8 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/prosopo/captcha.git"
+		"url": "git+https://github.com/prosopo/captcha.git",
+		"directory": "packages/procaptcha-react"
 	},
 	"bugs": {
 		"url": "https://github.com/prosopo/captcha/issues"

--- a/packages/procaptcha-wrapper/package.json
+++ b/packages/procaptcha-wrapper/package.json
@@ -42,5 +42,10 @@
 		"url": "https://github.com/prosopo/captcha/issues"
 	},
 	"homepage": "https://github.com/prosopo/captcha#readme",
-	"sideEffects": false
+	"sideEffects": false,
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/prosopo/captcha.git",
+		"directory": "packages/procaptcha-wrapper"
+	}
 }

--- a/packages/procaptcha/package.json
+++ b/packages/procaptcha/package.json
@@ -58,7 +58,8 @@
 	"keywords": [],
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/prosopo/captcha.git"
+		"url": "git+https://github.com/prosopo/captcha.git",
+		"directory": "packages/procaptcha"
 	},
 	"bugs": {
 		"url": "https://github.com/prosopo/captcha/issues"

--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -73,7 +73,8 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "git+ssh://git@github.com/prosopo/provider.git"
+		"url": "git+https://github.com/prosopo/captcha.git",
+		"directory": "packages/provider"
 	},
 	"description": "The easiest way to deploy the Prosopo contract and run the Provider node is via the [captcha repository](https://github.com/prosopo/captcha/).",
 	"bugs": {

--- a/packages/redis-client/package.json
+++ b/packages/redis-client/package.json
@@ -28,7 +28,8 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "git+ssh://git@github.com/prosopo/captcha.git"
+		"url": "git+https://github.com/prosopo/captcha.git",
+		"directory": "packages/redis-client"
 	},
 	"author": "Prosopo Limited",
 	"license": "Apache-2.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -26,7 +26,8 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/prosopo/captcha.git"
+		"url": "git+https://github.com/prosopo/captcha.git",
+		"directory": "packages/server"
 	},
 	"author": "PROSOPO LIMITED",
 	"license": "Apache-2.0",

--- a/packages/testpkg2/package.json
+++ b/packages/testpkg2/package.json
@@ -25,7 +25,8 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/prosopo/captcha.git"
+		"url": "git+https://github.com/prosopo/captcha.git",
+		"directory": "packages/testpkg2"
 	},
 	"author": "PROSOPO LIMITED <info@prosopo.io>",
 	"license": "Apache-2.0",

--- a/packages/types-database/package.json
+++ b/packages/types-database/package.json
@@ -26,7 +26,8 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "git+ssh://git@github.com/prosopo/captcha.git"
+		"url": "git+https://github.com/prosopo/captcha.git",
+		"directory": "packages/types-database"
 	},
 	"author": "Prosopo Limited",
 	"license": "Apache-2.0",

--- a/packages/types-env/package.json
+++ b/packages/types-env/package.json
@@ -26,7 +26,8 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "git+ssh://git@github.com/prosopo/captcha.git"
+		"url": "git+https://github.com/prosopo/captcha.git",
+		"directory": "packages/types-env"
 	},
 	"author": "Prosopo Limited",
 	"license": "Apache-2.0",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -26,7 +26,8 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "git+ssh://git@github.com/prosopo/types.git"
+		"url": "git+https://github.com/prosopo/captcha.git",
+		"directory": "packages/types"
 	},
 	"author": "Prosopo Limited",
 	"license": "Apache-2.0",

--- a/packages/user-access-policy/package.json
+++ b/packages/user-access-policy/package.json
@@ -72,5 +72,10 @@
 		"url": "https://github.com/prosopo/captcha/issues"
 	},
 	"homepage": "https://github.com/prosopo/captcha#readme",
-	"sideEffects": false
+	"sideEffects": false,
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/prosopo/captcha.git",
+		"directory": "packages/user-access-policy"
+	}
 }

--- a/packages/util-crypto/package.json
+++ b/packages/util-crypto/package.json
@@ -52,7 +52,8 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/prosopo/captcha.git"
+		"url": "git+https://github.com/prosopo/captcha.git",
+		"directory": "packages/util-crypto"
 	},
 	"bugs": {
 		"url": "https://github.com/prosopo/captcha/issues"

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -64,7 +64,8 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/prosopo/captcha.git"
+		"url": "git+https://github.com/prosopo/captcha.git",
+		"directory": "packages/util"
 	},
 	"bugs": {
 		"url": "https://github.com/prosopo/captcha/issues"

--- a/packages/widget-skeleton/package.json
+++ b/packages/widget-skeleton/package.json
@@ -26,7 +26,8 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "git+ssh://git@github.com/prosopo/types.git"
+		"url": "git+https://github.com/prosopo/captcha.git",
+		"directory": "packages/widget-skeleton"
 	},
 	"author": "Prosopo Limited",
 	"license": "Apache-2.0",


### PR DESCRIPTION
## Summary
- Adds \`repository: { type, url, directory }\` to every workspace package.json that publishes to npm.
- Restores \`--provenance\` on the publish step.

## Why
v3.6.30 publish got past OIDC auth but failed provenance verification:

> Failed to validate repository information: package.json: \"repository.url\" is \"\", expected to match \"https://github.com/prosopo/captcha\" from provenance

The npm registry verifies every published manifest's \`repository.url\` against the OIDC claim from GitHub Actions. Several packages had no \`repository\` at all; others (legacy) pointed at \`prosopo/types.git\` from when types lived in its own repo.

This sweep sets all of them to the same canonical url and adds the \`directory\` field so consumers can navigate straight to the source.

## Test plan
- [ ] Merge → re-run \`publish_release\` workflow against tag \`v3.6.30\` → all packages publish with provenance attestations visible on the npmjs.com package pages.