### PR TITLE
chore(changeset): bump cli for caddy-l4 deploy

### DIFF
--- a/.changeset/caddy-l4-sni-passthrough.md
+++ b/.changeset/caddy-l4-sni-passthrough.md
@@ -1,0 +1,5 @@
+---
+"@prosopo/cli": patch
+---
+
+Caddy now SNI-routes :443 with caddy-l4. Pixel URL drops the :9362 port; HTTP-01 ACME renewals keep working via auto-managed :80.


### PR DESCRIPTION
Adds the changeset that triggers v3.6.33 release for the caddy-l4 + dns-on-:443 changes merged in #2650.