### PR TITLE
feat(caddy): respond to load-balanced pronode.prosopo.io alongside per-host

### DIFF
--- a/docker/provider.Caddyfile
+++ b/docker/provider.Caddyfile
@@ -90,21 +90,15 @@ http://:9090 {
 	metrics /metrics
 }
 
-# Main site: bound on :8443. Layer4 (above) proxies non-trap-subzone
-# SNI connections from :443 in. ACME issuer is restricted to HTTP-01
-# because TLS-ALPN-01 requires control of :443. The :80 redirect
-# server is auto-created by Caddy (auto_https=on); it serves both
-# ACME HTTP-01 challenges AND HTTP→HTTPS redirects targeting port
-# 443 (i.e. the layer4 listener), which forwards non-matching SNIs
-# back to this same :8443 server.
-https://{$CADDY_DOMAIN}:8443 {
-
-	tls {
-		issuer acme {
-			disable_tlsalpn_challenge
-		}
-	}
-	
+# Shared route/handler config. Imported by both the per-host site
+# ({$CADDY_DOMAIN} = pronodeN.prosopo.io) and the load-balanced site
+# ({$CADDY_GLOBAL_DOMAIN} = pronode.prosopo.io). Only the TLS strategy
+# differs between the two: per-host uses ACME HTTP-01 (works because each
+# pronodeN's A record points to one IP), load-balanced uses `tls internal`
+# because DNS round-robin breaks HTTP-01 challenges — a real cert
+# distribution mechanism (shared storage, DNS-01, or pre-provisioned PEM)
+# is a follow-up.
+(provider_site) {
 	handle /robots.txt {
 		uri strip_prefix / # removes leading /, so it looks directly in root
 		root * /srv/static
@@ -289,4 +283,32 @@ https://{$CADDY_DOMAIN}:8443 {
 	log {
 		format json
 	}
+}
+
+# Per-host site: bound on :8443. Layer4 (above) proxies non-trap-subzone
+# SNI connections from :443 in. ACME issuer is restricted to HTTP-01
+# because TLS-ALPN-01 requires control of :443. The :80 redirect server
+# is auto-created by Caddy (auto_https=on); it serves both ACME HTTP-01
+# challenges AND HTTP→HTTPS redirects targeting port 443 (i.e. the layer4
+# listener), which forwards non-matching SNIs back to this same :8443.
+https://{$CADDY_DOMAIN}:8443 {
+	tls {
+		issuer acme {
+			disable_tlsalpn_challenge
+		}
+	}
+	import provider_site
+}
+
+# Load-balanced site for pronode.prosopo.io. Pronode operators round-robin
+# DNS this hostname across every pronode, so ACME HTTP-01 doesn't work
+# here — challenges land on whichever node DNS hands out, which usually
+# isn't the one renewing. `tls internal` issues a Caddy-CA cert so the
+# layer4 → :8443 routing path is exercised without Caddy attempting (and
+# failing) ACME for this hostname. Replace with a real cert strategy
+# (shared storage / DNS-01 / pre-provisioned PEM) before this domain
+# is exposed to real browser traffic.
+https://{$CADDY_GLOBAL_DOMAIN}:8443 {
+	tls internal
+	import provider_site
 }


### PR DESCRIPTION
## Summary

- Extracts the existing route/handler block in `docker/provider.Caddyfile` into a `(provider_site)` snippet imported by two site blocks
- `{$CADDY_DOMAIN}` (pronodeN.prosopo.io) keeps ACME HTTP-01 — works because each pronode's A record points to one IP
- Adds `{$CADDY_GLOBAL_DOMAIN}` (pronode.prosopo.io) with `tls internal` as a placeholder cert. DNS round-robins this hostname across all pronodes, which breaks HTTP-01 per-node renewal; the real cert strategy (shared storage, DNS-01, or pre-provisioned PEM) is intentionally a follow-up
- The layer4 :443 SNI router needs no change — its matcher only catches `*.t.{$CADDY_DOMAIN}` for the dns-trap subzone, so both the per-host and load-balanced hostnames fall through to the default 127.0.0.1:8443 upstream where Caddy now multiplexes by SNI

## Why this PR

First step toward DNS-based provider load balancing: caddy needs to terminate TLS on `pronode.prosopo.io` so the frontend can do an initial round-robin hop before redirecting to a specific `pronodeN.prosopo.io` for the rest of the flow. Cert distribution for the shared hostname is a separate problem and is left as a deliberate placeholder.

## Test plan

- [ ] Deploy to a staging pronode with `CADDY_GLOBAL_DOMAIN=staging.pronode.prosopo.io` set in env
- [ ] `openssl s_client -connect <pronodeN>:443 -servername pronodeN.prosopo.io` → real Let's Encrypt cert
- [ ] `openssl s_client -connect <pronodeN>:443 -servername staging.pronode.prosopo.io` → Caddy-CA self-signed cert (expected placeholder)
- [ ] Same `route { }` (rate limits, header_up reverse proxy, metrics, robots.txt) is served on both hostnames

🤖 Generated with [Claude Code](https://claude.com/claude-code)