### PR TITLE
feat(traffic-filter): exclude VPN-on-datacenter from datacenter block

### DIFF
--- a/.changeset/datacenter-vpn-exclusion.md
+++ b/.changeset/datacenter-vpn-exclusion.md
@@ -1,0 +1,5 @@
+---
+"@prosopo/provider": patch
+---
+
+`checkTrafficFilter` no longer treats VPN traffic that exits from a datacenter IP as datacenter traffic. Commercial VPNs (Mullvad, NordVPN, ProtonVPN, …) all run on cloud providers, so operators who enabled `blockDatacenter` but not `blockVpn` were silently catching VPN end-users they did not intend to block. The datacenter rule is now suppressed when `ipInfo.isVPN` is true and `blockVpn` is false. Closes prosopo/captcha-private#3479.

--- a/packages/provider/src/tasks/spam/checkTrafficFilter.ts
+++ b/packages/provider/src/tasks/spam/checkTrafficFilter.ts
@@ -40,6 +40,15 @@ export type TrafficCheckResult =
  * abuser, etc.) is evaluated independently. A missing or invalid
  * `ipInfo` falls back to "not blocked" so an outage in the upstream
  * service can't block all traffic.
+ *
+ * One cross-filter rule: when an operator enables `blockDatacenter` but
+ * leaves `blockVpn` off, commercial VPNs that exit from datacenter IPs
+ * (which is most of them — Mullvad, NordVPN, ProtonVPN, etc. all run on
+ * AWS/OVH/Hetzner) would otherwise be caught by the datacenter rule.
+ * Operators almost never intend that: "block data centers" is about
+ * scraping/automation traffic, not VPN end-users. So the datacenter
+ * rule is suppressed for IPs also flagged as VPN unless the operator
+ * has opted in to blocking VPN traffic explicitly.
  */
 export const checkTrafficFilter = (
 	ipInfo: IPInfoResponse | undefined,
@@ -74,7 +83,11 @@ export const checkTrafficFilter = (
 		}
 	}
 
-	if (trafficFilter.blockDatacenter && ipInfo.isDatacenter) {
+	if (
+		trafficFilter.blockDatacenter &&
+		ipInfo.isDatacenter &&
+		!(ipInfo.isVPN && !trafficFilter.blockVpn)
+	) {
 		return { isBlocked: true, reason: ResultReason.DATACENTER_BLOCKED };
 	}
 

--- a/packages/provider/src/tests/unit/tasks/spam/checkTrafficFilter.unit.test.ts
+++ b/packages/provider/src/tests/unit/tasks/spam/checkTrafficFilter.unit.test.ts
@@ -106,6 +106,38 @@ describe("checkTrafficFilter", () => {
 		});
 	});
 
+	it("does not block VPN-on-datacenter IPs when blockDatacenter is on but blockVpn is off", () => {
+		// Commercial VPNs run on datacenter IPs. Operators who enabled
+		// datacenter blocking but not VPN blocking did not intend to
+		// catch VPN end-users.
+		const result = checkTrafficFilter(
+			baseInfo({ isDatacenter: true, isVPN: true }),
+			{ ...allBlocked, blockVpn: false },
+		);
+		expect(result).toEqual({ isBlocked: false });
+	});
+
+	it("still blocks raw datacenter (non-VPN) IPs when blockDatacenter is on and blockVpn is off", () => {
+		const result = checkTrafficFilter(
+			baseInfo({ isDatacenter: true, isVPN: false }),
+			{ ...allBlocked, blockVpn: false },
+		);
+		expect(result).toEqual({
+			isBlocked: true,
+			reason: "API.DATACENTER_BLOCKED",
+		});
+	});
+
+	it("blocks VPN-on-datacenter IPs as VPN when both filters are enabled", () => {
+		// The VPN check runs first and short-circuits before the
+		// datacenter rule, so the reason should be VPN_BLOCKED.
+		const result = checkTrafficFilter(
+			baseInfo({ isDatacenter: true, isVPN: true }),
+			allBlocked,
+		);
+		expect(result).toEqual({ isBlocked: true, reason: "API.VPN_BLOCKED" });
+	});
+
 	it("blocks mobile when blockMobile is true", () => {
 		const result = checkTrafficFilter(baseInfo({ isMobile: true }), allBlocked);
 		expect(result).toEqual({ isBlocked: true, reason: "API.MOBILE_BLOCKED" });


### PR DESCRIPTION
## Summary

Closes prosopo/captcha-private#3479.

Commercial VPNs (Mullvad, NordVPN, ProtonVPN, …) all exit from datacenter IPs, so ipinfo flags them as both `isDatacenter: true` and `isVPN: true`. Operators who enabled `blockDatacenter` but left `blockVpn` off were silently catching VPN end-users they did not intend to block — `blockDatacenter` is about scraping / automation traffic, not VPN users.

`checkTrafficFilter` now suppresses the datacenter rule when the IP is also flagged as a VPN and `blockVpn` is `false`. When `blockVpn` is `true` the VPN check runs first and short-circuits with `VPN_BLOCKED`, so both-flagged IPs still get blocked when both filters are on — only the reason code differs.

Only the datacenter/VPN intersection is touched. Proxy and Tor blocking are unchanged (per the ticket).

## Test plan

- [x] Existing 14 `checkTrafficFilter` tests still pass.
- [x] 4 new tests cover: VPN-on-datacenter passes when only datacenter is on; raw datacenter still blocks when only datacenter is on; both-flagged IP returns `VPN_BLOCKED` when both filters are on.
- [x] `npm run -w @prosopo/provider build:tsc` clean.

## Companion PR

- protect: prosopo/Protect#feat/3479-datacenter-vpn-exclusion (separate PR — same issue, different repo).