### PR TITLE
fix(dns-event): atomic merge + PROXY-v2 for real peer IP

### DIFF
--- a/.changeset/dns-event-merge-and-peerip.md
+++ b/.changeset/dns-event-merge-and-peerip.md
@@ -1,0 +1,5 @@
+---
+"@prosopo/cli": patch
+---
+
+DNS sidecar event merge: atomic dotted-path `$set` so DNS + HTTP legs co-occur on one session (was clobbering: prior projection omitted `dnsEvent`, every write started from `undefined`). Caddy now forwards PROXY-protocol v2 on the `*.t.{domain}` route and the sidecar (≥0.1.6) reads it, so `dnsEvent.peerIp` records the real client IP instead of the docker bridge address.

--- a/docker/docker-compose.provider.yml
+++ b/docker/docker-compose.provider.yml
@@ -242,6 +242,11 @@ services:
     environment:
       - DNS_HTTPS_PORT=443
       - DNS_HTTPS_BIND=0.0.0.0
+      # Caddy `layer4` raw-proxies *.t.{CADDY_DOMAIN} to dns:443 with a
+      # PROXY v2 header so the sidecar sees the real client peer instead
+      # of Caddy's docker bridge address. Must be paired with
+      # `proxy_protocol v2` on the @dns_subzone route in provider.Caddyfile.
+      - DNS_PROXY_PROTOCOL=1
     volumes:
       - /data/dns:/data
       # dns-tenants.json is rendered per host by ansible

--- a/docker/provider.Caddyfile
+++ b/docker/provider.Caddyfile
@@ -33,9 +33,13 @@
 		:443 {
 			@dns_subzone tls sni *.t.{$CADDY_DOMAIN}
 			route @dns_subzone {
-				# The dns sidecar (Rust) doesn't speak PROXY protocol —
-				# proxy the raw TCP only on this branch.
+				# dns sidecar ≥0.1.6 reads PROXY v2 when DNS_PROXY_PROTOCOL=1,
+				# so we send the real client peer through instead of letting
+				# the sidecar see Caddy's docker bridge IP. Without this every
+				# `dnsEvent.peerIp` is `172.19.0.x` and fails to correlate
+				# with `ipInfo.ip`.
 				proxy {
+					proxy_protocol v2
 					upstream dns:443
 				}
 			}

--- a/packages/database/src/databases/provider.ts
+++ b/packages/database/src/databases/provider.ts
@@ -1588,6 +1588,57 @@ export class ProviderDatabase
 	}
 
 	/**
+	 * Merge a DNS sidecar observation into the session's `dnsEvent` subdoc
+	 * using dotted-path `$set` so DNS-leg and HTTP-leg events on the same
+	 * session don't clobber each other. Replaces the prior read-modify-write
+	 * pattern that lost half the fields under any race (and 100% of the time
+	 * when the read projection didn't include `dnsEvent`).
+	 *
+	 * `receivedAtIfAbsent` is written only on the first hit for a session
+	 * via a `$cond` in an aggregation-pipeline update; later events leave
+	 * the original timestamp alone.
+	 */
+	async mergeSessionDnsEvent(
+		sessionId: string,
+		fields: {
+			resolverIp?: string;
+			peerIp?: string;
+			pathValid?: boolean;
+		},
+		receivedAtIfAbsent: Date,
+	): Promise<boolean> {
+		// Aggregation-pipeline $set: nested string/bool literals stand for
+		// themselves, $ifNull preserves the existing receivedAt on later hits.
+		const setStage: Record<string, unknown> = {
+			"dnsEvent.receivedAt": {
+				$ifNull: ["$dnsEvent.receivedAt", receivedAtIfAbsent],
+			},
+			lastUpdatedTimestamp: new Date(),
+			pendingStage: true,
+		};
+		if (fields.resolverIp !== undefined) {
+			setStage["dnsEvent.resolverIp"] = fields.resolverIp;
+		}
+		if (fields.peerIp !== undefined) {
+			setStage["dnsEvent.peerIp"] = fields.peerIp;
+		}
+		if (fields.pathValid !== undefined) {
+			setStage["dnsEvent.pathValid"] = fields.pathValid;
+		}
+		try {
+			const result = await this.tables.session.updateOne({ sessionId }, [
+				{ $set: setStage },
+			]);
+			return result.matchedCount > 0;
+		} catch (err) {
+			throw new ProsopoDBError("DATABASE.SESSION_GET_FAILED", {
+				context: { error: err, sessionId },
+				logger: this.logger,
+			});
+		}
+	}
+
+	/**
 	 * Get an active session by user IP hash
 	 * @param userSitekeyIpHash The hash of user, IP and sitekey combination
 	 * @returns The session record if it exists and is not deleted, undefined otherwise

--- a/packages/provider/src/api/admin/apiDnsEventEndpoint.ts
+++ b/packages/provider/src/api/admin/apiDnsEventEndpoint.ts
@@ -18,32 +18,26 @@ import {
 	ApiEndpointResponseStatus,
 } from "@prosopo/api-route";
 import { type Logger, getLogger } from "@prosopo/logger";
-import {
-	type DnsEvent,
-	DnsEventBatchSchema,
-	type Session,
-} from "@prosopo/types";
+import { type DnsEvent, DnsEventBatchSchema } from "@prosopo/types";
 import type { IProviderDatabase } from "@prosopo/types-database";
 import type { z } from "zod";
 
 type DnsEventBatchSchemaType = typeof DnsEventBatchSchema;
 
-// Exported for unit tests.
-export const dnsEventToPartialSession = (
+// Exported for unit tests — picks out the field(s) one DnsEvent contributes.
+export const dnsEventToFields = (
 	event: DnsEvent,
-	existing: Session["dnsEvent"] | undefined,
-): Session["dnsEvent"] => {
-	const receivedAt = existing?.receivedAt ?? new Date();
-	const merged: Session["dnsEvent"] = { ...(existing ?? {}), receivedAt };
+): { resolverIp?: string; peerIp?: string; pathValid?: boolean } => {
 	if (event.kind === "dns") {
-		merged.resolverIp = event.src_ip;
-	} else {
-		merged.peerIp = event.src_ip;
-		if (typeof event.path_valid === "boolean") {
-			merged.pathValid = event.path_valid;
-		}
+		return { resolverIp: event.src_ip };
 	}
-	return merged;
+	const out: { peerIp: string; pathValid?: boolean } = {
+		peerIp: event.src_ip,
+	};
+	if (typeof event.path_valid === "boolean") {
+		out.pathValid = event.path_valid;
+	}
+	return out;
 };
 
 class ApiDnsEventEndpoint implements ApiEndpoint<DnsEventBatchSchemaType> {
@@ -58,6 +52,7 @@ class ApiDnsEventEndpoint implements ApiEndpoint<DnsEventBatchSchemaType> {
 
 		let stored = 0;
 		let errors = 0;
+		const now = new Date();
 
 		for (const event of events) {
 			const sessionId = event.jti;
@@ -66,13 +61,15 @@ class ApiDnsEventEndpoint implements ApiEndpoint<DnsEventBatchSchemaType> {
 			}
 
 			try {
-				const session = await this.db.getSessionRecordBySessionId(sessionId);
-				if (!session) {
-					continue;
+				const fields = dnsEventToFields(event);
+				const matched = await this.db.mergeSessionDnsEvent(
+					sessionId,
+					fields,
+					now,
+				);
+				if (matched) {
+					stored += 1;
 				}
-				const dnsEvent = dnsEventToPartialSession(event, session.dnsEvent);
-				await this.db.updateSessionRecord(sessionId, { dnsEvent });
-				stored += 1;
 			} catch (err) {
 				errors += 1;
 				logger.warn(() => ({

--- a/packages/provider/src/tests/unit/api/admin/apiDnsEventEndpoint.unit.test.ts
+++ b/packages/provider/src/tests/unit/api/admin/apiDnsEventEndpoint.unit.test.ts
@@ -95,10 +95,7 @@ describe("ApiDnsEventEndpoint", () => {
 			src_ip: "1.2.3.4",
 			jti: "session-A",
 		};
-		await endpoint.processRequest(
-			{ events: [event] },
-			mockLogger as never,
-		);
+		await endpoint.processRequest({ events: [event] }, mockLogger as never);
 		expect(mergeSessionDnsEvent).toHaveBeenCalledTimes(1);
 		expect(mergeSessionDnsEvent).toHaveBeenCalledWith(
 			"session-A",
@@ -115,10 +112,7 @@ describe("ApiDnsEventEndpoint", () => {
 			jti: "session-B",
 			path_valid: false,
 		};
-		await endpoint.processRequest(
-			{ events: [event] },
-			mockLogger as never,
-		);
+		await endpoint.processRequest({ events: [event] }, mockLogger as never);
 		expect(mergeSessionDnsEvent).toHaveBeenCalledWith(
 			"session-B",
 			{ peerIp: "5.6.7.8", pathValid: false },
@@ -142,10 +136,7 @@ describe("ApiDnsEventEndpoint", () => {
 			jti: "session-X",
 			path_valid: true,
 		};
-		await endpoint.processRequest(
-			{ events: [dns, http] },
-			mockLogger as never,
-		);
+		await endpoint.processRequest({ events: [dns, http] }, mockLogger as never);
 		expect(mergeSessionDnsEvent).toHaveBeenCalledTimes(2);
 		expect(mergeSessionDnsEvent).toHaveBeenNthCalledWith(
 			1,

--- a/packages/provider/src/tests/unit/api/admin/apiDnsEventEndpoint.unit.test.ts
+++ b/packages/provider/src/tests/unit/api/admin/apiDnsEventEndpoint.unit.test.ts
@@ -1,0 +1,220 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { ApiEndpointResponseStatus } from "@prosopo/api-route";
+import type { DnsEvent } from "@prosopo/types";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	ApiDnsEventEndpoint,
+	dnsEventToFields,
+} from "../../../../api/admin/apiDnsEventEndpoint.js";
+
+describe("dnsEventToFields", () => {
+	it("extracts resolverIp from a dns-kind event", () => {
+		const event: DnsEvent = {
+			kind: "dns",
+			ts: "2026-06-08T15:00:00Z",
+			src_ip: "1.2.3.4",
+			jti: "session-1",
+		};
+		expect(dnsEventToFields(event)).toEqual({ resolverIp: "1.2.3.4" });
+	});
+
+	it("extracts peerIp + pathValid from an http-kind event", () => {
+		const event: DnsEvent = {
+			kind: "http",
+			ts: "2026-06-08T15:00:00Z",
+			src_ip: "5.6.7.8",
+			jti: "session-1",
+			path_valid: true,
+		};
+		expect(dnsEventToFields(event)).toEqual({
+			peerIp: "5.6.7.8",
+			pathValid: true,
+		});
+	});
+
+	it("omits pathValid when not present on the event", () => {
+		const event: DnsEvent = {
+			kind: "http",
+			ts: "2026-06-08T15:00:00Z",
+			src_ip: "5.6.7.8",
+			jti: "session-1",
+		};
+		expect(dnsEventToFields(event)).toEqual({ peerIp: "5.6.7.8" });
+	});
+});
+
+describe("ApiDnsEventEndpoint", () => {
+	let mergeSessionDnsEvent: ReturnType<typeof vi.fn>;
+	let endpoint: ApiDnsEventEndpoint;
+	let mockLogger: {
+		info: ReturnType<typeof vi.fn>;
+		warn: ReturnType<typeof vi.fn>;
+	};
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mergeSessionDnsEvent = vi.fn().mockResolvedValue(true);
+		mockLogger = { info: vi.fn(), warn: vi.fn() };
+		endpoint = new ApiDnsEventEndpoint({
+			mergeSessionDnsEvent,
+		} as never);
+	});
+
+	it("skips events with no jti", async () => {
+		const event: DnsEvent = {
+			kind: "dns",
+			ts: "2026-06-08T15:00:00Z",
+			src_ip: "1.2.3.4",
+		};
+		const result = await endpoint.processRequest(
+			{ events: [event] },
+			mockLogger as never,
+		);
+		expect(result.status).toBe(ApiEndpointResponseStatus.SUCCESS);
+		expect(result.data).toEqual({ stored: 0, errors: 0 });
+		expect(mergeSessionDnsEvent).not.toHaveBeenCalled();
+	});
+
+	it("calls mergeSessionDnsEvent with dotted resolverIp for a dns event", async () => {
+		const event: DnsEvent = {
+			kind: "dns",
+			ts: "2026-06-08T15:00:00Z",
+			src_ip: "1.2.3.4",
+			jti: "session-A",
+		};
+		await endpoint.processRequest(
+			{ events: [event] },
+			mockLogger as never,
+		);
+		expect(mergeSessionDnsEvent).toHaveBeenCalledTimes(1);
+		expect(mergeSessionDnsEvent).toHaveBeenCalledWith(
+			"session-A",
+			{ resolverIp: "1.2.3.4" },
+			expect.any(Date),
+		);
+	});
+
+	it("calls mergeSessionDnsEvent with peerIp + pathValid for an http event", async () => {
+		const event: DnsEvent = {
+			kind: "http",
+			ts: "2026-06-08T15:00:00Z",
+			src_ip: "5.6.7.8",
+			jti: "session-B",
+			path_valid: false,
+		};
+		await endpoint.processRequest(
+			{ events: [event] },
+			mockLogger as never,
+		);
+		expect(mergeSessionDnsEvent).toHaveBeenCalledWith(
+			"session-B",
+			{ peerIp: "5.6.7.8", pathValid: false },
+			expect.any(Date),
+		);
+	});
+
+	it("merges both legs onto the same session via two atomic calls", async () => {
+		// Regression test for the read-modify-write race that produced
+		// withBoth: 0 in production. Both calls must reach the DB.
+		const dns: DnsEvent = {
+			kind: "dns",
+			ts: "2026-06-08T15:00:00Z",
+			src_ip: "1.2.3.4",
+			jti: "session-X",
+		};
+		const http: DnsEvent = {
+			kind: "http",
+			ts: "2026-06-08T15:00:00.500Z",
+			src_ip: "5.6.7.8",
+			jti: "session-X",
+			path_valid: true,
+		};
+		await endpoint.processRequest(
+			{ events: [dns, http] },
+			mockLogger as never,
+		);
+		expect(mergeSessionDnsEvent).toHaveBeenCalledTimes(2);
+		expect(mergeSessionDnsEvent).toHaveBeenNthCalledWith(
+			1,
+			"session-X",
+			{ resolverIp: "1.2.3.4" },
+			expect.any(Date),
+		);
+		expect(mergeSessionDnsEvent).toHaveBeenNthCalledWith(
+			2,
+			"session-X",
+			{ peerIp: "5.6.7.8", pathValid: true },
+			expect.any(Date),
+		);
+	});
+
+	it("counts stored only when the session matched", async () => {
+		mergeSessionDnsEvent
+			.mockResolvedValueOnce(true)
+			.mockResolvedValueOnce(false);
+		const events: DnsEvent[] = [
+			{
+				kind: "dns",
+				ts: "2026-06-08T15:00:00Z",
+				src_ip: "1.2.3.4",
+				jti: "session-found",
+			},
+			{
+				kind: "dns",
+				ts: "2026-06-08T15:00:00Z",
+				src_ip: "9.9.9.9",
+				jti: "session-missing",
+			},
+		];
+		const result = await endpoint.processRequest(
+			{ events },
+			mockLogger as never,
+		);
+		expect(result.data).toEqual({ stored: 1, errors: 0 });
+	});
+
+	it("isolates per-event failures", async () => {
+		mergeSessionDnsEvent
+			.mockRejectedValueOnce(new Error("boom"))
+			.mockResolvedValueOnce(true);
+		const events: DnsEvent[] = [
+			{
+				kind: "dns",
+				ts: "2026-06-08T15:00:00Z",
+				src_ip: "1.2.3.4",
+				jti: "session-fail",
+			},
+			{
+				kind: "dns",
+				ts: "2026-06-08T15:00:00Z",
+				src_ip: "5.6.7.8",
+				jti: "session-ok",
+			},
+		];
+		const result = await endpoint.processRequest(
+			{ events },
+			mockLogger as never,
+		);
+		expect(result.status).toBe(ApiEndpointResponseStatus.SUCCESS);
+		expect(result.data).toEqual({ stored: 1, errors: 1 });
+		expect(mockLogger.warn).toHaveBeenCalledTimes(1);
+	});
+
+	it("returns the registered schema", () => {
+		const schema = endpoint.getRequestArgsSchema();
+		expect(schema).toBeDefined();
+	});
+});

--- a/packages/types-database/src/types/provider.ts
+++ b/packages/types-database/src/types/provider.ts
@@ -967,6 +967,25 @@ export interface IProviderDatabase extends IDatabase {
 		stage: SimdReadingsStage,
 	): Promise<void>;
 
+	/**
+	 * Merge a partial dnsEvent observation into the session record using
+	 * dotted-path `$set` so DNS-leg and HTTP-leg events can both land on
+	 * the same session without read-modify-write races. `receivedAt` is
+	 * only written if absent (`$setOnInsert`-style behaviour via $set
+	 * + a `$cond` would over-complicate; instead, the caller passes
+	 * `receivedAtIfAbsent` and we set it unconditionally only when no
+	 * field already exists). Returns true if the session existed.
+	 */
+	mergeSessionDnsEvent(
+		sessionId: string,
+		fields: {
+			resolverIp?: string;
+			peerIp?: string;
+			pathValid?: boolean;
+		},
+		receivedAtIfAbsent: Date,
+	): Promise<boolean>;
+
 	getSessionByuserSitekeyIpHash(
 		userSitekeyIpHash: string,
 	): Promise<SessionRecord | undefined>;


### PR DESCRIPTION
## Summary

Fixes two latent bugs in the dns-trap sidecar observation pipeline. Surfaced when querying production telemetry:

- **`withBoth: 0`** — no session ever had both `resolverIp` AND `peerIp`. The DNS-leg event always clobbered the HTTP-leg event (or vice versa).
- **`peerIp` was always `172.19.0.x`** — a docker bridge address, never the real client.

### Bug 1: read-modify-write race in `apiDnsEventEndpoint`

`getSessionRecordBySessionId` projects only `{ sessionId, ipInfo, scoreComponents, webView, reason, decryptedHeadHash }`. The endpoint did:

```ts
const session = await this.db.getSessionRecordBySessionId(sessionId);
const dnsEvent = dnsEventToPartialSession(event, session.dnsEvent); // ← always undefined
await this.db.updateSessionRecord(sessionId, { dnsEvent });         // ← clobbers
```

So every write started from an empty base and overwrote the prior subdoc.

**Fix:** new `IProviderDatabase.mergeSessionDnsEvent(sessionId, fields, receivedAtIfAbsent)` doing an aggregation-pipeline `$set` on dotted nested paths. Atomic at the mongo level, no projection dependency.

### Bug 2: docker bridge IP as `peerIp`

The layer4 `@dns_subzone` route raw-TCP-proxied to `dns:443` without PROXY protocol — the sidecar read `peer.ip()` from the post-proxy TCP socket and got Caddy's container IP.

**Fix (this PR):**
- `proxy_protocol v2` on the `@dns_subzone` route in `provider.Caddyfile`
- `DNS_PROXY_PROTOCOL=1` on the dns service in `docker-compose.provider.yml`

**Fix (sidecar side):** prosopo/Protect#257 adds the PROXY-v2 reader in `crates/dns/src/http/tls.rs`. Bump `dns_version` to `0.1.6` after that PR lands.

## Verification

End-to-end on staging-pronode{2,3,4} via `staging.demo.prosopo.io` browser captcha:

```json
{
  sessionId: "staging-pronode3-9b93aa0e-e1fc-4ec8-b2f3-2954306fea20",
  ipInfo:   { ip: "82.43.214.180", ... },
  dnsEvent: {
    receivedAt: 2026-06-08T16:47:22.210Z,
    resolverIp: "172.69.79.99",   // Cloudflare DNS resolver
    peerIp:     "82.43.214.180",  // real client (matches ipInfo.ip)
    pathValid:  true
  }
}
```

`withBoth > 0` and `peerIp === ipInfo.ip` confirmed across all three staging pronodes.

## Test plan

- [x] `npx vitest run packages/provider/src/tests/unit/api/admin/apiDnsEventEndpoint.unit.test.ts` — 10 new cases pass
- [x] `npm run -w @prosopo/provider build:tsc` clean
- [x] Real captcha session on `staging.demo.prosopo.io` → dnsEvent has both legs + real peerIp
- [ ] After merge: bump `dns_version: 0.1.6` and `compose_provider_image_version: 3.6.33` in `hosts.production.yml` (separate PR in `captcha-private2`)
- [ ] After merge: run `providerRollingDeploy.yml` against production

🤖 Generated with [Claude Code](https://claude.com/claude-code)