### PR TITLE
feat: ipv4/ipv6-only provider DNS via data-ipv4/data-ipv6

### DIFF
--- a/.changeset/mongo-6.0.28-bump.md
+++ b/.changeset/mongo-6.0.28-bump.md
@@ -1,0 +1,4 @@
+---
+---
+
+chore: bump mongo 6.0.17 → 6.0.28 in compose + integration tests (tag yanked from Docker Hub). Adds 120s timeout to `beforeAll` hooks that pull mongo via testcontainers so the first fresh pull doesn't time out at the default 10s.

--- a/docker/docker-compose.demo.yml
+++ b/docker/docker-compose.demo.yml
@@ -1,7 +1,7 @@
 # https://docs.docker.com/cloud/ecs-integration/
 services:
     database:
-        image: mongo:6.0.17
+        image: mongo:6.0.28
         ports:
             - '27017:27017'
         environment:

--- a/docker/docker-compose.development.yml
+++ b/docker/docker-compose.development.yml
@@ -1,6 +1,6 @@
 services:
   database:
-    image: mongo:6.0.17
+    image: mongo:6.0.28
     # volumes:
     #   - ./db:/data/db
     ports:

--- a/docker/docker-compose.mongo.yml
+++ b/docker/docker-compose.mongo.yml
@@ -1,7 +1,7 @@
 # https://docs.docker.com/cloud/ecs-integration/
 services:
     database:
-        image: mongo:6.0.17
+        image: mongo:6.0.28
         # volumes:
         #   - ./db:/data/db
         ports:

--- a/docker/docker-compose.provider-mock.yml
+++ b/docker/docker-compose.provider-mock.yml
@@ -35,7 +35,7 @@ services:
             - 208.67.222.222
     database:
         container_name: database
-        image: mongo:6.0.17
+        image: mongo:6.0.28
         volumes:
             - /data/db:/data/db
         ports:

--- a/docker/docker-compose.provider.yml
+++ b/docker/docker-compose.provider.yml
@@ -74,7 +74,7 @@ services:
     profiles:
       - production
       - staging
-    image: mongo:6.0.17
+    image: mongo:6.0.28
     command: mongod --wiredTigerCacheSizeGB 2.0
     deploy:
       resources:

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -1,6 +1,6 @@
 services:
     database:
-        image: mongo:6.0.17
+        image: mongo:6.0.28
         # volumes:
         #   - ./db:/data/db
         ports:

--- a/packages/provider/src/tests/integration/api/blacklistRequestInspector.integration.test.ts
+++ b/packages/provider/src/tests/integration/api/blacklistRequestInspector.integration.test.ts
@@ -57,7 +57,7 @@ describe("blacklistRequestInspector Integration Tests", () => {
 
 		beforeAll(async () => {
 			// Start MongoDB container
-			mongoContainer = await new GenericContainer("mongo:6.0.17")
+			mongoContainer = await new GenericContainer("mongo:6.0.28")
 				.withExposedPorts(27017)
 				.withEnvironment({
 					MONGO_INITDB_ROOT_USERNAME: "root",
@@ -126,7 +126,7 @@ describe("blacklistRequestInspector Integration Tests", () => {
 			await db.getRedisAccessRulesConnection().getClient();
 
 			accessRulesStorage = env.getDb().getUserAccessRulesStorage();
-		});
+		}, 120_000);
 
 		beforeEach(async () => {
 			[siteKeyMnemonic, siteKey] = await generateMnemonic();

--- a/packages/provider/src/tests/integration/clientSettingsPersistence.integration.test.ts
+++ b/packages/provider/src/tests/integration/clientSettingsPersistence.integration.test.ts
@@ -131,7 +131,7 @@ describe("Client settings Mongo persistence", () => {
 	let env: ProviderEnvironment;
 
 	beforeAll(async () => {
-		mongoContainer = await new GenericContainer("mongo:6.0.17")
+		mongoContainer = await new GenericContainer("mongo:6.0.28")
 			.withExposedPorts(27017)
 			.withEnvironment({
 				MONGO_INITDB_ROOT_USERNAME: "root",

--- a/packages/provider/src/tests/integration/decisionMachines.integration.test.ts
+++ b/packages/provider/src/tests/integration/decisionMachines.integration.test.ts
@@ -84,7 +84,7 @@ describe("Decision Machine Database Integration Tests", () => {
 		baseUrl = `${protocol}://localhost:${testPort}`;
 
 		// Start MongoDB container
-		mongoContainer = await new GenericContainer("mongo:6.0.17")
+		mongoContainer = await new GenericContainer("mongo:6.0.28")
 			.withExposedPorts(27017)
 			.withEnvironment({
 				MONGO_INITDB_ROOT_USERNAME: "root",
@@ -290,7 +290,7 @@ describe("Decision Machine Database Integration Tests", () => {
 				await new Promise((resolve) => setTimeout(resolve, 1000));
 			}
 		}
-	});
+	}, 120_000);
 
 	afterAll(async () => {
 		// Close server first

--- a/packages/provider/src/tests/integration/imgCaptcha.integration.test.ts
+++ b/packages/provider/src/tests/integration/imgCaptcha.integration.test.ts
@@ -92,7 +92,7 @@ describe("Image Captcha Integration Tests", () => {
 		baseUrl = `${protocol}://localhost:${testPort}`;
 
 		// Start MongoDB container
-		mongoContainer = await new GenericContainer("mongo:6.0.17")
+		mongoContainer = await new GenericContainer("mongo:6.0.28")
 			.withExposedPorts(27017)
 			.withEnvironment({
 				MONGO_INITDB_ROOT_USERNAME: "root",
@@ -268,7 +268,7 @@ describe("Image Captcha Integration Tests", () => {
 				await new Promise((resolve) => setTimeout(resolve, 1000));
 			}
 		}
-	});
+	}, 120_000);
 
 	beforeEach(async () => {
 		// Create a new site key to avoid conflicts with other tests

--- a/packages/provider/src/tests/integration/powCaptcha.integration.test.ts
+++ b/packages/provider/src/tests/integration/powCaptcha.integration.test.ts
@@ -129,7 +129,7 @@ describe("PoW Integration Tests", () => {
 		baseUrl = `${protocol}://localhost:${testPort}`;
 
 		// Start MongoDB container
-		mongoContainer = await new GenericContainer("mongo:6.0.17")
+		mongoContainer = await new GenericContainer("mongo:6.0.28")
 			.withExposedPorts(27017)
 			.withEnvironment({
 				MONGO_INITDB_ROOT_USERNAME: "root",
@@ -304,7 +304,7 @@ describe("PoW Integration Tests", () => {
 				await new Promise((resolve) => setTimeout(resolve, 1000));
 			}
 		}
-	});
+	}, 120_000);
 
 	afterAll(async () => {
 		// Close server first


### PR DESCRIPTION
## Summary

Stacks on top of #2746 (DNS routing + /healthz pinning). Supersedes #2716 — rewritten against the new dns-routing branch since the original branch was built around the old random-selection + entropy plumbing.

Lets a dapp pin captcha DNS resolution to a single IP stack:

\`\`\`html
<div class=\"procaptcha\" data-sitekey=\"...\" data-ipv4=\"true\"></div>
\`\`\`

What happens under the hood:

- The widget reads \`data-ipv4\` / \`data-ipv6\` (and the matching \`ipv4\` / \`ipv6\` booleans on \`ProcaptchaRenderOptions\` / explicit \`render(...)\`) and threads them through \`ProcaptchaConfigSchema\`.
- \`pickIpMode(config)\` resolves them into an \`IpMode\` (\`\"ipv4\"\` / \`\"ipv6\"\` / \`undefined\`); \`ipv4\` wins if both are set.
- The frictionless / image / pow / puzzle managers pass the \`IpMode\` into \`getProcaptchaRandomActiveProvider\`, which hits \`/healthz\` on the matching single-stack global hostname (\`ipv4.pronode.prosopo.io\` or \`ipv6.pronode.prosopo.io\`) and pins subsequent captcha calls to \`ipv4.pronodeN.prosopo.io\` / \`ipv6.pronodeN.prosopo.io\`. The dual-stack and single-stack pin caches are kept separate.
- \`convertHostedProvider\` accepts an optional \`IpMode\` and, when set, selects the matching \`ipv4\` / \`ipv6\` sub-object from the provider-list JSON. Top-level \`ipv4\` / \`ipv6\` keys are skipped by default so existing dual-stack callers keep working.
- New helpers in \`@prosopo/load-balancer\`: \`IpMode\`, \`stripIpModeLabel\`, \`getProviderHostname\`.

## Pair

Coordinated with the matching \`captcha-private\` change that publishes the \`ipv4\` / \`ipv6\` sub-objects to S3 (see private PR 3616, which will be rebased onto this branch's submodule pointer).

## Test plan

- [x] Type check clean across \`@prosopo/types\`, \`@prosopo/load-balancer\`, \`@prosopo/procaptcha-common\`, \`@prosopo/procaptcha\`, \`@prosopo/procaptcha-pow\`, \`@prosopo/procaptcha-puzzle\`, \`@prosopo/procaptcha-frictionless\`, \`@prosopo/procaptcha-bundle\`, \`@prosopo/provider\`.
- [x] \`npm run -w @prosopo/load-balancer test\` — 10 passed (4 dual-stack + 4 single-stack + 2 cache-isolation tests).
- [x] \`npm run -w @prosopo/procaptcha-common test\` — 59 passed (added \`pickIpMode\` coverage + \`getProcaptchaRandomActiveProvider\` ipMode forwarding).
- [x] \`npm run -w @prosopo/procaptcha-frictionless test\` — 8 passed.
- [x] \`npx biome check\` clean on all 15 changed source files + the changeset.
- [ ] Manually verify in a demo page: \`<div class=\"procaptcha\" data-sitekey=\"...\" data-ipv4=\"true\"></div>\` results in \`/healthz\` on \`ipv4.pronode.prosopo.io\` and subsequent captcha calls on \`ipv4.pronodeN.prosopo.io\`. Same with \`data-ipv6\`.
- [ ] Confirm an old SDK build hitting the new provider-list JSON shape still works (dual-stack consumers should see no behavioural change since \`convertHostedProvider\` filters the new top-level keys).