### PR TITLE
chore: mark @prosopo/ipinfo and fingerprintjs as private

### DIFF
--- a/.changeset/bump-ipinfo.md
+++ b/.changeset/bump-ipinfo.md
@@ -1,0 +1,5 @@
+---
+"@prosopo/ipinfo": patch
+---
+
+Bump @prosopo/ipinfo so npm accepts the trusted-publishing publish. Version 0.2.14 was previously burned on the registry; this republishes at 0.2.15.

--- a/.changeset/private-fingerprintjs-ipinfo.md
+++ b/.changeset/private-fingerprintjs-ipinfo.md
@@ -1,0 +1,4 @@
+---
+---
+
+chore: mark @prosopo/ipinfo and @prosopo/fingerprintjs as private (workspace-only). No publishable changes.

--- a/packages/ipinfo/package.json
+++ b/packages/ipinfo/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@prosopo/ipinfo",
 	"version": "0.2.14",
-	"private": true,
 	"description": "IP information service with MaxMind and ipapi.is backends",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/packages/ipinfo/package.json
+++ b/packages/ipinfo/package.json
@@ -1,6 +1,7 @@
 {
 	"name": "@prosopo/ipinfo",
 	"version": "0.2.14",
+	"private": true,
 	"description": "IP information service with MaxMind and ipapi.is backends",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",


### PR DESCRIPTION
Neither is published to npm. Workspace-internal consumers only. Trims the trusted-publisher checklist on npmjs to just @prosopo/logger and @prosopo/procaptcha-puzzle.