### PR TITLE
feat(captcha): split solutionTimeout (issuance→submit) from verifiedTimeout (submit→/verify)

### DIFF
--- a/.changeset/solution-timeout-split.md
+++ b/.changeset/solution-timeout-split.md
@@ -1,0 +1,8 @@
+---
+"@prosopo/provider": minor
+"@prosopo/types": minor
+"@prosopo/types-database": minor
+"@prosopo/cli": patch
+---
+
+Split `solutionTimeout` (challenge issuance → user submission) from `verifiedTimeout` (submission → dapp's /verify call) on `UserSettings`. Historically `verifiedTimeout` gated both windows in `verifyRecency` (at /pow|puzzle/solution submit) and in `serverVerifyPowCaptchaSolution` (at /verify), even though its doc comment only described the latter. Adds `solutionTimeout` to `ClientSettingsSchema` (zod) and `UserSettingsSchema` (mongoose) with `DEFAULT_POW_CAPTCHA_SOLUTION_TIMEOUT` (60s) as default. `submitPoWCaptchaSolution` and `submitPuzzleCaptchaSolution` now use `solutionTimeout` for the recency check and fall back to `verifiedTimeout` for pre-existing client records so behaviour is preserved until those records are backfilled. The `/verify` path is unchanged. Operators can now tighten `verifiedTimeout` (e.g. 20s) to invalidate stale solutions at verify time without also shrinking the user's solve budget.

--- a/demos/cypress-shared/cypress/support/commands.ts
+++ b/demos/cypress-shared/cypress/support/commands.ts
@@ -376,6 +376,7 @@ function registerSiteKey(
 			puzzleTolerance: puzzleToleranceDefault,
 			disallowWebView: false,
 			verifiedTimeout: 60000,
+			solutionTimeout: 60000,
 		};
 
 		// Use cy.request() to ensure Cypress correctly queues the request

--- a/packages/cli/src/commands/siteKeyRegister.ts
+++ b/packages/cli/src/commands/siteKeyRegister.ts
@@ -134,6 +134,7 @@ export default (
 						},
 					},
 					verifiedTimeout: 60000,
+					solutionTimeout: 60000,
 				});
 				logger.info(() => ({
 					data: { sitekey },

--- a/packages/cli/src/commands/siteKeyRegisterApi.ts
+++ b/packages/cli/src/commands/siteKeyRegisterApi.ts
@@ -121,6 +121,7 @@ export default (
 						puzzleTolerance: puzzleToleranceDefault,
 						disallowWebView: false,
 						verifiedTimeout: 60000,
+						solutionTimeout: 60000,
 					},
 					jwt,
 				);

--- a/packages/provider/src/api/captcha/submitPoWCaptchaSolution.ts
+++ b/packages/provider/src/api/captcha/submitPoWCaptchaSolution.ts
@@ -126,11 +126,20 @@ export default (env: ProviderEnvironment) =>
 				},
 			});
 
+			// `solutionTimeout` gates issuance → submit; falls back to
+			// `verifiedTimeout` for records that pre-date the field, since
+			// historically that value covered both windows. Mongoose `default`
+			// doesn't fire on reads, so the runtime value can be undefined
+			// even though the parsed schema type says `number`.
+			const persistedSolutionTimeout =
+				clientRecord.settings.solutionTimeout as number | undefined;
+			const submitWindowMs: number =
+				persistedSolutionTimeout ?? clientRecord.settings.verifiedTimeout;
 			const result = await tasks.powCaptchaManager.verifyPowCaptchaSolution(
 				challenge,
 				signature.provider.challenge,
 				nonce,
-				clientRecord.settings.verifiedTimeout,
+				submitWindowMs,
 				signature.user.timestamp,
 				getIPAddress(req.ip || ""),
 				flatHeaders,

--- a/packages/provider/src/api/captcha/submitPoWCaptchaSolution.ts
+++ b/packages/provider/src/api/captcha/submitPoWCaptchaSolution.ts
@@ -131,8 +131,9 @@ export default (env: ProviderEnvironment) =>
 			// historically that value covered both windows. Mongoose `default`
 			// doesn't fire on reads, so the runtime value can be undefined
 			// even though the parsed schema type says `number`.
-			const persistedSolutionTimeout =
-				clientRecord.settings.solutionTimeout as number | undefined;
+			const persistedSolutionTimeout = clientRecord.settings.solutionTimeout as
+				| number
+				| undefined;
 			const submitWindowMs: number =
 				persistedSolutionTimeout ?? clientRecord.settings.verifiedTimeout;
 			const result = await tasks.powCaptchaManager.verifyPowCaptchaSolution(

--- a/packages/provider/src/api/captcha/submitPuzzleCaptchaSolution.ts
+++ b/packages/provider/src/api/captcha/submitPuzzleCaptchaSolution.ts
@@ -102,6 +102,15 @@ export default (env: ProviderEnvironment) =>
 				);
 			}
 
+			// `solutionTimeout` gates issuance → submit; falls back to
+			// `verifiedTimeout` for records that pre-date the field, since
+			// historically that value covered both windows. Mongoose `default`
+			// doesn't fire on reads, so the runtime value can be undefined
+			// even though the parsed schema type says `number`.
+			const persistedSolutionTimeout =
+				clientRecord.settings.solutionTimeout as number | undefined;
+			const submitWindowMs: number =
+				persistedSolutionTimeout ?? clientRecord.settings.verifiedTimeout;
 			const verified =
 				await tasks.puzzleCaptchaManager.verifyPuzzleCaptchaSolution(
 					challenge,
@@ -109,7 +118,7 @@ export default (env: ProviderEnvironment) =>
 					finalX,
 					finalY,
 					puzzleEvents,
-					clientRecord.settings.verifiedTimeout,
+					submitWindowMs,
 					signature.user.timestamp,
 					getIPAddress(req.ip || ""),
 					flatten(req.headers),

--- a/packages/provider/src/api/captcha/submitPuzzleCaptchaSolution.ts
+++ b/packages/provider/src/api/captcha/submitPuzzleCaptchaSolution.ts
@@ -107,8 +107,9 @@ export default (env: ProviderEnvironment) =>
 			// historically that value covered both windows. Mongoose `default`
 			// doesn't fire on reads, so the runtime value can be undefined
 			// even though the parsed schema type says `number`.
-			const persistedSolutionTimeout =
-				clientRecord.settings.solutionTimeout as number | undefined;
+			const persistedSolutionTimeout = clientRecord.settings.solutionTimeout as
+				| number
+				| undefined;
 			const submitWindowMs: number =
 				persistedSolutionTimeout ?? clientRecord.settings.verifiedTimeout;
 			const verified =

--- a/packages/provider/src/tests/integration/api/admin/apiRegisterSiteKeyEndpoint.integration.test.ts
+++ b/packages/provider/src/tests/integration/api/admin/apiRegisterSiteKeyEndpoint.integration.test.ts
@@ -66,6 +66,7 @@ describe("apiRegisterSiteKeyEndpoint", () => {
 				imageMaxRounds: 3,
 				powDifficulty: 0.5,
 				verifiedTimeout: 120000,
+				solutionTimeout: 60000,
 				puzzleTolerance: 15,
 				disallowWebView: false,
 				contextAware: {
@@ -105,6 +106,7 @@ describe("apiRegisterSiteKeyEndpoint", () => {
 				imageMaxRounds: 3,
 				powDifficulty: 0.5,
 				verifiedTimeout: 120000,
+				solutionTimeout: 60000,
 				puzzleTolerance: 15,
 				disallowWebView: false,
 				contextAware: {

--- a/packages/provider/src/tests/integration/clientSettingsPersistence.integration.test.ts
+++ b/packages/provider/src/tests/integration/clientSettingsPersistence.integration.test.ts
@@ -52,6 +52,7 @@ const FULLY_POPULATED_SETTINGS = {
 	imageMaxRounds: 12,
 	autoBanScoreThreshold: 0.95,
 	verifiedTimeout: 120000,
+	solutionTimeout: 60000,
 	puzzleTolerance: 20,
 	disallowWebView: true,
 	contextAware: {

--- a/packages/provider/src/tests/unit/api/admin/apiRegisterSiteKeyEndpoint.unit.test.ts
+++ b/packages/provider/src/tests/unit/api/admin/apiRegisterSiteKeyEndpoint.unit.test.ts
@@ -61,6 +61,7 @@ describe("ApiRegisterSiteKeyEndpoint", () => {
 			imageThreshold: 0.5,
 			imageMaxRounds: 3,
 			verifiedTimeout: 120000,
+			solutionTimeout: 60000,
 			puzzleTolerance: 15,
 		};
 

--- a/packages/provider/src/tests/unit/tasks/captchaManager.unit.test.ts
+++ b/packages/provider/src/tests/unit/tasks/captchaManager.unit.test.ts
@@ -47,6 +47,7 @@ const defaultUserSettings: IUserSettings = {
 	imageThreshold: 0.8,
 	imageMaxRounds: 3,
 	verifiedTimeout: 120000,
+	solutionTimeout: 60000,
 	puzzleTolerance: 15,
 	disallowWebView: false,
 	contextAware: {

--- a/packages/types-database/src/types/client.ts
+++ b/packages/types-database/src/types/client.ts
@@ -15,6 +15,7 @@
 import {
 	CaptchaType,
 	ContextType,
+	DEFAULT_POW_CAPTCHA_SOLUTION_TIMEOUT,
 	DEFAULT_POW_CAPTCHA_VERIFIED_TIMEOUT,
 	type IUserData,
 	type IUserSettings,
@@ -120,6 +121,10 @@ export const UserSettingsSchema = new Schema({
 	verifiedTimeout: {
 		type: Number,
 		default: DEFAULT_POW_CAPTCHA_VERIFIED_TIMEOUT,
+	},
+	solutionTimeout: {
+		type: Number,
+		default: DEFAULT_POW_CAPTCHA_SOLUTION_TIMEOUT,
 	},
 	frictionlessThreshold: {
 		type: Number,

--- a/packages/types/src/client/settings.ts
+++ b/packages/types/src/client/settings.ts
@@ -12,7 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import { array, boolean, number, object, type output, string, z } from "zod";
-import { DEFAULT_POW_CAPTCHA_VERIFIED_TIMEOUT } from "../config/timeouts.js";
+import {
+	DEFAULT_POW_CAPTCHA_SOLUTION_TIMEOUT,
+	DEFAULT_POW_CAPTCHA_VERIFIED_TIMEOUT,
+} from "../config/timeouts.js";
 import { CaptchaType } from "./captchaType/captchaType.js";
 import { CaptchaTypeSpec } from "./captchaType/captchaTypeSpec.js";
 
@@ -232,6 +235,16 @@ export const ClientSettingsSchema = object({
 		.max(600000)
 		.optional()
 		.default(DEFAULT_POW_CAPTCHA_VERIFIED_TIMEOUT),
+	// Maximum ms between challenge issuance and the user's submission to
+	// /pow/solution or /puzzle/solution. Bounds how long the user has to
+	// solve the challenge before the submission is rejected as stale.
+	// Distinct from `verifiedTimeout` (which gates submission → /verify).
+	solutionTimeout: number()
+		.int()
+		.min(1000)
+		.max(600000)
+		.optional()
+		.default(DEFAULT_POW_CAPTCHA_SOLUTION_TIMEOUT),
 	frictionlessThreshold: number()
 		.min(0)
 		.max(1)


### PR DESCRIPTION
## Summary
- `UserSettings.verifiedTimeout` was overloaded as the budget for **both** the issuance→submit window (checked in `verifyRecency` at /pow|puzzle/solution) and the submit→/verify window (checked in `serverVerifyPowCaptchaSolution`). Its doc comment already documented it as the latter only.
- Adds `solutionTimeout` to `ClientSettingsSchema` (zod) and `UserSettingsSchema` (mongoose), gated to the issuance→submit window.
- `submitPoWCaptchaSolution` and `submitPuzzleCaptchaSolution` now pass `solutionTimeout ?? verifiedTimeout` so pre-existing client records (lacking the new field) keep their prior effective behaviour until backfilled.
- `/verify` path unchanged — already used `verifiedTimeout` for submit→/verify correctly.
- Default: `DEFAULT_POW_CAPTCHA_SOLUTION_TIMEOUT` (60s). Test fixtures + CLI/cypress writers updated to satisfy the new required field on `IUserSettings`.

After this lands, operators can tighten `verifiedTimeout` (e.g. 20s submit→/verify window for replay protection) without also shrinking the user's solve time.

## Test plan
- [ ] `npm run -w @prosopo/provider build:tsc` — clean
- [ ] `npm run -w @prosopo/types build:tsc` — clean
- [ ] Unit + integration tests for pow/puzzle submit paths still pass
- [ ] Manual: set `solutionTimeout=120000, verifiedTimeout=20000` on a staging site, issue challenge, solve in 90s — submit accepted, /verify call within 20s of submit accepted, /verify after 30s rejected with TIMESTAMP_TOO_OLD

🤖 Generated with [Claude Code](https://claude.com/claude-code)