### PR TITLE
fix(docker): bump mongo 6.0.17 -> 6.0.28 (tag yanked from Docker Hub)

### DIFF
--- a/.changeset/mongo-6.0.28-bump.md
+++ b/.changeset/mongo-6.0.28-bump.md
@@ -1,0 +1,4 @@
+---
+---
+
+chore: bump mongo 6.0.17 → 6.0.28 in compose + integration tests (tag yanked from Docker Hub). Adds 120s timeout to `beforeAll` hooks that pull mongo via testcontainers so the first fresh pull doesn't time out at the default 10s.

--- a/docker/docker-compose.demo.yml
+++ b/docker/docker-compose.demo.yml
@@ -1,7 +1,7 @@
 # https://docs.docker.com/cloud/ecs-integration/
 services:
     database:
-        image: mongo:6.0.17
+        image: mongo:6.0.28
         ports:
             - '27017:27017'
         environment:

--- a/docker/docker-compose.development.yml
+++ b/docker/docker-compose.development.yml
@@ -1,6 +1,6 @@
 services:
   database:
-    image: mongo:6.0.17
+    image: mongo:6.0.28
     # volumes:
     #   - ./db:/data/db
     ports:

--- a/docker/docker-compose.mongo.yml
+++ b/docker/docker-compose.mongo.yml
@@ -1,7 +1,7 @@
 # https://docs.docker.com/cloud/ecs-integration/
 services:
     database:
-        image: mongo:6.0.17
+        image: mongo:6.0.28
         # volumes:
         #   - ./db:/data/db
         ports:

--- a/docker/docker-compose.provider-mock.yml
+++ b/docker/docker-compose.provider-mock.yml
@@ -35,7 +35,7 @@ services:
             - 208.67.222.222
     database:
         container_name: database
-        image: mongo:6.0.17
+        image: mongo:6.0.28
         volumes:
             - /data/db:/data/db
         ports:

--- a/docker/docker-compose.provider.yml
+++ b/docker/docker-compose.provider.yml
@@ -74,7 +74,7 @@ services:
     profiles:
       - production
       - staging
-    image: mongo:6.0.17
+    image: mongo:6.0.28
     command: mongod --wiredTigerCacheSizeGB 2.0
     deploy:
       resources:

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -1,6 +1,6 @@
 services:
     database:
-        image: mongo:6.0.17
+        image: mongo:6.0.28
         # volumes:
         #   - ./db:/data/db
         ports:

--- a/packages/provider/src/tests/integration/api/blacklistRequestInspector.integration.test.ts
+++ b/packages/provider/src/tests/integration/api/blacklistRequestInspector.integration.test.ts
@@ -126,7 +126,7 @@ describe("blacklistRequestInspector Integration Tests", () => {
 			await db.getRedisAccessRulesConnection().getClient();
 
 			accessRulesStorage = env.getDb().getUserAccessRulesStorage();
-		});
+		}, 120_000);
 
 		beforeEach(async () => {
 			[siteKeyMnemonic, siteKey] = await generateMnemonic();

--- a/packages/provider/src/tests/integration/api/blacklistRequestInspector.integration.test.ts
+++ b/packages/provider/src/tests/integration/api/blacklistRequestInspector.integration.test.ts
@@ -57,7 +57,7 @@ describe("blacklistRequestInspector Integration Tests", () => {
 
 		beforeAll(async () => {
 			// Start MongoDB container
-			mongoContainer = await new GenericContainer("mongo:6.0.17")
+			mongoContainer = await new GenericContainer("mongo:6.0.28")
 				.withExposedPorts(27017)
 				.withEnvironment({
 					MONGO_INITDB_ROOT_USERNAME: "root",

--- a/packages/provider/src/tests/integration/clientSettingsPersistence.integration.test.ts
+++ b/packages/provider/src/tests/integration/clientSettingsPersistence.integration.test.ts
@@ -131,7 +131,7 @@ describe("Client settings Mongo persistence", () => {
 	let env: ProviderEnvironment;
 
 	beforeAll(async () => {
-		mongoContainer = await new GenericContainer("mongo:6.0.17")
+		mongoContainer = await new GenericContainer("mongo:6.0.28")
 			.withExposedPorts(27017)
 			.withEnvironment({
 				MONGO_INITDB_ROOT_USERNAME: "root",

--- a/packages/provider/src/tests/integration/decisionMachines.integration.test.ts
+++ b/packages/provider/src/tests/integration/decisionMachines.integration.test.ts
@@ -84,7 +84,7 @@ describe("Decision Machine Database Integration Tests", () => {
 		baseUrl = `${protocol}://localhost:${testPort}`;
 
 		// Start MongoDB container
-		mongoContainer = await new GenericContainer("mongo:6.0.17")
+		mongoContainer = await new GenericContainer("mongo:6.0.28")
 			.withExposedPorts(27017)
 			.withEnvironment({
 				MONGO_INITDB_ROOT_USERNAME: "root",

--- a/packages/provider/src/tests/integration/decisionMachines.integration.test.ts
+++ b/packages/provider/src/tests/integration/decisionMachines.integration.test.ts
@@ -290,7 +290,7 @@ describe("Decision Machine Database Integration Tests", () => {
 				await new Promise((resolve) => setTimeout(resolve, 1000));
 			}
 		}
-	});
+	}, 120_000);
 
 	afterAll(async () => {
 		// Close server first

--- a/packages/provider/src/tests/integration/imgCaptcha.integration.test.ts
+++ b/packages/provider/src/tests/integration/imgCaptcha.integration.test.ts
@@ -268,7 +268,7 @@ describe("Image Captcha Integration Tests", () => {
 				await new Promise((resolve) => setTimeout(resolve, 1000));
 			}
 		}
-	});
+	}, 120_000);
 
 	beforeEach(async () => {
 		// Create a new site key to avoid conflicts with other tests

--- a/packages/provider/src/tests/integration/imgCaptcha.integration.test.ts
+++ b/packages/provider/src/tests/integration/imgCaptcha.integration.test.ts
@@ -92,7 +92,7 @@ describe("Image Captcha Integration Tests", () => {
 		baseUrl = `${protocol}://localhost:${testPort}`;
 
 		// Start MongoDB container
-		mongoContainer = await new GenericContainer("mongo:6.0.17")
+		mongoContainer = await new GenericContainer("mongo:6.0.28")
 			.withExposedPorts(27017)
 			.withEnvironment({
 				MONGO_INITDB_ROOT_USERNAME: "root",

--- a/packages/provider/src/tests/integration/powCaptcha.integration.test.ts
+++ b/packages/provider/src/tests/integration/powCaptcha.integration.test.ts
@@ -304,7 +304,7 @@ describe("PoW Integration Tests", () => {
 				await new Promise((resolve) => setTimeout(resolve, 1000));
 			}
 		}
-	});
+	}, 120_000);
 
 	afterAll(async () => {
 		// Close server first

--- a/packages/provider/src/tests/integration/powCaptcha.integration.test.ts
+++ b/packages/provider/src/tests/integration/powCaptcha.integration.test.ts
@@ -129,7 +129,7 @@ describe("PoW Integration Tests", () => {
 		baseUrl = `${protocol}://localhost:${testPort}`;
 
 		// Start MongoDB container
-		mongoContainer = await new GenericContainer("mongo:6.0.17")
+		mongoContainer = await new GenericContainer("mongo:6.0.28")
 			.withExposedPorts(27017)
 			.withEnvironment({
 				MONGO_INITDB_ROOT_USERNAME: "root",


### PR DESCRIPTION
## Summary
- Docker Hub removed the `mongo:6.0.17` manifest (latest 6.0 patch is now `6.0.28`), breaking `docker compose pull` on production nodes (pronode6 deploy failed today).
- Bumps all `mongo:6.0.17` references to `mongo:6.0.28` — same major.minor, no data file format change.
- Covers 6 docker-compose files + 5 integration test files using `GenericContainer("mongo:...")`.

## Test plan
- [ ] Integration tests still spin up MongoDB and pass (`powCaptcha`, `imgCaptcha`, `decisionMachines`, `blacklistRequestInspector`, `clientSettingsPersistence`)
- [ ] After merge, re-run the provider Ansible playbook against pronode6 — `pull images` task succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)