### PR TITLE
fix(provider): honour user access policy on frictionless session-dedup

### DIFF
--- a/.changeset/frictionless-dedup-access-policy.md
+++ b/.changeset/frictionless-dedup-access-policy.md
@@ -1,0 +1,5 @@
+---
+"@prosopo/provider": patch
+---
+
+Frictionless: honour an active user access policy on the session-dedup fast path. A reused session whose captchaType conflicts with the policy — e.g. an IP rate-limit rule (`IP_HIGH_REQUEST_RATE_SIMPLE`) forcing `image` over a previously-cached `pow` session — was served as-is and then hard-rejected at the `/captcha/{type}` gate with `INCORRECT_CAPTCHA_TYPE`, breaking the widget. The dedup branch now re-checks the policy, and on conflict evicts the stale session and falls through so the access policy (or decision machine) selects the correct captcha type.

--- a/packages/provider/src/api/captcha/getFrictionlessCaptchaChallenge/handler.ts
+++ b/packages/provider/src/api/captcha/getFrictionlessCaptchaChallenge/handler.ts
@@ -21,7 +21,10 @@ import {
 	type ScoreComponents,
 } from "@prosopo/types";
 import type { ProviderEnvironment } from "@prosopo/types-env";
-import type { AccessRulesStorage } from "@prosopo/user-access-policy";
+import {
+	AccessPolicyType,
+	type AccessRulesStorage,
+} from "@prosopo/user-access-policy";
 import { flatten } from "@prosopo/util";
 import type { NextFunction, Request, Response } from "express";
 import { getCompositeIpAddress } from "../../../compositeIpAddress.js";
@@ -169,33 +172,97 @@ export default (
 			}
 
 			if (dedup) {
-				req.logger.info(() => ({
-					msg: "Reusing existing session for user-IP-sitekey combination",
-					data: {
-						userSitekeyIpHash,
-						sessionId: dedup.sessionId,
-						captchaType: dedup.captchaType,
-					},
-				}));
-				req.logger.info(() => ({
-					msg: "Frictionless decision",
-					data: {
-						decision: "reuse_session",
-						captchaType: dedup.captchaType,
-						sessionId: dedup.sessionId,
-					},
-				}));
-				recordFrictionlessDecision("reuse_session");
-				attachHoneypot(res, clientRecord);
-				return res.json({
-					[ApiParams.captchaType]: dedup.captchaType as
-						| CaptchaType.image
-						| CaptchaType.pow
-						| CaptchaType.puzzle,
-					[ApiParams.sessionId]: dedup.sessionId,
-					[ApiParams.status]: "ok",
-					dns_url: buildDnsEventUrl(dedup.sessionId),
-				});
+				// A reused session must still honour an active user access policy.
+				// This fast-path returns before handleAccessPolicy / runDecisionMachine
+				// below, so a cached session whose captchaType conflicts with the
+				// policy — e.g. an IP rate-limit rule forcing `image` over a
+				// previously-cached `pow` session — would be served as-is and then
+				// hard-rejected at the /captcha/{type} gate with INCORRECT_CAPTCHA_TYPE.
+				// Re-check the policy here; on conflict evict the stale session and
+				// fall through so the access policy (or decision machine) selects the
+				// correct captcha type.
+				const dedupCountryCode =
+					req.ipInfo && "isValid" in req.ipInfo && req.ipInfo.isValid
+						? req.ipInfo.countryCode
+						: undefined;
+				const dedupAsn =
+					req.ipInfo && "isValid" in req.ipInfo && req.ipInfo.isValid
+						? req.ipInfo.asnNumber
+						: undefined;
+				const dedupUserScope = getRequestUserScope(
+					flatten(req.headers),
+					req.ja4,
+					normalizedIp,
+					user,
+					undefined,
+					undefined,
+					dedupCountryCode,
+					dedupAsn,
+				);
+				const dedupAccessPolicy = (
+					await tasks.frictionlessManager.getPrioritisedAccessPolicies(
+						userAccessRulesStorage,
+						dapp,
+						dedupUserScope,
+					)
+				)[0];
+				const dedupConflictsWithPolicy =
+					dedupAccessPolicy !== undefined &&
+					(dedupAccessPolicy.type === AccessPolicyType.Block ||
+						(dedupAccessPolicy.captchaType !== undefined &&
+							dedupAccessPolicy.captchaType !== dedup.captchaType));
+
+				if (dedupConflictsWithPolicy) {
+					req.logger.info(() => ({
+						msg: "Evicting reused session: cached captchaType conflicts with access policy",
+						data: {
+							userSitekeyIpHash,
+							sessionId: dedup.sessionId,
+							cachedCaptchaType: dedup.captchaType,
+							policyType: dedupAccessPolicy.type,
+							policyCaptchaType: dedupAccessPolicy.captchaType,
+						},
+					}));
+					// Mongo is authoritative for dedup (see resolveSessionDedup): mark
+					// the stale session deleted so the next request doesn't re-reuse it,
+					// and drop the Redis pointers up front to avoid a resurrection race.
+					await tasks.db.checkAndRemoveSession(dedup.sessionId);
+					await Promise.all([
+						tasks.writeQueue?.invalidateCachedSession(dedup.sessionId) ??
+							Promise.resolve(),
+						tasks.writeQueue?.invalidateCachedSessionByHash(
+							userSitekeyIpHash,
+						) ?? Promise.resolve(),
+					]);
+				} else {
+					req.logger.info(() => ({
+						msg: "Reusing existing session for user-IP-sitekey combination",
+						data: {
+							userSitekeyIpHash,
+							sessionId: dedup.sessionId,
+							captchaType: dedup.captchaType,
+						},
+					}));
+					req.logger.info(() => ({
+						msg: "Frictionless decision",
+						data: {
+							decision: "reuse_session",
+							captchaType: dedup.captchaType,
+							sessionId: dedup.sessionId,
+						},
+					}));
+					recordFrictionlessDecision("reuse_session");
+					attachHoneypot(res, clientRecord);
+					return res.json({
+						[ApiParams.captchaType]: dedup.captchaType as
+							| CaptchaType.image
+							| CaptchaType.pow
+							| CaptchaType.puzzle,
+						[ApiParams.sessionId]: dedup.sessionId,
+						[ApiParams.status]: "ok",
+						dns_url: buildDnsEventUrl(dedup.sessionId),
+					});
+				}
 			}
 
 			const ipAddress = getCompositeIpAddress(normalizedIp);

--- a/packages/provider/src/tests/unit/api/getFrictionlessCaptchaChallenge.unit.test.ts
+++ b/packages/provider/src/tests/unit/api/getFrictionlessCaptchaChallenge.unit.test.ts
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import { CaptchaType, ContextType } from "@prosopo/types";
+import { AccessPolicyType } from "@prosopo/user-access-policy";
 import { type Mock, beforeEach, describe, expect, it, vi } from "vitest";
 import getHandler from "../../../api/captcha/getFrictionlessCaptchaChallenge.js";
 import { FrictionlessReason } from "../../../tasks/frictionless/frictionlessTasks.js";
@@ -42,6 +43,7 @@ type MockTasks = {
 		getSessionRecordByToken: MockFn;
 		getSessionByuserSitekeyIpHash: MockFn;
 		getClientRecord: MockFn;
+		checkAndRemoveSession: MockFn;
 	};
 	logger: Record<string, unknown>;
 };
@@ -170,6 +172,7 @@ vi.mock("../../../tasks/index.js", async () => {
 					getSessionRecordByToken: vi.fn().mockResolvedValue(null),
 					getSessionByuserSitekeyIpHash: vi.fn().mockResolvedValue(null),
 					getClientRecord: vi.fn(),
+					checkAndRemoveSession: vi.fn().mockResolvedValue(undefined),
 				},
 				logger: mockLogger as unknown as Record<string, unknown>,
 			}),
@@ -227,6 +230,7 @@ describe("getFrictionlessCaptchaChallenge - context selection", () => {
 			getSessionRecordByToken: vi.fn().mockResolvedValue(null),
 			getSessionByuserSitekeyIpHash: vi.fn().mockResolvedValue(null),
 			getClientRecord: vi.fn(),
+			checkAndRemoveSession: vi.fn().mockResolvedValue(undefined),
 		},
 		logger: mockLogger as unknown as Record<string, unknown>,
 	});
@@ -463,6 +467,100 @@ describe("getFrictionlessCaptchaChallenge - context selection", () => {
 				siteKey: "siteBlocked",
 				reason: FrictionlessReason.ACCESS_POLICY_BLOCK,
 			}),
+		);
+	});
+
+	it("evicts the reused session and re-routes when an access policy forces a different captchaType", async () => {
+		const clientRecord = {
+			account: "siteDedupConflict",
+			settings: {
+				captchaType: CaptchaType.frictionless,
+				frictionlessThreshold: 0.5,
+				imageMaxRounds: 2,
+				disallowWebView: false,
+			},
+		};
+		tasksInstance.db.getClientRecord.mockResolvedValue(clientRecord);
+
+		// A previously-cached pow session for this user+IP+sitekey.
+		tasksInstance.db.getSessionByuserSitekeyIpHash.mockResolvedValue({
+			sessionId: "stale-pow-session",
+			captchaType: CaptchaType.pow,
+		});
+
+		// An access rule (e.g. IP rate-limit) now forces image for this scope.
+		tasksInstance.frictionlessManager.getPrioritisedAccessPolicies.mockResolvedValue(
+			[{ type: AccessPolicyType.Restrict, captchaType: CaptchaType.image }],
+		);
+
+		tasksInstance.frictionlessManager.decryptPayload.mockResolvedValue({
+			baseBotScore: 0,
+			timestamp: Date.now(),
+			userId: "u",
+			userAgent: "844bc172f032bdd2d0baae3536c1d66c",
+			webView: false,
+			iFrame: false,
+			decryptedHeadHash: "abc",
+			decryptionFailed: false,
+		});
+
+		const body = {
+			token: "tConflict",
+			headHash: "hhConflict",
+			dapp: "siteDedupConflict",
+			user: "u",
+		};
+		const { req, res, next } = buildReqRes(body);
+
+		// biome-ignore lint/suspicious/noExplicitAny: mock request
+		await handler(req as any, res as any, next);
+
+		expect(next).not.toHaveBeenCalled();
+		// The stale pow session is evicted rather than reused...
+		expect(tasksInstance.db.checkAndRemoveSession).toHaveBeenCalledWith(
+			"stale-pow-session",
+		);
+		// ...and the request falls through to the access policy, which serves image.
+		expect(
+			tasksInstance.frictionlessManager.sendImageCaptcha,
+		).toHaveBeenCalled();
+	});
+
+	it("reuses the cached session when no access policy conflicts with its captchaType", async () => {
+		const clientRecord = {
+			account: "siteDedupOk",
+			settings: {
+				captchaType: CaptchaType.frictionless,
+				frictionlessThreshold: 0.5,
+				disallowWebView: false,
+			},
+		};
+		tasksInstance.db.getClientRecord.mockResolvedValue(clientRecord);
+
+		tasksInstance.db.getSessionByuserSitekeyIpHash.mockResolvedValue({
+			sessionId: "live-pow-session",
+			captchaType: CaptchaType.pow,
+		});
+		// No matching access policy (default mock returns []) → reuse as-is.
+
+		const body = {
+			token: "tOk",
+			headHash: "hhOk",
+			dapp: "siteDedupOk",
+			user: "u",
+		};
+		const { req, res, next } = buildReqRes(body);
+
+		// biome-ignore lint/suspicious/noExplicitAny: mock request
+		await handler(req as any, res as any, next);
+
+		expect(next).not.toHaveBeenCalled();
+		expect(tasksInstance.db.checkAndRemoveSession).not.toHaveBeenCalled();
+		expect(
+			tasksInstance.frictionlessManager.sendImageCaptcha,
+		).not.toHaveBeenCalled();
+		expect(res.json).toHaveBeenCalledWith(
+			expect.objectContaining({ sessionId: "live-pow-session" }),
 		);
 	});
 


### PR DESCRIPTION
## Problem

A frictionless/PoW site key returned **`Incorrect CAPTCHA type`** (`API.INCORRECT_CAPTCHA_TYPE`) to users whose IP had been flagged by the `IP_HIGH_REQUEST_RATE_SIMPLE` rate-limit detector (which writes a `restrict → image` user access rule).

### Root cause

The frictionless handler's **session-dedup fast-path** returns the cached session's `captchaType` and `return`s *before* `handleAccessPolicy` / `runDecisionMachine`:

- A `pow` session is cached for `user+IP+sitekey`.
- An access rule later forces `image` for that IP.
- The next frictionless request hits dedup → returns `pow` (skipping the access-policy step entirely).
- The client requests a PoW challenge → `GetPoWCaptchaChallenge` loads the access policy and `captchaManager.ts` rejects it: `userAccessPolicy.captchaType (image) !== requestedCaptchaType (pow)` → `INCORRECT_CAPTCHA_TYPE`.

The decision machine is **not** involved — this reproduces on any frictionless site key with a conflicting access rule. The normal (non-dedup) path already reconciles this via `handleAccessPolicy` (serves an `image` session); only the dedup fast-path skipped it.

## Fix

In the dedup branch, re-check the prioritised access policy. On conflict (policy is a `block`, or its `captchaType` differs from the cached session's), evict the stale session (`checkAndRemoveSession` — Mongo is authoritative for dedup — plus Redis pointer invalidation) and **fall through** so the access policy / decision machine selects the correct captcha type. When there's no conflict, the session is reused exactly as before.

Scope is computed locally in the branch, so the non-dedup path is unchanged.

## Tests

- New unit tests in `getFrictionlessCaptchaChallenge.unit.test.ts`:
  - evicts the reused session and re-routes to `image` when an access policy forces a different `captchaType`;
  - reuses the cached session when no policy conflicts.
- Full provider unit suite, `build:tsc`, and biome all pass locally. (Two unrelated `spam email domain checking` tests time out locally because they perform live DNS/MX lookups with no network in the sandbox; they are untouched by this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)