### PR TITLE
feat(compose): pass HOST_IPV6 as DNS_AAAA_RECORD to dns sidecar

### DIFF
--- a/docker/docker-compose.provider.yml
+++ b/docker/docker-compose.provider.yml
@@ -247,6 +247,13 @@ services:
       # of Caddy's docker bridge address. Must be paired with
       # `proxy_protocol v2` on the @dns_subzone route in provider.Caddyfile.
       - DNS_PROXY_PROTOCOL=1
+      # Dual-stack: serve AAAA pointing at the host's public ipv6
+      # alongside the existing A record. Without this, v6-preferring
+      # browsers happy-eyeballs back to v4 for the pixel and
+      # `dnsEvent.peerIp` records the v4 exit instead of the real v6.
+      # Unset on v4-only hosts — the sidecar (≥0.1.7) treats blank as
+      # "no AAAA" and serves A only.
+      - DNS_AAAA_RECORD=${HOST_IPV6:-}
     volumes:
       - /data/dns:/data
       # dns-tenants.json is rendered per host by ansible


### PR DESCRIPTION
## Summary

Wires `${HOST_IPV6}` through docker-compose into the dns sidecar as `DNS_AAAA_RECORD`. With prosopo/dns ≥0.1.7 the sidecar serves AAAA alongside A — v6-preferring browsers fetch the pixel over v6 and `dnsEvent.peerIp` records the real v6 exit instead of the happy-eyeballs v4 fallback.

Empty `HOST_IPV6` (v4-only hosts) is handled cleanly via `${HOST_IPV6:-}` — sidecar treats blank as "no AAAA" and continues serving A only.

Pairs with:
- prosopo/Protect#261 (sidecar code) — **merged**
- `captcha-private` provider playbook already passes `HOST_IPV6` via the inventory's `ipv6` field

## Test plan

- [x] `prosopo/dns:0.1.7` built + pushed (both prod and `-staging` tags live on Docker Hub)
- [x] Cloudflare AAAA glue cleanup verified — sidecar is reachable over v4 only for the NS query path, AAAA only goes in the *answer*, so no v6 listening required
- [ ] After merge: bump captcha submodule pointer in captcha-private + `dns_version: "0.1.7"`, force-recreate dns containers (no rolling deploy needed — only the trap subzone is affected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)