### PR TITLE
feat(blocked-sessions): log access-policy 401s + persist synthetic session

### DIFF
--- a/.changeset/blocked-session-logging.md
+++ b/.changeset/blocked-session-logging.md
@@ -1,0 +1,8 @@
+---
+"@prosopo/provider": minor
+"@prosopo/database": minor
+"@prosopo/types": minor
+"@prosopo/types-database": minor
+---
+
+Log + persist access-policy block decisions. When `blockMiddleware` 401s a request, the inspector now emits a structured `"Access policy block"` log line carrying the matched rule's identity (`ruleHash`, `ruleType`, `ruleDescription`, `policyType`) and the request's user-scope (ja4 / ip / userAgent / userId / countryCode / asn), and writes a synthetic `Session` record with `blocked: true`, `deleted: true`, `reason: ACCESS_POLICY_BLOCK`, and the same rule fields surfaced on three new optional columns (`ruleHash`, `ruleType`, `ruleDescription`). Persistence is fire-and-forget and any Mongo failure is swallowed-and-logged so the 401 response is never delayed. The new fields are gated by `blocked: true` so legit sessions stay untouched, and two sparse indexes (`{siteKey, blocked, createdAt}`, `{ruleHash}`) keep the per-rule and per-client block aggregations the Traffic page will query off the existing sessions collection without bloating the index on normal traffic.

--- a/packages/database/src/databases/provider.ts
+++ b/packages/database/src/databases/provider.ts
@@ -1473,6 +1473,60 @@ export class ProviderDatabase
 	}
 
 	/**
+	 * Persist a synthetic Session record for a request that was 401'd at the
+	 * request-time block middleware. The record is written with
+	 * `blocked=true` + `deleted=true` so the captcha flow can't pick it up
+	 * downstream, and with sentinel values for the schema-required fields
+	 * the blocked request never had a chance to populate (score / threshold /
+	 * captchaType / etc.).
+	 *
+	 * Designed for fire-and-forget: callers `void`-cast the promise and any
+	 * Mongo error is swallowed-and-logged so the 401 response is never
+	 * delayed by a persistence failure. The structured log line at the call
+	 * site is the source of truth either way.
+	 *
+	 * Mirrors `storeSessionRecord` enough that the Traffic-page
+	 * aggregations can read these records out of the central-streamer
+	 * pipeline once the UI work lands.
+	 */
+	async storeBlockedSession(record: Session): Promise<void> {
+		try {
+			const stored: Session = {
+				...record,
+				blocked: true,
+				deleted: true,
+				// Stamp storedAtTimestamp so the existing TTL index on the
+				// sessions collection sweeps the record after one day.
+				storedAtTimestamp: record.storedAtTimestamp ?? record.createdAt,
+				lastUpdatedTimestamp: record.lastUpdatedTimestamp ?? record.createdAt,
+			};
+			await this.tables.session.create(stored);
+			this.centralStreamer?.streamSessionRecord(
+				stored as unknown as StoredSession,
+				(ts) =>
+					this.tables.session
+						.updateOne(
+							{
+								sessionId: stored.sessionId,
+								lastUpdatedTimestamp: { $lte: ts },
+							},
+							{ $set: { storedAtTimestamp: ts } },
+						)
+						.then(() => {}),
+			);
+		} catch (err) {
+			// Swallow — the structured log line at the inspector's call site
+			// captures the same information for OO2, and a 401 must not be
+			// delayed by Mongo write trouble.
+			this.logger.warn(() => ({
+				err,
+				msg: "Failed to persist blocked session record",
+				data: { sessionId: record.sessionId, siteKey: record.siteKey },
+			}));
+		}
+	}
+
+	/**
 	 * Get a session record by sessionId
 	 */
 	async getSessionRecordBySessionId(

--- a/packages/provider/src/api/blacklistRequestInspector.ts
+++ b/packages/provider/src/api/blacklistRequestInspector.ts
@@ -12,8 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { randomUUID } from "node:crypto";
 import type { Logger } from "@prosopo/logger";
-import { ApiPrefix, type IPInfoResponse } from "@prosopo/types";
+import {
+	ApiPrefix,
+	CaptchaStatus,
+	CaptchaType,
+	FrictionlessReason,
+	type IPInfoResponse,
+	type RequestHeaders,
+	ResultReason,
+	type Session,
+} from "@prosopo/types";
+import type { IProviderDatabase } from "@prosopo/types-database";
 import {
 	AccessPolicyType,
 	type AccessRule,
@@ -21,9 +32,11 @@ import {
 	FilterScopeMatch,
 	type UserScope,
 	type UserScopeRecord,
+	makeAccessRuleHash,
 	userScopeInput,
 } from "@prosopo/user-access-policy";
 import type { NextFunction, Request, Response } from "express";
+import { getCompositeIpAddress } from "../compositeIpAddress.js";
 
 export const getRequestUserScope = (
 	requestHeaders: Record<string, unknown>,
@@ -74,6 +87,47 @@ const SCALAR_USER_SCOPE_FIELDS = [
 	"countryCode",
 	"asn",
 ] as const satisfies ReadonlyArray<keyof UserScope>;
+
+// Derive the populated-scope field list for a matched rule (the same shape
+// as Mongo's `accessControlRules.ruleType`). Used when persisting a blocked
+// session so the Traffic page can group blocks by rule-type — `['ja4Hash']`
+// vs `['ja4Hash','coords']` vs `['ip']` — without re-parsing the rule.
+const deriveRuleType = (rule: AccessRule): string[] => {
+	const fields: string[] = [];
+	for (const f of SCALAR_USER_SCOPE_FIELDS) {
+		if (rule[f] !== undefined) {
+			fields.push(f);
+		}
+	}
+	if (rule.numericIp !== undefined) {
+		fields.push("ip");
+	} else if (
+		rule.numericIpMaskMin !== undefined &&
+		rule.numericIpMaskMax !== undefined
+	) {
+		fields.push("ipMask");
+	}
+	return fields;
+};
+
+// Strip header values that aren't strings so the Session.headers object
+// matches the schema (RequestHeaders is `Record<string, string>`). Mirrors
+// what the frictionless path stores; cheaper than dragging every catch-all
+// header through and keeps the blocked-session doc the same shape as a
+// normal session for the Traffic-page aggregations.
+const sanitizeRequestHeaders = (
+	headers: Record<string, unknown>,
+): RequestHeaders => {
+	const out: Record<string, string> = {};
+	for (const [k, v] of Object.entries(headers)) {
+		if (typeof v === "string") {
+			out[k] = v;
+		} else if (Array.isArray(v)) {
+			out[k] = v.map((x) => String(x)).join(", ");
+		}
+	}
+	return out as RequestHeaders;
+};
 
 const ruleHasIpConstraint = (rule: AccessRule): boolean =>
 	rule.numericIp !== undefined ||
@@ -213,6 +267,12 @@ export class BlacklistRequestInspector {
 	public constructor(
 		private readonly userAccessRulesStorage: AccessRulesStorage,
 		private readonly environmentReadinessWaiter: () => Promise<void>,
+		// Optional so existing test-suite construction (where the DB isn't
+		// always plumbed) keeps working. When provided, every request that
+		// the inspector decides to 401 also writes a synthetic
+		// `blocked=true, deleted=true` session record so the Traffic page
+		// can aggregate per-rule block counts.
+		private readonly db?: IProviderDatabase,
 	) {}
 
 	public async abortRequestForBlockedUsers(
@@ -314,7 +374,28 @@ export class BlacklistRequestInspector {
 			}
 			const accessPolicy = enforceable[0];
 
-			return AccessPolicyType.Block === accessPolicy.type;
+			const isBlock = AccessPolicyType.Block === accessPolicy.type;
+			if (isBlock) {
+				// `Restrict` policies aren't logged or persisted here — those
+				// don't 401, they let the request through with modified
+				// captcha params and the downstream captcha-creation path
+				// already writes a normal session record.
+				this.recordBlockDecision(
+					accessPolicy,
+					{
+						userId,
+						clientId,
+						rawIp,
+						ja4,
+						requestHeaders,
+						ipInfo,
+						countryCode,
+						asn,
+					},
+					logger,
+				);
+			}
+			return isBlock;
 		} catch (err) {
 			logger.error(() => ({
 				err,
@@ -323,6 +404,105 @@ export class BlacklistRequestInspector {
 
 			return true;
 		}
+	}
+
+	/**
+	 * Emit a structured log line and (if a DB is wired) persist a synthetic
+	 * Session record for the request we're about to 401. Fire-and-forget on
+	 * the Mongo side — the structured log line is the source of truth and
+	 * the 401 response is never delayed by a persistence failure.
+	 *
+	 * Carries the matched rule's identity (hash + ruleType + description)
+	 * so the Traffic page can surface "what's blocking traffic for this
+	 * site" without re-reading the rules collection.
+	 */
+	private recordBlockDecision(
+		accessPolicy: AccessRule,
+		ctx: {
+			userId?: string;
+			clientId?: string;
+			rawIp: string;
+			ja4: string;
+			requestHeaders: Record<string, unknown>;
+			ipInfo?: IPInfoResponse;
+			countryCode?: string;
+			asn?: number;
+		},
+		logger: Logger,
+	): void {
+		const ruleHash = makeAccessRuleHash(accessPolicy);
+		const ruleType = deriveRuleType(accessPolicy);
+		const ruleDescription = accessPolicy.description;
+		const userAgent =
+			typeof ctx.requestHeaders["user-agent"] === "string"
+				? (ctx.requestHeaders["user-agent"] as string)
+				: undefined;
+
+		logger.info(() => ({
+			msg: "Access policy block",
+			data: {
+				ruleHash,
+				ruleType,
+				ruleDescription,
+				policyType: accessPolicy.type,
+				clientId: ctx.clientId,
+				userScope: {
+					userId: ctx.userId,
+					ja4: ctx.ja4,
+					ip: ctx.rawIp,
+					userAgent,
+					countryCode: ctx.countryCode,
+					asn: ctx.asn,
+				},
+			},
+		}));
+
+		// Persistence is optional and best-effort. The log line above is the
+		// primary record; storeBlockedSession swallows its own errors so the
+		// 401 path is unaffected if Mongo is unhappy.
+		if (!this.db) {
+			return;
+		}
+		const ipAddress = ctx.rawIp ? getCompositeIpAddress(ctx.rawIp) : undefined;
+		if (!ipAddress) {
+			// Schema requires ipAddress; without a parseable IP we drop the
+			// persistence and rely on the log line.
+			return;
+		}
+		const headers = sanitizeRequestHeaders(ctx.requestHeaders);
+		const session: Session = {
+			sessionId: `blocked-${randomUUID()}`,
+			createdAt: new Date(),
+			// Sentinel values for schema-required fields the blocked request
+			// never reached the point of populating.
+			token: "",
+			score: 1,
+			threshold: 0,
+			scoreComponents: { baseScore: 1 },
+			providerSelectEntropy: 0,
+			captchaType: CaptchaType.frictionless,
+			webView: false,
+			iFrame: false,
+			decryptedHeadHash: "",
+			// Real data the inspector did collect.
+			siteKey: ctx.clientId,
+			ipAddress,
+			ipInfo: ctx.ipInfo,
+			headers,
+			reason: FrictionlessReason.ACCESS_POLICY_BLOCK,
+			result: {
+				status: CaptchaStatus.disapproved,
+				reason: ResultReason.ACCESS_POLICY_BLOCK,
+			},
+			// Rule identity — the whole point of writing this record.
+			ruleHash,
+			ruleType,
+			ruleDescription,
+			// blocked + deleted are stamped inside storeBlockedSession so
+			// the synthetic record is unmistakably a block-middleware
+			// artefact and can never be picked up by the captcha flow.
+		};
+		void this.db.storeBlockedSession(session);
 	}
 
 	protected isApiUnrelatedRoute(url: string): boolean {

--- a/packages/provider/src/api/block.ts
+++ b/packages/provider/src/api/block.ts
@@ -29,12 +29,12 @@ export const blockMiddleware = (providerEnvironment: ProviderEnvironment) => {
 	return (req: Request, res: Response, next: NextFunction) => {
 		if (!blacklistRequestInspector) {
 			try {
-				const userAccessRulesStorage = providerEnvironment
-					.getDb()
-					.getUserAccessRulesStorage();
+				const db = providerEnvironment.getDb();
+				const userAccessRulesStorage = db.getUserAccessRulesStorage();
 				blacklistRequestInspector = new BlacklistRequestInspector(
 					userAccessRulesStorage,
 					environmentReadinessWaiter,
+					db,
 				);
 			} catch {
 				// Storage still not ready — skip the blocklist check this hop.

--- a/packages/provider/src/tests/unit/api/blacklistRequestInspector.unit.test.ts
+++ b/packages/provider/src/tests/unit/api/blacklistRequestInspector.unit.test.ts
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 import type { Logger } from "@prosopo/logger";
-import type { IPInfoResponse } from "@prosopo/types";
+import { FrictionlessReason, type IPInfoResponse } from "@prosopo/types";
+import type { IProviderDatabase } from "@prosopo/types-database";
 import {
 	AccessPolicyType,
 	type AccessRule,
@@ -325,6 +326,383 @@ describe("BlacklistRequestInspector.shouldAbortRequest", () => {
 			validIpInfo("DE"),
 		);
 		expect(shouldAbort).toBe(true);
+	});
+});
+
+// Coverage for the synthetic blocked-session persistence + structured log
+// the inspector emits at the 401 decision point. Separate `describe` so the
+// fixtures (a stub `IProviderDatabase` with a spyable storeBlockedSession,
+// and a logger that records arguments) don't bleed into the abort-decision
+// fixtures above.
+describe("BlacklistRequestInspector blocked-session persistence", () => {
+	// Logger stub that captures the lazy log payloads so individual assertions
+	// can inspect what was logged without depending on call order across
+	// info/debug/warn calls.
+	const captureLogger = () => {
+		const calls: Array<{
+			level: "info" | "warn" | "error" | "debug";
+			payload: ReturnType<() => Record<string, unknown>>;
+		}> = [];
+		const lvl = (level: "info" | "warn" | "error" | "debug") =>
+			vi.fn((fn: () => Record<string, unknown>) => {
+				calls.push({ level, payload: fn() });
+			});
+		return {
+			logger: {
+				info: lvl("info"),
+				warn: lvl("warn"),
+				error: lvl("error"),
+				debug: lvl("debug"),
+			} as unknown as Logger,
+			calls,
+		};
+	};
+
+	const buildStorage = (rules: Partial<AccessRule>[]): AccessRulesStorage =>
+		({
+			findRules: vi.fn().mockResolvedValue(rules),
+		}) as unknown as AccessRulesStorage;
+
+	const buildDb = (
+		impl?: (session: unknown) => Promise<void>,
+	): { db: IProviderDatabase; spy: ReturnType<typeof vi.fn> } => {
+		const spy = vi.fn(impl ?? (async () => undefined));
+		return {
+			db: { storeBlockedSession: spy } as unknown as IProviderDatabase,
+			spy,
+		};
+	};
+
+	const validIpInfo = (countryCode: string): IPInfoResponse => ({
+		ip: "1.1.1.1",
+		isValid: true,
+		isVPN: false,
+		isTor: false,
+		isProxy: false,
+		isDatacenter: false,
+		isAbuser: false,
+		isMobile: false,
+		isSatellite: false,
+		isCrawler: false,
+		countryCode,
+	});
+
+	const BOT_JA4 = "t13d1313h2_f57a46bbacb6_7f0f34a4126d";
+	const BOT_UA =
+		"Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15";
+
+	it("emits a structured 'Access policy block' log line on Block decisions, carrying the matched rule's identity", async () => {
+		const { logger, calls } = captureLogger();
+		const storage = buildStorage([
+			{
+				type: AccessPolicyType.Block,
+				ja4Hash: BOT_JA4,
+				description: "ja4 block — custom (Twickets-targeted)",
+			},
+		]);
+		const inspector = new BlacklistRequestInspector(
+			storage,
+			async () => undefined,
+		);
+
+		const shouldAbort = await inspector.shouldAbortRequest(
+			"/v1/prosopo/provider/client/captcha/frictionless",
+			"1.1.1.1",
+			BOT_JA4,
+			{ "user-agent": BOT_UA, "prosopo-site-key": "sk-twickets" },
+			{},
+			logger,
+			validIpInfo("GB"),
+		);
+		expect(shouldAbort).toBe(true);
+
+		const blockLog = calls.find((c) => c.payload.msg === "Access policy block");
+		expect(blockLog).toBeDefined();
+		const data = blockLog?.payload.data as Record<string, unknown>;
+		expect(data.policyType).toBe(AccessPolicyType.Block);
+		expect(typeof data.ruleHash).toBe("string");
+		// Rule was scoped only on ja4Hash — derived ruleType reflects that.
+		expect(data.ruleType).toEqual(["ja4Hash"]);
+		expect(data.ruleDescription).toBe("ja4 block — custom (Twickets-targeted)");
+		const userScope = data.userScope as Record<string, unknown>;
+		expect(userScope.ja4).toBe(BOT_JA4);
+		expect(userScope.userAgent).toBe(BOT_UA);
+		expect(userScope.ip).toBe("1.1.1.1");
+		expect(userScope.countryCode).toBe("GB");
+	});
+
+	it("calls db.storeBlockedSession with blocked=true, ACCESS_POLICY_BLOCK reason and the rule identity on Block decisions", async () => {
+		const { logger } = captureLogger();
+		const { db, spy } = buildDb();
+		const storage = buildStorage([
+			{
+				type: AccessPolicyType.Block,
+				ja4Hash: BOT_JA4,
+				description: "ja4 block — Solver",
+			},
+		]);
+		const inspector = new BlacklistRequestInspector(
+			storage,
+			async () => undefined,
+			db,
+		);
+
+		const shouldAbort = await inspector.shouldAbortRequest(
+			"/v1/prosopo/provider/client/captcha/frictionless",
+			"1.1.1.1",
+			BOT_JA4,
+			{ "user-agent": BOT_UA },
+			{},
+			logger,
+			validIpInfo("GB"),
+		);
+		expect(shouldAbort).toBe(true);
+		// Fire-and-forget — give the microtask queue a tick to drain the
+		// void'd promise before asserting on the spy.
+		await Promise.resolve();
+		expect(spy).toHaveBeenCalledTimes(1);
+		const written = spy.mock.calls[0]?.[0] as Record<string, unknown>;
+		expect(written.reason).toBe(FrictionlessReason.ACCESS_POLICY_BLOCK);
+		expect(written.ruleHash).toEqual(expect.any(String));
+		expect(written.ruleType).toEqual(["ja4Hash"]);
+		expect(written.ruleDescription).toBe("ja4 block — Solver");
+		const headers = written.headers as Record<string, unknown>;
+		expect(headers["user-agent"]).toBe(BOT_UA);
+		// Sentinel required-field values that the request never reached
+		// the point of populating — asserted so the schema-required fields
+		// can never silently regress to undefined and trip Mongoose
+		// validation at write time.
+		expect(written.score).toBe(1);
+		expect(written.threshold).toBe(0);
+		expect(written.providerSelectEntropy).toBe(0);
+		expect(written.captchaType).toBe("frictionless");
+		const result = written.result as Record<string, unknown>;
+		expect(result.status).toBe("Disapproved");
+	});
+
+	it("does NOT call storeBlockedSession when no rule matches", async () => {
+		const { logger } = captureLogger();
+		const { db, spy } = buildDb();
+		const storage = buildStorage([]); // no rules match
+		const inspector = new BlacklistRequestInspector(
+			storage,
+			async () => undefined,
+			db,
+		);
+
+		const shouldAbort = await inspector.shouldAbortRequest(
+			"/v1/prosopo/provider/client/captcha/frictionless",
+			"1.1.1.1",
+			"clean-ja4",
+			{ "user-agent": "clean-ua" },
+			{},
+			logger,
+			validIpInfo("GB"),
+		);
+		expect(shouldAbort).toBe(false);
+		await Promise.resolve();
+		expect(spy).not.toHaveBeenCalled();
+	});
+
+	it("does NOT call storeBlockedSession when matched policy is Restrict (not Block)", async () => {
+		const { logger } = captureLogger();
+		const { db, spy } = buildDb();
+		const storage = buildStorage([
+			{
+				type: AccessPolicyType.Restrict,
+				ja4Hash: BOT_JA4,
+				description: "restrict — higher image rounds",
+			},
+		]);
+		const inspector = new BlacklistRequestInspector(
+			storage,
+			async () => undefined,
+			db,
+		);
+
+		const shouldAbort = await inspector.shouldAbortRequest(
+			"/v1/prosopo/provider/client/captcha/frictionless",
+			"1.1.1.1",
+			BOT_JA4,
+			{ "user-agent": BOT_UA },
+			{},
+			logger,
+			validIpInfo("GB"),
+		);
+		// Restrict policies don't 401 at middleware — they let the request
+		// through with modified captcha params; the downstream captcha-
+		// creation path then writes a normal session record. So no
+		// blocked-session doc should be created here.
+		expect(shouldAbort).toBe(false);
+		await Promise.resolve();
+		expect(spy).not.toHaveBeenCalled();
+	});
+
+	it("does NOT call storeBlockedSession when only matching Block policy has deferToVerify=true", async () => {
+		const { logger } = captureLogger();
+		const { db, spy } = buildDb();
+		const storage = buildStorage([
+			{
+				type: AccessPolicyType.Block,
+				deferToVerify: true,
+				ja4Hash: BOT_JA4,
+				description: "deferred ja4 block",
+			},
+		]);
+		const inspector = new BlacklistRequestInspector(
+			storage,
+			async () => undefined,
+			db,
+		);
+
+		const shouldAbort = await inspector.shouldAbortRequest(
+			"/v1/prosopo/provider/client/captcha/frictionless",
+			"1.1.1.1",
+			BOT_JA4,
+			{ "user-agent": BOT_UA },
+			{},
+			logger,
+			validIpInfo("GB"),
+		);
+		// deferToVerify policies are filtered before the block decision so
+		// the request passes through unimpeded — the verify-step path
+		// already writes its own commitment record.
+		expect(shouldAbort).toBe(false);
+		await Promise.resolve();
+		expect(spy).not.toHaveBeenCalled();
+	});
+
+	it("still 401s when storeBlockedSession rejects (DB write must not block the response)", async () => {
+		const { logger, calls } = captureLogger();
+		const { db } = buildDb(async () => {
+			throw new Error("simulated mongo failure");
+		});
+		const storage = buildStorage([
+			{
+				type: AccessPolicyType.Block,
+				ja4Hash: BOT_JA4,
+				description: "ja4 block — Solver",
+			},
+		]);
+		const inspector = new BlacklistRequestInspector(
+			storage,
+			async () => undefined,
+			db,
+		);
+
+		const shouldAbort = await inspector.shouldAbortRequest(
+			"/v1/prosopo/provider/client/captcha/frictionless",
+			"1.1.1.1",
+			BOT_JA4,
+			{ "user-agent": BOT_UA },
+			{},
+			logger,
+			validIpInfo("GB"),
+		);
+		// The block decision returns synchronously; the void'd promise can
+		// reject in the background without affecting the 401.
+		expect(shouldAbort).toBe(true);
+		// Structured "Access policy block" log line still landed.
+		expect(calls.some((c) => c.payload.msg === "Access policy block")).toBe(
+			true,
+		);
+	});
+
+	it("works without a db dependency — log fires, no persistence attempt", async () => {
+		const { logger, calls } = captureLogger();
+		const storage = buildStorage([
+			{
+				type: AccessPolicyType.Block,
+				ja4Hash: BOT_JA4,
+				description: "ja4 block — Solver",
+			},
+		]);
+		// Constructor with the legacy 2-arg form (no db) — existing
+		// production code paths that construct the inspector without a db
+		// must keep working.
+		const inspector = new BlacklistRequestInspector(
+			storage,
+			async () => undefined,
+		);
+
+		const shouldAbort = await inspector.shouldAbortRequest(
+			"/v1/prosopo/provider/client/captcha/frictionless",
+			"1.1.1.1",
+			BOT_JA4,
+			{ "user-agent": BOT_UA },
+			{},
+			logger,
+			validIpInfo("GB"),
+		);
+		expect(shouldAbort).toBe(true);
+		expect(calls.some((c) => c.payload.msg === "Access policy block")).toBe(
+			true,
+		);
+	});
+
+	it("derives ruleType as ['ip'] when the rule scopes on numericIp", async () => {
+		const { logger } = captureLogger();
+		const { db, spy } = buildDb();
+		// 1.1.1.1 == 16843009 as a big-int integer-encoded IPv4.
+		const storage = buildStorage([
+			{
+				type: AccessPolicyType.Block,
+				numericIp: 16843009n,
+				description: "single-IP block — 1.1.1.1",
+			},
+		]);
+		const inspector = new BlacklistRequestInspector(
+			storage,
+			async () => undefined,
+			db,
+		);
+
+		const shouldAbort = await inspector.shouldAbortRequest(
+			"/v1/prosopo/provider/client/captcha/frictionless",
+			"1.1.1.1",
+			"unrelated-ja4",
+			{ "user-agent": BOT_UA },
+			{},
+			logger,
+			validIpInfo("GB"),
+		);
+		expect(shouldAbort).toBe(true);
+		await Promise.resolve();
+		const written = spy.mock.calls[0]?.[0] as Record<string, unknown>;
+		expect(written.ruleType).toEqual(["ip"]);
+	});
+
+	it("derives ruleType as ['ipMask'] when the rule scopes on a CIDR range", async () => {
+		const { logger } = captureLogger();
+		const { db, spy } = buildDb();
+		// 1.1.1.0/24 → numericIpMaskMin=16843008, max=16843263
+		const storage = buildStorage([
+			{
+				type: AccessPolicyType.Block,
+				numericIpMaskMin: 16843008n,
+				numericIpMaskMax: 16843263n,
+				description: "CIDR block 1.1.1.0/24",
+			},
+		]);
+		const inspector = new BlacklistRequestInspector(
+			storage,
+			async () => undefined,
+			db,
+		);
+
+		const shouldAbort = await inspector.shouldAbortRequest(
+			"/v1/prosopo/provider/client/captcha/frictionless",
+			"1.1.1.1",
+			"unrelated-ja4",
+			{ "user-agent": BOT_UA },
+			{},
+			logger,
+			validIpInfo("GB"),
+		);
+		expect(shouldAbort).toBe(true);
+		await Promise.resolve();
+		const written = spy.mock.calls[0]?.[0] as Record<string, unknown>;
+		expect(written.ruleType).toEqual(["ipMask"]);
 	});
 });
 

--- a/packages/types-database/src/types/provider.ts
+++ b/packages/types-database/src/types/provider.ts
@@ -577,6 +577,13 @@ export const SessionRecordSchema = new Schema<SessionRecord>({
 	siteKey: { type: String, required: false },
 	reason: { type: String, required: false },
 	blocked: { type: Boolean, required: false },
+	// On synthetic blocked-session records (blocked=true, deleted=true)
+	// these carry the identity of the access-policy rule that fired at the
+	// request-time block middleware — the Traffic page joins on these to
+	// surface which rules are blocking traffic and at what volume.
+	ruleHash: { type: String, required: false },
+	ruleType: { type: [String], required: false },
+	ruleDescription: { type: String, required: false },
 	// Full ipinfo payload — replaces flat `countryCode` / `geolocation`
 	// fields. Mirrors the captcha record schemas (PoW / Puzzle /
 	// UserCommitment).
@@ -632,6 +639,13 @@ SessionRecordSchema.index({ userSitekeyIpHash: 1 });
 SessionRecordSchema.index({ providerSelectEntropy: 1 });
 SessionRecordSchema.index({ token: 1 });
 SessionRecordSchema.index({ siteKey: 1 }, { background: true, sparse: true });
+// Traffic-page aggregations group blocked-session records by rule. Sparse
+// so legit sessions (no rule fields) don't bloat the index.
+SessionRecordSchema.index(
+	{ siteKey: 1, blocked: 1, createdAt: 1 },
+	{ background: true, sparse: true },
+);
+SessionRecordSchema.index({ ruleHash: 1 }, { background: true, sparse: true });
 // Compound indexes for session aggregation queries
 SessionRecordSchema.index({
 	createdAt: 1,
@@ -950,6 +964,8 @@ export interface IProviderDatabase extends IDatabase {
 	getClientRecord(account: string): Promise<ClientRecord | undefined>;
 
 	storeSessionRecord(sessionRecord: Session): Promise<void>;
+
+	storeBlockedSession(sessionRecord: Session): Promise<void>;
 
 	getSessionRecordBySessionId(sessionId: string): Promise<Session | undefined>;
 

--- a/packages/types/src/provider/database.ts
+++ b/packages/types/src/provider/database.ts
@@ -411,6 +411,10 @@ export const SessionSchema = object({
 		.optional()
 		.transform((v) => v as FrictionlessReason | undefined),
 	blocked: boolean().optional(),
+	// See Session.ruleHash — populated on synthetic blocked-session records.
+	ruleHash: string().optional(),
+	ruleType: string().array().optional(),
+	ruleDescription: string().optional(),
 	// Full ipinfo payload from ipInfoMiddleware at session-creation
 	// time. Replaces the flat `countryCode` / `geolocation` fields —
 	// consumers narrow on `ipInfo.isValid` and read whichever sub-field
@@ -470,6 +474,14 @@ export type Session = {
 	siteKey?: string;
 	reason?: FrictionlessReason;
 	blocked?: boolean;
+	// When `blocked` is true, these record which access-policy rule matched
+	// at the request-time block middleware. Populated only on synthetic
+	// "blocked session" records the inspector writes when it 401s a request,
+	// so the Traffic page can surface "why are we blocking traffic for this
+	// site?" without an extra Mongo lookup against the rules collection.
+	ruleHash?: string; // == the redis-key suffix of the matched rule
+	ruleType?: string[]; // populated scope fields, e.g. ['ja4Hash'], ['ja4Hash','coords']
+	ruleDescription?: string; // operator-set description copied from the rule's AccessPolicy
 	// Full ipinfo payload from ipInfoMiddleware at session-creation
 	// time. Replaces the flat `countryCode` / `geolocation` fields.
 	ipInfo?: IPInfoResponse;


### PR DESCRIPTION
## Summary
- `blockMiddleware` now emits a structured `"Access policy block"` log line at the 401 decision point carrying the matched rule's identity (`ruleHash`, `ruleType`, `ruleDescription`, `policyType`) and the request's user-scope (ja4 / ip / userAgent / userId / countryCode / asn).
- Fires-and-forgets a `Session` insert with `blocked: true`, `deleted: true`, `reason: ACCESS_POLICY_BLOCK`, and the same three rule fields surfaced on new optional columns. Sentinel values fill the schema-required fields the blocked request never reached the point of populating.
- Two sparse indexes (`{siteKey, blocked, createdAt}` + `{ruleHash}`) so the upcoming Traffic-page aggregations are fast and the index doesn't bloat on normal sessions.

## Why
Today the inspector 401s a request silently — no log line, no Mongo write. When real iPhone Safari users got swept up by an over-broad JA4 block rule we had no signal that the block was happening, let alone *which* rule fired. Phase 1 of the blocked-traffic surfacing work:

- **Log**: lands in OO2 immediately. Same source as caddy's 401 stream but with the *reason* — we can answer "what's blocking real users right now" without diffing caddy logs against the rules collection.
- **Persist**: lays the data foundation for the Traffic page's "Blocked at middleware" tile and "Blocks by rule" chart. Keeps everything on the existing `sessions` collection — the page already aggregates from there — instead of introducing a new collection.

## Wire-level changes
**`@prosopo/types` / `@prosopo/types-database`** — three new optional fields on `Session` / `SessionRecordSchema`:
- `ruleHash?: string` — the redis-key suffix of the matched rule
- `ruleType?: string[]` — populated scope fields (`['ja4Hash']`, `['ja4Hash','coords']`, `['ip']`, …) derived from the rule
- `ruleDescription?: string` — operator-set description, copied from the rule's AccessPolicy

Two new sparse indexes on `SessionRecordSchema`:
- `{ siteKey: 1, blocked: 1, createdAt: 1 }` — for per-client-per-time-bucket block counts
- `{ ruleHash: 1 }` — for per-rule drill-down

**`@prosopo/database` (`ProviderDatabase`)** — new `storeBlockedSession(session: Session): Promise<void>`. Stamps `blocked: true` + `deleted: true` + `storedAtTimestamp` (so the existing TTL sweeps it after a day), inserts into `tables.session`, and forwards through the central streamer same as `storeSessionRecord`. Any Mongo error is caught and logged-warn so the 401 path never throws.

**`@prosopo/provider` (`blacklistRequestInspector`)** — at the spot where `isBlock` is determined, calls a new private `recordBlockDecision(accessPolicy, ctx, logger)` that emits the structured log line and (if the inspector was constructed with a DB) `void`'s a `storeBlockedSession` call. New helpers `deriveRuleType` and `sanitizeRequestHeaders` are local to the file. The `db` constructor arg is **optional** so existing unit tests (which construct the inspector with two args) keep working unchanged.

**`@prosopo/provider` (`block.ts`)** — passes the provider's DB into the inspector constructor.

## Design notes
- **Restrict policies are not touched.** They don't 401 at middleware; they pass through with modified captcha params and the downstream captcha-creation path already writes a real session. Including them here would double-write.
- **`deleted: true` from the start** is the discriminator that keeps the blocked-session record out of `checkAndRemoveSession`'s `{deleted: {$exists: false}}` filter — the captcha flow can never accidentally pick one up.
- **No new TTL.** Reuses the existing `storedAtTimestamp` 1-day TTL on the sessions collection. No new collection, no new sweep.
- **Sentinel `captchaType: frictionless`** is the closest fit since the blocked request was on its way to the frictionless endpoint.
- **Sentinel score=1 / threshold=0 / baseScore=1** mean "would have failed anything" — readable as "this request never had a chance" if anyone hits these docs in mongo.

## Test plan
- [x] Existing 27 inspector + block tests still pass (constructor backward-compatible).
- [x] Existing captchaManager tests still pass.
- [x] `npm run typecheck` clean across `@prosopo/{types,types-database,database,provider}`.
- [x] `biome check` clean.
- [ ] Smoke-test in staging: hit a route covered by a known Block rule, observe (a) the `"Access policy block"` log line in OO2 with the matched ruleHash, (b) a new doc in `captchastorage.sessions` with `blocked: true`, `deleted: true`, `reason: "ACCESS_POLICY_BLOCK"`, and populated `ruleHash`/`ruleType`/`ruleDescription`.
- [ ] Mongo write failure path: bring the DB connection down, fire a blocked request, confirm the 401 still returns and the warn log fires.

## Follow-ups (Phase 2 / 3, separate PRs)
- API endpoint `GET /portal/sites/traffic/blocks?clientId=&from=&to=&granularity=` aggregating from the new indexes.
- Traffic page tile `Blocked at middleware: N (X% of all requests)`.
- `BlocksByRuleChart` stacked-area per ruleType, modelled on `TrafficFlagsChart`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)