### PR TITLE
test(provider): per-field assertions on trafficFilter persistence

### DIFF
--- a/.changeset/test-traffic-filter-persistence-per-field.md
+++ b/.changeset/test-traffic-filter-persistence-per-field.md
@@ -1,0 +1,5 @@
+---
+"@prosopo/provider": patch
+---
+
+Convert the `clientSettingsPersistence` integration test's `trafficFilter` assertion from a single `toMatchObject` to per-field `expect` calls. Matches the convention already used for top-level settings fields so a future regression that drops one of the trafficFilter sub-fields will surface the specific field name in the failure rather than dumping the whole nested object diff.

--- a/packages/provider/src/tests/integration/clientSettingsPersistence.integration.test.ts
+++ b/packages/provider/src/tests/integration/clientSettingsPersistence.integration.test.ts
@@ -243,8 +243,46 @@ describe("Client settings Mongo persistence", () => {
 		expect(stored.spamFilter).toMatchObject(
 			FULLY_POPULATED_SETTINGS.spamFilter,
 		);
-		expect(stored.trafficFilter).toMatchObject(
-			FULLY_POPULATED_SETTINGS.trafficFilter,
+
+		// trafficFilter — per-field rather than wholesale, since this is the
+		// schema most frequently extended (each new opt-in / allowlist /
+		// threshold lands here). Per-field asserts surface the dropped name
+		// directly rather than dumping the whole nested object diff.
+		const trafficFilter = stored.trafficFilter;
+		expect(trafficFilter).toBeDefined();
+		if (!trafficFilter) return;
+		expect(trafficFilter.blockVpn).toBe(
+			FULLY_POPULATED_SETTINGS.trafficFilter.blockVpn,
+		);
+		expect(trafficFilter.blockProxy).toBe(
+			FULLY_POPULATED_SETTINGS.trafficFilter.blockProxy,
+		);
+		expect(trafficFilter.blockTor).toBe(
+			FULLY_POPULATED_SETTINGS.trafficFilter.blockTor,
+		);
+		expect(trafficFilter.blockAbuser).toBe(
+			FULLY_POPULATED_SETTINGS.trafficFilter.blockAbuser,
+		);
+		expect(trafficFilter.abuserScoreThreshold).toBe(
+			FULLY_POPULATED_SETTINGS.trafficFilter.abuserScoreThreshold,
+		);
+		expect(trafficFilter.blockDatacenter).toBe(
+			FULLY_POPULATED_SETTINGS.trafficFilter.blockDatacenter,
+		);
+		expect(trafficFilter.datacenterNameAllowlist).toEqual(
+			FULLY_POPULATED_SETTINGS.trafficFilter.datacenterNameAllowlist,
+		);
+		expect(trafficFilter.skipExtrasOnValidDnsPath).toBe(
+			FULLY_POPULATED_SETTINGS.trafficFilter.skipExtrasOnValidDnsPath,
+		);
+		expect(trafficFilter.blockMobile).toBe(
+			FULLY_POPULATED_SETTINGS.trafficFilter.blockMobile,
+		);
+		expect(trafficFilter.blockSatellite).toBe(
+			FULLY_POPULATED_SETTINGS.trafficFilter.blockSatellite,
+		);
+		expect(trafficFilter.blockCrawler).toBe(
+			FULLY_POPULATED_SETTINGS.trafficFilter.blockCrawler,
 		);
 	}, 60_000);
 });


### PR DESCRIPTION
## Summary

Follow-up to #2729. Converts the `trafficFilter` assertion in `clientSettingsPersistence.integration.test.ts` from one wholesale `toMatchObject` to per-field `expect` calls.

The suite already asserted every top-level field individually — the comment at the top of the assertion block calls out that this is deliberate so a future drop names the specific field rather than dumping a diff. The nested filter objects were exempt by convention; `trafficFilter` is the one that gets extended most often (every new opt-in / allowlist / threshold lands there), so it's the highest-value one to migrate.

## Test plan

- [x] `npm run -w @prosopo/provider build:tsc` — clean
- [x] Existing assertion would have caught a dropped `skipExtrasOnValidDnsPath` via `toMatchObject`, the new per-field form just names the field in the failure
