### PR TITLE
fix(procaptcha-react): hold image-captcha Manager in a useRef

### DIFF
--- a/.changeset/image-widget-manager-ref.md
+++ b/.changeset/image-widget-manager-ref.md
@@ -1,0 +1,13 @@
+---
+"@prosopo/procaptcha-react": patch
+---
+
+fix(procaptcha-react): hold image-captcha Manager in a useRef
+
+Image widget rebuilt the Manager on every render, so the closure
+variables that hold the checkbox click coords (set on start) were
+overwritten by `(0, 0)` on the next render — including the re-render
+that fires immediately after `setLoading(true)` in the click handler.
+By the time `submit()` ran, it was on a newer Manager instance that
+had never seen the click, so every captcha persisted
+`coords[0] = [[0, 0]]`. Matches the pattern PoW and Puzzle already use.

--- a/packages/procaptcha-react/src/components/ProcaptchaWidget.tsx
+++ b/packages/procaptcha-react/src/components/ProcaptchaWidget.tsx
@@ -40,13 +40,21 @@ const ProcaptchaWidget = (props: ProcaptchaProps) => {
 	const [state, updateState] = useProcaptcha(useState, useRef);
 	const [loading, setLoading] = useState(false);
 	const hpRef = useRef<HTMLInputElement>(null);
-	const manager = Manager(
-		config,
-		state,
-		updateState,
-		callbacks,
-		frictionlessState,
-		() => hpRef.current?.value || undefined,
+	// Held in a ref so the closure variables that capture the checkbox
+	// click coords (set on start) survive across re-renders and are
+	// still in scope when submit() runs. PoW and Puzzle widgets do the
+	// same — recreating Manager on every render loses the (x,y) by the
+	// time the user submits, which is why image captcha was persisting
+	// coords[0] = [[0,0]] for every session.
+	const manager = useRef(
+		Manager(
+			config,
+			state,
+			updateState,
+			callbacks,
+			frictionlessState,
+			() => hpRef.current?.value || undefined,
+		),
 	);
 	const theme = "light" === props.config.theme ? lightTheme : darkTheme;
 
@@ -65,11 +73,11 @@ const ProcaptchaWidget = (props: ProcaptchaProps) => {
 		}
 	}, [i18n, config.language]);
 
-	// biome-ignore lint/correctness/useExhaustiveDependencies: manager is recreated each render; only autoStart triggers this
+	// biome-ignore lint/correctness/useExhaustiveDependencies: manager.current is stable across renders
 	useEffect(() => {
 		if (props.autoStart) {
 			setLoading(true);
-			manager.start().then(
+			manager.current.start().then(
 				() => setLoading(false),
 				() => setLoading(false),
 			);
@@ -97,10 +105,10 @@ const ProcaptchaWidget = (props: ProcaptchaProps) => {
 			});
 
 			// If we need to load a challenge or do other initialization
-			if (!state.challenge && manager.start) {
+			if (!state.challenge && manager.current.start) {
 				console.log("No challenge set, attempting to start verification");
 				try {
-					manager.start();
+					manager.current.start();
 				} catch (error) {
 					console.error("Error starting verification:", error);
 				}
@@ -116,7 +124,7 @@ const ProcaptchaWidget = (props: ProcaptchaProps) => {
 				handleExecuteEvent,
 			);
 		};
-	}, [manager, state.challenge, updateState]); // Add dependencies
+	}, [state.challenge, updateState]);
 
 	const honeypot = frictionlessState?.hp ? (
 		<Honeypot ref={hpRef} encodedQuestion={frictionlessState.hp} />
@@ -132,11 +140,11 @@ const ProcaptchaWidget = (props: ProcaptchaProps) => {
 							challenge={state.challenge}
 							index={state.index}
 							solutions={state.solutions}
-							onSubmit={manager.submit}
-							onCancel={manager.cancel}
-							onClick={manager.select}
-							onNext={manager.nextRound}
-							onReload={manager.reload}
+							onSubmit={manager.current.submit}
+							onCancel={manager.current.cancel}
+							onClick={manager.current.select}
+							onNext={manager.current.nextRound}
+							onReload={manager.current.reload}
 							themeColor={config.theme ?? "light"}
 						/>
 					) : null}
@@ -154,11 +162,11 @@ const ProcaptchaWidget = (props: ProcaptchaProps) => {
 						challenge={state.challenge}
 						index={state.index}
 						solutions={state.solutions}
-						onSubmit={manager.submit}
-						onCancel={manager.cancel}
-						onClick={manager.select}
-						onNext={manager.nextRound}
-						onReload={manager.reload}
+						onSubmit={manager.current.submit}
+						onCancel={manager.current.cancel}
+						onClick={manager.current.select}
+						onNext={manager.current.nextRound}
+						onReload={manager.current.reload}
 						themeColor={config.theme ?? "light"}
 					/>
 				) : (
@@ -193,7 +201,7 @@ const ProcaptchaWidget = (props: ProcaptchaProps) => {
 						y = nativeEvent.clientY;
 					}
 
-					await manager.start(x, y);
+					await manager.current.start(x, y);
 					setLoading(false);
 				}}
 				checked={state.isHuman}


### PR DESCRIPTION
## Summary

- Image widget rebuilt `Manager(...)` on every React render, dropping the closure that captured the checkbox click coords.
- The handler that captured `(x, y)` from the click also called `setLoading(true)`, triggering an immediate re-render — by the time `manager.submit()` ran, it was on a *newer* Manager instance whose `checkboxClickX/Y` were still `(0, 0)`.
- Wrapped Manager in `useRef` to give it a stable identity across renders, mirroring what `procaptcha-pow` and `procaptcha-puzzle` already do. Updated all `manager.x` → `manager.current.x` (12 references).

## Why

Confirmed in production data: of 14,322 user-submitted image captchas for dappAccount `5E1bGh…iJ3s` in a 2h window, **100%** had `coords[0] = [[0, 0]]`. PoW on the same site captures real coords ~99.98% of the time — same `Checkbox` component, same handler shape, but PoW's Manager is held in a ref.

## Test plan

- [ ] CI green
- [ ] Manual smoke: visible-mode image captcha on a dapp, confirm submitted `coords[0]` reflects the real click position (non-zero on click, zero on keyboard activation as expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)