### PR TITLE
fix(caddy): serve /robots.txt as 200 instead of 308 redirect loop

### DIFF
--- a/docker/provider.Caddyfile
+++ b/docker/provider.Caddyfile
@@ -106,7 +106,11 @@ https://{$CADDY_DOMAIN}:8443 {
 	}
 	
 	handle /robots.txt {
-		uri strip_prefix / # removes leading /, so it looks directly in root
+		# Serve /srv/static/robots.txt. Do NOT strip the leading slash:
+		# file_server prepends `root` to the request path, so `/robots.txt`
+		# already resolves to `/srv/static/robots.txt`. Rewriting the path to
+		# `robots.txt` (no leading slash) makes file_server issue a 308
+		# canonical redirect to re-add the slash, which loops forever (#3467).
 		root * /srv/static
 		file_server
 		header Content-Type "text/plain"


### PR DESCRIPTION
## What

Fixes `/robots.txt` on provider nodes returning **HTTP 308** (redirect loop) instead of **200** with the robots.txt body.

Closes prosopo/captcha-private#3467

## Root cause

The `/robots.txt` handler in `docker/provider.Caddyfile` ran `uri strip_prefix /`, rewriting the request path from `/robots.txt` to `robots.txt` (no leading slash). But `file_server` prepends the configured `root` to the request path, so the leading slash was never needed — and with it stripped, `file_server` issued a **308 canonical redirect** to re-add the slash, which loops forever.

This matches the logs in the issue, where every `/robots.txt` request returned `308`.

## Fix

Drop the `uri strip_prefix /` line. With `root * /srv/static`, `/robots.txt` now resolves directly to `/srv/static/robots.txt` and returns `200`. The served content is unchanged (`User-agent: *` / `Disallow: /`, baked into the caddy image).

## Validation

Built the project caddy image (with the `caddy-ratelimit`, `chaddy`, `caddy-requestid`, `caddy-l4` plugins) and ran `caddy validate` against the full `provider.Caddyfile` with the production env placeholders set → **`Valid configuration`**.
