### PR TITLE
feat(dm): expose ipInfo to verify-phase decision machine

### DIFF
--- a/.changeset/dm-verify-ipinfo.md
+++ b/.changeset/dm-verify-ipinfo.md
@@ -1,0 +1,18 @@
+---
+"@prosopo/types": patch
+"@prosopo/provider": patch
+---
+
+Expose `ipInfo` to the verify-phase decision machine. The frictionless DM already gets the full `IPInfoResponse`; the verify-phase DM was only receiving `countryCode`, so rules that need `isDatacenter`, `isVPN`, `isAbuser`, `asnNumber` etc. couldn't run at submission time.
+
+`DecisionMachineInput` now carries an optional `ipInfo` field (alongside `countryCode`, which is kept for backwards compatibility). The three verify-phase call sites — `powTasks`, `puzzleTasks`, `imgCaptchaTasks` — forward `challengeRecord.ipInfo` / `solution.ipInfo` into the input.
+
+This unblocks rules like:
+```
+if (input.behavioralDataPacked &&
+    !input.behavioralDataPacked.c1.length &&
+    !input.behavioralDataPacked.c2.length &&
+    !input.behavioralDataPacked.c3.length &&
+    input.ipInfo?.isDatacenter) return Deny;
+```
+which catches the datacenter-class bots (Sparkle, Versatel, OVH) that submit empty `behavioralDataPacked` — observed at 100% empty-bDP across a 21-row Sparkle sample, versus 1–3% in genuine traffic.

--- a/packages/provider/src/tasks/imgCaptcha/imgCaptchaTasks.ts
+++ b/packages/provider/src/tasks/imgCaptcha/imgCaptchaTasks.ts
@@ -979,6 +979,7 @@ export class ImgCaptchaManager extends CaptchaManager {
 				countryCode: solution.ipInfo?.isValid
 					? solution.ipInfo.countryCode
 					: undefined,
+				ipInfo: solution.ipInfo,
 				dnsEvent: enrichedDnsEvent,
 			};
 

--- a/packages/provider/src/tasks/powCaptcha/powTasks.ts
+++ b/packages/provider/src/tasks/powCaptcha/powTasks.ts
@@ -795,6 +795,7 @@ export class PowCaptchaManager extends CaptchaManager {
 					countryCode: challengeRecord.ipInfo?.isValid
 						? challengeRecord.ipInfo.countryCode
 						: undefined,
+					ipInfo: challengeRecord.ipInfo,
 					dnsEvent: enrichedDnsEvent,
 				};
 

--- a/packages/provider/src/tasks/puzzleCaptcha/puzzleTasks.ts
+++ b/packages/provider/src/tasks/puzzleCaptcha/puzzleTasks.ts
@@ -684,6 +684,7 @@ export class PuzzleCaptchaManager extends CaptchaManager {
 				countryCode: challengeRecord.ipInfo?.isValid
 					? challengeRecord.ipInfo.countryCode
 					: undefined,
+				ipInfo: challengeRecord.ipInfo,
 				dnsEvent: enrichedDnsEvent,
 			};
 

--- a/packages/types/src/decisionMachine/index.ts
+++ b/packages/types/src/decisionMachine/index.ts
@@ -76,6 +76,12 @@ export type DecisionMachineInput = {
 	behavioralDataPacked?: DecisionMachineBehavioralDataPacked;
 	deviceCapability?: string;
 	countryCode?: string;
+	// Full ipinfo payload. `countryCode` is kept as a separate top-level
+	// field for backwards compatibility with existing decision machines, but
+	// rules that need isDatacenter / isVPN / asnNumber / isAbuser etc. should
+	// read from `ipInfo` (set to the same payload stored on the captcha
+	// challenge record). Undefined for invalid lookups.
+	ipInfo?: IPInfoResponse;
 	dnsEvent?: EnrichedDnsEvent;
 };
 


### PR DESCRIPTION
## Summary
- Verify-phase decision machines were only receiving `countryCode`, not the full `IPInfoResponse`. This blocked any rule that wants to act on `isDatacenter`, `isVPN`, `isAbuser`, `asnNumber` etc. at submission time (which is exactly where the bot-discriminating signals are richest).
- Add `ipInfo?: IPInfoResponse` to `DecisionMachineInput` (keeping `countryCode` for backwards compatibility — existing DMs still work).
- Forward `challengeRecord.ipInfo` / `solution.ipInfo` from the three verify-phase call sites: `powTasks`, `puzzleTasks`, `imgCaptchaTasks`.