### PR TITLE
feat(caddy): per-host ipv4./ipv6. SANs in the per-host site block

### DIFF
--- a/docker/provider.Caddyfile
+++ b/docker/provider.Caddyfile
@@ -295,7 +295,18 @@ http://:9090 {
 # challenges AND HTTP→HTTPS redirects targeting port 443 (i.e. the
 # layer4 listener), which forwards non-matching SNIs back to this same
 # :8443.
-https://{$CADDY_DOMAIN}:8443 {
+#
+# Three SNIs share one site block and one cert lineage so Caddy issues a
+# single multi-SAN cert covering {host}, ipv4.{host}, ipv6.{host}. The
+# single-stack variants exist as their own DNS records (A only for
+# ipv4.{host}, AAAA only for ipv6.{host}) so callers that need to pin a
+# specific IP stack can do so without losing TLS. The new captcha
+# DNS-routing client returns the per-host name from /healthz and the
+# load-balancer prepends `ipv4.` / `ipv6.`, so without these SANs the
+# single-stack path would fail the TLS handshake.
+https://{$CADDY_DOMAIN}:8443,
+https://ipv4.{$CADDY_DOMAIN}:8443,
+https://ipv6.{$CADDY_DOMAIN}:8443 {
 	tls {
 		issuer acme {
 			disable_tlsalpn_challenge


### PR DESCRIPTION
## Summary

- Adds `ipv4.{$CADDY_DOMAIN}:8443` and `ipv6.{$CADDY_DOMAIN}:8443` to the per-host site block in `docker/provider.Caddyfile` so Caddy issues a single multi-SAN cert covering all three hostnames per pronode.
- One-line semantic change; comment block in front explains why.

## Why now — this fixes a live prod gap

The DNS-routing client landed in #2746 (and `captcha-private` #3651 / v3.6.47). The widget now reads the per-host name from `/healthz` and prepends `ipv4.` / `ipv6.` whenever the dapp sets `data-ipv4` / `data-ipv6`:

```ts
// packages/load-balancer/src/providers.ts
parsed.hostname = withIpModeLabel(host, ipMode); // "ipv4.pronode6.prosopo.io"
```

But on every prod pronode the per-host Caddy site only binds `{$CADDY_DOMAIN}:8443`, so the auto-ACME cert has a single SAN:

```sh
$ openssl s_client -connect 92.118.58.186:443 -servername ipv4.pronode6.prosopo.io
# error:0A000438:SSL routines::tlsv1 alert internal error
# pronode6 dual-stack SAN: DNS:pronode6.prosopo.io
```

Same handshake failure on pronode 6/7/8/9/10/11/12/13/15/16 — every single prod pronode. Any dapp using `data-ipv4` / `data-ipv6` against prod today silently falls back to the dual-stack URL.

## What this does

Three SNIs share one site block, so the lineage gets reissued with all three SANs once Caddy reloads:

```caddy
https://{$CADDY_DOMAIN}:8443,
https://ipv4.{$CADDY_DOMAIN}:8443,
https://ipv6.{$CADDY_DOMAIN}:8443 {
    tls {
        issuer acme {
            disable_tlsalpn_challenge
        }
    }
    import provider_site
}
```

DNS records for the single-stack variants are already in Cloudflare for every prod pronode (`ipv4.pronodeN.prosopo.io` = A only, `ipv6.pronodeN.prosopo.io` = AAAA only), and the matching DNS records have been added on staging in this PR's sibling work.

## Test plan

Validated on all 3 staging pronodes (`captcha-private` PR linked below) by force-recreating Caddy after this Caddyfile change:

- [x] Caddy ACME-issues new lineages: `tls.obtain certificate obtained successfully identifier="ipv4.staging-pronode2.prosopo.io"` etc. for all 6 (ipv4/ipv6 × 3 pronodes)
- [x] `curl https://ipv4.staging-pronodeN.prosopo.io/healthz` returns `HTTP 200` with `remote_ip` matching the right backend, for N ∈ {2,3,4}
- [x] `openssl s_client -servername ipv6.staging-pronodeN.prosopo.io` returns a cert with the correct single-stack SAN

## Rollout note for prod

Picked up on the next prod deploy. **Caddy needs to be force-recreated**, not just reloaded — the docker bind-mount captures the Caddyfile inode at container start, so an in-place `ansible.builtin.copy` plus `caddy reload` is a no-op against the running container. `providerRollingDeploy.yml` already recreates Caddy as part of the per-host loop, so a rolling deploy is the right vehicle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)