### PR TITLE
test(provider): cover empty-SNI flag and GREASE-lookalike cipher

### DIFF
--- a/.changeset/ja4-extra-coverage.md
+++ b/.changeset/ja4-extra-coverage.md
@@ -1,0 +1,5 @@
+---
+"@prosopo/provider": patch
+---
+
+Add JA4 unit coverage for the empty-SNI 'd' flag and a GREASE-lookalike cipher that must be counted and hashed.

--- a/packages/provider/src/tests/unit/api/ja4.unit.test.ts
+++ b/packages/provider/src/tests/unit/api/ja4.unit.test.ts
@@ -229,6 +229,14 @@ describe("calculateJa4 — SNI flag", () => {
 		const fp = calculateJa4(buildClientHello(0x0303, [0xc02f], []));
 		expect(fp[3]).toBe("i");
 	});
+
+	it("sets 'd' when the SNI extension is present but empty (no host_name)", () => {
+		// JA4 keys the flag off the extension's presence, not a parsed host_name.
+		const fp = calculateJa4(
+			buildClientHello(0x0303, [0xc02f], [{ id: 0x0000, data: Buffer.alloc(0) }]),
+		);
+		expect(fp[3]).toBe("d");
+	});
 });
 
 describe("calculateJa4 — counts", () => {
@@ -237,6 +245,13 @@ describe("calculateJa4 — counts", () => {
 		const fp = calculateJa4(
 			buildClientHello(0x0303, [0x0a0a, 0x1301, 0x1302], []),
 		);
+		expect(fp.slice(4, 6)).toBe("02");
+	});
+
+	it("counts a GREASE-lookalike with unequal bytes (0x0a1a) as a real cipher", () => {
+		// 0x0a1a matches the nibble pattern but the bytes differ, so it is NOT a
+		// real RFC 8701 GREASE value and must be counted/hashed.
+		const fp = calculateJa4(buildClientHello(0x0303, [0x0a1a, 0x1301], []));
 		expect(fp.slice(4, 6)).toBe("02");
 	});
 

--- a/packages/provider/src/tests/unit/api/ja4.unit.test.ts
+++ b/packages/provider/src/tests/unit/api/ja4.unit.test.ts
@@ -232,8 +232,10 @@ describe("calculateJa4 — SNI flag", () => {
 
 	it("sets 'd' when the SNI extension is present but empty (no host_name)", () => {
 		// JA4 keys the flag off the extension's presence, not a parsed host_name.
+		// Well-formed empty SNI: a server_name_list of length 0.
+		const emptySni = Buffer.from([0x00, 0x00]);
 		const fp = calculateJa4(
-			buildClientHello(0x0303, [0xc02f], [{ id: 0x0000, data: Buffer.alloc(0) }]),
+			buildClientHello(0x0303, [0xc02f], [{ id: 0x0000, data: emptySni }]),
 		);
 		expect(fp[3]).toBe("d");
 	});
@@ -253,6 +255,16 @@ describe("calculateJa4 — counts", () => {
 		// real RFC 8701 GREASE value and must be counted/hashed.
 		const fp = calculateJa4(buildClientHello(0x0303, [0x0a1a, 0x1301], []));
 		expect(fp.slice(4, 6)).toBe("02");
+
+		// Being a real cipher, it must also contribute to the cipher hash:
+		// dropping it changes the hash, unlike a true GREASE value.
+		const withLookalike = calculateJa4(
+			buildClientHello(0x0303, [0x0a1a, 0x1301], []),
+		).split("_")[1];
+		const withoutLookalike = calculateJa4(
+			buildClientHello(0x0303, [0x1301], []),
+		).split("_")[1];
+		expect(withLookalike).not.toBe(withoutLookalike);
 	});
 
 	it("extension count excludes GREASE", () => {


### PR DESCRIPTION
Follow-up test coverage for the JA4 spec fixes merged in #2627.

Adds two regression tests to `ja4.unit.test.ts`:
- **Empty SNI extension → 'd'**: asserts the SNI flag keys off the extension's *presence*, not a parsed host_name (an SNI extension with no host_name entry still yields `d`).
- **GREASE look-alike cipher**: asserts a value matching the nibble pattern but with unequal bytes (`0x0a1a`) is *not* filtered as GREASE and is counted as a real cipher.

Both pass against current `main`.