### PR TITLE
feat(image-captcha): propagate checkbox-click coords through submit salt

### DIFF
--- a/.changeset/image-checkbox-coords.md
+++ b/.changeset/image-checkbox-coords.md
@@ -1,0 +1,7 @@
+---
+"@prosopo/procaptcha": patch
+"@prosopo/procaptcha-react": patch
+"@prosopo/provider": patch
+---
+
+Image-captcha widget now forwards the trusted checkbox click `(clientX, clientY)` through `manager.start(x, y)`. `Manager.submit` embeds the pair as a 2-number prefix on the first captcha's solution salt. Provider peels the prefix via length math against `solution.length` (no protocol version flag — older clients keep working unchanged) and prepends it as the first entry of `pairs`, which is written to `UserCommitment.coords`. Adds `peelCheckboxPrefix` helper in `pairs.ts` with round-trip unit tests.

--- a/packages/procaptcha-react/src/components/ProcaptchaWidget.tsx
+++ b/packages/procaptcha-react/src/components/ProcaptchaWidget.tsx
@@ -157,8 +157,8 @@ const ProcaptchaWidget = (props: ProcaptchaProps) => {
 			<TestModeBanner siteKey={config.account.address ?? ""} />
 			<Checkbox
 				theme={theme}
-				onChange={async (e: { isTrusted: boolean }) => {
-					if (!e.isTrusted) {
+				onChange={async (event: React.MouseEvent | React.TouchEvent) => {
+					if (!event.isTrusted) {
 						return;
 					}
 
@@ -166,7 +166,26 @@ const ProcaptchaWidget = (props: ProcaptchaProps) => {
 						return;
 					}
 					setLoading(true);
-					await manager.start();
+
+					let x = 0;
+					let y = 0;
+					const nativeEvent = event.nativeEvent;
+					if (
+						"touches" in nativeEvent &&
+						nativeEvent.touches.length > 0 &&
+						nativeEvent.touches[0]
+					) {
+						x = nativeEvent.touches[0].clientX;
+						y = nativeEvent.touches[0].clientY;
+					} else if (
+						"clientX" in nativeEvent &&
+						"clientY" in nativeEvent
+					) {
+						x = nativeEvent.clientX;
+						y = nativeEvent.clientY;
+					}
+
+					await manager.start(x, y);
 					setLoading(false);
 				}}
 				checked={state.isHuman}

--- a/packages/procaptcha-react/src/components/ProcaptchaWidget.tsx
+++ b/packages/procaptcha-react/src/components/ProcaptchaWidget.tsx
@@ -177,10 +177,7 @@ const ProcaptchaWidget = (props: ProcaptchaProps) => {
 					) {
 						x = nativeEvent.touches[0].clientX;
 						y = nativeEvent.touches[0].clientY;
-					} else if (
-						"clientX" in nativeEvent &&
-						"clientY" in nativeEvent
-					) {
+					} else if ("clientX" in nativeEvent && "clientY" in nativeEvent) {
 						x = nativeEvent.clientX;
 						y = nativeEvent.clientY;
 					}

--- a/packages/procaptcha/src/modules/Manager.ts
+++ b/packages/procaptcha/src/modules/Manager.ts
@@ -79,6 +79,9 @@ export function Manager(
 	// get the state update mechanism
 	const updateState = buildUpdateState(state, onStateUpdate);
 
+	let checkboxClickX = 0;
+	let checkboxClickY = 0;
+
 	/**
 	 * Build the config on demand, using the optional config passed in from the outside. State may override various
 	 * config values depending on the state of the captcha process. E.g. if the process has been started using account
@@ -102,7 +105,9 @@ export function Manager(
 	/**
 	 * Called on start of user verification. This is when the user ticks the box to claim they are human.
 	 */
-	const start = async () => {
+	const start = async (checkboxX = 0, checkboxY = 0) => {
+		checkboxClickX = checkboxX;
+		checkboxClickY = checkboxY;
 		events.onOpen();
 		await providerRetry(
 			async () => {
@@ -243,7 +248,11 @@ export function Manager(
 				const captchaSolution: CaptchaSolution[] = state.challenge.captchas.map(
 					(captcha, index) => {
 						const solution = at(state.solutions, index);
-						const coords = solution.flatMap(([_, x, y]) => [x, y]);
+						const shapeCoords = solution.flatMap(([_, x, y]) => [x, y]);
+						const coords =
+							index === 0
+								? [checkboxClickX, checkboxClickY, ...shapeCoords]
+								: shapeCoords;
 						const salt = randomAsHex(
 							coords
 								.map((x) => x.toString(16).length + 4)

--- a/packages/provider/src/pairs.ts
+++ b/packages/provider/src/pairs.ts
@@ -30,6 +30,23 @@ export const constructPairList = (list: number[]): [number, number][] => {
 	return pairList;
 };
 
+export const peelCheckboxPrefix = (
+	flat: number[][],
+	solutionLengths: number[],
+): { checkbox?: [number, number]; flat: number[][] } => {
+	const firstFlat = flat[0];
+	const firstLen = solutionLengths[0];
+	if (firstFlat === undefined || firstLen === undefined) {
+		return { flat };
+	}
+	if (firstFlat.length === 2 * firstLen + 2) {
+		const checkbox: [number, number] = [at(firstFlat, 0), at(firstFlat, 1)];
+		const stripped = [firstFlat.slice(2), ...flat.slice(1)];
+		return { checkbox, flat: stripped };
+	}
+	return { flat };
+};
+
 /**
  * Check if there are identical pairs in flattened lists of pairs
  * @param pairsLists

--- a/packages/provider/src/tasks/imgCaptcha/imgCaptchaTasks.ts
+++ b/packages/provider/src/tasks/imgCaptcha/imgCaptchaTasks.ts
@@ -57,7 +57,11 @@ import {
 	getCompositeIpAddress,
 	getIpAddressFromComposite,
 } from "../../compositeIpAddress.js";
-import { constructPairList, containsIdenticalPairs } from "../../pairs.js";
+import {
+	constructPairList,
+	containsIdenticalPairs,
+	peelCheckboxPrefix,
+} from "../../pairs.js";
 import { checkLangRules } from "../../rules/lang.js";
 import { deepValidateIpAddress, shuffleArray } from "../../util.js";
 import {
@@ -302,8 +306,15 @@ export class ImgCaptchaManager extends CaptchaManager {
 			const { storedCaptchas, receivedCaptchas, captchaIds } =
 				await this.validateReceivedCaptchasAgainstStoredCaptchas(captchas);
 
-			const flat = receivedCaptchas.map((c) => extractData(c.salt));
-			const pairs = flat.map((list) => constructPairList(list));
+			const rawFlat = receivedCaptchas.map((c) => extractData(c.salt));
+			const { checkbox: checkboxCoordPair, flat } = peelCheckboxPrefix(
+				rawFlat,
+				receivedCaptchas.map((c) => c.solution.length),
+			);
+			const shapePairs = flat.map((list) => constructPairList(list));
+			const pairs: [number, number][][] = checkboxCoordPair
+				? [[checkboxCoordPair], ...shapePairs]
+				: shapePairs;
 
 			const { tree, commitmentId } =
 				buildTreeAndGetCommitmentId(receivedCaptchas);

--- a/packages/provider/src/tests/unit/pairs.unit.test.ts
+++ b/packages/provider/src/tests/unit/pairs.unit.test.ts
@@ -13,7 +13,13 @@
 // limitations under the License.
 
 import { describe, expect, it } from "vitest";
-import { constructPairList, containsIdenticalPairs } from "../../pairs.js";
+import {
+	constructPairList,
+	containsIdenticalPairs,
+	peelCheckboxPrefix,
+} from "../../pairs.js";
+import { embedData, extractData } from "@prosopo/util";
+import { randomAsHex } from "@prosopo/util-crypto";
 
 describe("constructPairList", () => {
 	it("should construct pairs from even-length array", () => {
@@ -287,5 +293,94 @@ describe("containsIdenticalPairs", () => {
 		const result = containsIdenticalPairs(input);
 
 		expect(result).toBe(false);
+	});
+});
+
+const buildSalt = (data: number[]): string => {
+	const hexLength = data
+		.map((d) => d.toString(16).length + 4)
+		.reduce((acc, curr) => acc + curr, 0);
+	const randomHex = randomAsHex(hexLength);
+	return embedData(randomHex, data);
+};
+
+describe("peelCheckboxPrefix", () => {
+	it("returns no prefix when first list length matches 2 * solution.length", () => {
+		const salt0 = buildSalt([10, 20, 30, 40]);
+		const salt1 = buildSalt([50, 60]);
+		const flat = [extractData(salt0), extractData(salt1)];
+		const { checkbox, flat: out } = peelCheckboxPrefix(flat, [2, 1]);
+		expect(checkbox).toBeUndefined();
+		expect(out).toEqual(flat);
+	});
+
+	it("peels [x, y] when first list length is 2 * solution.length + 2", () => {
+		const salt0 = buildSalt([7, 13, 10, 20, 30, 40]);
+		const salt1 = buildSalt([50, 60]);
+		const flat = [extractData(salt0), extractData(salt1)];
+		const { checkbox, flat: out } = peelCheckboxPrefix(flat, [2, 1]);
+		expect(checkbox).toEqual([7, 13]);
+		expect(out[0]).toEqual([10, 20, 30, 40]);
+		expect(out[1]).toEqual([50, 60]);
+	});
+
+	it("round-trips client embed → server peel → constructPairList → prepend", () => {
+		const checkboxX = 142;
+		const checkboxY = 87;
+		const captcha0Shapes = [299, 244, 299, 352, 170, 358];
+		const captcha1Shapes = [180, 470, 297, 481];
+
+		const salt0 = buildSalt([checkboxX, checkboxY, ...captcha0Shapes]);
+		const salt1 = buildSalt(captcha1Shapes);
+
+		const rawFlat = [extractData(salt0), extractData(salt1)];
+		const { checkbox, flat } = peelCheckboxPrefix(
+			rawFlat,
+			[captcha0Shapes.length / 2, captcha1Shapes.length / 2],
+		);
+		const shapePairs = flat.map((list) => constructPairList(list));
+		const pairs = checkbox ? [[checkbox], ...shapePairs] : shapePairs;
+
+		expect(pairs).toEqual([
+			[[checkboxX, checkboxY]],
+			[
+				[299, 244],
+				[299, 352],
+				[170, 358],
+			],
+			[
+				[180, 470],
+				[297, 481],
+			],
+		]);
+	});
+
+	it("leaves rawFlat unchanged when only an older client (no prefix) submits", () => {
+		const captcha0Shapes = [10, 20, 30, 40];
+		const captcha1Shapes = [50, 60];
+		const salt0 = buildSalt(captcha0Shapes);
+		const salt1 = buildSalt(captcha1Shapes);
+
+		const rawFlat = [extractData(salt0), extractData(salt1)];
+		const { checkbox, flat } = peelCheckboxPrefix(
+			rawFlat,
+			[captcha0Shapes.length / 2, captcha1Shapes.length / 2],
+		);
+		const pairs = flat.map((list) => constructPairList(list));
+
+		expect(checkbox).toBeUndefined();
+		expect(pairs).toEqual([
+			[
+				[10, 20],
+				[30, 40],
+			],
+			[
+				[50, 60],
+			],
+		]);
+	});
+
+	it("handles empty inputs without throwing", () => {
+		expect(peelCheckboxPrefix([], [])).toEqual({ flat: [] });
 	});
 });

--- a/packages/provider/src/tests/unit/pairs.unit.test.ts
+++ b/packages/provider/src/tests/unit/pairs.unit.test.ts
@@ -12,14 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { embedData, extractData } from "@prosopo/util";
+import { randomAsHex } from "@prosopo/util-crypto";
 import { describe, expect, it } from "vitest";
 import {
 	constructPairList,
 	containsIdenticalPairs,
 	peelCheckboxPrefix,
 } from "../../pairs.js";
-import { embedData, extractData } from "@prosopo/util";
-import { randomAsHex } from "@prosopo/util-crypto";
 
 describe("constructPairList", () => {
 	it("should construct pairs from even-length array", () => {
@@ -334,10 +334,10 @@ describe("peelCheckboxPrefix", () => {
 		const salt1 = buildSalt(captcha1Shapes);
 
 		const rawFlat = [extractData(salt0), extractData(salt1)];
-		const { checkbox, flat } = peelCheckboxPrefix(
-			rawFlat,
-			[captcha0Shapes.length / 2, captcha1Shapes.length / 2],
-		);
+		const { checkbox, flat } = peelCheckboxPrefix(rawFlat, [
+			captcha0Shapes.length / 2,
+			captcha1Shapes.length / 2,
+		]);
 		const shapePairs = flat.map((list) => constructPairList(list));
 		const pairs = checkbox ? [[checkbox], ...shapePairs] : shapePairs;
 
@@ -362,10 +362,10 @@ describe("peelCheckboxPrefix", () => {
 		const salt1 = buildSalt(captcha1Shapes);
 
 		const rawFlat = [extractData(salt0), extractData(salt1)];
-		const { checkbox, flat } = peelCheckboxPrefix(
-			rawFlat,
-			[captcha0Shapes.length / 2, captcha1Shapes.length / 2],
-		);
+		const { checkbox, flat } = peelCheckboxPrefix(rawFlat, [
+			captcha0Shapes.length / 2,
+			captcha1Shapes.length / 2,
+		]);
 		const pairs = flat.map((list) => constructPairList(list));
 
 		expect(checkbox).toBeUndefined();
@@ -374,9 +374,7 @@ describe("peelCheckboxPrefix", () => {
 				[10, 20],
 				[30, 40],
 			],
-			[
-				[50, 60],
-			],
+			[[50, 60]],
 		]);
 	});
 


### PR DESCRIPTION
## Summary

- Image-flow widget reads the trusted checkbox click `(clientX, clientY)` and passes it to `manager.start(x, y)`.
- `Manager.submit` embeds it as a 2-number prefix on the first captcha's solution salt; remaining captchas unchanged.
- Provider peels the prefix via length math (`flat[0].length === 2 * solution.length + 2`) and prepends it as the first entry of `pairs`, which is written to `UserCommitment.coords`.
- New helper `peelCheckboxPrefix` in `pairs.ts`. Older clients embed no prefix; provider keeps existing behaviour for them — no protocol version flag required.

## Test plan

- [x] New round-trip unit tests in `pairs.unit.test.ts` covering: prefix present, prefix absent, empty inputs, and the full client-embed → server-extract → peel → `constructPairList` flow. 29/29 pass.
- [x] `tsc` clean on `@prosopo/procaptcha`, `@prosopo/procaptcha-react`, `@prosopo/provider`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)