### PR TITLE
fix(provider): preserve error status codes in verify routes

### DIFF
--- a/.changeset/fix-provider-verify-error-status.md
+++ b/.changeset/fix-provider-verify-error-status.md
@@ -1,0 +1,5 @@
+---
+"@prosopo/provider": patch
+---
+
+Preserve original error status codes in the image/pow/puzzle verify routes. Errors that already carry a status (e.g. a 401 `INVALID_SIGNATURE` or a 400 validation error) are now forwarded unchanged instead of being wrapped as a 500.

--- a/packages/provider/src/api/verify.ts
+++ b/packages/provider/src/api/verify.ts
@@ -171,6 +171,12 @@ export function prosopoVerifyRouter(env: ProviderEnvironment): Router {
 				res.json(verificationResponse);
 			} catch (err) {
 				req.logger.error(() => ({ err, data: { body: req.body } }));
+				// Preserve the status code of errors that already carry one
+				// (e.g. a 401 INVALID_SIGNATURE or a 400 validation error);
+				// only wrap genuinely-unexpected errors as a 500.
+				if (err instanceof ProsopoApiError) {
+					return next(err);
+				}
 				return next(
 					new ProsopoApiError("API.BAD_REQUEST", {
 						context: { code: 500, siteKey: req.body.dapp, user: req.body.user },
@@ -304,6 +310,12 @@ export function prosopoVerifyRouter(env: ProviderEnvironment): Router {
 					err,
 					data: { body: req.body },
 				}));
+				// Preserve the status code of errors that already carry one
+				// (e.g. a 401 INVALID_SIGNATURE or a 400 validation error);
+				// only wrap genuinely-unexpected errors as a 500.
+				if (err instanceof ProsopoApiError) {
+					return next(err);
+				}
 				return next(
 					new ProsopoApiError("API.BAD_REQUEST", {
 						context: { code: 500, error: err },
@@ -435,6 +447,12 @@ export function prosopoVerifyRouter(env: ProviderEnvironment): Router {
 					err,
 					data: { body: req.body },
 				}));
+				// Preserve the status code of errors that already carry one
+				// (e.g. a 401 INVALID_SIGNATURE or a 400 validation error);
+				// only wrap genuinely-unexpected errors as a 500.
+				if (err instanceof ProsopoApiError) {
+					return next(err);
+				}
 				return next(
 					new ProsopoApiError("API.BAD_REQUEST", {
 						context: { code: 500, error: err },


### PR DESCRIPTION
## What
In the image/pow/puzzle verify catch blocks, forward `ProsopoApiError`s unchanged (preserving their own status code) and only wrap genuinely-unexpected errors as 500.

## Why
Each catch block wrapped every error as `API.BAD_REQUEST` with `context.code: 500`, so client errors that already carried a proper status — a 401 `INVALID_SIGNATURE` for an invalid `dappSignature`, or a 400 `validateAddress` failure — surfaced to the client as 500.

File: `packages/provider/src/api/verify.ts` (image ~L172-186, pow ~L301-320, puzzle ~L432-450)

## Verification
`npm run -w @prosopo/provider build:tsc` yields the same 142 pre-existing errors with and without this change (no new errors, none in verify.ts). The pre-existing errors are environment-related — project-reference build artifacts for several `@prosopo/*` deps are absent in this checkout.