### PR TITLE
fix(ci): unshallow base fetch in dependabot-changeset (no-merge-base race)

### DIFF
--- a/.github/workflows/dependabot-changeset.yml
+++ b/.github/workflows/dependabot-changeset.yml
@@ -72,7 +72,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.PROSOPONATOR_PAT }}
         run: |
-          git fetch origin "$BASE_REF" --depth=1
+          # No --depth here: a shallow fetch cuts the base branch's history, so if the
+          # base advanced after this PR branch was created/rebased, `git diff
+          # origin/$BASE_REF...HEAD` in the script fails with "no merge base".
+          # checkout above already ran with fetch-depth: 0, so this fetch is cheap.
+          git fetch origin "$BASE_REF"
           node .github/scripts/dependabot-changeset.mjs
 
       - name: Commit and push


### PR DESCRIPTION
Follow-up to #2662. Two of the rebased Dependabot PRs (#2608, #2581) still failed the `changeset` job, with:

```
fatal: origin/main...HEAD: no merge base
```

**Race:** Dependabot rebased those branches onto the then-tip of main (`67f0727`), but #2665 merged a minute later. The workflow then ran `git fetch origin main --depth=1`, which shallow-fetches only the *new* main tip (`2d66d8e`) with its parent history cut off — so the actual merge base (`67f0727`) is unreachable and `git diff origin/main...HEAD` in `dependabot-changeset.mjs` aborts. Any merge to main in the window between a Dependabot push and the workflow's fetch reproduces this.

**Fix:** drop `--depth=1`. The checkout step already uses `fetch-depth: 0`, so a plain `git fetch origin \"$BASE_REF\"` is cheap and always has a merge base.

The same latent bug exists in captcha-private's copy of this workflow; I'll port it there separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)