### PR TITLE
chore: changeset to cut a fresh release after partial v3.6.30

### DIFF
--- a/.changeset/republish-trusted-publishing.md
+++ b/.changeset/republish-trusted-publishing.md
@@ -1,0 +1,8 @@
+---
+"@prosopo/cli": patch
+"@prosopo/provider": patch
+---
+
+Republish under npm trusted publishing.
+
+No runtime change. The v3.6.30 publish landed only a partial slice of the workspace before npm rejected the rest (provenance verification + repository-field mismatch). Cutting a fresh version so every package gets a clean publish under the new OIDC-based workflow with provenance attestations attached.

--- a/packages/datasets/package.json
+++ b/packages/datasets/package.json
@@ -36,12 +36,8 @@
 	},
 	"typesVersions": {
 		"*": {
-			"types": [
-				"dist/types"
-			],
-			"captcha": [
-				"dist/captcha"
-			]
+			"types": ["dist/types"],
+			"captcha": ["dist/captcha"]
 		}
 	},
 	"dependencies": {

--- a/packages/procaptcha-bundle/package.json
+++ b/packages/procaptcha-bundle/package.json
@@ -37,9 +37,7 @@
 		"serve": "NODE_ENV=${NODE_ENV:-development}; vite serve --config vite.serve.config.ts --mode $NODE_ENV --host",
 		"test": "NODE_ENV=${NODE_ENV:-test}; npx vitest run --config ./vite.test.config.ts"
 	},
-	"browserslist": [
-		"> 0.5%, last 2 versions, not dead"
-	],
+	"browserslist": ["> 0.5%, last 2 versions, not dead"],
 	"dependencies": {
 		"@prosopo/dotenv": "3.0.43",
 		"@prosopo/locale": "3.2.4",

--- a/packages/procaptcha-common/package.json
+++ b/packages/procaptcha-common/package.json
@@ -30,9 +30,7 @@
 		"test:watch": "NODE_ENV=${NODE_ENV:-test}; npx vitest --config ./vite.test.config.ts",
 		"test:coverage": "NODE_ENV=${NODE_ENV:-test}; npx vitest run --coverage --config ./vite.test.config.ts"
 	},
-	"browserslist": [
-		"> 0.5%, last 2 versions, not dead"
-	],
+	"browserslist": ["> 0.5%, last 2 versions, not dead"],
 	"dependencies": {
 		"@emotion/react": "11.11.1",
 		"@emotion/styled": "11.11.0",

--- a/packages/procaptcha-frictionless/package.json
+++ b/packages/procaptcha-frictionless/package.json
@@ -28,9 +28,7 @@
 		"build:cjs": "NODE_ENV=${NODE_ENV:-development}; vite build --config vite.cjs.config.ts --mode $NODE_ENV",
 		"typecheck": "tsc --project tsconfig.types.json"
 	},
-	"browserslist": [
-		"> 0.5%, last 2 versions, not dead"
-	],
+	"browserslist": ["> 0.5%, last 2 versions, not dead"],
 	"dependencies": {
 		"@prosopo/api": "3.4.8",
 		"@prosopo/common": "3.1.38",

--- a/packages/procaptcha-pow/package.json
+++ b/packages/procaptcha-pow/package.json
@@ -27,9 +27,7 @@
 		"build:cjs": "NODE_ENV=${NODE_ENV:-development}; vite build --config vite.cjs.config.ts --mode $NODE_ENV",
 		"typecheck": "tsc --project tsconfig.types.json"
 	},
-	"browserslist": [
-		"> 0.5%, last 2 versions, not dead"
-	],
+	"browserslist": ["> 0.5%, last 2 versions, not dead"],
 	"dependencies": {
 		"@polkadot/util": "13.5.7",
 		"@prosopo/api": "3.4.8",

--- a/packages/procaptcha-puzzle/package.json
+++ b/packages/procaptcha-puzzle/package.json
@@ -27,9 +27,7 @@
 		"build:cjs": "NODE_ENV=${NODE_ENV:-development}; vite build --config vite.cjs.config.ts --mode $NODE_ENV",
 		"typecheck": "tsc --project tsconfig.types.json"
 	},
-	"browserslist": [
-		"> 0.5%, last 2 versions, not dead"
-	],
+	"browserslist": ["> 0.5%, last 2 versions, not dead"],
 	"dependencies": {
 		"@polkadot/util": "13.5.7",
 		"@prosopo/api": "3.4.8",

--- a/packages/procaptcha-react/package.json
+++ b/packages/procaptcha-react/package.json
@@ -27,9 +27,7 @@
 		"build:cjs": "NODE_ENV=${NODE_ENV:-development}; vite build --config vite.cjs.config.ts --mode $NODE_ENV",
 		"typecheck": "tsc --project tsconfig.types.json"
 	},
-	"browserslist": [
-		"> 0.5%, last 2 versions, not dead"
-	],
+	"browserslist": ["> 0.5%, last 2 versions, not dead"],
 	"dependencies": {
 		"@prosopo/common": "3.1.38",
 		"@prosopo/locale": "3.2.4",


### PR DESCRIPTION
Cuts a new version so every package gets a clean publish under the trusted-publishing workflow.