### PR TITLE
fix(provider): resolve origin sessionId to escalation after post-PoW route()

### DIFF
--- a/.changeset/fix-postpow-escalation-session-cache.md
+++ b/.changeset/fix-postpow-escalation-session-cache.md
@@ -1,0 +1,10 @@
+---
+"@prosopo/database": patch
+"@prosopo/provider": patch
+---
+
+fix(provider): resolve origin sessionId to escalation when post-PoW route() escalates to image/puzzle
+
+When the decision machine's route() phase escalates the user from PoW to an image/puzzle captcha, `buildEscalation` mints a fresh session — but the originating session has already been consumed by the preceding /captcha/pow request. Widgets that didn't switch to the escalation sessionId on the next /captcha/* call (older bundled SDKs, hand-rolled wrappers, network-retry races, tab races) landed on NO_SESSION_FOUND. Production deploy of R1/R2 escalations at 18:39 UTC caused a 4.6× spike in CAPTCHA.NO_SESSION_FOUND (363/hr → 1,668/hr); rate dropped immediately once the routing artifact was deleted.
+
+Records an origin → escalation sessionId mapping in Redis at the moment `buildEscalation` creates the new session. On the next /captcha/* request, `isValidRequest` falls back to that mapping when `checkAndRemoveSession` returns null for the supplied sessionId, then invalidates the mapping (single-use). When Redis is unavailable the escalation still returns to the client unchanged — those deployments accept the widget must handle the new sessionId on its own.

--- a/packages/database/src/redisCache.ts
+++ b/packages/database/src/redisCache.ts
@@ -279,6 +279,108 @@ export class RedisWriteQueue {
 		}
 	}
 
+	/**
+	 * Cache an origin → escalation sessionId mapping for the post-PoW
+	 * escalation flow.
+	 *
+	 * Background: when the routing machine returns image/puzzle from the
+	 * postPow phase, `buildEscalation` (`api/captcha/submitPoWCaptchaSolution.ts`)
+	 * mints a new session with a fresh `sessionId` and returns it on the
+	 * `escalation` field. A widget that handles the escalation cleanly
+	 * mounts the next captcha with the new sessionId. But there are
+	 * several real-world paths where the widget keeps using the original
+	 * sessionId for the follow-up `/captcha/{type}` request — bundled SDK
+	 * versions that predate the escalation handler, dapps that hand-roll
+	 * the wrapper, network-glitch retries, or browser-tab races. The
+	 * original session has been consumed and soft-deleted by the
+	 * preceding `/captcha/pow`, so the follow-up gets
+	 * `CAPTCHA.NO_SESSION_FOUND` and the user sees an inline error → FAQ.
+	 *
+	 * This mapping lets `isValidRequest` resolve the original sessionId
+	 * forward to the live escalation session and proceed normally.
+	 *
+	 * TTL is short on purpose: escalation handoffs complete in seconds
+	 * (the user solves the follow-up immediately) and a stale mapping
+	 * pointing at a long-gone session would just produce a different
+	 * shape of NO_SESSION_FOUND.
+	 */
+	async cacheSessionEscalation(
+		originSessionId: string,
+		escalationSessionId: string,
+		ttlSeconds = 600,
+	): Promise<boolean> {
+		const client = await this.getClient();
+		if (!client) {
+			return false;
+		}
+
+		try {
+			const key = `cache:session:escalation:${originSessionId}`;
+			await client.set(key, escalationSessionId, { EX: ttlSeconds });
+			return true;
+		} catch (error) {
+			this.logger.warn(() => ({
+				msg: "Failed to cache session escalation mapping in Redis",
+				err: error,
+				originSessionId,
+				escalationSessionId,
+			}));
+			return false;
+		}
+	}
+
+	/**
+	 * Resolve an original sessionId to its escalation sessionId, if one was
+	 * recorded. Returns null when there is no mapping (either no escalation
+	 * happened, or the TTL has elapsed).
+	 */
+	async getCachedSessionEscalation(
+		originSessionId: string,
+	): Promise<string | null> {
+		const client = await this.getClient();
+		if (!client) {
+			return null;
+		}
+
+		try {
+			const key = `cache:session:escalation:${originSessionId}`;
+			return await client.get(key);
+		} catch (error) {
+			this.logger.warn(() => ({
+				msg: "Failed to get cached session escalation mapping from Redis",
+				err: error,
+				originSessionId,
+			}));
+			return null;
+		}
+	}
+
+	/**
+	 * Invalidate an escalation mapping. Called when the escalation session
+	 * itself is consumed so subsequent retries on the origin sessionId fall
+	 * through to the standard NO_SESSION_FOUND path rather than chasing a
+	 * second-hand stale pointer.
+	 */
+	async invalidateCachedSessionEscalation(
+		originSessionId: string,
+	): Promise<void> {
+		const client = await this.getClient();
+		if (!client) {
+			return;
+		}
+
+		try {
+			const key = `cache:session:escalation:${originSessionId}`;
+			await client.del(key);
+		} catch (error) {
+			this.logger.warn(() => ({
+				msg: "Failed to invalidate cached session escalation mapping",
+				err: error,
+				originSessionId,
+			}));
+		}
+	}
+
 	// ── Session write queue ─────────────────────────────────────────────
 
 	/**

--- a/packages/database/src/tests/unit/redisCacheEscalation.unit.test.ts
+++ b/packages/database/src/tests/unit/redisCacheEscalation.unit.test.ts
@@ -1,0 +1,188 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { Logger } from "@prosopo/logger";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { RedisWriteQueue } from "../../redisCache.js";
+
+// Minimal in-memory fake of the bits of `RedisClient` that
+// `cacheSessionEscalation` / `getCachedSessionEscalation` /
+// `invalidateCachedSessionEscalation` actually touch. This keeps the test
+// deterministic (no network) and decouples it from the real Redis client.
+const makeFakeClient = () => {
+	const store = new Map<string, { value: string; expiresAt: number | null }>();
+	return {
+		store,
+		set: vi.fn(async (key: string, value: string, opts?: { EX?: number }) => {
+			store.set(key, {
+				value,
+				expiresAt: opts?.EX ? Date.now() + opts.EX * 1000 : null,
+			});
+			return "OK";
+		}),
+		get: vi.fn(async (key: string): Promise<string | null> => {
+			const entry = store.get(key);
+			if (!entry) return null;
+			if (entry.expiresAt !== null && entry.expiresAt <= Date.now()) {
+				store.delete(key);
+				return null;
+			}
+			return entry.value;
+		}),
+		del: vi.fn(async (key: string) => {
+			const had = store.delete(key);
+			return had ? 1 : 0;
+		}),
+	};
+};
+
+// A noop-ish logger that captures warnings so the tests can assert
+// quietly on the error-path behavior.
+const makeLogger = () => {
+	const warn = vi.fn();
+	return {
+		debug: vi.fn(),
+		info: vi.fn(),
+		log: vi.fn(),
+		trace: vi.fn(),
+		warn,
+		error: vi.fn(),
+		fatal: vi.fn(),
+		with: vi.fn(),
+		level: "info" as const,
+		warnSpy: warn,
+	} as unknown as Logger & { warnSpy: ReturnType<typeof vi.fn> };
+};
+
+describe("RedisWriteQueue — session escalation mapping", () => {
+	let queue: RedisWriteQueue;
+	let fakeClient: ReturnType<typeof makeFakeClient>;
+	let logger: Logger & { warnSpy: ReturnType<typeof vi.fn> };
+
+	beforeEach(() => {
+		fakeClient = makeFakeClient();
+		logger = makeLogger();
+		// RedisWriteQueue takes (connection, logger). The connection is
+		// only used inside getClient(), which we stub below — so a stand-in
+		// sentinel value is fine here.
+		// biome-ignore lint/suspicious/noExplicitAny: test-only stub
+		queue = new RedisWriteQueue({} as any, logger);
+		// RedisWriteQueue connects lazily through getClient(); short-circuit
+		// that to our in-memory fake without dealing with the connection
+		// state machine.
+		(queue as unknown as { getClient: () => Promise<unknown> }).getClient =
+			async () => fakeClient;
+	});
+
+	it("cacheSessionEscalation stores the mapping under the documented key", async () => {
+		const ok = await queue.cacheSessionEscalation("origin-A", "escalation-B");
+		expect(ok).toBe(true);
+		expect(fakeClient.set).toHaveBeenCalledWith(
+			"cache:session:escalation:origin-A",
+			"escalation-B",
+			{ EX: 600 },
+		);
+		// Round-trip through the fake store.
+		expect(
+			fakeClient.store.get("cache:session:escalation:origin-A")?.value,
+		).toBe("escalation-B");
+	});
+
+	it("getCachedSessionEscalation returns the cached value when present", async () => {
+		await queue.cacheSessionEscalation("origin-A", "escalation-B");
+		const got = await queue.getCachedSessionEscalation("origin-A");
+		expect(got).toBe("escalation-B");
+	});
+
+	it("getCachedSessionEscalation returns null when no mapping was recorded", async () => {
+		const got = await queue.getCachedSessionEscalation("unknown-origin");
+		expect(got).toBeNull();
+	});
+
+	it("invalidateCachedSessionEscalation drops the mapping", async () => {
+		await queue.cacheSessionEscalation("origin-A", "escalation-B");
+		await queue.invalidateCachedSessionEscalation("origin-A");
+		expect(fakeClient.del).toHaveBeenCalledWith(
+			"cache:session:escalation:origin-A",
+		);
+		const got = await queue.getCachedSessionEscalation("origin-A");
+		expect(got).toBeNull();
+	});
+
+	it("invalidateCachedSessionEscalation is a no-op on missing keys (idempotent)", async () => {
+		await queue.invalidateCachedSessionEscalation("never-cached");
+		// Should not throw, nothing in the store, no warning logged.
+		expect(logger.warnSpy).not.toHaveBeenCalled();
+	});
+
+	it("cacheSessionEscalation honours a custom TTL", async () => {
+		await queue.cacheSessionEscalation("origin-A", "escalation-B", 30);
+		expect(fakeClient.set).toHaveBeenCalledWith(
+			"cache:session:escalation:origin-A",
+			"escalation-B",
+			{ EX: 30 },
+		);
+	});
+
+	it("cacheSessionEscalation returns false and logs when Redis is unavailable", async () => {
+		(queue as unknown as { getClient: () => Promise<null> }).getClient =
+			async () => null;
+		const ok = await queue.cacheSessionEscalation("origin-A", "escalation-B");
+		expect(ok).toBe(false);
+	});
+
+	it("getCachedSessionEscalation returns null when Redis is unavailable", async () => {
+		(queue as unknown as { getClient: () => Promise<null> }).getClient =
+			async () => null;
+		const got = await queue.getCachedSessionEscalation("origin-A");
+		expect(got).toBeNull();
+	});
+
+	it("set failure surfaces as false + a logged warning, not a thrown error", async () => {
+		fakeClient.set.mockRejectedValueOnce(new Error("REDIS_DOWN"));
+		const ok = await queue.cacheSessionEscalation("origin-A", "escalation-B");
+		expect(ok).toBe(false);
+		expect(logger.warnSpy).toHaveBeenCalled();
+	});
+
+	it("get failure surfaces as null + a logged warning, not a thrown error", async () => {
+		fakeClient.get.mockRejectedValueOnce(new Error("REDIS_DOWN"));
+		const got = await queue.getCachedSessionEscalation("origin-A");
+		expect(got).toBeNull();
+		expect(logger.warnSpy).toHaveBeenCalled();
+	});
+
+	it("del failure surfaces as a logged warning, not a thrown error", async () => {
+		fakeClient.del.mockRejectedValueOnce(new Error("REDIS_DOWN"));
+		await expect(
+			queue.invalidateCachedSessionEscalation("origin-A"),
+		).resolves.toBeUndefined();
+		expect(logger.warnSpy).toHaveBeenCalled();
+	});
+
+	it("entries respect TTL expiry", async () => {
+		// Cache with 1s TTL, fast-forward virtual time past it.
+		vi.useFakeTimers();
+		try {
+			await queue.cacheSessionEscalation("origin-A", "escalation-B", 1);
+			expect(await queue.getCachedSessionEscalation("origin-A")).toBe(
+				"escalation-B",
+			);
+			vi.advanceTimersByTime(2_000);
+			expect(await queue.getCachedSessionEscalation("origin-A")).toBeNull();
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+});

--- a/packages/provider/src/api/captcha/submitPoWCaptchaSolution.ts
+++ b/packages/provider/src/api/captcha/submitPoWCaptchaSolution.ts
@@ -215,8 +215,11 @@ export default (env: ProviderEnvironment) =>
  * session of the chosen captcha type, carrying forward the originating
  * session's risk profile (score, headers, IP, etc.). Returns undefined when
  * the router decided to keep the user on PoW (i.e. no escalation needed).
+ *
+ * Exported for unit testing only — the handler above is the production entry
+ * point.
  */
-const buildEscalation = async (
+export const buildEscalation = async (
 	tasks: Tasks,
 	result: { verified: boolean; routingOutput?: { captchaType: CaptchaType } },
 	challenge: string,
@@ -272,6 +275,19 @@ const buildEscalation = async (
 		originSession.mode,
 		originSession.simdReadings,
 	);
+
+	// Record the origin → escalation sessionId mapping so a /captcha/*
+	// request that arrives carrying the originating sessionId (because the
+	// widget didn't switch to the escalation id, or a network retry fired
+	// on the old state) resolves forward to `newSession` instead of
+	// landing on NO_SESSION_FOUND. See `cacheSessionEscalation` in
+	// `packages/database/src/redisCache.ts` for the full rationale.
+	if (tasks.writeQueue) {
+		await tasks.writeQueue.cacheSessionEscalation(
+			powRecord.sessionId,
+			newSession.sessionId,
+		);
+	}
 
 	return {
 		captchaType: routed.captchaType,

--- a/packages/provider/src/tasks/captchaManager.ts
+++ b/packages/provider/src/tasks/captchaManager.ts
@@ -318,7 +318,43 @@ export class CaptchaManager {
 					: Promise.resolve(),
 			]);
 
-			const sessionRecord = await this.db.checkAndRemoveSession(sessionId);
+			let sessionRecord = await this.db.checkAndRemoveSession(sessionId);
+			let resolvedSessionId = sessionId;
+			if (!sessionRecord && this.writeQueue) {
+				// Origin session was consumed (or never existed). Before
+				// returning NO_SESSION_FOUND, check whether a post-PoW
+				// escalation minted a follow-up session for this origin.
+				// `buildEscalation` in submitPoWCaptchaSolution.ts writes
+				// this mapping when the routing machine returns image or
+				// puzzle from postPow. Real-world widgets and dapps that
+				// don't fully wire `onEscalate` keep calling /captcha/*
+				// with the original sessionId — without this fallback they
+				// see CAPTCHA.NO_SESSION_FOUND and the user lands on the
+				// FAQ page.
+				const escalationSessionId =
+					await this.writeQueue.getCachedSessionEscalation(sessionId);
+				if (escalationSessionId && escalationSessionId !== sessionId) {
+					this.logger.info(() => ({
+						msg: "Resolving origin sessionId to escalation",
+						data: {
+							account: clientSettings.account,
+							originSessionId: sessionId,
+							escalationSessionId,
+						},
+					}));
+					const escalationRecord =
+						await this.db.checkAndRemoveSession(escalationSessionId);
+					if (escalationRecord) {
+						sessionRecord = escalationRecord;
+						resolvedSessionId = escalationSessionId;
+					}
+					// The escalation mapping is single-use: once we've
+					// followed it (or tried to and the escalation session
+					// is also gone), drop the pointer so subsequent
+					// retries don't keep chasing a dead reference.
+					await this.writeQueue.invalidateCachedSessionEscalation(sessionId);
+				}
+			}
 			if (!sessionRecord) {
 				this.logger.warn(() => ({
 					msg: "No session found",
@@ -350,6 +386,12 @@ export class CaptchaManager {
 					type: requestedCaptchaType,
 				};
 			}
+			// From here on, `sessionId` (the variable) tracks whichever
+			// sessionId we actually resolved against. Subsequent cache
+			// invalidations and downstream consumers should use that, not
+			// the originally requested id — otherwise the escalation
+			// session's own cache entries leak past the consume.
+			sessionId = resolvedSessionId;
 
 			// Invalidate the Redis session cache so that subsequent
 			// requests do not receive this now-deleted sessionId from

--- a/packages/provider/src/tests/unit/api/captcha/submitPoWCaptchaSolution.escalation.unit.test.ts
+++ b/packages/provider/src/tests/unit/api/captcha/submitPoWCaptchaSolution.escalation.unit.test.ts
@@ -1,0 +1,226 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { CaptchaType, type Session } from "@prosopo/types";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { buildEscalation } from "../../../../api/captcha/submitPoWCaptchaSolution.js";
+
+// Minimal Tasks-shape required by `buildEscalation`. The function only
+// reaches for: tasks.db.getPowCaptchaRecordByChallenge,
+// tasks.db.getSessionRecordBySessionId,
+// tasks.frictionlessManager.createSession, and tasks.writeQueue.cacheSessionEscalation.
+// Everything else can be left undefined.
+const makeTasks = () => {
+	const cacheSessionEscalation = vi.fn().mockResolvedValue(true);
+	const createSession = vi.fn().mockImplementation(async () => ({
+		sessionId: "escalation-id",
+	}));
+	const getPowCaptchaRecordByChallenge = vi.fn();
+	const getSessionRecordBySessionId = vi.fn();
+
+	const tasks = {
+		db: {
+			getPowCaptchaRecordByChallenge,
+			getSessionRecordBySessionId,
+		},
+		frictionlessManager: {
+			createSession,
+		},
+		writeQueue: {
+			cacheSessionEscalation,
+		},
+	} as unknown as Parameters<typeof buildEscalation>[0];
+
+	return {
+		tasks,
+		spies: {
+			cacheSessionEscalation,
+			createSession,
+			getPowCaptchaRecordByChallenge,
+			getSessionRecordBySessionId,
+		},
+	};
+};
+
+const makeOriginSession = (): Session =>
+	({
+		sessionId: "origin-id",
+		token: "origin-token",
+		score: 0.2,
+		threshold: 0.5,
+		scoreComponents: { baseScore: 0.2 },
+		ipAddress: { lower: 0n, type: "v4" },
+		captchaType: CaptchaType.pow,
+		siteKey: "site",
+		userSitekeyIpHash: "hash-xyz",
+		webView: false,
+		iFrame: false,
+		decryptedHeadHash: "headhash",
+		ipInfo: undefined,
+		headers: undefined,
+		mode: undefined,
+		simdReadings: undefined,
+	}) as unknown as Session;
+
+describe("submitPoWCaptchaSolution.buildEscalation", () => {
+	let env: ReturnType<typeof makeTasks>;
+
+	beforeEach(() => {
+		env = makeTasks();
+	});
+
+	it("returns undefined when no routing output was supplied (no escalation)", async () => {
+		const out = await buildEscalation(
+			env.tasks,
+			{ verified: true, routingOutput: undefined },
+			"challenge",
+		);
+		expect(out).toBeUndefined();
+		expect(env.spies.cacheSessionEscalation).not.toHaveBeenCalled();
+		expect(env.spies.createSession).not.toHaveBeenCalled();
+	});
+
+	it("returns undefined when PoW didn't verify (route() shouldn't fire if PoW failed)", async () => {
+		const out = await buildEscalation(
+			env.tasks,
+			{
+				verified: false,
+				routingOutput: { captchaType: CaptchaType.image },
+			},
+			"challenge",
+		);
+		expect(out).toBeUndefined();
+		expect(env.spies.cacheSessionEscalation).not.toHaveBeenCalled();
+	});
+
+	it("returns undefined when the router kept the user on PoW (no escalation needed)", async () => {
+		const out = await buildEscalation(
+			env.tasks,
+			{ verified: true, routingOutput: { captchaType: CaptchaType.pow } },
+			"challenge",
+		);
+		expect(out).toBeUndefined();
+		expect(env.spies.cacheSessionEscalation).not.toHaveBeenCalled();
+	});
+
+	it("writes an origin → escalation mapping to Redis when escalating to image", async () => {
+		env.spies.getPowCaptchaRecordByChallenge.mockResolvedValue({
+			sessionId: "origin-id",
+			dappAccount: "dapp",
+		});
+		env.spies.getSessionRecordBySessionId.mockResolvedValue(
+			makeOriginSession(),
+		);
+
+		const out = await buildEscalation(
+			env.tasks,
+			{ verified: true, routingOutput: { captchaType: CaptchaType.image } },
+			"challenge",
+		);
+
+		expect(out).toEqual({
+			captchaType: CaptchaType.image,
+			sessionId: "escalation-id",
+		});
+		// The whole point of this PR: the mapping must be written
+		// alongside the new session so a /captcha/* request carrying the
+		// original sessionId can be resolved forward.
+		expect(env.spies.cacheSessionEscalation).toHaveBeenCalledWith(
+			"origin-id",
+			"escalation-id",
+		);
+	});
+
+	it("writes the mapping when escalating to puzzle as well as image", async () => {
+		env.spies.getPowCaptchaRecordByChallenge.mockResolvedValue({
+			sessionId: "origin-id",
+			dappAccount: "dapp",
+		});
+		env.spies.getSessionRecordBySessionId.mockResolvedValue(
+			makeOriginSession(),
+		);
+
+		await buildEscalation(
+			env.tasks,
+			{ verified: true, routingOutput: { captchaType: CaptchaType.puzzle } },
+			"challenge",
+		);
+
+		expect(env.spies.cacheSessionEscalation).toHaveBeenCalledWith(
+			"origin-id",
+			"escalation-id",
+		);
+	});
+
+	it("is a no-op on the cache write when writeQueue is null (Redis not configured)", async () => {
+		// Some deployments run without Redis. The escalation must still
+		// be returned to the client; the cache write just doesn't happen
+		// — those deployments accept that the widget has to handle the
+		// escalation correctly on its own.
+		env.spies.getPowCaptchaRecordByChallenge.mockResolvedValue({
+			sessionId: "origin-id",
+			dappAccount: "dapp",
+		});
+		env.spies.getSessionRecordBySessionId.mockResolvedValue(
+			makeOriginSession(),
+		);
+		(env.tasks as unknown as { writeQueue: unknown }).writeQueue = null;
+
+		const out = await buildEscalation(
+			env.tasks,
+			{ verified: true, routingOutput: { captchaType: CaptchaType.image } },
+			"challenge",
+		);
+
+		expect(out).toEqual({
+			captchaType: CaptchaType.image,
+			sessionId: "escalation-id",
+		});
+		// `cacheSessionEscalation` was never on the null writeQueue so
+		// the original spy can never have been called.
+		expect(env.spies.cacheSessionEscalation).not.toHaveBeenCalled();
+	});
+
+	it("does not write a mapping when the PoW record lookup fails (no origin to map from)", async () => {
+		env.spies.getPowCaptchaRecordByChallenge.mockResolvedValue(null);
+
+		const out = await buildEscalation(
+			env.tasks,
+			{ verified: true, routingOutput: { captchaType: CaptchaType.image } },
+			"challenge",
+		);
+
+		expect(out).toBeUndefined();
+		expect(env.spies.cacheSessionEscalation).not.toHaveBeenCalled();
+		expect(env.spies.createSession).not.toHaveBeenCalled();
+	});
+
+	it("does not write a mapping when the origin session is gone (race against checkAndRemove)", async () => {
+		env.spies.getPowCaptchaRecordByChallenge.mockResolvedValue({
+			sessionId: "origin-id",
+			dappAccount: "dapp",
+		});
+		env.spies.getSessionRecordBySessionId.mockResolvedValue(undefined);
+
+		const out = await buildEscalation(
+			env.tasks,
+			{ verified: true, routingOutput: { captchaType: CaptchaType.image } },
+			"challenge",
+		);
+
+		expect(out).toBeUndefined();
+		expect(env.spies.cacheSessionEscalation).not.toHaveBeenCalled();
+		expect(env.spies.createSession).not.toHaveBeenCalled();
+	});
+});

--- a/packages/provider/src/tests/unit/tasks/captchaManager.unit.test.ts
+++ b/packages/provider/src/tests/unit/tasks/captchaManager.unit.test.ts
@@ -21,7 +21,12 @@ import {
 	type Session,
 	contextAwareThresholdDefault,
 } from "@prosopo/types";
-import { CaptchaType, type IUserSettings, Tier } from "@prosopo/types";
+import {
+	CaptchaType,
+	type IUserSettings,
+	ResultReason,
+	Tier,
+} from "@prosopo/types";
 import type { ClientRecord, IProviderDatabase } from "@prosopo/types-database";
 import type { ProviderEnvironment } from "@prosopo/types-env";
 import {
@@ -103,6 +108,9 @@ describe("CaptchaManager", () => {
 			invalidateCachedSession: vi.fn().mockResolvedValue(undefined),
 			invalidateCachedSessionByHash: vi.fn().mockResolvedValue(undefined),
 			getCachedSession: vi.fn().mockResolvedValue(null),
+			cacheSessionEscalation: vi.fn().mockResolvedValue(true),
+			getCachedSessionEscalation: vi.fn().mockResolvedValue(null),
+			invalidateCachedSessionEscalation: vi.fn().mockResolvedValue(undefined),
 		} as unknown as RedisWriteQueue;
 
 		captchaManager = new CaptchaManager(
@@ -328,6 +336,201 @@ describe("CaptchaManager", () => {
 				"hash-xyz",
 			);
 		});
+		// ---------- post-PoW escalation fallback ----------
+		//
+		// When the routing machine returns image/puzzle from postPow,
+		// `submitPoWCaptchaSolution.buildEscalation` mints a new session
+		// with a fresh sessionId and writes an `origin → escalation`
+		// mapping into Redis. A widget that handles the escalation
+		// response correctly switches to the new sessionId. But several
+		// real-world paths keep using the original sessionId for the
+		// follow-up `/captcha/{type}` request — old bundled SDKs, dapps
+		// that hand-roll the wrapper, network-glitch retries, browser-tab
+		// races. Without the fallback below, those requests landed on
+		// CAPTCHA.NO_SESSION_FOUND because the origin session had already
+		// been consumed by the preceding /captcha/pow. The four tests
+		// below pin the contract.
+
+		it("resolves to the escalation session when the origin sessionId is consumed and an escalation mapping exists", async () => {
+			// Origin session was consumed by the earlier /captcha/pow:
+			// checkAndRemoveSession returns undefined for the origin id.
+			// The escalation session is still live: checkAndRemoveSession
+			// returns it for the escalation id.
+			const checkAndRemove = db.checkAndRemoveSession as unknown as ReturnType<
+				typeof vi.fn
+			>;
+			checkAndRemove.mockImplementation(async (sessionId: string) => {
+				if (sessionId === "escalation-id") {
+					return {
+						sessionId: "escalation-id",
+						captchaType: CaptchaType.image,
+						userSitekeyIpHash: "hash-xyz",
+					} as Pick<Session, "sessionId" | "captchaType" | "userSitekeyIpHash">;
+				}
+				return undefined;
+			});
+			(
+				mockWriteQueue.getCachedSessionEscalation as unknown as ReturnType<
+					typeof vi.fn
+				>
+			).mockResolvedValueOnce("escalation-id");
+
+			const result = await captchaManager.isValidRequest(
+				{
+					account: "account",
+					tier: Tier.Free,
+					settings: {
+						...defaultUserSettings,
+						captchaType: CaptchaType.frictionless,
+					},
+				},
+				CaptchaType.image,
+				mockEnv,
+				"origin-id",
+				undefined,
+				"127.0.0.1",
+			);
+
+			expect(result).toEqual({
+				valid: true,
+				type: CaptchaType.image,
+				sessionId: "escalation-id",
+			});
+			// The escalation mapping is single-use: invalidate so the
+			// next retry on origin-id falls through to NO_SESSION_FOUND
+			// instead of chasing a now-consumed escalation.
+			expect(
+				mockWriteQueue.invalidateCachedSessionEscalation,
+			).toHaveBeenCalledWith("origin-id");
+			// The escalation session's own cache entries must also be
+			// invalidated (it's been consumed).
+			expect(mockWriteQueue.invalidateCachedSession).toHaveBeenCalledWith(
+				"escalation-id",
+			);
+			expect(mockWriteQueue.invalidateCachedSessionByHash).toHaveBeenCalledWith(
+				"hash-xyz",
+			);
+		});
+
+		it("returns NO_SESSION_FOUND when origin is consumed AND escalation session is also gone", async () => {
+			// Both the origin and the escalation have been consumed (the
+			// user-double-click-the-button case: PoW solved → escalation
+			// minted → user solves escalation → user/widget then retries
+			// PoW submit with the original sessionId, finds neither
+			// alive).
+			(
+				db.checkAndRemoveSession as unknown as ReturnType<typeof vi.fn>
+			).mockResolvedValue(undefined);
+			(
+				mockWriteQueue.getCachedSessionEscalation as unknown as ReturnType<
+					typeof vi.fn
+				>
+			).mockResolvedValueOnce("escalation-id");
+
+			const result = await captchaManager.isValidRequest(
+				{
+					account: "account",
+					tier: Tier.Free,
+					settings: {
+						...defaultUserSettings,
+						captchaType: CaptchaType.frictionless,
+					},
+				},
+				CaptchaType.image,
+				mockEnv,
+				"origin-id",
+				undefined,
+				"127.0.0.1",
+			);
+
+			expect(result).toEqual({
+				valid: false,
+				reason: ResultReason.CAPTCHA_NO_SESSION_FOUND,
+				type: CaptchaType.image,
+			});
+			// Even when the escalation can't be resolved, the mapping is
+			// dropped so retries fall through cleanly rather than
+			// repeating the same Redis round-trip.
+			expect(
+				mockWriteQueue.invalidateCachedSessionEscalation,
+			).toHaveBeenCalledWith("origin-id");
+		});
+
+		it("falls through to NO_SESSION_FOUND when no escalation mapping was recorded", async () => {
+			// Origin consumed, no postPow escalation happened, no mapping
+			// in Redis — should behave exactly like before the fix.
+			(
+				db.checkAndRemoveSession as unknown as ReturnType<typeof vi.fn>
+			).mockResolvedValue(undefined);
+			(
+				mockWriteQueue.getCachedSessionEscalation as unknown as ReturnType<
+					typeof vi.fn
+				>
+			).mockResolvedValueOnce(null);
+
+			const result = await captchaManager.isValidRequest(
+				{
+					account: "account",
+					tier: Tier.Free,
+					settings: {
+						...defaultUserSettings,
+						captchaType: CaptchaType.frictionless,
+					},
+				},
+				CaptchaType.pow,
+				mockEnv,
+				"origin-id",
+				undefined,
+				"127.0.0.1",
+			);
+
+			expect(result).toEqual({
+				valid: false,
+				reason: ResultReason.CAPTCHA_NO_SESSION_FOUND,
+				type: CaptchaType.pow,
+			});
+			// No mapping to invalidate; the early-out should not call
+			// `invalidateCachedSessionEscalation` for `null` mappings.
+			expect(
+				mockWriteQueue.invalidateCachedSessionEscalation,
+			).not.toHaveBeenCalled();
+		});
+
+		it("does not consult the escalation mapping when origin session is still live", async () => {
+			// Origin session is live (typical happy path). The mapping
+			// lookup must NOT run — it would just be wasted Redis round
+			// trips, and we don't want to invalidate something that may
+			// still be needed if the widget DOES handle the escalation
+			// correctly later.
+			(
+				db.checkAndRemoveSession as unknown as ReturnType<typeof vi.fn>
+			).mockResolvedValue({
+				sessionId: "origin-id",
+				captchaType: CaptchaType.pow,
+			} as Pick<Session, "sessionId" | "captchaType">);
+
+			await captchaManager.isValidRequest(
+				{
+					account: "account",
+					tier: Tier.Free,
+					settings: {
+						...defaultUserSettings,
+						captchaType: CaptchaType.frictionless,
+					},
+				},
+				CaptchaType.pow,
+				mockEnv,
+				"origin-id",
+				undefined,
+				"127.0.0.1",
+			);
+
+			expect(mockWriteQueue.getCachedSessionEscalation).not.toHaveBeenCalled();
+			expect(
+				mockWriteQueue.invalidateCachedSessionEscalation,
+			).not.toHaveBeenCalled();
+		});
+
 		it("should not throw when writeQueue is null and session is consumed", async () => {
 			const managerWithoutRedis = new CaptchaManager(
 				db,


### PR DESCRIPTION
## Summary
- **Root cause:** post-PoW `route()` escalations to image/puzzle mint a fresh session, but the originating session was already consumed by the preceding `/captcha/pow` request. Widgets that didn't switch to the escalation `sessionId` on the next `/captcha/*` call hit `NO_SESSION_FOUND`. Production deploy of R1/R2 escalations at 18:39 UTC drove a **4.6× spike** in `CAPTCHA.NO_SESSION_FOUND` (363/hr → 1,668/hr). Rate dropped immediately when the routing artifact was removed at 21:42 UTC.
- **Fix:** record an origin → escalation `sessionId` mapping in Redis (`cache:session:escalation:{origin}`, TTL 600s, single-use) at the moment `buildEscalation` mints the new session. On the next `/captcha/*` request, `isValidRequest` falls back to that mapping when `checkAndRemoveSession` returns null for the supplied `sessionId`, consumes the escalation session, and invalidates the pointer.
- **No widget changes required.** Deployments without Redis continue to return the escalation unchanged — those accept the widget must handle the new `sessionId` itself.

## Test plan
- [x] `redisCacheEscalation.unit.test.ts` — 12 tests covering cache, get, invalidate, TTL expiry, error/null-client paths
- [x] `submitPoWCaptchaSolution.escalation.unit.test.ts` — 8 tests for `buildEscalation`: no routing output, PoW failure, route-kept-on-PoW, escalation to image, escalation to puzzle, null `writeQueue`, missing PoW record, missing origin session
- [x] `captchaManager.unit.test.ts` — 4 new tests on `isValidRequest`: resolve to escalation when origin consumed + mapping exists; return NO_SESSION_FOUND when both gone; fall through when no mapping; do not consult mapping when origin is live (happy path)
- [x] Full provider test suite — 887/887 passing
- [x] `npm run -w @prosopo/database build:tsc` + `npm run -w @prosopo/provider build:tsc` clean
- [x] `npx biome check` clean on all 6 changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)