### PR TITLE
fix(provider): apply autoBanScoreThreshold after access-policy bump

### DIFF
--- a/.changeset/autoban-after-access-policy.md
+++ b/.changeset/autoban-after-access-policy.md
@@ -2,12 +2,15 @@
 "@prosopo/provider": patch
 ---
 
-fix(provider): apply autoBanScoreThreshold after access-policy bump
+fix(provider): defensive autoBan re-check inside access-policy path
 
-`handleAccessPolicy` applies `scoreIncreaseAccessPolicy` and then short-circuits
-to `sendImageCaptcha` / `sendPowCaptcha` / `sendPuzzleCaptcha` for non-block
-policies. The autoBan check in `runDecisionMachine` never sees the post-bump
-score because the access-policy outcome returns first. Re-evaluate the
-threshold after the bump so a session whose access-policy penalty pushes it
-over `autoBanScoreThreshold` is registered as `AUTO_BAN_SCORE` and 401's,
-regardless of whether the policy routes to image, pow, or puzzle.
+`runDecisionMachine` already re-evaluates `autoBanScoreThreshold` after the
+webView / timestamp / unverifiedHost score bumps (#2738). `handleAccessPolicy`
+runs *before* `runDecisionMachine` and applies its own
+`scoreIncreaseAccessPolicy` bump, but for non-block policies it short-circuits
+straight to `sendImageCaptcha` / `sendPowCaptcha` / `sendPuzzleCaptcha` —
+bypassing the downstream autoBan check. Close that gap by re-evaluating the
+threshold inside `handleAccessPolicy` right after the bump.
+
+No live traffic was observed hitting this path; this is a defensive close,
+not a fix for an active incident.

--- a/.changeset/autoban-after-access-policy.md
+++ b/.changeset/autoban-after-access-policy.md
@@ -1,0 +1,13 @@
+---
+"@prosopo/provider": patch
+---
+
+fix(provider): apply autoBanScoreThreshold after access-policy bump
+
+`handleAccessPolicy` applies `scoreIncreaseAccessPolicy` and then short-circuits
+to `sendImageCaptcha` / `sendPowCaptcha` / `sendPuzzleCaptcha` for non-block
+policies. The autoBan check in `runDecisionMachine` never sees the post-bump
+score because the access-policy outcome returns first. Re-evaluate the
+threshold after the bump so a session whose access-policy penalty pushes it
+over `autoBanScoreThreshold` is registered as `AUTO_BAN_SCORE` and 401's,
+regardless of whether the policy routes to image, pow, or puzzle.

--- a/packages/provider/src/api/captcha/getFrictionlessCaptchaChallenge/accessPolicy.ts
+++ b/packages/provider/src/api/captcha/getFrictionlessCaptchaChallenge/accessPolicy.ts
@@ -110,11 +110,11 @@ export const handleAccessPolicy = async (
 		};
 	}
 
-	// Re-evaluate autoBan after the access-policy bump. Without this, a
-	// non-block policy (image/pow/puzzle routing) bypasses autoBan even
-	// when its score bump pushes the session over the threshold — the
-	// later runDecisionMachine autoBan check never runs because the
-	// access-policy outcome short-circuits before it.
+	// Defensive: re-evaluate autoBan after the access-policy bump so the
+	// non-block branches below can't dispatch to image/pow/puzzle when
+	// the bumped score now meets the threshold. The autoBan check added
+	// to runDecisionMachine (#2738) doesn't cover this path because
+	// handleAccessPolicy short-circuits before runDecisionMachine runs.
 	const autoBanThreshold = clientRecord.settings.autoBanScoreThreshold;
 	if (autoBanThreshold !== undefined && Number(botScore) >= autoBanThreshold) {
 		logger.info(() => ({

--- a/packages/provider/src/api/captcha/getFrictionlessCaptchaChallenge/accessPolicy.ts
+++ b/packages/provider/src/api/captcha/getFrictionlessCaptchaChallenge/accessPolicy.ts
@@ -110,6 +110,37 @@ export const handleAccessPolicy = async (
 		};
 	}
 
+	// Re-evaluate autoBan after the access-policy bump. Without this, a
+	// non-block policy (image/pow/puzzle routing) bypasses autoBan even
+	// when its score bump pushes the session over the threshold — the
+	// later runDecisionMachine autoBan check never runs because the
+	// access-policy outcome short-circuits before it.
+	const autoBanThreshold = clientRecord.settings.autoBanScoreThreshold;
+	if (autoBanThreshold !== undefined && Number(botScore) >= autoBanThreshold) {
+		logger.info(() => ({
+			msg: "Frictionless decision",
+			data: {
+				requestId,
+				decision: "auto_ban_score",
+				botScore,
+				autoBanThreshold,
+				captchaType: userAccessPolicy.captchaType,
+			},
+		}));
+		await tasks.frictionlessManager.registerBlockedSession({
+			solvedImagesCount: clientRecord.settings.imageMaxRounds,
+			userSitekeyIpHash: input.userSitekeyIpHash,
+			reason: FrictionlessReason.AUTO_BAN_SCORE,
+			siteKey: input.dapp,
+			ipInfo: input.ipInfo,
+			headers: input.flatHeaders,
+		});
+		return {
+			handled: true,
+			response: res.status(401).json({ error: "Unauthorized" }),
+		};
+	}
+
 	const captchaTypeBaseParams = {
 		userSitekeyIpHash: input.userSitekeyIpHash,
 		reason: FrictionlessReason.USER_ACCESS_POLICY,

--- a/packages/provider/src/tests/unit/api/captcha/getFrictionlessCaptchaChallenge/accessPolicy.unit.test.ts
+++ b/packages/provider/src/tests/unit/api/captcha/getFrictionlessCaptchaChallenge/accessPolicy.unit.test.ts
@@ -149,7 +149,8 @@ describe("handleAccessPolicy", () => {
 		// sendPowCaptcha and the later autoBan check in runDecisionMachine
 		// never ran. Each route must now register AUTO_BAN_SCORE and 401.
 		const withAutoBanInput = (
-			captchaType: typeof CaptchaType.image
+			captchaType:
+				| typeof CaptchaType.image
 				| typeof CaptchaType.pow
 				| typeof CaptchaType.puzzle,
 			threshold = 1.1,
@@ -207,15 +208,13 @@ describe("handleAccessPolicy", () => {
 				expect.objectContaining({ reason: "AUTO_BAN_SCORE" }),
 			);
 			expect(res.status).toHaveBeenCalledWith(401);
-			expect(tasks.frictionlessManager.sendPuzzleCaptcha).not.toHaveBeenCalled();
+			expect(
+				tasks.frictionlessManager.sendPuzzleCaptcha,
+			).not.toHaveBeenCalled();
 		});
 
 		it("still routes when bumped score stays below threshold", async () => {
-			const { tasks, input } = withAutoBanInput(
-				CaptchaType.puzzle,
-				1.5,
-				1.0,
-			);
+			const { tasks, input } = withAutoBanInput(CaptchaType.puzzle, 1.5, 1.0);
 			const res = buildRes();
 			const r = await handleAccessPolicy(input as never, res as never);
 			expect(r.handled).toBe(true);

--- a/packages/provider/src/tests/unit/api/captcha/getFrictionlessCaptchaChallenge/accessPolicy.unit.test.ts
+++ b/packages/provider/src/tests/unit/api/captcha/getFrictionlessCaptchaChallenge/accessPolicy.unit.test.ts
@@ -140,4 +140,104 @@ describe("handleAccessPolicy", () => {
 		expect(r.handled).toBe(true);
 		expect(tasks.frictionlessManager.sendPuzzleCaptcha).toHaveBeenCalled();
 	});
+
+	describe("auto-ban threshold (post-policy bump)", () => {
+		// Repro: site has autoBanScoreThreshold=1.1, session arrives at
+		// access policy with botScore=1.0. The access-policy bump adds
+		// +0.1 → 1.1, which meets the threshold. Pre-fix the access
+		// policy short-circuited to sendImageCaptcha / sendPuzzleCaptcha /
+		// sendPowCaptcha and the later autoBan check in runDecisionMachine
+		// never ran. Each route must now register AUTO_BAN_SCORE and 401.
+		const withAutoBanInput = (
+			captchaType: typeof CaptchaType.image
+				| typeof CaptchaType.pow
+				| typeof CaptchaType.puzzle,
+			threshold = 1.1,
+			startScore = 1.0,
+		) => {
+			const { tasks, input } = buildInput();
+			input.botScore = startScore;
+			input.baseBotScore = startScore;
+			input.clientRecord = {
+				settings: { imageMaxRounds: 5, autoBanScoreThreshold: threshold },
+			};
+			input.userAccessPolicy = {
+				type: AccessPolicyType.Restrict,
+				captchaType,
+			};
+			return { tasks, input };
+		};
+
+		it("fires when image-typed access policy bump crosses threshold", async () => {
+			const { tasks, input } = withAutoBanInput(CaptchaType.image);
+			const res = buildRes();
+			const r = await handleAccessPolicy(input as never, res as never);
+			expect(r.handled).toBe(true);
+			expect(
+				tasks.frictionlessManager.registerBlockedSession,
+			).toHaveBeenCalledWith(
+				expect.objectContaining({ reason: "AUTO_BAN_SCORE" }),
+			);
+			expect(res.status).toHaveBeenCalledWith(401);
+			expect(tasks.frictionlessManager.sendImageCaptcha).not.toHaveBeenCalled();
+		});
+
+		it("fires when pow-typed access policy bump crosses threshold", async () => {
+			const { tasks, input } = withAutoBanInput(CaptchaType.pow);
+			const res = buildRes();
+			const r = await handleAccessPolicy(input as never, res as never);
+			expect(r.handled).toBe(true);
+			expect(
+				tasks.frictionlessManager.registerBlockedSession,
+			).toHaveBeenCalledWith(
+				expect.objectContaining({ reason: "AUTO_BAN_SCORE" }),
+			);
+			expect(res.status).toHaveBeenCalledWith(401);
+			expect(tasks.frictionlessManager.sendPowCaptcha).not.toHaveBeenCalled();
+		});
+
+		it("fires when puzzle-typed access policy bump crosses threshold", async () => {
+			const { tasks, input } = withAutoBanInput(CaptchaType.puzzle);
+			const res = buildRes();
+			const r = await handleAccessPolicy(input as never, res as never);
+			expect(r.handled).toBe(true);
+			expect(
+				tasks.frictionlessManager.registerBlockedSession,
+			).toHaveBeenCalledWith(
+				expect.objectContaining({ reason: "AUTO_BAN_SCORE" }),
+			);
+			expect(res.status).toHaveBeenCalledWith(401);
+			expect(tasks.frictionlessManager.sendPuzzleCaptcha).not.toHaveBeenCalled();
+		});
+
+		it("still routes when bumped score stays below threshold", async () => {
+			const { tasks, input } = withAutoBanInput(
+				CaptchaType.puzzle,
+				1.5,
+				1.0,
+			);
+			const res = buildRes();
+			const r = await handleAccessPolicy(input as never, res as never);
+			expect(r.handled).toBe(true);
+			expect(
+				tasks.frictionlessManager.registerBlockedSession,
+			).not.toHaveBeenCalled();
+			expect(tasks.frictionlessManager.sendPuzzleCaptcha).toHaveBeenCalled();
+		});
+
+		it("does nothing when autoBanScoreThreshold is undefined", async () => {
+			const { tasks, input } = buildInput();
+			input.botScore = 5.0;
+			input.userAccessPolicy = {
+				type: AccessPolicyType.Restrict,
+				captchaType: CaptchaType.puzzle,
+			};
+			const res = buildRes();
+			await handleAccessPolicy(input as never, res as never);
+			expect(
+				tasks.frictionlessManager.registerBlockedSession,
+			).not.toHaveBeenCalled();
+			expect(tasks.frictionlessManager.sendPuzzleCaptcha).toHaveBeenCalled();
+		});
+	});
 });

--- a/packages/provider/src/tests/unit/api/captcha/getFrictionlessCaptchaChallenge/accessPolicy.unit.test.ts
+++ b/packages/provider/src/tests/unit/api/captcha/getFrictionlessCaptchaChallenge/accessPolicy.unit.test.ts
@@ -159,8 +159,9 @@ describe("handleAccessPolicy", () => {
 			const { tasks, input } = buildInput();
 			input.botScore = startScore;
 			input.baseBotScore = startScore;
-			input.clientRecord = {
-				settings: { imageMaxRounds: 5, autoBanScoreThreshold: threshold },
+			(input.clientRecord as { settings: Record<string, unknown> }).settings = {
+				imageMaxRounds: 5,
+				autoBanScoreThreshold: threshold,
 			};
 			input.userAccessPolicy = {
 				type: AccessPolicyType.Restrict,


### PR DESCRIPTION
## Summary

**Defensive close, not a hotfix.** The autoBan check added to `runDecisionMachine` in #2738 already covers the webView / timestamp / unverifiedHost bump paths. `handleAccessPolicy` runs *before* `runDecisionMachine`, applies its own `scoreIncreaseAccessPolicy` bump, and for non-block policies short-circuits to `sendImageCaptcha` / `sendPowCaptcha` / `sendPuzzleCaptcha` — so the downstream autoBan check never runs on that path.

This PR adds a single re-check of `autoBanScoreThreshold` inside `handleAccessPolicy` immediately after `scoreIncreaseAccessPolicy`. If the bumped score now meets the threshold the session is registered as `AUTO_BAN_SCORE` and 401'd, regardless of whether the access policy would otherwise have routed it to image, pow, or puzzle.

## Tests

`accessPolicy.unit.test.ts` adds an `auto-ban threshold (post-policy bump)` describe block covering:

- Image-typed access policy bump crossing threshold → 401 `AUTO_BAN_SCORE`, no `sendImageCaptcha`.
- Pow-typed access policy bump crossing threshold → 401, no `sendPowCaptcha`.
- Puzzle-typed access policy bump crossing threshold → 401, no `sendPuzzleCaptcha`.
- Bumped score still below threshold → policy routes as normal, no ban.
- `autoBanScoreThreshold` undefined → never bans, policy routes as normal.

All 11 tests in the file pass locally.

## Test plan

- [ ] CI green
- [ ] Manual smoke (optional): set `autoBanScoreThreshold` low enough that a session lands above it after the access-policy bump, confirm 401 and `AUTO_BAN_SCORE` reason

🤖 Generated with [Claude Code](https://claude.com/claude-code)