### PR TITLE
fix(procaptcha): auto-start image/puzzle widget after PoW escalation

### DIFF
--- a/.changeset/fix-escalation-auto-start.md
+++ b/.changeset/fix-escalation-auto-start.md
@@ -1,0 +1,8 @@
+---
+"@prosopo/procaptcha-frictionless": patch
+"@prosopo/procaptcha-react": patch
+"@prosopo/procaptcha-puzzle": patch
+"@prosopo/types": patch
+---
+
+Auto-start image/puzzle widget after PoW escalation so the user does not need to click the checkbox a second time.

--- a/packages/procaptcha-frictionless/src/ProcaptchaFrictionless.tsx
+++ b/packages/procaptcha-frictionless/src/ProcaptchaFrictionless.tsx
@@ -159,15 +159,20 @@ export const ProcaptchaFrictionless = ({
 	const renderForCaptchaType = async (
 		captchaType: string,
 		frictionlessState: FrictionlessState,
+		autoStart = false,
 	) => {
 		const onEscalate = (
 			next: CaptchaType.image | CaptchaType.puzzle,
 			newSessionId: string,
 		) => {
-			void renderForCaptchaType(next, {
-				...frictionlessState,
-				sessionId: newSessionId,
-			});
+			void renderForCaptchaType(
+				next,
+				{
+					...frictionlessState,
+					sessionId: newSessionId,
+				},
+				true,
+			);
 		};
 
 		if (captchaType === CaptchaType.image) {
@@ -178,6 +183,7 @@ export const ProcaptchaFrictionless = ({
 					callbacks={callbacks}
 					frictionlessState={frictionlessState}
 					i18n={i18n}
+					autoStart={autoStart}
 				/>,
 			);
 		} else if (captchaType === CaptchaType.puzzle) {
@@ -188,6 +194,7 @@ export const ProcaptchaFrictionless = ({
 					callbacks={callbacks}
 					frictionlessState={frictionlessState}
 					i18n={i18n}
+					autoStart={autoStart}
 				/>,
 			);
 		} else {

--- a/packages/procaptcha-puzzle/src/components/ProcaptchaPuzzle.tsx
+++ b/packages/procaptcha-puzzle/src/components/ProcaptchaPuzzle.tsx
@@ -33,6 +33,7 @@ export const ProcaptchaPuzzle = (props: ProcaptchaProps) => (
 			callbacks={props.callbacks}
 			frictionlessState={props.frictionlessState}
 			i18n={props.i18n}
+			autoStart={props.autoStart}
 		/>
 	</Suspense>
 );

--- a/packages/procaptcha-puzzle/src/components/ProcaptchaWidget.tsx
+++ b/packages/procaptcha-puzzle/src/components/ProcaptchaWidget.tsx
@@ -88,7 +88,7 @@ const Procaptcha = (props: ProcaptchaProps) => {
 				() => setLoading(false),
 			);
 		}
-	}, []);
+	}, [props.autoStart]);
 
 	useEffect(() => {
 		if (!state.error) return undefined;

--- a/packages/procaptcha-puzzle/src/components/ProcaptchaWidget.tsx
+++ b/packages/procaptcha-puzzle/src/components/ProcaptchaWidget.tsx
@@ -74,6 +74,23 @@ const Procaptcha = (props: ProcaptchaProps) => {
 	}, [i18n, config.language]);
 
 	useEffect(() => {
+		if (props.autoStart) {
+			setLoading(true);
+			setShowRetry(false);
+			manager.current.start().then(
+				(challenge) => {
+					if (challenge) {
+						setChallengeData(challenge);
+						setPuzzlePhase("dragging");
+					}
+					setLoading(false);
+				},
+				() => setLoading(false),
+			);
+		}
+	}, []);
+
+	useEffect(() => {
 		if (!state.error) return undefined;
 		setLoading(false);
 		setPuzzlePhase("checkbox");

--- a/packages/procaptcha-react/src/components/Procaptcha.tsx
+++ b/packages/procaptcha-react/src/components/Procaptcha.tsx
@@ -12,25 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import type { Ti18n } from "@prosopo/locale";
-import type {
-	FrictionlessState,
-	ProcaptchaCallbacks,
-	ProcaptchaClientConfigInput,
-} from "@prosopo/types";
+import type { ProcaptchaProps } from "@prosopo/types";
 import { type LazyExoticComponent, Suspense, lazy } from "react";
 import type { ReactElement } from "react";
 
 //https://github.com/microsoft/TypeScript/issues/42873
 const ProcaptchaWidget: LazyExoticComponent<
-	(props: {
-		config: ProcaptchaClientConfigInput;
-		callbacks: ProcaptchaCallbacks;
-		frictionlessState?: FrictionlessState;
-		i18n: Ti18n;
-	}) => ReactElement
+	(props: ProcaptchaProps) => ReactElement
 > = lazy(async () => import("./ProcaptchaWidget.js"));
-type ProcaptchaProps = React.ComponentProps<typeof ProcaptchaWidget>;
 
 const Procaptcha = (props: ProcaptchaProps) => (
 	<Suspense>

--- a/packages/procaptcha-react/src/components/ProcaptchaWidget.tsx
+++ b/packages/procaptcha-react/src/components/ProcaptchaWidget.tsx
@@ -65,6 +65,7 @@ const ProcaptchaWidget = (props: ProcaptchaProps) => {
 		}
 	}, [i18n, config.language]);
 
+	// biome-ignore lint/correctness/useExhaustiveDependencies: manager is recreated each render; only autoStart triggers this
 	useEffect(() => {
 		if (props.autoStart) {
 			setLoading(true);

--- a/packages/procaptcha-react/src/components/ProcaptchaWidget.tsx
+++ b/packages/procaptcha-react/src/components/ProcaptchaWidget.tsx
@@ -73,7 +73,7 @@ const ProcaptchaWidget = (props: ProcaptchaProps) => {
 				() => setLoading(false),
 			);
 		}
-	}, []);
+	}, [props.autoStart]);
 
 	useEffect(() => {
 		if (state.error) {

--- a/packages/procaptcha-react/src/components/ProcaptchaWidget.tsx
+++ b/packages/procaptcha-react/src/components/ProcaptchaWidget.tsx
@@ -66,6 +66,16 @@ const ProcaptchaWidget = (props: ProcaptchaProps) => {
 	}, [i18n, config.language]);
 
 	useEffect(() => {
+		if (props.autoStart) {
+			setLoading(true);
+			manager.start().then(
+				() => setLoading(false),
+				() => setLoading(false),
+			);
+		}
+	}, []);
+
+	useEffect(() => {
 		if (state.error) {
 			setLoading(false);
 			if (state.error.key === "CAPTCHA.NO_SESSION_FOUND" && frictionlessState) {

--- a/packages/types/src/procaptcha/props.ts
+++ b/packages/types/src/procaptcha/props.ts
@@ -94,4 +94,8 @@ export interface ProcaptchaProps {
 	// solution that the provider chose to escalate can be transitioned into
 	// the appropriate image/puzzle widget without a full restart.
 	onEscalate?: ProcaptchaEscalationHandler;
+	// When true the widget calls manager.start() on mount instead of waiting
+	// for a checkbox click. Set by ProcaptchaFrictionless after a PoW
+	// escalation so the user doesn't have to click the checkbox a second time.
+	autoStart?: boolean;
 }


### PR DESCRIPTION
## Summary
- After a PoW escalation (e.g. fingerprint proof validation failure), the frictionless wrapper mounts the image or puzzle widget but the user had to click the checkbox a **second** time to trigger the challenge fetch
- Adds an `autoStart` prop to `ProcaptchaProps` — when `true`, the widget calls `manager.start()` on mount instead of waiting for a checkbox click
- `ProcaptchaFrictionless` passes `autoStart={true}` only on the escalation path (via `onEscalate`), leaving the initial frictionless→image/puzzle flow unchanged

## Test plan
- [ ] On staging, set `window.__prosopoFingerprintProofTest__ = "omit"` in console before triggering captcha
- [ ] Verify PoW completes, then image challenge modal appears automatically (no second checkbox click)
- [ ] Repeat with `window.__prosopoFingerprintProofTest__ = "malformed"` — same escalation behavior
- [ ] Verify normal frictionless→PoW flow (without the test hook) still requires a checkbox click as before
- [ ] Verify normal frictionless→image flow (non-escalation) still requires a checkbox click

🤖 Generated with [Claude Code](https://claude.com/claude-code)