### PR TITLE
feat(traffic-filter): allowlist datacenter operators by name (e.g. iCloud Private Relay)

### DIFF
--- a/.changeset/datacenter-name-allowlist.md
+++ b/.changeset/datacenter-name-allowlist.md
@@ -1,0 +1,19 @@
+---
+"@prosopo/ipinfo": patch
+"@prosopo/provider": patch
+"@prosopo/types": patch
+"@prosopo/types-database": patch
+---
+
+feat(traffic-filter): allowlist datacenter operators by name
+
+Apple's iCloud Private Relay exits from datacenter IPs, so sites with
+`blockDatacenter: true` were dropping legitimate Safari traffic. ipapi
+already reports the operator name verbatim in `datacenter.datacenter`
+— expose it on `IPInfoResult.datacenterName` and let `TrafficFilter`
+carry an optional `datacenterNameAllowlist` so operators can opt the
+relay traffic through without disabling the rest of the rule. Match
+is case-/whitespace-insensitive; the allowlist only suppresses the
+datacenter check, so a VPN/Tor/Proxy/Abuser hit on the same IP still
+blocks. New field is wired through Zod (capped 50 × 128 chars) and
+the Mongoose client settings schema so it persists.

--- a/packages/ipinfo/src/backends/ipapi.ts
+++ b/packages/ipinfo/src/backends/ipapi.ts
@@ -103,6 +103,7 @@ export class IpapiBackend {
 					providerType: data.company?.type || data.asn?.type,
 					asnNumber: data.asn?.asn,
 					asnOrganization: data.asn?.org,
+					datacenterName: data.datacenter?.datacenter,
 
 					country: data.location?.country,
 					countryCode: data.location?.country_code,

--- a/packages/provider/src/tasks/spam/checkTrafficFilter.ts
+++ b/packages/provider/src/tasks/spam/checkTrafficFilter.ts
@@ -37,6 +37,25 @@ type EvaluateOptions = {
 	suppressVpnDatacenterInteraction: boolean;
 };
 
+// Datacenter names come from the upstream `datacenter.datacenter` field, which
+// is human-curated and may drift in casing/whitespace across records (e.g.
+// "iCloud Private Relay" vs "icloud private relay"). Compare trimmed and
+// lowercased so an operator can paste the value verbatim from one record and
+// still match the others.
+const isDatacenterNameAllowlisted = (
+	datacenterName: string | undefined,
+	allowlist: ReadonlyArray<string> | undefined,
+): boolean => {
+	if (!datacenterName || !allowlist || allowlist.length === 0) {
+		return false;
+	}
+	const needle = datacenterName.trim().toLowerCase();
+	if (!needle) {
+		return false;
+	}
+	return allowlist.some((entry) => entry.trim().toLowerCase() === needle);
+};
+
 const evaluateIpInfo = (
 	ipInfo: IPInfoResponse | undefined,
 	trafficFilter: Partial<ITrafficFilter>,
@@ -78,6 +97,10 @@ const evaluateIpInfo = (
 			options.suppressVpnDatacenterInteraction &&
 			ipInfo.isVPN &&
 			!trafficFilter.blockVpn
+		) &&
+		!isDatacenterNameAllowlisted(
+			ipInfo.datacenterName,
+			trafficFilter.datacenterNameAllowlist,
 		)
 	) {
 		return { isBlocked: true, reason: ResultReason.DATACENTER_BLOCKED };
@@ -114,6 +137,12 @@ const evaluateIpInfo = (
  * scraping/automation traffic, not VPN end-users. So the datacenter
  * rule is suppressed for IPs also flagged as VPN unless the operator
  * has opted in to blocking VPN traffic explicitly.
+ *
+ * The datacenter rule also honours `datacenterNameAllowlist`: consumer
+ * relays such as Apple's iCloud Private Relay route through datacenter
+ * ranges and are reported as `is_datacenter=true` by upstream, but the
+ * exiting users are real humans. Operators can list the upstream
+ * `datacenter.datacenter` names they want to allow through.
  */
 export const checkTrafficFilter = (
 	ipInfo: IPInfoResponse | undefined,

--- a/packages/provider/src/tests/integration/clientSettingsPersistence.integration.test.ts
+++ b/packages/provider/src/tests/integration/clientSettingsPersistence.integration.test.ts
@@ -117,6 +117,7 @@ const FULLY_POPULATED_SETTINGS = {
 		blockAbuser: true,
 		abuserScoreThreshold: 0.33,
 		blockDatacenter: true,
+		datacenterNameAllowlist: ["iCloud Private Relay"],
 		blockMobile: false,
 		blockSatellite: true,
 		blockCrawler: true,

--- a/packages/provider/src/tests/unit/tasks/spam/checkTrafficFilter.unit.test.ts
+++ b/packages/provider/src/tests/unit/tasks/spam/checkTrafficFilter.unit.test.ts
@@ -279,4 +279,131 @@ describe("checkTrafficFilter", () => {
 			expect(result).toEqual({ isBlocked: true, reason: "API.TOR_BLOCKED" });
 		});
 	});
+
+	describe("datacenterNameAllowlist", () => {
+		it("suppresses datacenter block when name matches the allowlist", () => {
+			// iCloud Private Relay exits from datacenter IPs but the users
+			// behind them are real humans, so an operator can allowlist the
+			// datacenter name reported by upstream and still keep the rest
+			// of the datacenter block on.
+			const result = checkTrafficFilter(
+				baseInfo({
+					isDatacenter: true,
+					datacenterName: "iCloud Private Relay",
+				}),
+				{ ...allBlocked, datacenterNameAllowlist: ["iCloud Private Relay"] },
+			);
+			expect(result).toEqual({ isBlocked: false });
+		});
+
+		it("matches the allowlist case-insensitively and ignores whitespace", () => {
+			const result = checkTrafficFilter(
+				baseInfo({
+					isDatacenter: true,
+					datacenterName: "  iCloud Private Relay  ",
+				}),
+				{
+					...allBlocked,
+					datacenterNameAllowlist: ["icloud private relay"],
+				},
+			);
+			expect(result).toEqual({ isBlocked: false });
+		});
+
+		it("still blocks datacenter IPs whose name does not match", () => {
+			const result = checkTrafficFilter(
+				baseInfo({ isDatacenter: true, datacenterName: "Amazon AWS" }),
+				{ ...allBlocked, datacenterNameAllowlist: ["iCloud Private Relay"] },
+			);
+			expect(result).toEqual({
+				isBlocked: true,
+				reason: "API.DATACENTER_BLOCKED",
+			});
+		});
+
+		it("still blocks datacenter IPs that report no datacenter name", () => {
+			// Operators can only opt traffic out by name. A missing name
+			// must keep behaving like before the allowlist existed.
+			const result = checkTrafficFilter(
+				baseInfo({ isDatacenter: true }),
+				{ ...allBlocked, datacenterNameAllowlist: ["iCloud Private Relay"] },
+			);
+			expect(result).toEqual({
+				isBlocked: true,
+				reason: "API.DATACENTER_BLOCKED",
+			});
+		});
+
+		it("preserves the legacy behavior when the allowlist is missing or empty", () => {
+			const missing = checkTrafficFilter(
+				baseInfo({
+					isDatacenter: true,
+					datacenterName: "iCloud Private Relay",
+				}),
+				allBlocked,
+			);
+			expect(missing).toEqual({
+				isBlocked: true,
+				reason: "API.DATACENTER_BLOCKED",
+			});
+
+			const empty = checkTrafficFilter(
+				baseInfo({
+					isDatacenter: true,
+					datacenterName: "iCloud Private Relay",
+				}),
+				{ ...allBlocked, datacenterNameAllowlist: [] },
+			);
+			expect(empty).toEqual({
+				isBlocked: true,
+				reason: "API.DATACENTER_BLOCKED",
+			});
+		});
+
+		it("does not suppress non-datacenter blocks for the same IP", () => {
+			// Allowlist must not become a backdoor: a VPN or Tor exit that
+			// also reports an allowlisted datacenter name should still
+			// trip whichever earlier rule fires first.
+			const torResult = checkTrafficFilter(
+				baseInfo({
+					isTor: true,
+					isDatacenter: true,
+					datacenterName: "iCloud Private Relay",
+				}),
+				{ ...allBlocked, datacenterNameAllowlist: ["iCloud Private Relay"] },
+			);
+			expect(torResult).toEqual({
+				isBlocked: true,
+				reason: "API.TOR_BLOCKED",
+			});
+
+			const vpnResult = checkTrafficFilter(
+				baseInfo({
+					isVPN: true,
+					isDatacenter: true,
+					datacenterName: "iCloud Private Relay",
+				}),
+				{ ...allBlocked, datacenterNameAllowlist: ["iCloud Private Relay"] },
+			);
+			expect(vpnResult).toEqual({
+				isBlocked: true,
+				reason: "API.VPN_BLOCKED",
+			});
+		});
+
+		it("applies the allowlist to extra IPs as well", () => {
+			const result = checkTrafficFilter(
+				baseInfo({ ip: "192.0.2.1" }),
+				{ ...allBlocked, datacenterNameAllowlist: ["iCloud Private Relay"] },
+				[
+					baseInfo({
+						ip: "198.51.100.10",
+						isDatacenter: true,
+						datacenterName: "iCloud Private Relay",
+					}),
+				],
+			);
+			expect(result).toEqual({ isBlocked: false });
+		});
+	});
 });

--- a/packages/provider/src/tests/unit/tasks/spam/checkTrafficFilter.unit.test.ts
+++ b/packages/provider/src/tests/unit/tasks/spam/checkTrafficFilter.unit.test.ts
@@ -324,10 +324,10 @@ describe("checkTrafficFilter", () => {
 		it("still blocks datacenter IPs that report no datacenter name", () => {
 			// Operators can only opt traffic out by name. A missing name
 			// must keep behaving like before the allowlist existed.
-			const result = checkTrafficFilter(
-				baseInfo({ isDatacenter: true }),
-				{ ...allBlocked, datacenterNameAllowlist: ["iCloud Private Relay"] },
-			);
+			const result = checkTrafficFilter(baseInfo({ isDatacenter: true }), {
+				...allBlocked,
+				datacenterNameAllowlist: ["iCloud Private Relay"],
+			});
 			expect(result).toEqual({
 				isBlocked: true,
 				reason: "API.DATACENTER_BLOCKED",

--- a/packages/types-database/src/types/client.ts
+++ b/packages/types-database/src/types/client.ts
@@ -196,6 +196,7 @@ export const UserSettingsSchema = new Schema({
 		blockAbuser: { type: Boolean, default: true },
 		abuserScoreThreshold: { type: Number, min: 0, max: 1, default: 0 },
 		blockDatacenter: { type: Boolean, default: false },
+		datacenterNameAllowlist: { type: [String], required: false },
 		blockMobile: { type: Boolean, default: false },
 		blockSatellite: { type: Boolean, default: false },
 		blockCrawler: { type: Boolean, default: false },

--- a/packages/types/src/api/ipapi.ts
+++ b/packages/types/src/api/ipapi.ts
@@ -142,6 +142,13 @@ export interface IPInfoResult {
 	asnNumber?: number;
 	asnOrganization?: string;
 
+	// Datacenter operator name taken verbatim from the upstream
+	// `datacenter.datacenter` field. Distinct from `providerName`, which
+	// also accepts company.name; this one is reserved for strict name
+	// comparisons (e.g. the traffic filter's datacenter allowlist for
+	// iCloud Private Relay).
+	datacenterName?: string;
+
 	// Geolocation
 	country?: string;
 	countryCode?: string;

--- a/packages/types/src/client/settings.ts
+++ b/packages/types/src/client/settings.ts
@@ -183,6 +183,14 @@ export const SpamFilterRulesSchema = object({
 
 export const trafficFilterAbuserScoreThresholdDefault = 0.5;
 
+// Operators almost always want `blockDatacenter` to catch scraping/automation
+// traffic but not legitimate consumer relays that exit from datacenter IPs
+// (Apple's iCloud Private Relay being the canonical example). Entries are
+// compared case-insensitively against `IPInfoResult.datacenterName`, which
+// comes from the upstream ipapi `datacenter.datacenter` field.
+const MAX_DATACENTER_ALLOWLIST_ENTRIES = 50;
+const MAX_DATACENTER_ALLOWLIST_ENTRY_LENGTH = 128;
+
 export const TrafficFilterSchema = object({
 	blockVpn: boolean().optional().default(false),
 	blockProxy: boolean().optional().default(false),
@@ -194,6 +202,11 @@ export const TrafficFilterSchema = object({
 		.optional()
 		.default(trafficFilterAbuserScoreThresholdDefault),
 	blockDatacenter: boolean().optional().default(false),
+	datacenterNameAllowlist: array(
+		string().min(1).max(MAX_DATACENTER_ALLOWLIST_ENTRY_LENGTH),
+	)
+		.max(MAX_DATACENTER_ALLOWLIST_ENTRIES)
+		.optional(),
 	blockMobile: boolean().optional().default(false),
 	blockSatellite: boolean().optional().default(false),
 	blockCrawler: boolean().optional().default(false),


### PR DESCRIPTION
## Summary
- Apple's iCloud Private Relay routes through datacenter IPs, so sites with `blockDatacenter: true` were dropping legitimate Safari traffic. ipapi already reports the operator name verbatim in `datacenter.datacenter` — expose it on `IPInfoResult.datacenterName` and let `TrafficFilter` carry an optional `datacenterNameAllowlist` so operators can opt the relay traffic through without disabling the rest of the rule.
- Match is case-/whitespace-insensitive; the allowlist only suppresses the datacenter check. A VPN/Tor/Proxy/Abuser hit on the same IP still blocks.
- Field is wired through Zod (`TrafficFilterSchema`, capped 50 entries × 128 chars) and the Mongoose client settings schema so it persists.

## Test plan
- [x] `npm run -w @prosopo/types build:tsc`
- [x] `npm run -w @prosopo/ipinfo build:tsc`
- [x] `npm run -w @prosopo/types-database build:tsc`
- [x] `npm run -w @prosopo/provider build:tsc`
- [x] `npx vitest run src/tests/unit/tasks/spam/checkTrafficFilter.unit.test.ts` (32/32 pass — 7 new allowlist tests + 25 existing)
- [ ] CI green
- [ ] Companion captcha-private PR landing the `updateSite` propagation + portal UI follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)