### PR TITLE
feat(user-access-policy): block-only filter on findRules

### DIFF
--- a/.changeset/block-only-rule-lookup.md
+++ b/.changeset/block-only-rule-lookup.md
@@ -1,0 +1,6 @@
+---
+"@prosopo/user-access-policy": patch
+"@prosopo/provider": patch
+---
+
+Add an indexed `type` field on the access-rules Redis index and a `blockOnly` filter on `findRules`. The request-time block middleware and the verify-time hard-block check now pre-filter the candidate pool to Block rules at the Redis layer, so dense Restrict / routing-Block populations can no longer push hard-block rules past the server-side ranking cap. Schema rehash triggers automatic index recreate on next provider start.

--- a/packages/provider/src/api/blacklistRequestInspector.ts
+++ b/packages/provider/src/api/blacklistRequestInspector.ts
@@ -252,6 +252,7 @@ export const getPrioritisedAccessRule = async (
 	userAccessRulesStorage: AccessRulesStorage,
 	userScope: UserScope | UserScopeRecord,
 	clientId?: string,
+	options?: { blockOnly?: boolean },
 ): Promise<AccessRule[]> => {
 	const parsedUserScope = userScopeInput.parse(userScope);
 
@@ -264,6 +265,7 @@ export const getPrioritisedAccessRule = async (
 		policyScopeMatch: FilterScopeMatch.Greedy,
 		userScope: parsedUserScope,
 		userScopeMatch: FilterScopeMatch.Greedy,
+		...(options?.blockOnly && { blockOnly: true }),
 	};
 
 	const candidates = await userAccessRulesStorage.findRules(
@@ -372,6 +374,13 @@ export class BlacklistRequestInspector {
 					asn,
 				),
 				clientId,
+				// Request-time middleware only ever fires on Block policies
+				// (Restrict rules flow through and let the captcha-creation
+				// path decorate the response). Restrict the Redis-side
+				// candidate pool so the SERVER_SIDE_RANK_TOP_N cap can't
+				// crowd out hard-block rules in clients with dense Restrict
+				// rule populations.
+				{ blockOnly: true },
 			);
 			// Skip policies that have explicitly opted out of request-time
 			// enforcement (`deferToVerify`). Those are matched again from

--- a/packages/provider/src/tasks/captchaManager.ts
+++ b/packages/provider/src/tasks/captchaManager.ts
@@ -468,11 +468,13 @@ export class CaptchaManager {
 		userAccessRulesStorage: AccessRulesStorage,
 		clientId: string,
 		userScope: UserScope | UserScopeRecord,
+		options?: { blockOnly?: boolean },
 	) {
 		return getPrioritisedAccessRule(
 			userAccessRulesStorage,
 			userScope,
 			clientId,
+			options,
 		);
 	}
 
@@ -638,6 +640,11 @@ export class CaptchaManager {
 			userAccessRulesStorage,
 			challengeRecord.dappAccount,
 			userScope,
+			// Hard-block lookup only — restrict the Redis-side candidate
+			// pool to Block rules so the SERVER_SIDE_RANK_TOP_N cap can't
+			// crowd a hard-block out of the top-N with Restrict or
+			// routing-Block (captchaType-scoped) entries.
+			{ blockOnly: true },
 		);
 
 		return findHardBlockPolicy(accessPolicies);

--- a/packages/user-access-policy/src/redis/reader/redisRulesQuery.ts
+++ b/packages/user-access-policy/src/redis/reader/redisRulesQuery.ts
@@ -12,7 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { AccessPolicyType, type PolicyScope, type UserIp, type UserScope } from "#policy/rule.js";
+import {
+	AccessPolicyType,
+	type PolicyScope,
+	type UserIp,
+	type UserScope,
+} from "#policy/rule.js";
 import { userScopeSchema } from "#policy/ruleInput/userScopeInput.js";
 import {
 	type AccessRulesFilter,

--- a/packages/user-access-policy/src/redis/reader/redisRulesQuery.ts
+++ b/packages/user-access-policy/src/redis/reader/redisRulesQuery.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import type { PolicyScope, UserIp, UserScope } from "#policy/rule.js";
+import { AccessPolicyType, type PolicyScope, type UserIp, type UserScope } from "#policy/rule.js";
 import { userScopeSchema } from "#policy/ruleInput/userScopeInput.js";
 import {
 	type AccessRulesFilter,
@@ -201,6 +201,10 @@ export const getRulesRedisQuery = (
 
 	if (filter.groupId) {
 		queryParts.push(`@groupId:{${filter.groupId}}`);
+	}
+
+	if (filter.blockOnly) {
+		queryParts.push(`@type:{${AccessPolicyType.Block}}`);
 	}
 
 	const policyScopeQuery = getPolicyScopeQuery(

--- a/packages/user-access-policy/src/redis/redisRuleIndex.ts
+++ b/packages/user-access-policy/src/redis/redisRuleIndex.ts
@@ -66,6 +66,12 @@ export const accessRuleRedisSchema: RediSearchSchema = {
 	...policyScopeRedisSchema,
 	...userScopeRedisSchema,
 	groupId: { type: SCHEMA_FIELD_TYPE.TAG, INDEXMISSING: true },
+	// Indexed so request-time callers that only care about Block policies
+	// (checkForHardBlock, blockMiddleware) can pre-filter via @type:{block}
+	// before the SERVER_SIDE_RANK_TOP_N cap kicks in. Without this, dense
+	// Restrict / routing-Block populations push the hard-block rules out
+	// of the top-N candidate set and the lookup silently misses them.
+	type: { type: SCHEMA_FIELD_TYPE.TAG, INDEXMISSING: true },
 } satisfies Keys<AccessRule>;
 
 export const ACCESS_RULES_REDIS_INDEX_NAME = "index:user-access-rules";

--- a/packages/user-access-policy/src/ruleInput/ruleInput.ts
+++ b/packages/user-access-policy/src/ruleInput/ruleInput.ts
@@ -84,6 +84,7 @@ export const accessRulesFilterInput = z.object({
 		.nativeEnum(FilterScopeMatch)
 		.default(FilterScopeMatch.Exact),
 	groupId: z.string().optional(),
+	blockOnly: z.boolean().optional(),
 } satisfies AllKeys<AccessRulesFilterInput>) satisfies ZodType<AccessRulesFilterInput>;
 
 export const getAccessRuleFiltersFromInput = (

--- a/packages/user-access-policy/src/rulesStorage.ts
+++ b/packages/user-access-policy/src/rulesStorage.ts
@@ -33,6 +33,15 @@ export type AccessRulesFilter = {
 	 */
 	userScopeMatch?: FilterScopeMatch;
 	groupId?: string;
+	/**
+	 * Restrict the result to Block-type rules. Hot-path callers
+	 * (checkForHardBlock, blockMiddleware) set this so the Redis-side
+	 * candidate pool excludes Restrict and routing-Block rules before
+	 * the SERVER_SIDE_RANK_TOP_N cap is applied — without it, dense
+	 * Restrict populations can push the hard-block rules past the cap
+	 * and the lookup misses them.
+	 */
+	blockOnly?: boolean;
 };
 
 export type AccessRuleEntry = {

--- a/packages/user-access-policy/src/tests/redis/reader/redisRulesQuery.unit.test.ts
+++ b/packages/user-access-policy/src/tests/redis/reader/redisRulesQuery.unit.test.ts
@@ -297,4 +297,53 @@ describe("getRulesRedisQuery", () => {
 		expect(query).toContain("@headHash:{abc123def456}");
 		expect(query).toContain("ismissing(@userAgentHash)");
 	});
+
+	it("prepends @type:{block} when blockOnly is set on the filter", () => {
+		const filter = {
+			userScope: {
+				ja4Hash: "ja4Hash",
+			},
+			userScopeMatch: FilterScopeMatch.Greedy,
+			blockOnly: true,
+		} as AccessRulesFilter;
+
+		const query = getRulesRedisQuery(filter, false);
+
+		expect(query).toContain("@type:{block}");
+		// blockOnly precedes the userScope clause so callers get the
+		// pre-filter benefit on a single Redis pass.
+		const typeIdx = query.indexOf("@type:{block}");
+		const userScopeIdx = query.indexOf("@ja4Hash");
+		expect(typeIdx).toBeGreaterThanOrEqual(0);
+		expect(typeIdx).toBeLessThan(userScopeIdx);
+	});
+
+	it("omits @type:{block} when blockOnly is not set", () => {
+		const filter = {
+			userScope: {
+				ja4Hash: "ja4Hash",
+			},
+			userScopeMatch: FilterScopeMatch.Greedy,
+		} as AccessRulesFilter;
+
+		const query = getRulesRedisQuery(filter, false);
+
+		expect(query).not.toContain("@type:");
+	});
+
+	it("composes blockOnly with clientId policy scope", () => {
+		const filter = {
+			policyScope: { clientId: "site-A" },
+			policyScopeMatch: FilterScopeMatch.Greedy,
+			userScope: { ja4Hash: "ja4Hash" },
+			userScopeMatch: FilterScopeMatch.Greedy,
+			blockOnly: true,
+		} as AccessRulesFilter;
+
+		const query = getRulesRedisQuery(filter, false);
+
+		expect(query).toContain("@type:{block}");
+		expect(query).toContain("@clientId:{site-A}");
+		expect(query).toContain("@ja4Hash:{ja4Hash}");
+	});
 });

--- a/packages/user-access-policy/src/tests/redis/redisRulesStorage.integration.test.ts
+++ b/packages/user-access-policy/src/tests/redis/redisRulesStorage.integration.test.ts
@@ -1495,6 +1495,145 @@ describe("redisAccessRulesStorage", () => {
 			expect(foundAccessRules[0]).toEqual(topRule);
 			expect(foundAccessRules[1]).toEqual(bottomRule);
 		});
+
+		test("blockOnly filter returns only Block rules even when Restrict rules share the same user scope", async () => {
+			// Mix the two policy types across the same (clientId, ja4Hash)
+			// space so the strict-match query would otherwise return both.
+			// Without blockOnly, the result includes Restrict rules; with
+			// blockOnly the Redis-side `@type:{block}` clause excludes
+			// them before the JS sees the candidates.
+			const clientId = getUniqueString();
+			const ja4Hash = "t13d_blockonly";
+
+			const block1: AccessRule = {
+				type: AccessPolicyType.Block,
+				clientId,
+				ja4Hash,
+			};
+			const block2: AccessRule = {
+				type: AccessPolicyType.Block,
+				clientId,
+				ja4Hash,
+				coords: "[[[1,2]]]",
+			};
+			const restrict1: AccessRule = {
+				type: AccessPolicyType.Restrict,
+				clientId,
+				ja4Hash,
+			};
+			const restrict2: AccessRule = {
+				type: AccessPolicyType.Restrict,
+				clientId,
+				ja4Hash,
+				coords: "[[[3,4]]]",
+			};
+			const blockOtherClient: AccessRule = {
+				type: AccessPolicyType.Block,
+				clientId: getUniqueString(),
+				ja4Hash,
+			};
+
+			await insertRules([
+				block1,
+				block2,
+				restrict1,
+				restrict2,
+				blockOtherClient,
+			]);
+
+			// Greedy / no blockOnly → both Block and Restrict for this
+			// clientId come back. The other-client rule is excluded by
+			// the greedy policy scope match (different clientId AND set).
+			const mixed = await accessRulesReader.findRules({
+				policyScope: { clientId },
+				policyScopeMatch: FilterScopeMatch.Greedy,
+				userScope: { ja4Hash },
+				userScopeMatch: FilterScopeMatch.Greedy,
+			});
+			const mixedTypes = mixed.map((r) => r.type).sort();
+			expect(mixed).toHaveLength(4);
+			expect(mixedTypes).toEqual([
+				AccessPolicyType.Block,
+				AccessPolicyType.Block,
+				AccessPolicyType.Restrict,
+				AccessPolicyType.Restrict,
+			]);
+
+			// Same query with blockOnly → only the two Block rules for
+			// this clientId. Restrict rules must be filtered server-side.
+			const blockOnly = await accessRulesReader.findRules({
+				policyScope: { clientId },
+				policyScopeMatch: FilterScopeMatch.Greedy,
+				userScope: { ja4Hash },
+				userScopeMatch: FilterScopeMatch.Greedy,
+				blockOnly: true,
+			});
+			expect(blockOnly).toHaveLength(2);
+			for (const rule of blockOnly) {
+				expect(rule.type).toBe(AccessPolicyType.Block);
+				expect(rule.clientId).toBe(clientId);
+			}
+			const blockHashes = new Set(blockOnly.map((r) => r.coords));
+			expect(blockHashes).toEqual(new Set([undefined, "[[[1,2]]]"]));
+		});
+
+		test("blockOnly composes with matchingFieldsOnly on the ranked hot path — Restrict rules never come back", async () => {
+			// Exercises the production hot path: greedy user-scope match
+			// with matchingFieldsOnly=true (the FT.AGGREGATE-ranked
+			// branch). The greedy ja4 query is permissive enough that
+			// `ruleApplies` is still the last word on whether a rule
+			// applies; the only guarantee this layer is supposed to
+			// uphold is that Restrict candidates are gone before JS sees
+			// them. That's what blockOnly is for.
+			const clientId = getUniqueString();
+			const ja4Hash = "t13d_hotpath";
+
+			const blockMatch: AccessRule = {
+				type: AccessPolicyType.Block,
+				clientId,
+				ja4Hash,
+			};
+			const restrictMatch: AccessRule = {
+				type: AccessPolicyType.Restrict,
+				clientId,
+				ja4Hash,
+			};
+			const restrictMatchWithCoords: AccessRule = {
+				type: AccessPolicyType.Restrict,
+				clientId,
+				ja4Hash,
+				coords: "[[[5,6]]]",
+			};
+
+			await insertRules([
+				blockMatch,
+				restrictMatch,
+				restrictMatchWithCoords,
+			]);
+
+			const found = await accessRulesReader.findRules(
+				{
+					policyScope: { clientId },
+					policyScopeMatch: FilterScopeMatch.Greedy,
+					userScope: { ja4Hash },
+					userScopeMatch: FilterScopeMatch.Greedy,
+					blockOnly: true,
+				},
+				true, // matchingFieldsOnly — ranked path
+			);
+
+			// Restrict rules must not appear; at least the matching
+			// Block rule must be present.
+			expect(found.some((r) => r.type === AccessPolicyType.Restrict)).toBe(
+				false,
+			);
+			expect(
+				found.some(
+					(r) =>
+						r.type === AccessPolicyType.Block && r.ja4Hash === ja4Hash,
+				),
+			).toBe(true);
+		});
 	});
 
 	afterAll(async () => {

--- a/packages/user-access-policy/src/tests/redis/redisRulesStorage.integration.test.ts
+++ b/packages/user-access-policy/src/tests/redis/redisRulesStorage.integration.test.ts
@@ -1605,11 +1605,7 @@ describe("redisAccessRulesStorage", () => {
 				coords: "[[[5,6]]]",
 			};
 
-			await insertRules([
-				blockMatch,
-				restrictMatch,
-				restrictMatchWithCoords,
-			]);
+			await insertRules([blockMatch, restrictMatch, restrictMatchWithCoords]);
 
 			const found = await accessRulesReader.findRules(
 				{
@@ -1629,8 +1625,7 @@ describe("redisAccessRulesStorage", () => {
 			);
 			expect(
 				found.some(
-					(r) =>
-						r.type === AccessPolicyType.Block && r.ja4Hash === ja4Hash,
+					(r) => r.type === AccessPolicyType.Block && r.ja4Hash === ja4Hash,
 				),
 			).toBe(true);
 		});


### PR DESCRIPTION
## Summary

- Index the `type` field on the access-rules Redis index
- Add `blockOnly` flag to `AccessRulesFilter`; prepends `@type:{block}` to the query when set
- Pass `blockOnly: true` from `checkForHardBlock` and the request-time block middleware — the two call sites that only act on Block policies

## Why

`findRulesRanked` returns at most `SERVER_SIDE_RANK_TOP_N = 20` candidates pre-filtered only by user-scope. With dense per-client rule populations (mixed Block, Restrict, captchaType-scoped routing-Block at equal specificity), hard-block rules can sit past the cap and the lookup silently returns no block. Pre-filtering on `@type:{block}` at the Redis layer keeps the candidate pool relevant for hot-path callers.

Other handlers that need the full policy ranking (image/pow/puzzle/frictionless challenge) are unchanged and continue to see Restrict rules.

## Test plan

- [ ] `npm run -w @prosopo/user-access-policy build:tsc` clean
- [ ] `npm run -w @prosopo/provider build:tsc` clean
- [ ] `npm run -w @prosopo/user-access-policy test:unit` — 4 files / 51 tests pass, including 3 new cases on `getRulesRedisQuery` for the `blockOnly` flag
- [ ] Smoke check on a staging pronode: confirm `FT.SEARCH index:user-access-rules "@clientId:{...} @type:{block}"` returns block rules after deploy (schema-rehash triggers automatic dropIndex+create on first start; brief reindex window)

🤖 Generated with [Claude Code](https://claude.com/claude-code)