### PR TITLE
ci(changesets): flip access to public

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -5,7 +5,7 @@
 	"prettier": false,
 	"fixed": [],
 	"linked": [],
-	"access": "restricted",
+	"access": "public",
 	"baseBranch": "origin/main",
 	"updateInternalDependencies": "patch",
 	"ignore": []


### PR DESCRIPTION
changeset publish was honouring `access: restricted` and asking npm to publish each workspace as a private package; npm replied 402. All these packages are public. Match config to reality.