### PR TITLE
fix(provider): run maintenance-mode short-circuit before constructing Tasks

### DIFF
--- a/.changeset/maintenance-mode-tasks-order-fix.md
+++ b/.changeset/maintenance-mode-tasks-order-fix.md
@@ -1,0 +1,5 @@
+---
+"@prosopo/provider": patch
+---
+
+Run the `getMaintenanceMode()` short-circuit before constructing `Tasks` in every captcha and verify handler. The `Tasks` constructor calls `env.getDb()`, which throws synchronously when `env.db` is undefined (the maintenance-mode case), so the existing short-circuits were unreachable and the provider was throwing `db not setup! Please call isReady() first` on every request the moment maintenance mode was toggled on. Also adds a maintenance-mode bypass to `getImageCaptchaChallenge` (empty-captchas response, mirroring the existing `submitImageCaptchaSolution` shape) and `checkSpamEmail` (`isSpam: false`) so those endpoints stay usable while Mongo is unavailable.

--- a/packages/provider/src/api/captcha/checkSpamEmail.ts
+++ b/packages/provider/src/api/captcha/checkSpamEmail.ts
@@ -20,6 +20,7 @@ import { object, string } from "zod";
 import type { AugmentedRequest } from "../../express.js";
 import { Tasks } from "../../tasks/index.js";
 import { checkSpamEmail as checkSpamEmailFn } from "../../tasks/spam/checkSpamEmail.js";
+import { getMaintenanceMode } from "../admin/apiToggleMaintenanceModeEndpoint.js";
 
 const CheckSpamEmailRequestBody = object({
 	email: string(),
@@ -33,7 +34,6 @@ export default (env: ProviderEnvironment) =>
 		next: NextFunction,
 	) => {
 		try {
-			const tasks = new Tasks(env, req.logger);
 			const { email, dapp } = CheckSpamEmailRequestBody.parse(req.body);
 			const emailDomain = extractDomainFromEmail(email);
 			req.logger.info(() => ({
@@ -44,6 +44,21 @@ export default (env: ProviderEnvironment) =>
 					method: req.method,
 				},
 			}));
+
+			// Maintenance-mode short-circuit must run before `new Tasks(env, ...)`
+			// because the Tasks constructor calls `env.getDb()`, which throws when
+			// `env.db` is undefined (the maintenance-mode case). Let the user
+			// through (isSpam=false) so the form submission isn't blocked while
+			// Mongo is unavailable.
+			if (getMaintenanceMode()) {
+				req.logger.info(() => ({
+					msg: "Maintenance mode active - returning isSpam=false",
+					data: { emailDomain },
+				}));
+				return res.json({ isSpam: false, emailDomain });
+			}
+
+			const tasks = new Tasks(env, req.logger);
 			// Get client record and perform the same validation as frictionless flow
 			const clientRecord = await tasks.db.getClientRecord(dapp);
 			if (!clientRecord) {

--- a/packages/provider/src/api/captcha/getFrictionlessCaptchaChallenge/handler.ts
+++ b/packages/provider/src/api/captcha/getFrictionlessCaptchaChallenge/handler.ts
@@ -65,14 +65,9 @@ export default (
 				}));
 			});
 
-			const tasks = new Tasks(env, req.logger);
 			const { token, headHash, dapp, user, mode, simdReadings } =
 				GetFrictionlessCaptchaChallengeRequestBody.parse(req.body);
 
-			const decodedSimdReadings = await decryptIncomingSimdReadings(
-				tasks.frictionlessManager,
-				simdReadings,
-			);
 			const normalizedIp = normalizeRequestIp(req.ip, req.logger);
 			const sessionMode =
 				mode === ModeEnum.invisible ? ModeEnum.invisible : undefined;
@@ -92,7 +87,9 @@ export default (
 				},
 			}));
 
-			// Maintenance mode: short-circuit before any DB access. The matching
+			// Maintenance mode: short-circuit before constructing Tasks. The
+			// Tasks constructor calls `env.getDb()`, which throws when `env.db`
+			// is undefined (the maintenance-mode case). The matching
 			// /captcha/{type} and /submit/{type} endpoints also short-circuit so
 			// the captcha widget keeps rendering while Mongo is unavailable.
 			if (getMaintenanceMode()) {
@@ -107,6 +104,13 @@ export default (
 					),
 				);
 			}
+
+			const tasks = new Tasks(env, req.logger);
+
+			const decodedSimdReadings = await decryptIncomingSimdReadings(
+				tasks.frictionlessManager,
+				simdReadings,
+			);
 
 			// Reserved CI test site keys: serve an invisible PoW session (no DB
 			// record required) so the flow is deterministic and non-interactive.

--- a/packages/provider/src/api/captcha/getImageCaptchaChallenge.ts
+++ b/packages/provider/src/api/captcha/getImageCaptchaChallenge.ts
@@ -31,8 +31,10 @@ import type { NextFunction, Request, Response } from "express";
 import type { AugmentedRequest } from "../../express.js";
 import { Tasks } from "../../tasks/index.js";
 import { normalizeRequestIp } from "../../utils/normalizeRequestIp.js";
+import { getMaintenanceMode } from "../admin/apiToggleMaintenanceModeEndpoint.js";
 import { getRequestUserScope } from "../blacklistRequestInspector.js";
 import { validateAddr, validateSiteKey } from "../validateAddress.js";
+import { buildImageMaintenanceResponse } from "./maintenanceModeResponses.js";
 
 export default (
 	env: ProviderEnvironment,
@@ -43,7 +45,6 @@ export default (
 		res: Response,
 		next: NextFunction,
 	) => {
-		const tasks = new Tasks(env, req.logger);
 		let parsed: CaptchaRequestBodyTypeOutput;
 
 		const normalizedIp = normalizeRequestIp(req.ip, req.logger);
@@ -75,6 +76,19 @@ export default (
 
 		validateSiteKey(dapp);
 		validateAddr(user);
+
+		// Maintenance-mode short-circuit must run before `new Tasks(env, ...)`
+		// because the Tasks constructor calls `env.getDb()`, which throws when
+		// `env.db` is undefined (the maintenance-mode case).
+		if (getMaintenanceMode()) {
+			req.logger.info(() => ({
+				msg: "Maintenance mode active - returning dummy image challenge",
+				data: { dapp, user, sessionId },
+			}));
+			return res.json(buildImageMaintenanceResponse());
+		}
+
+		const tasks = new Tasks(env, req.logger);
 
 		try {
 			const clientRecord = await tasks.db.getClientRecord(dapp);

--- a/packages/provider/src/api/captcha/getPoWCaptchaChallenge.ts
+++ b/packages/provider/src/api/captcha/getPoWCaptchaChallenge.ts
@@ -43,8 +43,6 @@ export default (
 		next: NextFunction,
 	) => {
 		let parsed: GetPowCaptchaChallengeRequestBodyTypeOutput;
-		const tasks = new Tasks(env);
-		tasks.setLogger(req.logger);
 
 		try {
 			parsed = GetPowCaptchaChallengeRequestBody.parse(req.body);
@@ -63,6 +61,9 @@ export default (
 		validateSiteKey(dapp);
 		validateAddr(user);
 
+		// Maintenance-mode short-circuit must run before `new Tasks(env, ...)`
+		// because the Tasks constructor calls `env.getDb()`, which throws when
+		// `env.db` is undefined (the maintenance-mode case).
 		if (getMaintenanceMode()) {
 			req.logger.info(() => ({
 				msg: "Maintenance mode active - returning dummy PoW challenge",
@@ -70,6 +71,9 @@ export default (
 			}));
 			return res.json(buildPowMaintenanceResponse(user, dapp));
 		}
+
+		const tasks = new Tasks(env);
+		tasks.setLogger(req.logger);
 
 		try {
 			const clientSettings = await tasks.db.getClientRecord(dapp);

--- a/packages/provider/src/api/captcha/getPuzzleCaptchaChallenge.ts
+++ b/packages/provider/src/api/captcha/getPuzzleCaptchaChallenge.ts
@@ -43,8 +43,6 @@ export default (
 		next: NextFunction,
 	) => {
 		let parsed: GetPuzzleCaptchaChallengeRequestBodyTypeOutput;
-		const tasks = new Tasks(env, req.logger);
-		tasks.setLogger(req.logger);
 
 		try {
 			parsed = GetPuzzleCaptchaChallengeRequestBody.parse(req.body);
@@ -63,6 +61,9 @@ export default (
 		validateSiteKey(dapp);
 		validateAddr(user);
 
+		// Maintenance-mode short-circuit must run before `new Tasks(env, ...)`
+		// because the Tasks constructor calls `env.getDb()`, which throws when
+		// `env.db` is undefined (the maintenance-mode case).
 		if (getMaintenanceMode()) {
 			req.logger.info(() => ({
 				msg: "Maintenance mode active - returning dummy puzzle challenge",
@@ -70,6 +71,9 @@ export default (
 			}));
 			return res.json(buildPuzzleMaintenanceResponse(user, dapp));
 		}
+
+		const tasks = new Tasks(env, req.logger);
+		tasks.setLogger(req.logger);
 
 		try {
 			const clientSettings = await tasks.db.getClientRecord(dapp);

--- a/packages/provider/src/api/captcha/maintenanceModeResponses.ts
+++ b/packages/provider/src/api/captcha/maintenanceModeResponses.ts
@@ -15,6 +15,7 @@
 import { randomUUID } from "node:crypto";
 import {
 	ApiParams,
+	type CaptchaResponseBody,
 	type CaptchaType,
 	type GetFrictionlessCaptchaResponse,
 	type GetPowCaptchaResponse,
@@ -61,6 +62,21 @@ export const buildPowMaintenanceResponse = (
 		},
 	};
 };
+
+// Image-only clients still hit this endpoint in maintenance mode (the
+// frictionless route returns CaptchaType.pow, but direct image-mode
+// integrations don't go through frictionless). Empty captchas matches
+// what /submit/image returns in maintenance mode so the surfaces stay
+// in sync: nothing to solve, nothing to verify.
+export const buildImageMaintenanceResponse = (): CaptchaResponseBody => ({
+	[ApiParams.status]: "ok",
+	[ApiParams.captchas]: [],
+	[ApiParams.requestHash]: "",
+	[ApiParams.timestamp]: Date.now().toString(),
+	[ApiParams.signature]: {
+		[ApiParams.provider]: { [ApiParams.requestHash]: "" },
+	},
+});
 
 // Tolerance is intentionally generous: the widget uses it client-side to
 // decide whether the drop counts as "complete". Submit doesn't validate

--- a/packages/provider/src/api/captcha/submitImageCaptchaSolution.ts
+++ b/packages/provider/src/api/captcha/submitImageCaptchaSolution.ts
@@ -34,9 +34,9 @@ export default (env: ProviderEnvironment) =>
 		res: Response,
 		next: NextFunction,
 	) => {
-		const tasks = new Tasks(env, req.logger);
-
-		// If in maintenance mode, always return verified
+		// Maintenance-mode short-circuit must run before `new Tasks(env, ...)`
+		// because the Tasks constructor calls `env.getDb()`, which throws when
+		// `env.db` is undefined (the maintenance-mode case).
 		if (getMaintenanceMode()) {
 			req.logger.info(() => ({
 				msg: "Maintenance mode active - returning verified for image captcha",
@@ -48,6 +48,8 @@ export default (env: ProviderEnvironment) =>
 			};
 			return res.json(result);
 		}
+
+		const tasks = new Tasks(env, req.logger);
 
 		let parsed: CaptchaSolutionBodyType;
 		try {

--- a/packages/provider/src/api/captcha/submitPoWCaptchaSolution.ts
+++ b/packages/provider/src/api/captcha/submitPoWCaptchaSolution.ts
@@ -35,10 +35,9 @@ export default (env: ProviderEnvironment) =>
 		res: Response,
 		next: NextFunction,
 	) => {
-		let parsed: SubmitPowCaptchaSolutionBodyTypeOutput;
-		const tasks = new Tasks(env, req.logger);
-
-		// If in maintenance mode, always return verified
+		// Maintenance-mode short-circuit must run before `new Tasks(env, ...)`
+		// because the Tasks constructor calls `env.getDb()`, which throws when
+		// `env.db` is undefined (the maintenance-mode case).
 		if (getMaintenanceMode()) {
 			req.logger.info(() => ({
 				msg: "Maintenance mode active - returning verified",
@@ -49,6 +48,9 @@ export default (env: ProviderEnvironment) =>
 			};
 			return res.json(response);
 		}
+
+		let parsed: SubmitPowCaptchaSolutionBodyTypeOutput;
+		const tasks = new Tasks(env, req.logger);
 
 		try {
 			parsed = SubmitPowCaptchaSolutionBody.parse(req.body);

--- a/packages/provider/src/api/captcha/submitPuzzleCaptchaSolution.ts
+++ b/packages/provider/src/api/captcha/submitPuzzleCaptchaSolution.ts
@@ -32,10 +32,9 @@ export default (env: ProviderEnvironment) =>
 		res: Response,
 		next: NextFunction,
 	) => {
-		let parsed: SubmitPuzzleCaptchaSolutionBodyTypeOutput;
-		const tasks = new Tasks(env, req.logger);
-
-		// If in maintenance mode, always return verified
+		// Maintenance-mode short-circuit must run before `new Tasks(env, ...)`
+		// because the Tasks constructor calls `env.getDb()`, which throws when
+		// `env.db` is undefined (the maintenance-mode case).
 		if (getMaintenanceMode()) {
 			req.logger.info(() => ({
 				msg: "Maintenance mode active - returning verified",
@@ -46,6 +45,9 @@ export default (env: ProviderEnvironment) =>
 			};
 			return res.json(response);
 		}
+
+		let parsed: SubmitPuzzleCaptchaSolutionBodyTypeOutput;
+		const tasks = new Tasks(env, req.logger);
 
 		try {
 			parsed = SubmitPuzzleCaptchaSolutionBody.parse(req.body);

--- a/packages/provider/src/api/verify.ts
+++ b/packages/provider/src/api/verify.ts
@@ -69,9 +69,9 @@ export function prosopoVerifyRouter(env: ProviderEnvironment): Router {
 	router.post(
 		ClientApiPaths.VerifyImageCaptchaSolutionDapp,
 		async (req, res, next) => {
-			const tasks = new Tasks(env, req.logger);
-
-			// If in maintenance mode, always return verified before any checks
+			// Maintenance-mode short-circuit must run before `new Tasks(env, ...)`
+			// because the Tasks constructor calls `env.getDb()`, which throws when
+			// `env.db` is undefined (the maintenance-mode case).
 			if (getMaintenanceMode()) {
 				req.logger.info(() => ({
 					msg: "Maintenance mode active - returning verified for image captcha verification",
@@ -82,6 +82,8 @@ export function prosopoVerifyRouter(env: ProviderEnvironment): Router {
 				};
 				return res.json(verificationResponse);
 			}
+
+			const tasks = new Tasks(env, req.logger);
 
 			// We can be helpful and provide a more detailed error message when there are missing fields
 			let parsed: VerifySolutionBodyTypeOutput;
@@ -190,9 +192,9 @@ export function prosopoVerifyRouter(env: ProviderEnvironment): Router {
 	router.post(
 		ClientApiPaths.VerifyPowCaptchaSolution,
 		async (req, res, next) => {
-			const tasks = new Tasks(env, req.logger);
-
-			// If in maintenance mode, always return verified before any checks
+			// Maintenance-mode short-circuit must run before `new Tasks(env, ...)`
+			// because the Tasks constructor calls `env.getDb()`, which throws when
+			// `env.db` is undefined (the maintenance-mode case).
 			if (getMaintenanceMode()) {
 				req.logger.info(() => ({
 					msg: "Maintenance mode active - returning verified for PoW captcha verification",
@@ -203,6 +205,8 @@ export function prosopoVerifyRouter(env: ProviderEnvironment): Router {
 				};
 				return res.json(verificationResponse);
 			}
+
+			const tasks = new Tasks(env, req.logger);
 
 			let parsed: ServerPowCaptchaVerifyRequestBodyOutput;
 
@@ -321,9 +325,9 @@ export function prosopoVerifyRouter(env: ProviderEnvironment): Router {
 	router.post(
 		ClientApiPaths.VerifyPuzzleCaptchaSolution,
 		async (req, res, next) => {
-			const tasks = new Tasks(env, req.logger);
-
-			// If in maintenance mode, always return verified before any checks
+			// Maintenance-mode short-circuit must run before `new Tasks(env, ...)`
+			// because the Tasks constructor calls `env.getDb()`, which throws when
+			// `env.db` is undefined (the maintenance-mode case).
 			if (getMaintenanceMode()) {
 				req.logger.info(() => ({
 					msg: "Maintenance mode active - returning verified for puzzle captcha verification",
@@ -334,6 +338,8 @@ export function prosopoVerifyRouter(env: ProviderEnvironment): Router {
 				};
 				return res.json(verificationResponse);
 			}
+
+			const tasks = new Tasks(env, req.logger);
 
 			let parsed: ServerPuzzleCaptchaVerifyRequestBodyOutput;
 


### PR DESCRIPTION
## Summary

- Every captcha/verify handler built `new Tasks(env, req.logger)` before the `getMaintenanceMode()` early-return. `Tasks` calls `env.getDb()` in its constructor, which throws synchronously when `env.db` is undefined — i.e. the entire maintenance-mode case — so the short-circuit was unreachable and every request errored with `db not setup! Please call isReady() first`.
- Move the maintenance check above `new Tasks(env, ...)` in every handler that already had one (verify ×3, frictionless challenge, PoW/puzzle/image submit, PoW/puzzle challenge).
- Add a maintenance bypass to the two handlers that lacked one: `getImageCaptchaChallenge` (returns empty-captchas via new `buildImageMaintenanceResponse()` helper, matching the existing `submitImageCaptchaSolution` shape) and `checkSpamEmail` (returns `{ isSpam: false, emailDomain }` so form submissions aren't blocked while Mongo is unavailable).

## Why this didn't show up sooner

Existing `maintenanceModeShortCircuit.unit.test.ts` mocks `Tasks` directly (lines 64–71), so `env.getDb()` never ran in tests — the bypass appeared to work. On staging the toggle also looks clean because there's no live traffic to exercise the broken path. Production exposed it because every request hit a broken handler the moment maintenance mode flipped on, and the provider1 container ended up restart-looping every ~15s on every prod node during today's deploy.

OO2 trace from `production_provider_node` on pronode8 during today's failed window (11:59–12:00 UTC) showed `Prosopo app listening` followed immediately by floods of `db not setup! Please call isReady() first` from `Error in frictionless captcha challenge`, `Error getting provider details`, etc. — the maintenance bypass was logging `MAINTENANCE_MODE=true — skipping DB import on startup` correctly, but the handler-level bypass was unreachable.

## Test plan

- [x] `npm run -w @prosopo/provider build:tsc` — clean
- [x] Existing maintenance unit tests still pass (23/23 across `apiToggleMaintenanceModeEndpoint`, `maintenanceModeResponses`, `maintenanceModeShortCircuit`)
- [ ] Toggle staging into maintenance mode with `providerToggleMaintenanceMode.yml` and exercise the staging demo site / verify endpoints end-to-end
- [ ] Follow-up: add a regression test that uses the real `Tasks` against an `env` with `db: undefined` — the current tests would not have caught the original bug

## Caveats

- Image-only integrations will see an empty captcha grid in maintenance mode (backend won't crash, but the widget UX is degraded). Same trade-off as the existing empty-captchas behaviour in `submitImageCaptchaSolution`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)