### PR TITLE
feat(caddy): cert-getter addendum for pronode.prosopo.io

### DIFF
--- a/docker/docker-compose.provider.yml
+++ b/docker/docker-compose.provider.yml
@@ -132,6 +132,15 @@ services:
       - ./provider.Caddyfile:/etc/caddy/Caddyfile
       - caddy_data:/data
       - caddy_config:/config
+      # PEM for the load-balanced pronode.prosopo.io hostname. The cert
+      # getter (pronode4) obtains it via certbot DNS-01 against Bunny,
+      # then provider.yml's distribute step rsyncs it to every pronode
+      # under ./certs/pronode-global/. The site block in
+      # provider.cert-getter.Caddyfile references the path inside the
+      # container. KEEP THIS MOUNT — removing it breaks TLS for the
+      # global hostname on the next `up --force-recreate` even though
+      # an already-running container keeps the old mount alive.
+      - ./certs/pronode-global:/certs/pronode-global:ro
     networks:
       external:
       internal:

--- a/docker/provider.Caddyfile
+++ b/docker/provider.Caddyfile
@@ -90,21 +90,14 @@ http://:9090 {
 	metrics /metrics
 }
 
-# Main site: bound on :8443. Layer4 (above) proxies non-trap-subzone
-# SNI connections from :443 in. ACME issuer is restricted to HTTP-01
-# because TLS-ALPN-01 requires control of :443. The :80 redirect
-# server is auto-created by Caddy (auto_https=on); it serves both
-# ACME HTTP-01 challenges AND HTTP→HTTPS redirects targeting port
-# 443 (i.e. the layer4 listener), which forwards non-matching SNIs
-# back to this same :8443 server.
-https://{$CADDY_DOMAIN}:8443 {
-
-	tls {
-		issuer acme {
-			disable_tlsalpn_challenge
-		}
-	}
-	
+# Shared route/handler config. Imported by the per-host site below
+# ({$CADDY_DOMAIN} = pronodeN.prosopo.io) and, on the cert getter, by
+# the global site for the load-balanced pronode.prosopo.io hostname
+# defined in provider.cert-getter.Caddyfile. Only the TLS strategy
+# differs between the two: per-host uses ACME HTTP-01 (A record points
+# to one IP per pronodeN), global uses a PEM provisioned by certbot on
+# the cert getter (see ansible playbooks/providerCertbotProvision.yml).
+(provider_site) {
 	handle /robots.txt {
 		# Serve /srv/static/robots.txt. Do NOT strip the leading slash:
 		# file_server prepends `root` to the request path, so `/robots.txt`
@@ -293,4 +286,20 @@ https://{$CADDY_DOMAIN}:8443 {
 	log {
 		format json
 	}
+}
+
+# Per-host site: bound on :8443. Layer4 (above) proxies non-trap-subzone
+# SNI connections from :443 in. ACME issuer is restricted to HTTP-01
+# because TLS-ALPN-01 requires control of :443. The :80 redirect server
+# is auto-created by Caddy (auto_https=on); it serves both ACME HTTP-01
+# challenges AND HTTP→HTTPS redirects targeting port 443 (i.e. the
+# layer4 listener), which forwards non-matching SNIs back to this same
+# :8443.
+https://{$CADDY_DOMAIN}:8443 {
+	tls {
+		issuer acme {
+			disable_tlsalpn_challenge
+		}
+	}
+	import provider_site
 }

--- a/docker/provider.cert-getter.Caddyfile
+++ b/docker/provider.cert-getter.Caddyfile
@@ -1,0 +1,24 @@
+# Cert-getter addendum to provider.Caddyfile. Concatenated onto the
+# base file by ansible (playbooks/provider.yml) when
+# `cert_getter: true` is set on the host in hosts.{env}.yml — currently
+# pronode4 only. Defines an extra HTTPS site for the load-balanced
+# pronode.prosopo.io hostname.
+#
+# Why a single cert getter:
+#   pronode.prosopo.io is DNS-round-robined across every pronode, which
+#   breaks ACME HTTP-01 per-node renewal (the challenge lands on
+#   whichever node DNS hands out, usually not the one renewing). We
+#   solve this by having exactly one node (the cert getter) own ACME for
+#   the hostname, using DNS-01 against the Bunny DNS zone that
+#   pronode.prosopo.io is delegated to. The PEM is provisioned by
+#   certbot outside Caddy (see playbooks/providerCertbotProvision.yml)
+#   and dropped into the bind-mounted /certs/pronode-global/ dir. The
+#   other pronodes don't carry this block — distribution of the PEM to
+#   the rest of the fleet is a manual ansible step done out of band.
+https://{$CADDY_GLOBAL_DOMAIN}:8443 {
+	# Static PEM provisioned by certbot's deploy hook. Caddy does not
+	# poll file-based certs, so the deploy hook must run `caddy reload`
+	# after copying the new PEM in.
+	tls /certs/pronode-global/fullchain.pem /certs/pronode-global/privkey.pem
+	import provider_site
+}


### PR DESCRIPTION
## Summary

- Extracts the existing route/handler block in `docker/provider.Caddyfile` into a `(provider_site)` snippet imported by the per-host site (same shape as #2670).
- Adds `docker/provider.cert-getter.Caddyfile` as a deploy-time addendum that ansible concatenates onto the base file on hosts flagged `cert_getter: true` in the inventory. The addendum defines a second site block on `:8443` for the load-balanced `pronode.prosopo.io` hostname.
- TLS for the global hostname uses a PEM at `/certs/pronode-global/{fullchain,privkey}.pem`. The PEM is provisioned out of band by certbot via Bunny DNS-01 — installed and renewed by a sibling ansible playbook in the captcha-private repo (see companion PR there).

## Why this PR

#2670 left the global hostname TLS strategy as a `tls internal` placeholder and called the real cert distribution mechanism a follow-up. This is that follow-up for the cert-getter side: one node (pronode4) owns ACME for `pronode.prosopo.io` against Bunny DNS, terminates TLS for it, and the addendum lives only on that node. Distribution of the PEM to the other 13 pronodes is a manual ansible step done out of band.

## Test plan

- [x] On pronode4 (the cert getter): `openssl s_client -connect <ip>:443 -servername pronode.prosopo.io` returns a Let's Encrypt cert with `CN=pronode.prosopo.io`.
- [x] On pronode4: `openssl s_client -connect <ip>:443 -servername pronode4.prosopo.io` still returns the original per-host LE cert (no regression).
- [x] On pronode4: `curl -sS -o /dev/null -w '%{http_code} %{ssl_verify_result}' https://pronode.prosopo.io/healthz` returns `200 0`.
- [ ] On a non-cert-getter pronode: deploying the base `provider.Caddyfile` (without the addendum) still loads cleanly and serves the per-host hostname (snippet extraction is the only base-file change; behaviour-equivalent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)