### PR TITLE
feat(caddy): caddy-l4 SNI passthrough on :443, drop :9362 from pixel URL

### DIFF
--- a/docker/docker-compose.provider.yml
+++ b/docker/docker-compose.provider.yml
@@ -236,11 +236,9 @@ services:
       # ${HOST_IPV4} is exported by the ansible playbook.
       - "${HOST_IPV4}:53:53/udp"
       - "${HOST_IPV4}:53:53/tcp"
-      # HTTPS pixel on host:9362 because Caddy owns :443 (the embedded
-      # layer4 SNI-passthrough integration is a follow-up — needs the
-      # HTTP server moved off :443 so layer4 can own it). dns_url
-      # includes :9362 in the URL via DNS_EVENT_PORT.
-      - "9362:443"
+      # No host port for the HTTPS pixel: Caddy's layer4 block on :443
+      # SNI-routes `*.t.{CADDY_DOMAIN}` straight to dns:443 over the
+      # docker network. URLs no longer carry a :9362 suffix.
     environment:
       - DNS_HTTPS_PORT=443
       - DNS_HTTPS_BIND=0.0.0.0

--- a/docker/provider.Caddyfile
+++ b/docker/provider.Caddyfile
@@ -2,7 +2,18 @@
 {
 	# debug
 	http_port {$CADDY_HTTP_PORT:80}
-	auto_https {$CADDY_AUTO_HTTPS:disable_redirects}
+	# auto_https defaults to "on" — that's what we want now. Caddy
+	# auto-creates a :80 server that serves HTTP-01 ACME challenges
+	# AND redirects everything else to https://{host}{uri} (port
+	# 443, NOT :8443 — Caddy uses the global https_port for the
+	# redirect target, and :443 is owned by layer4 below which
+	# forwards the request straight back to the :8443 main site for
+	# non-trap-subzone SNIs). Removing the previous
+	# `disable_redirects` setting + the explicit :80 site below
+	# fixes silent ACME-renewal failure: with the old `terminal:
+	# true` redirect route Caddy had no place to inject its
+	# challenge handler.
+	auto_https {$CADDY_AUTO_HTTPS:on}
 	admin {$CADDY_ADMIN_API::2020} # set the admin api to run on localhost:2020 (default is 2019 which can conflict with caddy daemon)
 
 	# Caddy must be told custom rate_limit module its order
@@ -59,19 +70,13 @@ http://:9090 {
 	metrics /metrics
 }
 
-# Port-80 listener: serves ACME HTTP-01 challenges (the only ACME
-# challenge type we can use now that :443 belongs to layer4 — TLS-
-# ALPN-01 is explicitly disabled on the main site below) and
-# redirects everything else to HTTPS. The acme path is left
-# untouched so Caddy's own challenge handler picks it up.
-http://{$CADDY_DOMAIN} {
-	@notacme not path /.well-known/acme-challenge/*
-	redir @notacme https://{host}{uri}
-}
-
 # Main site: bound on :8443. Layer4 (above) proxies non-trap-subzone
 # SNI connections from :443 in. ACME issuer is restricted to HTTP-01
-# because TLS-ALPN-01 requires control of :443.
+# because TLS-ALPN-01 requires control of :443. The :80 redirect
+# server is auto-created by Caddy (auto_https=on); it serves both
+# ACME HTTP-01 challenges AND HTTP→HTTPS redirects targeting port
+# 443 (i.e. the layer4 listener), which forwards non-matching SNIs
+# back to this same :8443 server.
 https://{$CADDY_DOMAIN}:8443 {
 
 	tls {

--- a/docker/provider.Caddyfile
+++ b/docker/provider.Caddyfile
@@ -2,18 +2,16 @@
 {
 	# debug
 	http_port {$CADDY_HTTP_PORT:80}
-	# auto_https defaults to "on" — that's what we want now. Caddy
-	# auto-creates a :80 server that serves HTTP-01 ACME challenges
-	# AND redirects everything else to https://{host}{uri} (port
-	# 443, NOT :8443 — Caddy uses the global https_port for the
-	# redirect target, and :443 is owned by layer4 below which
-	# forwards the request straight back to the :8443 main site for
-	# non-trap-subzone SNIs). Removing the previous
-	# `disable_redirects` setting + the explicit :80 site below
-	# fixes silent ACME-renewal failure: with the old `terminal:
-	# true` redirect route Caddy had no place to inject its
-	# challenge handler.
-	auto_https {$CADDY_AUTO_HTTPS:on}
+	# `auto_https` intentionally omitted — its valid Caddyfile values
+	# are off / disable_redirects / disable_certs / ignore_loaded_certs,
+	# none of which match the default ("fully on"). Letting it default
+	# means Caddy auto-creates the :80 server with BOTH HTTP-01 ACME
+	# challenge handling AND HTTP→HTTPS redirects targeting port 443
+	# (the global https_port; layer4 below sits on it and SNI-routes
+	# the request back to the :8443 main site for non-trap subzones).
+	# The previous setting `disable_redirects` plus an explicit
+	# `http://{$CADDY_DOMAIN}` site left Caddy nowhere to inject the
+	# challenge handler, so renewals were silently broken.
 	admin {$CADDY_ADMIN_API::2020} # set the admin api to run on localhost:2020 (default is 2019 which can conflict with caddy daemon)
 
 	# Caddy must be told custom rate_limit module its order

--- a/docker/provider.Caddyfile
+++ b/docker/provider.Caddyfile
@@ -8,6 +8,32 @@
 	# Caddy must be told custom rate_limit module its order
 	order rate_limit before basicauth
 
+	# Layer-4 SNI router on :443. Lets the dns sidecar serve the
+	# pixel endpoint on the standard HTTPS port — sessions get
+	# `https://{sessionId}.t.{host}/...` instead of dragging a :9362
+	# port suffix through every URL.
+	#
+	# Connections whose ClientHello SNI matches the dns-trap subzone
+	# pattern `*.t.{$CADDY_DOMAIN}` are proxied raw (TLS not
+	# terminated here) to the dns container which has its own
+	# Let's-Encrypt cert. Everything else falls through to Caddy's
+	# normal HTTPS server, bound on :8443 below so :443 is free for
+	# this router. Provided by `github.com/mholt/caddy-l4` (baked
+	# into the prosopo/caddy image at 2.5.7-dns-3455+).
+	layer4 {
+		:443 {
+			@dns_subzone tls sni *.t.{$CADDY_DOMAIN}
+			route @dns_subzone {
+				proxy {
+					upstream dns:443
+				}
+			}
+			route {
+				proxy 127.0.0.1:8443
+			}
+		}
+	}
+
 	client_hello {
 		# Configure the maximum allowed ClientHello packet size in bytes (1-16384)
 		max_client_hello_size 16384
@@ -33,12 +59,26 @@ http://:9090 {
 	metrics /metrics
 }
 
-{$CADDY_DOMAIN} {
+# Port-80 listener: serves ACME HTTP-01 challenges (the only ACME
+# challenge type we can use now that :443 belongs to layer4 — TLS-
+# ALPN-01 is explicitly disabled on the main site below) and
+# redirects everything else to HTTPS. The acme path is left
+# untouched so Caddy's own challenge handler picks it up.
+http://{$CADDY_DOMAIN} {
+	@notacme not path /.well-known/acme-challenge/*
+	redir @notacme https://{host}{uri}
+}
 
-    @httpOnly {
-        protocol http
-    }
-    redir @httpOnly https://{host}{uri}
+# Main site: bound on :8443. Layer4 (above) proxies non-trap-subzone
+# SNI connections from :443 in. ACME issuer is restricted to HTTP-01
+# because TLS-ALPN-01 requires control of :443.
+https://{$CADDY_DOMAIN}:8443 {
+
+	tls {
+		issuer acme {
+			disable_tlsalpn_challenge
+		}
+	}
 	
 	handle /robots.txt {
 		uri strip_prefix / # removes leading /, so it looks directly in root


### PR DESCRIPTION
## Summary
- caddy-l4 owns `:443` and SNI-routes `*.t.{CADDY_DOMAIN}` → `dns:443` (over docker network); everything else → `127.0.0.1:8443`.
- Main site rebound to `:8443` with TLS-ALPN-01 disabled (HTTP-01 only, since :443 is taken by layer4).
- Tiny `:80` listener handles HTTP→HTTPS redirect with `/.well-known/acme-challenge/*` exempted so HTTP-01 still works.
- `9362:443` host port mapping removed from the dns service in compose.

## Why
Pixel URL was `https://{sid}.t.{host}:9362/...`. With this change it becomes the clean `https://{sid}.t.{host}/...`.

## Test plan
- [ ] Merge → release v3.6.33 → staging caddy + dns recreate via ansible
- [ ] `curl -sIv https://test.t.staging-pronode2.prosopo.io/abc.webp?sid=test` returns HTTP 200 image/webp with no port in the URL
- [ ] LE cert chain still validates (`ssl_verify_result=0`)
- [ ] Main site (`https://staging-pronode2.prosopo.io`) still reachable, still served by Caddy (not the sidecar)