### PR TITLE
feat(provider): enrich traffic-filter with dnsEvent peer + resolver IPs

### DIFF
--- a/.changeset/traffic-filter-dns-event-extras.md
+++ b/.changeset/traffic-filter-dns-event-extras.md
@@ -1,0 +1,5 @@
+---
+"@prosopo/provider": minor
+---
+
+Extend `checkTrafficFilter` to accept an optional `extraIpInfos` list and apply the same per-rule checks across additional IPs. Each verify path threads `session.dnsEvent` IPs through `resolveTrafficFilterCheck` so its peer / resolver enrichments are evaluated alongside the primary client IP.

--- a/packages/provider/src/tasks/captchaManager.ts
+++ b/packages/provider/src/tasks/captchaManager.ts
@@ -648,6 +648,8 @@ export class CaptchaManager {
 	 * - If the dapp's server passed up the end user's current IP via the
 	 *   verify call, look that up fresh — it's the "now" IP for filtering
 	 *   and may differ from the IP that originally requested the captcha.
+	 * - When the session carries a `dnsEvent`, its `peerIp` and `resolverIp`
+	 *   are enriched and passed alongside the primary IP.
 	 * - `blockAbuser` defaults to true so abusive networks are always
 	 *   blocked even when the site hasn't configured a trafficFilter.
 	 * - Returns `{ isBlocked: false }` if every filter flag is off, without
@@ -662,16 +664,31 @@ export class CaptchaManager {
 		recordIpInfo: IPInfoResponse | undefined,
 		trafficFilter: Partial<ITrafficFilter> | undefined,
 		currentIp?: string,
+		dnsEvent?: Session["dnsEvent"],
 	): Promise<TrafficCheckResult> {
 		const effective = { blockAbuser: true, ...trafficFilter };
 		const hasAny = Object.values(effective).some((v) => v);
 		if (!hasAny) {
 			return { isBlocked: false };
 		}
-		const ipInfo = currentIp
-			? await env.ipInfoService.lookup(currentIp)
-			: recordIpInfo;
-		return checkTrafficFilter(ipInfo, effective);
+
+		const dnsIps = new Set<string>();
+		const primaryIp = currentIp ?? recordIpInfo?.ip;
+		const dnsPeerIp = dnsEvent?.peerIp;
+		const dnsResolverIp = dnsEvent?.resolverIp;
+		if (dnsPeerIp && dnsPeerIp !== primaryIp) {
+			dnsIps.add(dnsPeerIp);
+		}
+		if (dnsResolverIp && dnsResolverIp !== primaryIp) {
+			dnsIps.add(dnsResolverIp);
+		}
+
+		const [ipInfo, ...extras] = await Promise.all([
+			currentIp ? env.ipInfoService.lookup(currentIp) : recordIpInfo,
+			...[...dnsIps].map((ip) => env.ipInfoService.lookup(ip)),
+		]);
+
+		return checkTrafficFilter(ipInfo, effective, extras);
 	}
 
 	static canClientSeeScore(tier: Tier, score?: number) {

--- a/packages/provider/src/tasks/imgCaptcha/imgCaptchaTasks.ts
+++ b/packages/provider/src/tasks/imgCaptcha/imgCaptchaTasks.ts
@@ -792,6 +792,10 @@ export class ImgCaptchaManager extends CaptchaManager {
 			}
 		}
 
+		const sessionRecord = solution.sessionId
+			? await this.db.getSessionRecordBySessionId(solution.sessionId)
+			: undefined;
+
 		// Traffic filter: block VPN/proxy/Tor/abuser etc. Resolved in
 		// CaptchaManager so all three verify paths (pow/image/puzzle)
 		// share the same "compute effective filter, optionally fresh
@@ -802,6 +806,7 @@ export class ImgCaptchaManager extends CaptchaManager {
 				solution.ipInfo,
 				trafficFilter,
 				ip,
+				sessionRecord?.dnsEvent,
 			);
 			if (check.isBlocked) {
 				this.logger.info(() => ({
@@ -883,46 +888,41 @@ export class ImgCaptchaManager extends CaptchaManager {
 		}
 
 		let score: number | undefined;
-		if (solution.sessionId) {
-			const sessionRecord = await this.db.getSessionRecordBySessionId(
-				solution.sessionId,
-			);
-			if (sessionRecord) {
-				score = computeFrictionlessScore(sessionRecord?.scoreComponents);
-				this.logger.info(() => ({
-					data: {
-						scoreComponents: sessionRecord?.scoreComponents,
-						score: score,
-					},
-				}));
+		if (sessionRecord) {
+			score = computeFrictionlessScore(sessionRecord?.scoreComponents);
+			this.logger.info(() => ({
+				data: {
+					scoreComponents: sessionRecord?.scoreComponents,
+					score: score,
+				},
+			}));
 
-				if (
-					!failStatus &&
-					disallowWebView === true &&
-					(sessionRecord.webView === true ||
-						(sessionRecord.scoreComponents.webView || 0) > 0)
-				) {
-					this.logger.info(() => ({
-						msg: "Disallowing webview access - user not verified",
-					}));
-					commitmentUpdates.result = {
-						status: CaptchaStatus.disapproved,
-						reason: ResultReason.DISALLOWED_WEBVIEW,
-					};
-					failStatus = ResultReason.DISALLOWED_WEBVIEW;
-					isApproved = false;
-					failureStatus = ResultReason.DISALLOWED_WEBVIEW;
-				}
-				if (
-					contextAwareEnabled &&
-					sessionRecord.reason ===
-						FrictionlessReason.CONTEXT_AWARE_VALIDATION_FAILED
-				) {
-					this.logger.info(() => ({
-						msg: "Context aware validation failed",
-					}));
-					//return { status: "API.USER_NOT_VERIFIED", verified: false };
-				}
+			if (
+				!failStatus &&
+				disallowWebView === true &&
+				(sessionRecord.webView === true ||
+					(sessionRecord.scoreComponents.webView || 0) > 0)
+			) {
+				this.logger.info(() => ({
+					msg: "Disallowing webview access - user not verified",
+				}));
+				commitmentUpdates.result = {
+					status: CaptchaStatus.disapproved,
+					reason: ResultReason.DISALLOWED_WEBVIEW,
+				};
+				failStatus = ResultReason.DISALLOWED_WEBVIEW;
+				isApproved = false;
+				failureStatus = ResultReason.DISALLOWED_WEBVIEW;
+			}
+			if (
+				contextAwareEnabled &&
+				sessionRecord.reason ===
+					FrictionlessReason.CONTEXT_AWARE_VALIDATION_FAILED
+			) {
+				this.logger.info(() => ({
+					msg: "Context aware validation failed",
+				}));
+				//return { status: "API.USER_NOT_VERIFIED", verified: false };
 			}
 		}
 

--- a/packages/provider/src/tasks/powCaptcha/powTasks.ts
+++ b/packages/provider/src/tasks/powCaptcha/powTasks.ts
@@ -663,6 +663,10 @@ export class PowCaptchaManager extends CaptchaManager {
 			}
 		}
 
+		const sessionRecord = challengeRecord.sessionId
+			? await this.db.getSessionRecordBySessionId(challengeRecord.sessionId)
+			: undefined;
+
 		// Traffic filter: block VPN/proxy/Tor/abuser etc. Resolved in
 		// CaptchaManager so all three verify paths (pow/image/puzzle)
 		// share the same "compute effective filter, optionally fresh
@@ -673,6 +677,7 @@ export class PowCaptchaManager extends CaptchaManager {
 				challengeRecord.ipInfo,
 				trafficFilter,
 				ip,
+				sessionRecord?.dnsEvent,
 			);
 			if (check.isBlocked) {
 				this.logger.info(() => ({
@@ -736,19 +741,14 @@ export class PowCaptchaManager extends CaptchaManager {
 		}
 
 		let score: number | undefined;
-		if (challengeRecord.sessionId) {
-			const sessionRecord = await this.db.getSessionRecordBySessionId(
-				challengeRecord.sessionId,
-			);
-			if (sessionRecord) {
-				score = computeFrictionlessScore(sessionRecord?.scoreComponents);
-				this.logger.info(() => ({
-					data: {
-						scoreComponents: { ...(sessionRecord?.scoreComponents || {}) },
-						score,
-					},
-				}));
-			}
+		if (sessionRecord) {
+			score = computeFrictionlessScore(sessionRecord?.scoreComponents);
+			this.logger.info(() => ({
+				data: {
+					scoreComponents: { ...(sessionRecord?.scoreComponents || {}) },
+					score,
+				},
+			}));
 		}
 
 		// Decision machine evaluation (only if no prior failures)

--- a/packages/provider/src/tasks/puzzleCaptcha/puzzleTasks.ts
+++ b/packages/provider/src/tasks/puzzleCaptcha/puzzleTasks.ts
@@ -533,6 +533,10 @@ export class PuzzleCaptchaManager extends CaptchaManager {
 			}
 		}
 
+		const sessionRecord = challengeRecord.sessionId
+			? await this.db.getSessionRecordBySessionId(challengeRecord.sessionId)
+			: undefined;
+
 		// Traffic filter: block VPN/proxy/Tor/abuser etc. Resolved in
 		// CaptchaManager so all three verify paths (pow/image/puzzle)
 		// share the same "compute effective filter, optionally fresh
@@ -543,6 +547,7 @@ export class PuzzleCaptchaManager extends CaptchaManager {
 				challengeRecord.ipInfo,
 				trafficFilter,
 				ip,
+				sessionRecord?.dnsEvent,
 			);
 			if (check.isBlocked) {
 				this.logger.info(() => ({
@@ -626,19 +631,14 @@ export class PuzzleCaptchaManager extends CaptchaManager {
 		}
 
 		let score: number | undefined;
-		if (challengeRecord.sessionId) {
-			const sessionRecord = await this.db.getSessionRecordBySessionId(
-				challengeRecord.sessionId,
-			);
-			if (sessionRecord) {
-				score = computeFrictionlessScore(sessionRecord?.scoreComponents);
-				this.logger.info(() => ({
-					data: {
-						scoreComponents: { ...(sessionRecord?.scoreComponents || {}) },
-						score,
-					},
-				}));
-			}
+		if (sessionRecord) {
+			score = computeFrictionlessScore(sessionRecord?.scoreComponents);
+			this.logger.info(() => ({
+				data: {
+					scoreComponents: { ...(sessionRecord?.scoreComponents || {}) },
+					score,
+				},
+			}));
 		}
 
 		// We know solution is correct by this point. Run decision machine evaluation to process additional checks.

--- a/packages/provider/src/tasks/spam/checkTrafficFilter.ts
+++ b/packages/provider/src/tasks/spam/checkTrafficFilter.ts
@@ -33,26 +33,14 @@ export type TrafficCheckResult =
 	| { isBlocked: false }
 	| { isBlocked: true; reason: TrafficBlockReason };
 
-/**
- * Checks whether a request should be blocked based on traffic filter
- * settings and the request's already-resolved IP info (attached to
- * `req.ipInfo` by `ipInfoMiddleware`). Each filter (VPN, proxy, Tor,
- * abuser, etc.) is evaluated independently. A missing or invalid
- * `ipInfo` falls back to "not blocked" so an outage in the upstream
- * service can't block all traffic.
- *
- * One cross-filter rule: when an operator enables `blockDatacenter` but
- * leaves `blockVpn` off, commercial VPNs that exit from datacenter IPs
- * (which is most of them — Mullvad, NordVPN, ProtonVPN, etc. all run on
- * AWS/OVH/Hetzner) would otherwise be caught by the datacenter rule.
- * Operators almost never intend that: "block data centers" is about
- * scraping/automation traffic, not VPN end-users. So the datacenter
- * rule is suppressed for IPs also flagged as VPN unless the operator
- * has opted in to blocking VPN traffic explicitly.
- */
-export const checkTrafficFilter = (
+type EvaluateOptions = {
+	suppressVpnDatacenterInteraction: boolean;
+};
+
+const evaluateIpInfo = (
 	ipInfo: IPInfoResponse | undefined,
 	trafficFilter: Partial<ITrafficFilter>,
+	options: EvaluateOptions,
 ): TrafficCheckResult => {
 	if (!ipInfo || !ipInfo.isValid) {
 		return { isBlocked: false };
@@ -86,7 +74,11 @@ export const checkTrafficFilter = (
 	if (
 		trafficFilter.blockDatacenter &&
 		ipInfo.isDatacenter &&
-		!(ipInfo.isVPN && !trafficFilter.blockVpn)
+		!(
+			options.suppressVpnDatacenterInteraction &&
+			ipInfo.isVPN &&
+			!trafficFilter.blockVpn
+		)
 	) {
 		return { isBlocked: true, reason: ResultReason.DATACENTER_BLOCKED };
 	}
@@ -101,6 +93,47 @@ export const checkTrafficFilter = (
 
 	if (trafficFilter.blockCrawler && ipInfo.isCrawler) {
 		return { isBlocked: true, reason: ResultReason.CRAWLER_BLOCKED };
+	}
+
+	return { isBlocked: false };
+};
+
+/**
+ * Checks whether a request should be blocked based on traffic filter
+ * settings and the request's already-resolved IP info (attached to
+ * `req.ipInfo` by `ipInfoMiddleware`). Each filter (VPN, proxy, Tor,
+ * abuser, etc.) is evaluated independently. A missing or invalid
+ * `ipInfo` falls back to "not blocked" so an outage in the upstream
+ * service can't block all traffic.
+ *
+ * One cross-filter rule: when an operator enables `blockDatacenter` but
+ * leaves `blockVpn` off, commercial VPNs that exit from datacenter IPs
+ * (which is most of them — Mullvad, NordVPN, ProtonVPN, etc. all run on
+ * AWS/OVH/Hetzner) would otherwise be caught by the datacenter rule.
+ * Operators almost never intend that: "block data centers" is about
+ * scraping/automation traffic, not VPN end-users. So the datacenter
+ * rule is suppressed for IPs also flagged as VPN unless the operator
+ * has opted in to blocking VPN traffic explicitly.
+ */
+export const checkTrafficFilter = (
+	ipInfo: IPInfoResponse | undefined,
+	trafficFilter: Partial<ITrafficFilter>,
+	extraIpInfos?: ReadonlyArray<IPInfoResponse | undefined>,
+): TrafficCheckResult => {
+	const primary = evaluateIpInfo(ipInfo, trafficFilter, {
+		suppressVpnDatacenterInteraction: true,
+	});
+	if (primary.isBlocked) {
+		return primary;
+	}
+
+	for (const extra of extraIpInfos ?? []) {
+		const result = evaluateIpInfo(extra, trafficFilter, {
+			suppressVpnDatacenterInteraction: false,
+		});
+		if (result.isBlocked) {
+			return result;
+		}
 	}
 
 	return { isBlocked: false };

--- a/packages/provider/src/tests/unit/tasks/spam/checkTrafficFilter.unit.test.ts
+++ b/packages/provider/src/tests/unit/tasks/spam/checkTrafficFilter.unit.test.ts
@@ -196,4 +196,87 @@ describe("checkTrafficFilter", () => {
 		);
 		expect(result).toEqual({ isBlocked: false });
 	});
+
+	describe("extraIpInfos", () => {
+		const cleanPrimary = baseInfo({ ip: "192.0.2.1" });
+
+		it("blocks when an extra IP is a datacenter", () => {
+			const result = checkTrafficFilter(cleanPrimary, allBlocked, [
+				baseInfo({ ip: "198.51.100.10", isDatacenter: true }),
+			]);
+			expect(result).toEqual({
+				isBlocked: true,
+				reason: "API.DATACENTER_BLOCKED",
+			});
+		});
+
+		it("blocks when an extra IP exceeds the abuser score threshold", () => {
+			const result = checkTrafficFilter(
+				cleanPrimary,
+				{ ...allBlocked, abuserScoreThreshold: 80 },
+				[
+					baseInfo({
+						ip: "203.0.113.10",
+						isAbuser: true,
+						abuserScore: 95,
+					}),
+				],
+			);
+			expect(result).toEqual({
+				isBlocked: true,
+				reason: "API.ABUSER_BLOCKED",
+			});
+		});
+
+		it("does NOT apply VPN-datacenter suppression to extra IPs", () => {
+			const noVpnBlock: ITrafficFilter = { ...allBlocked, blockVpn: false };
+			const result = checkTrafficFilter(cleanPrimary, noVpnBlock, [
+				baseInfo({
+					ip: "198.51.100.10",
+					isVPN: true,
+					isDatacenter: true,
+				}),
+			]);
+			expect(result).toEqual({
+				isBlocked: true,
+				reason: "API.DATACENTER_BLOCKED",
+			});
+		});
+
+		it("does apply VPN-datacenter suppression to the primary IP", () => {
+			const noVpnBlock: ITrafficFilter = { ...allBlocked, blockVpn: false };
+			const result = checkTrafficFilter(
+				baseInfo({ isVPN: true, isDatacenter: true }),
+				noVpnBlock,
+			);
+			expect(result).toEqual({ isBlocked: false });
+		});
+
+		it("allows through when extra IPs are clean", () => {
+			const result = checkTrafficFilter(cleanPrimary, allBlocked, [
+				baseInfo({ ip: "8.8.8.8" }),
+				baseInfo({ ip: "1.1.1.1" }),
+			]);
+			expect(result).toEqual({ isBlocked: false });
+		});
+
+		it("ignores undefined / invalid entries in the extras list", () => {
+			const result = checkTrafficFilter(cleanPrimary, allBlocked, [
+				undefined,
+				{ isValid: false, error: "lookup failed", ip: "1.2.3.4" },
+				baseInfo({ ip: "198.51.100.10", isDatacenter: true }),
+			]);
+			expect(result).toEqual({
+				isBlocked: true,
+				reason: "API.DATACENTER_BLOCKED",
+			});
+		});
+
+		it("primary block takes precedence over extra block", () => {
+			const result = checkTrafficFilter(baseInfo({ isTor: true }), allBlocked, [
+				baseInfo({ ip: "198.51.100.10", isDatacenter: true }),
+			]);
+			expect(result).toEqual({ isBlocked: true, reason: "API.TOR_BLOCKED" });
+		});
+	});
 });


### PR DESCRIPTION
## Summary

`checkTrafficFilter` now accepts an optional `extraIpInfos` list and applies the same per-rule checks (VPN / proxy / Tor / abuser / datacenter / mobile / satellite / crawler) to every entry. The VPN-datacenter cross-filter suppression remains primary-only.

`resolveTrafficFilterCheck` accepts an optional `dnsEvent` and enriches its `peerIp` + `resolverIp` in parallel with the primary lookup, deduped against the primary IP, then forwards as `extraIpInfos`.

Each of the three verify paths (pow / image / puzzle) hoists the existing session fetch above the traffic-filter call so the same `sessionRecord` is reused for both `dnsEvent` enrichment and the existing score / webview checks — no new DB calls.

## Tests

`checkTrafficFilter.unit.test.ts` extended from 18 to 25 cases covering the new branches and the primary-vs-extra suppression asymmetry. Img / pow / puzzle suites unchanged at 108 passing.

## Test plan

- [ ] CI green
- [ ] In staging, verify with a sessionId whose `dnsEvent.resolverIp` falls within a configured `blockDatacenter` source and confirm `DATACENTER_BLOCKED`.
- [ ] Verify the primary-IP VPN-DC suppression still allows commercial-VPN users on sites with `blockDatacenter: true, blockVpn: false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)