### PR TITLE
chore(compose): tighten dns sidecar shipper flush to 50ms

### DIFF
--- a/docker/docker-compose.provider.yml
+++ b/docker/docker-compose.provider.yml
@@ -254,6 +254,12 @@ services:
       # Unset on v4-only hosts — the sidecar (≥0.1.7) treats blank as
       # "no AAAA" and serves A only.
       - DNS_AAAA_RECORD=${HOST_IPV6:-}
+      # Tight shipper batch flush. Default 1000ms adds ~500ms average
+      # buffering latency to every dnsEvent on the way to provider1's
+      # admin endpoint. Empty batches are skipped (see shipper.rs), so
+      # the cost on idle hosts is just a tokio tick wakeup. Real POST
+      # volume is bounded by the event rate, not the flush rate.
+      - DNS_SHIPPER_FLUSH_MS=50
     volumes:
       - /data/dns:/data
       # dns-tenants.json is rendered per host by ansible


### PR DESCRIPTION
## Summary

Sets `DNS_SHIPPER_FLUSH_MS=50` (default is 1000) on the dns container. The dns sidecar batches outgoing events on a tick; the tick interval is roughly the average buffering latency each `dnsEvent` accumulates between the browser firing the pixel and the provider's admin endpoint persisting it on the session.

## Measured impact (live prod, all 12 pronodes)

920 sessions after dropping to 100ms vs 8,120 sessions over the prior 12h 1000ms baseline:

| | Before (1000ms) | After (100ms) | Δ |
|---|---:|---:|---:|
| p25 | 424 ms | 251 ms | −41% |
| p50 | 678 ms | 358 ms | **−47%** |
| p75 | 923 ms | 546 ms | −41% |
| p90 | 1,077 ms | 702 ms | −35% |
| p95 | 1,132 ms | 798 ms | **−30%** |
| p99 | 1,312 ms | 1,172 ms | −11% |
| max | 4,166 ms | 2,368 ms | −43% |

Going 100 → 50 ms shaves another ~25 ms at p50. The wire path (DNS resolve → TLS handshake → HTTPS GET → provider mongo merge) is now ~280 ms p50 and dominates.

## Why

The verify-endpoint pixel-gate (separate WIP — image/pow verify denying tokens whose sessions never fired the pixel beacon) needs to wait for the pixel before deciding. With this change the gate can use a 1 s timeout instead of 2 s while still catching ~98.5% of legit hits, halving the worst-case latency the developer's backend sees on their verify call.

## Cost

Empty batches are skipped (`shipper.rs:102` — `if !buf.is_empty()` before POST). At 50 ms the dns sidecar wakes the tokio task ~1200 times/min, but real POST volume to `provider1` is bounded by the event rate (~30 events/min/host), not the flush rate. Idle hosts add nothing measurable.

## Test plan

- [x] Verified `DNS_SHIPPER_FLUSH_MS=100` propagated to all 12 pronode dns containers
- [x] Measured p50 dropped from 678 → 358 ms on live prod traffic
- [x] No errors observed in dns sidecar or provider1 logs after recreate
- [ ] Roll out 50 ms to all 12 pronodes after merge
- [ ] After merge: ansible deploys will re-render compose with this baked in

🤖 Generated with [Claude Code](https://claude.com/claude-code)