### PR TITLE
fix(user-access-policy): paginate greedy findRules to avoid silent truncation

### DIFF
--- a/.changeset/uap-greedy-search-pagination.md
+++ b/.changeset/uap-greedy-search-pagination.md
@@ -1,0 +1,5 @@
+---
+"@prosopo/user-access-policy": patch
+---
+
+Paginate the greedy `findRules` RediSearch query via `FT.AGGREGATE WITHCURSOR` so the candidate set is no longer truncated at `REDIS_BATCH_SIZE` (1000). Under high-volume bot traffic, a single popular ja4 fingerprint can be carried by thousands of rules; the OR-style greedy query returned > 1000 candidates and `FT.SEARCH`'s LIMIT silently dropped the tail — block rules emitted by less-frequent detectors sat past offset 1000 and never reached the JS-side specificity sort, letting matching requests through. Aggregation cursors return the full result set, so ranking sees every candidate.

--- a/packages/user-access-policy/src/redis/reader/redisAggregate.ts
+++ b/packages/user-access-policy/src/redis/reader/redisAggregate.ts
@@ -29,6 +29,7 @@ export const aggregateRedisKeys = async (
 	query: string,
 	logger: Logger,
 	batchHandler?: (keys: string[]) => Promise<void>,
+	maxKeys?: number,
 ): Promise<string[]> => {
 	const keyField = "__key";
 
@@ -38,8 +39,13 @@ export const aggregateRedisKeys = async (
 	});
 
 	const foundKeys: string[] = [];
+	let stopRequested = false;
 
 	const addRecordKeys = async (records: object[]) => {
+		if (stopRequested) {
+			return;
+		}
+
 		const parsedRecords = parseRedisRecords(records, recordSchema, logger);
 
 		const recordKeys = parsedRecords.map((record) => record[keyField]);
@@ -47,6 +53,21 @@ export const aggregateRedisKeys = async (
 		if (batchHandler) {
 			await batchHandler(recordKeys);
 		} else {
+			if (maxKeys !== undefined && foundKeys.length + recordKeys.length > maxKeys) {
+				const remaining = Math.max(0, maxKeys - foundKeys.length);
+				foundKeys.push(...recordKeys.slice(0, remaining));
+				stopRequested = true;
+
+				logger.warn(() => ({
+					msg: "Redis aggregation candidate cap hit; truncating result set. This can suppress less-frequent rules and should be investigated.",
+					data: {
+						maxKeys,
+						query,
+					},
+				}));
+				return;
+			}
+
 			foundKeys.push(...recordKeys);
 
 			logger.debug(() => ({
@@ -68,6 +89,7 @@ export const aggregateRedisKeys = async (
 			LOAD: `@${keyField}`,
 		},
 		addRecordKeys,
+		() => stopRequested,
 	);
 
 	return foundKeys;
@@ -78,6 +100,7 @@ const executeAggregation = async (
 	query: string,
 	aggregateOptions: FtAggregateWithCursorOptions,
 	handleBatch: (records: object[]) => Promise<void>,
+	shouldStop?: () => boolean,
 ): Promise<void> => {
 	const initialReply = await client.ft.aggregateWithCursor(
 		ACCESS_RULES_REDIS_INDEX_NAME,
@@ -89,7 +112,7 @@ const executeAggregation = async (
 
 	let cursor = initialReply.cursor;
 
-	while (0 !== cursor) {
+	while (0 !== cursor && !shouldStop?.()) {
 		const batchReply = await client.ft.cursorRead(
 			ACCESS_RULES_REDIS_INDEX_NAME,
 			cursor,

--- a/packages/user-access-policy/src/redis/reader/redisAggregate.ts
+++ b/packages/user-access-policy/src/redis/reader/redisAggregate.ts
@@ -53,7 +53,10 @@ export const aggregateRedisKeys = async (
 		if (batchHandler) {
 			await batchHandler(recordKeys);
 		} else {
-			if (maxKeys !== undefined && foundKeys.length + recordKeys.length > maxKeys) {
+			if (
+				maxKeys !== undefined &&
+				foundKeys.length + recordKeys.length > maxKeys
+			) {
 				const remaining = Math.max(0, maxKeys - foundKeys.length);
 				foundKeys.push(...recordKeys.slice(0, remaining));
 				stopRequested = true;

--- a/packages/user-access-policy/src/redis/reader/redisRulesReader.ts
+++ b/packages/user-access-policy/src/redis/reader/redisRulesReader.ts
@@ -23,10 +23,7 @@ import {
 	getMissingRedisKeys,
 	parseRedisRecords,
 } from "#policy/redis/redisClient.js";
-import {
-	ACCESS_RULES_REDIS_INDEX_NAME,
-	ACCESS_RULE_REDIS_KEY_PREFIX,
-} from "#policy/redis/redisRuleIndex.js";
+import { ACCESS_RULE_REDIS_KEY_PREFIX } from "#policy/redis/redisRuleIndex.js";
 import type { AccessRule } from "#policy/rule.js";
 import { accessRuleInput } from "#policy/ruleInput/ruleInput.js";
 import type {

--- a/packages/user-access-policy/src/redis/reader/redisRulesReader.ts
+++ b/packages/user-access-policy/src/redis/reader/redisRulesReader.ts
@@ -16,10 +16,7 @@ import * as util from "node:util";
 import { chunkIntoBatches, executeBatchesSequentially } from "@prosopo/common";
 import type { Logger } from "@prosopo/logger";
 import type { RedisClientType } from "redis";
-import {
-	REDIS_QUERY_DIALECT,
-	getRulesRedisQuery,
-} from "#policy/redis/reader/redisRulesQuery.js";
+import { getRulesRedisQuery } from "#policy/redis/reader/redisRulesQuery.js";
 import {
 	REDIS_BATCH_SIZE,
 	fetchRedisHashRecords,
@@ -38,6 +35,15 @@ import type {
 	AccessRulesReader,
 } from "#policy/rulesStorage.js";
 import { aggregateRedisKeys } from "./redisAggregate.js";
+
+// Verify-time lookup safety cap. The greedy `userScopeMatch` OR-query can match
+// thousands of candidates on bot-attack-scale accounts; we still need to bring
+// every candidate back so JS-side specificity ranking can pick the right rule,
+// but a hard cap prevents a pathological match (e.g. an attacker crafting a
+// userScope that hits the entire account's rule index) from spiralling the
+// per-request cost. 10× the page size leaves comfortable headroom over the
+// observed worst case (~2k candidates).
+export const FIND_RULES_MAX_CANDIDATES = REDIS_BATCH_SIZE * 10;
 
 export class RedisRulesReader implements AccessRulesReader {
 	constructor(
@@ -85,46 +91,45 @@ export class RedisRulesReader implements AccessRulesReader {
 		}
 
 		try {
-			// Use searchNoContent to get document keys only, then fetch data separately.
-			// This avoids a bug in @redis/search where ft.search crashes with
-			// "Cannot read properties of null (reading 'length')" when a document
-			// is deleted/expired between the index scan and data retrieval.
-			const searchReply = await this.client.ft.searchNoContent(
-				ACCESS_RULES_REDIS_INDEX_NAME,
+			// FT.AGGREGATE WITHCURSOR (via aggregateRedisKeys) instead of
+			// FT.SEARCH. FT.SEARCH's LIMIT caps the candidate set at
+			// REDIS_BATCH_SIZE (1000), silently dropping anything past that.
+			// Under the greedy `userScopeMatch` mode (#2657), the OR-of-fields
+			// query for a popular ja4 hash returns thousands of candidates —
+			// matches sitting past offset 1000 (block rules emitted by
+			// less-frequent detectors like SUDDEN_VOLUME_INCREASE) were lost,
+			// so verify-time ranking only saw the high-volume rules and the
+			// most-specific block rule for the request never reached the
+			// JS-side specificity sort.
+			const ruleKeys = await aggregateRedisKeys(
+				this.client,
 				query,
-				{
-					DIALECT: REDIS_QUERY_DIALECT,
-					// FT.search doesn't support "unlimited" selects
-					LIMIT: {
-						from: 0,
-						size: REDIS_BATCH_SIZE,
-					},
-				},
+				this.logger,
+				undefined,
+				FIND_RULES_MAX_CANDIDATES,
 			);
 
-			if (searchReply.total > 0) {
-				this.logger.debug(() => ({
-					msg: "Executed search query",
-					data: {
-						inspect: util.inspect(
-							{
-								filter: filter,
-								searchReply: searchReply,
-								query: query,
-							},
-							{ depth: null },
-						),
-					},
-				}));
-			}
-
-			if (searchReply.documents.length === 0) {
+			if (ruleKeys.length === 0) {
 				return [];
 			}
 
+			this.logger.debug(() => ({
+				msg: "Executed search query",
+				data: {
+					inspect: util.inspect(
+						{
+							filter: filter,
+							foundCount: ruleKeys.length,
+							query: query,
+						},
+						{ depth: null },
+					),
+				},
+			}));
+
 			const { records } = await fetchRedisHashRecords(
 				this.client,
-				searchReply.documents,
+				ruleKeys,
 				this.logger,
 			);
 

--- a/packages/user-access-policy/src/tests/redis/redisRulesStorage.integration.test.ts
+++ b/packages/user-access-policy/src/tests/redis/redisRulesStorage.integration.test.ts
@@ -1115,6 +1115,58 @@ describe("redisAccessRulesStorage", () => {
 			expect(foundAccessRules).toEqual([]);
 		});
 
+		test("returns all matches when the candidate set exceeds the FT.SEARCH page size", async () => {
+			// Regression: under the production traffic profile of a high-volume
+			// bot attack, the greedy `@field:{X} | @field:{Y}` query returns
+			// thousands of candidate rules sharing the dominant ja4 fingerprint.
+			// FT.SEARCH's LIMIT (1000) silently truncated the candidate set,
+			// dropping less-frequent block rules — they never reached the
+			// JS-side specificity sort, so verify let the bot through.
+			// FT.AGGREGATE WITHCURSOR paginates the result and returns all of
+			// them. This test inserts > 1000 rules so the old code would
+			// truncate; the target block rule must still come back.
+			const clientId = getUniqueString();
+			const popularJa4 = `t13d1516h2_${getUniqueString()}`;
+
+			const targetBlockRule: AccessRule = {
+				type: AccessPolicyType.Block,
+				clientId: clientId,
+				ja4Hash: popularJa4,
+				coords: "[[[867,60]]]",
+			};
+
+			// 1500 noise rules sharing the popular ja4 but with distinct coords.
+			// 1500 > REDIS_BATCH_SIZE (1000) — guarantees the targetBlockRule's
+			// FT index position has at least a 1/3 chance of sitting past the
+			// truncation boundary on any given run. With pagination, it must
+			// always come back regardless of indexed order.
+			const noiseRules: AccessRule[] = Array.from({ length: 1500 }, (_, i) => ({
+				type: AccessPolicyType.Restrict,
+				clientId: clientId,
+				ja4Hash: popularJa4,
+				coords: `[[[${i % 1024},${60 + (i % 32)}]]]`,
+				description: `noise-${i}`,
+			}));
+
+			await insertRules([targetBlockRule, ...noiseRules]);
+
+			const indexRecordsCount = await getIndexRecordsCount(indexName);
+			expect(indexRecordsCount).toBe(1501);
+
+			const found = await accessRulesReader.findRules({
+				policyScope: { clientId: clientId },
+				policyScopeMatch: FilterScopeMatch.Greedy,
+				userScope: {
+					ja4Hash: popularJa4,
+					coords: "[[[867,60]]]",
+				},
+				userScopeMatch: FilterScopeMatch.Greedy,
+			});
+
+			expect(found.length).toBe(1501);
+			expect(found).toContainEqual(targetBlockRule);
+		}, 60_000);
+
 		test("finds rules with matchingFieldsOnly when only userId is set and all IP fields are missing", async () => {
 			// This is the exact scenario from the production error where the query
 			// contained duplicate ismissing(@numericIpMaskMin) ismissing(@numericIpMaskMax)


### PR DESCRIPTION
## Summary

Verify-time access rule lookup was silently dropping block rules under heavy bot traffic, letting matching requests through.

PR #2657 ("allow ASN as a user-scope field") refactored `getPrioritisedAccessRule` from N targeted FT.SEARCH queries to a single greedy `userScopeMatch` query. The greedy form is an OR across every populated userScope field. Under bot traffic that shares one dominant ja4 fingerprint, that OR matches thousands of rules (every detector emits rules carrying that ja4). The FT.SEARCH `LIMIT { from: 0, size: REDIS_BATCH_SIZE }` (1000) then silently truncated the candidate set, dropping anything past offset 1000 — typically the lowest-volume detectors' block rules — before the JS-side specificity sort ever saw them.

Observed on prod (Edge sitekey, 2026-06-13):
- 2,077 rules total for the account
- Greedy query returned 1,887 candidates for a single bot request
- Page 1 (0..1000): 4 SUDDEN_VOLUME_INCREASE BLOCK rules
- Page 2 (1000..2000): **26** SUDDEN_VOLUME_INCREASE BLOCK rules dropped
- Net effect: ~87% of the relevant block rules never reached ranking, so bots solving captcha got verified instead of blocked.

## Change

- `findRules` switches from `FT.SEARCH searchNoContent` to `FT.AGGREGATE WITHCURSOR` (existing helper `aggregateRedisKeys`). Cursors paginate the result so the full candidate set is returned.
- Adds a 10× page-size hard cap (`FIND_RULES_MAX_CANDIDATES = 10,000`) and a warning log. 10× comfortably exceeds the observed worst case (~2k) while preventing a pathological match from spiralling per-request cost.
- `aggregateRedisKeys` gains an optional `maxKeys` parameter so callers can opt into the cap. `findRuleIds` and `fetchAllRuleIds` keep their existing unbounded behavior (consistent with prior intent).

## Test plan

- [x] New integration test: insert 1,501 rules sharing one ja4, run greedy findRules, assert all 1,501 returned and the target block rule is among them. The old code returns only 1,000 → test fails. The fix returns all 1,501 → test passes.
- [x] Full integration suite passes (26/26 tests, including the 1-million-rules deletion test).
- [x] Full unit suite passes (48/48).
- [x] `npm run -w @prosopo/user-access-policy build:tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)