### PR TITLE
feat(pow): bit-level granular PoW difficulty (Phase 1 — JS solver)

### DIFF
--- a/.changeset/bit-level-pow-difficulty.md
+++ b/.changeset/bit-level-pow-difficulty.md
@@ -1,0 +1,7 @@
+---
+"@prosopo/util": minor
+"@prosopo/provider": minor
+"@prosopo/types": minor
+---
+
+Bit-level granular PoW difficulty via target-threshold check. `solvePoW` (client) and `validateSolution` (server) now compare the hash as a 256-bit big-endian integer against `target = 2^(256 - round(4 * difficulty))`, shared via `targetForDifficulty` / `hashMeetsDifficulty` in `@prosopo/util`. Integer difficulties produce *identical* behaviour to the legacy hex-prefix check (d=4 ≡ 16 leading zero bits ≡ threshold 2^240), so existing clients, configs, anomaly detectors, and stored records are unchanged. Fractional values quantise to bit-level granularity: each 0.25 step ≡ 1 bit ≡ 2× work, so providers can tune d=4.25, d=4.5, d=4.75 to fill the 16× gap between today's d=4 and d=5 — useful for landing on a sensible mobile UX. `powDifficulty` in `ClientSettingsSchema` and `RoutingMachineOutputSchema` drops `.int()`; wire format (nonce as `u32`, difficulty as `number`) is unchanged.

--- a/packages/provider/src/tasks/powCaptcha/powTasksUtils.ts
+++ b/packages/provider/src/tasks/powCaptcha/powTasksUtils.ts
@@ -15,6 +15,7 @@
 import { sha256 } from "@noble/hashes/sha256";
 import { stringToHex } from "@polkadot/util";
 import { ProsopoApiError } from "@prosopo/common";
+import { hashMeetsDifficulty } from "@prosopo/util";
 import { signatureVerify } from "@prosopo/util-crypto";
 
 export const validateSolution = (
@@ -22,10 +23,10 @@ export const validateSolution = (
 	challenge: string,
 	difficulty: number,
 ): boolean =>
-	Array.from(sha256(new TextEncoder().encode(nonce + challenge)))
-		.map((byte) => byte.toString(16).padStart(2, "0"))
-		.join("")
-		.startsWith("0".repeat(difficulty));
+	hashMeetsDifficulty(
+		sha256(new TextEncoder().encode(nonce + challenge)),
+		difficulty,
+	);
 
 export const checkPowSignature = (
 	message: string,

--- a/packages/provider/src/tests/unit/tasks/powCaptcha/powTasksUtils.unit.test.ts
+++ b/packages/provider/src/tests/unit/tasks/powCaptcha/powTasksUtils.unit.test.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { sha256 } from "@noble/hashes/sha256";
 import { ProsopoApiError } from "@prosopo/common";
 import { signatureVerify } from "@prosopo/util-crypto";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -80,6 +81,54 @@ describe("validateSolution", () => {
 
 		const result = validateSolution(nonce, challenge, difficulty);
 		expect(result).toBe(false);
+	});
+
+	it("should accept fractional difficulty (bit-level granularity)", () => {
+		// Each 0.25 step in difficulty ≡ 1 bit of work. A solution that meets
+		// difficulty N must also meet any difficulty < N.
+		const nonce = 42;
+		const challenge = "fractional-test";
+
+		// boolean type for all fractional steps in [4, 5]
+		for (const d of [4, 4.25, 4.5, 4.75, 5]) {
+			expect(typeof validateSolution(nonce, challenge, d)).toBe("boolean");
+		}
+	});
+
+	it("should be monotonic — harder difficulty implies easier difficulty", () => {
+		// If a (nonce, challenge) hash meets difficulty 5, it must meet 4.75, 4.5, etc.
+		// Search for one that satisfies the higher bar so the property is testable.
+		const challenge = "monotonic";
+		let solvingNonce = -1;
+		for (let n = 0; n < 100_000; n++) {
+			if (validateSolution(n, challenge, 5)) {
+				solvingNonce = n;
+				break;
+			}
+		}
+		expect(solvingNonce).toBeGreaterThanOrEqual(0);
+		for (const easier of [4.75, 4.5, 4.25, 4, 3, 2, 1]) {
+			expect(validateSolution(solvingNonce, challenge, easier)).toBe(true);
+		}
+	});
+
+	it("should treat integer difficulties identically to the legacy hex-prefix check", () => {
+		// Equivalence: old check was sha256(...).hex.startsWith('0'.repeat(d)).
+		// New check is hash < 2^(256 - 4*d). For integer d these are identical.
+		const challenge = "legacy-equivalence";
+		const legacy = (nonce: number, d: number): boolean => {
+			const hash = Array.from(
+				sha256(new TextEncoder().encode(nonce + challenge)),
+			)
+				.map((b: number) => b.toString(16).padStart(2, "0"))
+				.join("");
+			return hash.startsWith("0".repeat(d));
+		};
+		for (const d of [1, 2, 3, 4]) {
+			for (let n = 0; n < 500; n++) {
+				expect(validateSolution(n, challenge, d)).toBe(legacy(n, d));
+			}
+		}
 	});
 });
 

--- a/packages/provider/src/tests/unit/tasks/powCaptcha/powTasksUtils.unit.test.ts
+++ b/packages/provider/src/tests/unit/tasks/powCaptcha/powTasksUtils.unit.test.ts
@@ -96,18 +96,19 @@ describe("validateSolution", () => {
 	});
 
 	it("should be monotonic — harder difficulty implies easier difficulty", () => {
-		// If a (nonce, challenge) hash meets difficulty 5, it must meet 4.75, 4.5, etc.
-		// Search for one that satisfies the higher bar so the property is testable.
+		// Search at d=3 (12 bits ≡ ~1/4k); over 200k iterations the probability
+		// of no match is e^-48, no flake risk. Searching at d=5 (~1/1M) in the
+		// same budget misses too often.
 		const challenge = "monotonic";
 		let solvingNonce = -1;
-		for (let n = 0; n < 100_000; n++) {
-			if (validateSolution(n, challenge, 5)) {
+		for (let n = 0; n < 200_000; n++) {
+			if (validateSolution(n, challenge, 3)) {
 				solvingNonce = n;
 				break;
 			}
 		}
 		expect(solvingNonce).toBeGreaterThanOrEqual(0);
-		for (const easier of [4.75, 4.5, 4.25, 4, 3, 2, 1]) {
+		for (const easier of [2.75, 2.5, 2.25, 2, 1]) {
 			expect(validateSolution(solvingNonce, challenge, easier)).toBe(true);
 		}
 	});

--- a/packages/types/src/client/settings.ts
+++ b/packages/types/src/client/settings.ts
@@ -251,7 +251,6 @@ export const ClientSettingsSchema = object({
 		.optional()
 		.default(frictionlessThresholdDefault),
 	powDifficulty: number()
-		.int()
 		.positive()
 		.min(1)
 		.max(10)

--- a/packages/types/src/decisionMachine/index.ts
+++ b/packages/types/src/decisionMachine/index.ts
@@ -234,5 +234,5 @@ export const RoutingMachineOutputSchema = z.object({
 		z.literal(CaptchaType.puzzle),
 	]),
 	solvedImagesCount: z.number().int().positive().optional(),
-	powDifficulty: z.number().int().positive().optional(),
+	powDifficulty: z.number().positive().optional(),
 });

--- a/packages/util/src/solverService.ts
+++ b/packages/util/src/solverService.ts
@@ -16,18 +16,48 @@ import { sha256 } from "@noble/hashes/sha256";
 // batching prevents complete lock of Browser renders during resolution
 const BATCH_SIZE = 1_000;
 
+// Difficulty is interpreted as "hex-character leading zeros" for backward
+// compatibility with integer values (e.g. difficulty 4 ≡ 4 hex zeros ≡ 16 bits
+// ≡ threshold = 2^240). Fractional values quantise to bit-level granularity:
+// each 0.25 step ≡ 1 bit (so 4.25 = 17 bits, 4.5 = 18 bits, 4.75 = 19 bits).
+const HEX_BITS_PER_DIFFICULTY = 4;
+const HASH_BITS = 256;
+
+const bitsRequired = (difficulty: number): number =>
+	Math.round(HEX_BITS_PER_DIFFICULTY * difficulty);
+
+export const targetForDifficulty = (difficulty: number): bigint => {
+	const bits = bitsRequired(difficulty);
+	if (bits <= 0) return 1n << BigInt(HASH_BITS);
+	if (bits >= HASH_BITS) return 1n;
+	return 1n << BigInt(HASH_BITS - bits);
+};
+
+const hashToBigInt = (hash: Uint8Array): bigint => {
+	let value = 0n;
+	for (const byte of hash) {
+		value = (value << 8n) | BigInt(byte);
+	}
+	return value;
+};
+
+export const hashMeetsDifficulty = (
+	hash: Uint8Array,
+	difficulty: number,
+): boolean => hashToBigInt(hash) < targetForDifficulty(difficulty);
+
 export const solvePoW = async (
 	data: string,
 	difficulty: number,
 ): Promise<number> => {
+	const target = targetForDifficulty(difficulty);
 	let nonce = 0;
-	const prefix = "0".repeat(difficulty);
 
 	while (true) {
 		const message = new TextEncoder().encode(nonce + data);
-		const hashHex = bufferToHex(sha256(message));
+		const hash = sha256(message);
 
-		if (hashHex.startsWith(prefix)) {
+		if (hashToBigInt(hash) < target) {
 			return nonce;
 		}
 
@@ -39,11 +69,6 @@ export const solvePoW = async (
 		}
 	}
 };
-
-const bufferToHex = (buffer: Uint8Array): string =>
-	Array.from(buffer)
-		.map((byte) => byte.toString(16).padStart(2, "0"))
-		.join("");
 
 /**
  * Usage:

--- a/packages/util/src/tests/solverService.unit.test.ts
+++ b/packages/util/src/tests/solverService.unit.test.ts
@@ -1,0 +1,101 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import { sha256 } from "@noble/hashes/sha256";
+import { describe, expect, it } from "vitest";
+import {
+	hashMeetsDifficulty,
+	solvePoW,
+	targetForDifficulty,
+} from "../solverService.js";
+
+describe("targetForDifficulty", () => {
+	it("returns 2^240 for difficulty 4 (16 bits)", () => {
+		expect(targetForDifficulty(4)).toBe(1n << 240n);
+	});
+
+	it("returns 2^236 for difficulty 5 (20 bits)", () => {
+		expect(targetForDifficulty(5)).toBe(1n << 236n);
+	});
+
+	it("quantises fractional difficulty to bit-level granularity", () => {
+		// 0.25 step ≡ 1 bit
+		expect(targetForDifficulty(4.25)).toBe(1n << 239n);
+		expect(targetForDifficulty(4.5)).toBe(1n << 238n);
+		expect(targetForDifficulty(4.75)).toBe(1n << 237n);
+	});
+
+	it("is strictly decreasing in difficulty", () => {
+		const ds = [1, 2, 3, 3.5, 4, 4.25, 4.5, 4.75, 5, 6, 7];
+		for (let i = 1; i < ds.length; i++) {
+			expect(targetForDifficulty(ds[i] as number)).toBeLessThan(
+				targetForDifficulty(ds[i - 1] as number),
+			);
+		}
+	});
+});
+
+describe("hashMeetsDifficulty", () => {
+	const hashOf = (data: string): Uint8Array =>
+		sha256(new TextEncoder().encode(data));
+
+	it("matches the legacy hex-prefix check for integer difficulty", () => {
+		for (let n = 0; n < 200; n++) {
+			const hash = hashOf(`${n}challenge`);
+			const hex = Array.from(hash)
+				.map((b: number) => b.toString(16).padStart(2, "0"))
+				.join("");
+			for (const d of [1, 2, 3, 4]) {
+				expect(hashMeetsDifficulty(hash, d)).toBe(
+					hex.startsWith("0".repeat(d)),
+				);
+			}
+		}
+	});
+
+	it("is monotonic — meeting harder difficulty implies meeting easier", () => {
+		// pick a nonce that meets difficulty 4 (~1 in 65k)
+		let met: Uint8Array | null = null;
+		for (let n = 0; n < 200_000; n++) {
+			const h = hashOf(`${n}monotonic`);
+			if (hashMeetsDifficulty(h, 4)) {
+				met = h;
+				break;
+			}
+		}
+		expect(met).not.toBeNull();
+		if (met) {
+			for (const easier of [3.75, 3.5, 3, 2, 1]) {
+				expect(hashMeetsDifficulty(met, easier)).toBe(true);
+			}
+		}
+	});
+});
+
+describe("solvePoW", () => {
+	it("returns a nonce whose hash meets the difficulty", async () => {
+		const challenge = "solver-roundtrip";
+		const difficulty = 2;
+		const nonce = await solvePoW(challenge, difficulty);
+		const hash = sha256(new TextEncoder().encode(nonce + challenge));
+		expect(hashMeetsDifficulty(hash, difficulty)).toBe(true);
+	});
+
+	it("respects fractional difficulty in the round-trip", async () => {
+		const challenge = "solver-fractional";
+		const difficulty = 2.5;
+		const nonce = await solvePoW(challenge, difficulty);
+		const hash = sha256(new TextEncoder().encode(nonce + challenge));
+		expect(hashMeetsDifficulty(hash, difficulty)).toBe(true);
+	});
+});

--- a/packages/util/src/tests/solverService.unit.test.ts
+++ b/packages/util/src/tests/solverService.unit.test.ts
@@ -64,18 +64,21 @@ describe("hashMeetsDifficulty", () => {
 	});
 
 	it("is monotonic — meeting harder difficulty implies meeting easier", () => {
-		// pick a nonce that meets difficulty 4 (~1 in 65k)
+		// Pick a nonce that meets difficulty 3 (12 bits ≡ ~1 in 4k). Over 200k
+		// attempts the probability of zero matches is e^(-48) — no flake risk,
+		// whereas a difficulty-4 search (16 bits ≡ ~1 in 65k) over the same
+		// budget misses ~5% of the time.
 		let met: Uint8Array | null = null;
 		for (let n = 0; n < 200_000; n++) {
 			const h = hashOf(`${n}monotonic`);
-			if (hashMeetsDifficulty(h, 4)) {
+			if (hashMeetsDifficulty(h, 3)) {
 				met = h;
 				break;
 			}
 		}
 		expect(met).not.toBeNull();
 		if (met) {
-			for (const easier of [3.75, 3.5, 3, 2, 1]) {
+			for (const easier of [2.75, 2.5, 2, 1]) {
 				expect(hashMeetsDifficulty(met, easier)).toBe(true);
 			}
 		}


### PR DESCRIPTION
## Summary

Replaces the legacy hex-prefix PoW difficulty check with a 256-bit threshold comparison, allowing **bit-level granular** difficulty values while staying wire-format compatible.

- **Integer difficulties produce identical behaviour** (d=4 ≡ 4 hex zeros ≡ 16 bits ≡ threshold 2^240). No migration needed for existing clients, configs, anomaly detectors, or stored records.
- **Fractional difficulty** quantises to bit-level granularity — each 0.25 step ≡ 1 bit of additional work:

  | difficulty | bits required | relative work vs. d=4 |
  | --- | --- | --- |
  | 4    | 16 | 1× |
  | 4.25 | 17 | 2× |
  | 4.5  | 18 | 4× |
  | 4.75 | 19 | 8× |
  | 5    | 20 | 16× |

  Today's mobile UX cliff between d=4 and d=5 (a 16× jump) is now four 2× steps. Providers can tune d=4.5 for slower-device cohorts without anyone changing the wire schema.

## Why bit-level, not the original `bit-level-pow-diff` design

The 14-month-old `bit-level-pow-diff` branch used a normalized `[0, 1]` difficulty and a `bigint` variable-length nonce. That's incompatible with the current wire format — `nonce` is encoded as SCALE `Option(u32)` in `packages/types/src/procaptcha/token.ts`. This PR achieves the same granularity goal without breaking the wire.

## Changes

- `packages/util/src/solverService.ts` — new helpers `targetForDifficulty(d): bigint` and `hashMeetsDifficulty(hash, d): boolean`. `solvePoW` switches its inner check from `hashHex.startsWith('0'.repeat(d))` to `hashBigInt < target`. Macrotask yielding preserved.
- `packages/provider/src/tasks/powCaptcha/powTasksUtils.ts` — `validateSolution` now delegates to `hashMeetsDifficulty` so client and server share the same math.
- `packages/types/src/client/settings.ts` — `powDifficulty` zod schema drops `.int()` (keeps `min(1).max(10)`, default `4`).
- `packages/types/src/decisionMachine/index.ts` — same for `RoutingMachineOutputSchema.powDifficulty`.

## Test plan
- [x] `npm run -w @prosopo/util build:tsc` — green
- [x] `npm run -w @prosopo/types build:tsc` — green
- [x] `npm run -w @prosopo/provider build:tsc` — green
- [x] `npm run -w @prosopo/util test` — 145 + new tests pass, 100% line coverage on `solverService.ts`
- [x] `npx vitest run src/tests/unit/tasks/powCaptcha/` in provider — 57 pass
- [x] Property test: integer difficulties produce identical output to the legacy hex-prefix check for all (n, d) where d ∈ {1..4}, n ∈ {0..499}
- [x] Property test: monotonicity — a hash meeting difficulty d also meets every easier difficulty
- [ ] Round-trip integration test on staging (not run yet)

## Follow-ups (out of scope)
- **Phase 2**: WASM solver (revive `pow-wasm` skeleton, finish the nonce loop in Rust). Multiplicative with this change — Phase 1 gives granularity, Phase 2 gives speed.
- Once this merges, bump `captcha` submodule in `captcha-private` so the orchestrator anomaly detector can start emitting fractional difficulties (e.g. `HARSH_POW_DIFFICULTY = 5.5`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)