### PR TITLE
fix(deps): align @angular/* package versions at 20.3.25

### DIFF
--- a/.changeset/angular-version-alignment.md
+++ b/.changeset/angular-version-alignment.md
@@ -1,0 +1,8 @@
+---
+"@prosopo/angular-procaptcha-integration-demo": patch
+"@prosopo/angular-procaptcha-wrapper": patch
+---
+
+fix(deps): align @angular/* package versions at 20.3.25
+
+Bumped @angular/common, @angular/platform-browser, @angular/router, @angular/cli, and @angular/compiler-cli from 20.3.16 to 20.3.25 to match @angular/core. Since each @angular/* subpackage pins its peer @angular/core to its own exact version, the prior mix produced an unresolvable peer-dep tree when installing from scratch.

--- a/integration/frameworks/angular/angular-procaptcha-integration-demo/package.json
+++ b/integration/frameworks/angular/angular-procaptcha-integration-demo/package.json
@@ -15,10 +15,10 @@
 		"dev": "npm run start"
 	},
 	"dependencies": {
-		"@angular/common": "20.3.16",
+		"@angular/common": "20.3.25",
 		"@angular/core": "20.3.25",
-		"@angular/platform-browser": "20.3.16",
-		"@angular/router": "20.3.16",
+		"@angular/platform-browser": "20.3.25",
+		"@angular/router": "20.3.25",
 		"@prosopo/angular-procaptcha-wrapper": "1.1.89"
 	},
 	"main": "dist/index.js",
@@ -34,8 +34,8 @@
 		"@prosopo/config": "3.3.4",
 		"@angular-builders/custom-webpack": "20.0.0",
 		"@angular-devkit/build-angular": "20.3.28",
-		"@angular/cli": "20.3.16",
-		"@angular/compiler-cli": "20.3.16",
+		"@angular/cli": "20.3.25",
+		"@angular/compiler-cli": "20.3.25",
 		"@types/jasmine": "5.1.15",
 		"@types/node": "22.10.2",
 		"del-cli": "6.0.0",

--- a/integration/frameworks/angular/angular-procaptcha-wrapper/package.json
+++ b/integration/frameworks/angular/angular-procaptcha-wrapper/package.json
@@ -21,7 +21,7 @@
 		"@angular/core": "20.3.25"
 	},
 	"devDependencies": {
-		"@angular/compiler-cli": "20.3.9",
+		"@angular/compiler-cli": "20.3.25",
 		"@prosopo/config": "3.3.4",
 		"@types/node": "22.10.2",
 		"del-cli": "6.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@prosopo/captcha",
-	"version": "3.6.47",
+	"version": "3.6.48",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@prosopo/captcha",
-			"version": "3.6.47",
+			"version": "3.6.48",
 			"license": "Apache-2.0",
 			"workspaces": [
 				"dev/*",
@@ -2433,17 +2433,17 @@
 			"name": "@prosopo/angular-procaptcha-integration-demo",
 			"version": "1.1.89",
 			"dependencies": {
-				"@angular/common": "20.3.16",
+				"@angular/common": "20.3.25",
 				"@angular/core": "20.3.25",
-				"@angular/platform-browser": "20.3.16",
-				"@angular/router": "20.3.16",
+				"@angular/platform-browser": "20.3.25",
+				"@angular/router": "20.3.25",
 				"@prosopo/angular-procaptcha-wrapper": "1.1.89"
 			},
 			"devDependencies": {
 				"@angular-builders/custom-webpack": "20.0.0",
 				"@angular-devkit/build-angular": "20.3.28",
-				"@angular/cli": "20.3.16",
-				"@angular/compiler-cli": "20.3.16",
+				"@angular/cli": "20.3.25",
+				"@angular/compiler-cli": "20.3.25",
 				"@prosopo/config": "3.3.4",
 				"@types/jasmine": "5.1.15",
 				"@types/node": "22.10.2",
@@ -3348,24 +3348,26 @@
 				"url": "https://github.com/sponsors/SuperchupuDev"
 			}
 		},
-		"integration/frameworks/angular/angular-procaptcha-integration-demo/node_modules/@angular/compiler": {
-			"version": "20.3.16",
-			"resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-20.3.16.tgz",
-			"integrity": "sha512-Pt9Ms9GwTThgzdxWBwMfN8cH1JEtQ2DK5dc2yxYtPSaD+WKmG9AVL1PrzIYQEbaKcWk2jxASUHpEWSlNiwo8uw==",
-			"dev": true,
+		"integration/frameworks/angular/angular-procaptcha-integration-demo/node_modules/@angular/common": {
+			"version": "20.3.25",
+			"resolved": "https://registry.npmjs.org/@angular/common/-/common-20.3.25.tgz",
+			"integrity": "sha512-rnRGcXbjet0DHgkRL4Dqxk21G2T4UypVfiTV/fay58H8w9U89PJ1L6gRmk8B/uyfpii/9r23cBwnpcguQykxYw==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"tslib": "^2.3.0"
 			},
 			"engines": {
 				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+			},
+			"peerDependencies": {
+				"@angular/core": "20.3.25",
+				"rxjs": "^6.5.3 || ^7.4.0"
 			}
 		},
 		"integration/frameworks/angular/angular-procaptcha-integration-demo/node_modules/@angular/compiler-cli": {
-			"version": "20.3.16",
-			"resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-20.3.16.tgz",
-			"integrity": "sha512-l3xF/fXfJAl/UrNnH9Ufkr79myjMgXdHq1mmmph2UnpeqilRB1b8lC9sLBV9MipQHVn3dwocxMIvtrcryfOaXw==",
+			"version": "20.3.25",
+			"resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-20.3.25.tgz",
+			"integrity": "sha512-iqxwVo5Pgzt3EfT49OZ6plxA6KKxwv7ixx1XNH7QRvaOJC9gmsPScWpx+LO7ZsVZdo/NkA+rnXDl0PauUgGciw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3386,13 +3388,53 @@
 				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
 			},
 			"peerDependencies": {
-				"@angular/compiler": "20.3.16",
+				"@angular/compiler": "20.3.25",
 				"typescript": ">=5.8 <6.0"
 			},
 			"peerDependenciesMeta": {
 				"typescript": {
 					"optional": true
 				}
+			}
+		},
+		"integration/frameworks/angular/angular-procaptcha-integration-demo/node_modules/@angular/platform-browser": {
+			"version": "20.3.25",
+			"resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-20.3.25.tgz",
+			"integrity": "sha512-0k06U/AJRQifGMLkcU3R9uEHWbuKEzkKMuKcGagXTrkeFvCG2Ub4JdsbcjFNWB2bspWgaxIMSceuj7c83U5wOA==",
+			"license": "MIT",
+			"dependencies": {
+				"tslib": "^2.3.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+			},
+			"peerDependencies": {
+				"@angular/animations": "20.3.25",
+				"@angular/common": "20.3.25",
+				"@angular/core": "20.3.25"
+			},
+			"peerDependenciesMeta": {
+				"@angular/animations": {
+					"optional": true
+				}
+			}
+		},
+		"integration/frameworks/angular/angular-procaptcha-integration-demo/node_modules/@angular/router": {
+			"version": "20.3.25",
+			"resolved": "https://registry.npmjs.org/@angular/router/-/router-20.3.25.tgz",
+			"integrity": "sha512-YIjLHWAufTaukNj15hEoys29e7XNhnCRsS1/95h/OqR69R3adbB8hV7ut7gO6XdXokriYqb4gtoUjoESxR+xFQ==",
+			"license": "MIT",
+			"dependencies": {
+				"tslib": "^2.3.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+			},
+			"peerDependencies": {
+				"@angular/common": "20.3.25",
+				"@angular/core": "20.3.25",
+				"@angular/platform-browser": "20.3.25",
+				"rxjs": "^6.5.3 || ^7.4.0"
 			}
 		},
 		"integration/frameworks/angular/angular-procaptcha-integration-demo/node_modules/@babel/core": {
@@ -4135,19 +4177,6 @@
 				"webpack": "^5.0.0"
 			}
 		},
-		"integration/frameworks/angular/angular-procaptcha-integration-demo/node_modules/picomatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
 		"integration/frameworks/angular/angular-procaptcha-integration-demo/node_modules/postcss": {
 			"version": "8.5.12",
 			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
@@ -4287,7 +4316,6 @@
 			"version": "2.8.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"dev": true,
 			"license": "0BSD"
 		},
 		"integration/frameworks/angular/angular-procaptcha-integration-demo/node_modules/typescript": {
@@ -4392,7 +4420,7 @@
 				"@prosopo/procaptcha-wrapper": "2.6.91"
 			},
 			"devDependencies": {
-				"@angular/compiler-cli": "20.3.9",
+				"@angular/compiler-cli": "20.3.25",
 				"@prosopo/config": "3.3.4",
 				"@types/node": "22.10.2",
 				"del-cli": "6.0.0",
@@ -4406,24 +4434,10 @@
 				"@angular/core": "20.3.25"
 			}
 		},
-		"integration/frameworks/angular/angular-procaptcha-wrapper/node_modules/@angular/compiler": {
-			"version": "20.3.9",
-			"resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-20.3.9.tgz",
-			"integrity": "sha512-nfzR/JpI77Yr4opRimnnTys//taZiibEco1ihV1C02eM4FDCQMOEp8WB+DT/yUESb6MRBlZe1MjeelwSfHlB7g==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"tslib": "^2.3.0"
-			},
-			"engines": {
-				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-			}
-		},
 		"integration/frameworks/angular/angular-procaptcha-wrapper/node_modules/@angular/compiler-cli": {
-			"version": "20.3.9",
-			"resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-20.3.9.tgz",
-			"integrity": "sha512-Fe7MIg2NWXoK+M4GtclxaYNoTdZX2U8f/Fd3N8zxtEMcRsvliJOnJ4oQtpx5kqMAuZVO4zY3wuIY1wAGXYCUbQ==",
+			"version": "20.3.25",
+			"resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-20.3.25.tgz",
+			"integrity": "sha512-iqxwVo5Pgzt3EfT49OZ6plxA6KKxwv7ixx1XNH7QRvaOJC9gmsPScWpx+LO7ZsVZdo/NkA+rnXDl0PauUgGciw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4444,7 +4458,7 @@
 				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
 			},
 			"peerDependencies": {
-				"@angular/compiler": "20.3.9",
+				"@angular/compiler": "20.3.25",
 				"typescript": ">=5.8 <6.0"
 			},
 			"peerDependenciesMeta": {
@@ -5108,13 +5122,13 @@
 			}
 		},
 		"node_modules/@angular-devkit/architect": {
-			"version": "0.2003.16",
-			"resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.2003.16.tgz",
-			"integrity": "sha512-W7FPVhZzIeHVP/duuKepfZU66LpQ0k9YMHFhrGpzaUuHPOwKmza6+pjVvvti3g6jzT8b1uVlb+XlYgNPZ5jrPQ==",
+			"version": "0.2003.25",
+			"resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.2003.25.tgz",
+			"integrity": "sha512-39pTqt4wSmpD1WeCee46oSGXRh6TR1PFd9GZEwyZoMvBTMs8mE2sXGxUgd4Qyi5CkQ1XnCM5XfgJcjUWUQRoGg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@angular-devkit/core": "20.3.16",
+				"@angular-devkit/core": "20.3.25",
 				"rxjs": "7.8.2"
 			},
 			"engines": {
@@ -5187,30 +5201,17 @@
 				}
 			}
 		},
-		"node_modules/@angular-devkit/build-webpack/node_modules/picomatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
 		"node_modules/@angular-devkit/core": {
-			"version": "20.3.16",
-			"resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-20.3.16.tgz",
-			"integrity": "sha512-6L9Lpe3lbkyz32gzqxZGVC8MhXxXht+yV+4LUsb4+6T/mG/V9lW6UTW0dhwVOS3vpWMEwpy75XHT298t7HcKEg==",
+			"version": "20.3.25",
+			"resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-20.3.25.tgz",
+			"integrity": "sha512-pSfeWEoS1y9zxqTOw0Etj2NXkRmp/aU52wdnyq3KqVA9cJtgxtlOHlBBNswTil4dReojEy+0K1xJm+mLuWuLxA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"ajv": "8.17.1",
+				"ajv": "8.18.0",
 				"ajv-formats": "3.0.1",
 				"jsonc-parser": "3.3.1",
-				"picomatch": "4.0.3",
+				"picomatch": "4.0.4",
 				"rxjs": "7.8.2",
 				"source-map": "0.7.6"
 			},
@@ -5228,31 +5229,14 @@
 				}
 			}
 		},
-		"node_modules/@angular-devkit/core/node_modules/ajv": {
-			"version": "8.17.1",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"fast-deep-equal": "^3.1.3",
-				"fast-uri": "^3.0.1",
-				"json-schema-traverse": "^1.0.0",
-				"require-from-string": "^2.0.2"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/epoberezkin"
-			}
-		},
 		"node_modules/@angular-devkit/schematics": {
-			"version": "20.3.16",
-			"resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-20.3.16.tgz",
-			"integrity": "sha512-3K8QwTpKjnLo3hIvNzB9sTjrlkeRyMK0TxdwgTbwJseewGhXLl98oBoTCWM2ygtpskiWNpYqXJNIhoslNN65WQ==",
+			"version": "20.3.25",
+			"resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-20.3.25.tgz",
+			"integrity": "sha512-IB0IHf8ZRqr69hT/XIfHkYLPAYHWQ/WUc6+fKHBwq58jJlm/y5QUeTEuXvJ18IX/+hUIqw+E2Q3T0N9rLDLzXg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@angular-devkit/core": "20.3.16",
+				"@angular-devkit/core": "20.3.25",
 				"jsonc-parser": "3.3.1",
 				"magic-string": "0.30.17",
 				"ora": "8.2.0",
@@ -5265,19 +5249,19 @@
 			}
 		},
 		"node_modules/@angular/cli": {
-			"version": "20.3.16",
-			"resolved": "https://registry.npmjs.org/@angular/cli/-/cli-20.3.16.tgz",
-			"integrity": "sha512-kjGp0ywIWebWrH6U5eCRkS4Tx1D/yMe2iT7DXMfEcLc8iMSrBozEriMJppbot9ou8O2LeEH5d1Nw0efNNo78Kw==",
+			"version": "20.3.25",
+			"resolved": "https://registry.npmjs.org/@angular/cli/-/cli-20.3.25.tgz",
+			"integrity": "sha512-QOSxza45CZY11kqPVpqsU+WGYF99rR/r9A9GykZQWuAHb5SEAxlXHyaaGMu/BMtBHy5HNIlJH25UlzelrbaNyQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@angular-devkit/architect": "0.2003.16",
-				"@angular-devkit/core": "20.3.16",
-				"@angular-devkit/schematics": "20.3.16",
+				"@angular-devkit/architect": "0.2003.25",
+				"@angular-devkit/core": "20.3.25",
+				"@angular-devkit/schematics": "20.3.25",
 				"@inquirer/prompts": "7.8.2",
 				"@listr2/prompt-adapter-inquirer": "3.0.1",
 				"@modelcontextprotocol/sdk": "1.26.0",
-				"@schematics/angular": "20.3.16",
+				"@schematics/angular": "20.3.25",
 				"@yarnpkg/lockfile": "1.1.0",
 				"algoliasearch": "5.35.0",
 				"ini": "5.0.0",
@@ -5327,20 +5311,18 @@
 				"url": "https://github.com/sponsors/colinhacks"
 			}
 		},
-		"node_modules/@angular/common": {
-			"version": "20.3.16",
-			"resolved": "https://registry.npmjs.org/@angular/common/-/common-20.3.16.tgz",
-			"integrity": "sha512-GRAziNlntwdnJy3F+8zCOvDdy7id0gITjDnM6P9+n2lXvtDuBLGJKU3DWBbvxcCjtD6JK/g/rEX5fbCxbUHkQQ==",
+		"node_modules/@angular/compiler": {
+			"version": "20.3.25",
+			"resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-20.3.25.tgz",
+			"integrity": "sha512-TSh6gVoQqlLPqWwsYMK0lfVEQYENQO+USzS+BHFXEHFfgBRap6qDpIUGnRdj0Y2PlaVJUVFbeq1855EZUPUEoA==",
+			"devOptional": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.3.0"
 			},
 			"engines": {
 				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-			},
-			"peerDependencies": {
-				"@angular/core": "20.3.16",
-				"rxjs": "^6.5.3 || ^7.4.0"
 			}
 		},
 		"node_modules/@angular/core": {
@@ -5366,46 +5348,6 @@
 				"zone.js": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/@angular/platform-browser": {
-			"version": "20.3.16",
-			"resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-20.3.16.tgz",
-			"integrity": "sha512-YsrLS6vyS77i4pVHg4gdSBW74qvzHjpQRTVQ5Lv/OxIjJdYYYkMmjNalCNgy1ZuyY6CaLIB11ccxhrNnxfKGOQ==",
-			"license": "MIT",
-			"dependencies": {
-				"tslib": "^2.3.0"
-			},
-			"engines": {
-				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-			},
-			"peerDependencies": {
-				"@angular/animations": "20.3.16",
-				"@angular/common": "20.3.16",
-				"@angular/core": "20.3.16"
-			},
-			"peerDependenciesMeta": {
-				"@angular/animations": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@angular/router": {
-			"version": "20.3.16",
-			"resolved": "https://registry.npmjs.org/@angular/router/-/router-20.3.16.tgz",
-			"integrity": "sha512-e1LiQFZaajKqc00cY5FboIrWJZSMnZ64GDp5R0UejritYrqorQQQNOqP1W85BMuY2owibMmxVfX+dJg/Mc8PuQ==",
-			"license": "MIT",
-			"dependencies": {
-				"tslib": "^2.3.0"
-			},
-			"engines": {
-				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-			},
-			"peerDependencies": {
-				"@angular/common": "20.3.16",
-				"@angular/core": "20.3.16",
-				"@angular/platform-browser": "20.3.16",
-				"rxjs": "^6.5.3 || ^7.4.0"
 			}
 		},
 		"node_modules/@asamuzakjp/css-color": {
@@ -16575,14 +16517,14 @@
 			}
 		},
 		"node_modules/@schematics/angular": {
-			"version": "20.3.16",
-			"resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-20.3.16.tgz",
-			"integrity": "sha512-KeOcsM5piwv/6tUKBmLD1zXTwtJlZBnR2WM/4T9ImaQbmFGe1MMHUABT5SQ3Bifv1YKCw58ImxiaQUY9sdNqEQ==",
+			"version": "20.3.25",
+			"resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-20.3.25.tgz",
+			"integrity": "sha512-ezoJpPKhhjXgE3LxuNcJO/ghSXs8f73xrqGvqouag7IbuliJYbHrt22WH3X75XSbD0+iOdiqA2bARvAO/ezyxQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@angular-devkit/core": "20.3.16",
-				"@angular-devkit/schematics": "20.3.16",
+				"@angular-devkit/core": "20.3.25",
+				"@angular-devkit/schematics": "20.3.25",
 				"jsonc-parser": "3.3.1"
 			},
 			"engines": {
@@ -31440,9 +31382,9 @@
 			"license": "ISC"
 		},
 		"node_modules/picomatch": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=12"


### PR DESCRIPTION
## Summary

- Bump `@angular/common`, `@angular/platform-browser`, `@angular/router`, `@angular/cli`, `@angular/compiler-cli` from `20.3.16` to `20.3.25` in `angular-procaptcha-integration-demo` to match `@angular/core`.
- Bump `@angular/compiler-cli` from `20.3.9` to `20.3.25` in `angular-procaptcha-wrapper`.
- Regenerate `package-lock.json` so all `@angular/*` packages resolve consistently.
- Add a patch-level changeset so both packages release in the next cut.

## Why

Each `@angular/*` subpackage pins its peer `@angular/core` to its own exact version. After dependabot bumped only `@angular/core` to `20.3.25` in #2697, the rest stayed at `20.3.16` (which peer-requires core `20.3.16`). The captcha submodule's lock somehow committed this mixed state, but a fresh `npm i` cannot resolve it.

This broke captcha-private's `Create Release PR` workflow at the `npm i` step after `npm run deps`:
- Failing run: https://github.com/prosopo/captcha-private/actions/runs/28111160108/job/83238631096

## Test plan

- [x] `npm i --ignore-scripts --include=dev` resolves cleanly without `--force` or `--legacy-peer-deps`
- [ ] CI green
- [ ] Once merged + v3.6.49 released, re-run captcha-private `create_release_pr` workflow and confirm it succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)