### PR TITLE
feat(provider): return compiled source in getAllDecisionMachines

### DIFF
--- a/.changeset/get-all-decision-machines-source.md
+++ b/.changeset/get-all-decision-machines-source.md
@@ -1,0 +1,6 @@
+---
+"@prosopo/types": patch
+"@prosopo/provider": patch
+---
+
+feat(provider): return compiled source in getAllDecisionMachines so the live code on each provider is auditable in a single call

--- a/packages/provider/src/tasks/client/clientTasks.ts
+++ b/packages/provider/src/tasks/client/clientTasks.ts
@@ -511,6 +511,7 @@ export class ClientTaskManager {
 			name?: string;
 			version?: string;
 			captchaType?: DecisionMachineCaptchaType;
+			source: string;
 			createdAt: string;
 			updatedAt: string;
 		}[]
@@ -526,6 +527,7 @@ export class ClientTaskManager {
 			name: artifact.name,
 			version: artifact.version,
 			captchaType: artifact.captchaType,
+			source: artifact.source,
 			createdAt: artifact.createdAt.toISOString(),
 			updatedAt: artifact.updatedAt.toISOString(),
 		}));

--- a/packages/provider/src/tests/integration/decisionMachines.integration.test.ts
+++ b/packages/provider/src/tests/integration/decisionMachines.integration.test.ts
@@ -410,6 +410,12 @@ describe("Decision Machine Database Integration Tests", () => {
 				expect(machine).toHaveProperty("runtime");
 				expect(machine).toHaveProperty("createdAt");
 				expect(machine).toHaveProperty("updatedAt");
+
+				// The full compiled source is included so operators can audit
+				// exactly which code is live without a per-machine get-by-id call.
+				expect(machine).toHaveProperty("source");
+				expect(typeof machine.source).toBe("string");
+				expect(machine.source.length).toBeGreaterThan(0);
 			}
 
 			// Find the machine we just created
@@ -422,6 +428,7 @@ describe("Decision Machine Database Integration Tests", () => {
 			expect(createdMachine?.runtime).toBe(DecisionMachineRuntime.Node);
 			expect(createdMachine?.language).toBe(DecisionMachineLanguage.JavaScript);
 			expect(createdMachine?.version).toBe("1.0.0");
+			expect(typeof createdMachine?.source).toBe("string");
 		});
 
 		it("should return valid MongoDB ObjectId format for _id in getAllDecisionMachines", async () => {
@@ -545,7 +552,7 @@ describe("Decision Machine Database Integration Tests", () => {
 			expect(machine).toHaveProperty("createdAt");
 			expect(machine).toHaveProperty("updatedAt");
 
-			// Verify the source field is present (not included in getAll)
+			// Verify the source field is present (get-all now includes it too)
 			expect(typeof machine.source).toBe("string");
 			expect(machine.source.length).toBeGreaterThan(0);
 		});

--- a/packages/types/src/provider/api.ts
+++ b/packages/types/src/provider/api.ts
@@ -712,8 +712,13 @@ export type DecisionMachineSummary = z.infer<
 	typeof DecisionMachineSummarySchema
 >;
 
+// Includes the full compiled `source` for every artifact so operators can
+// audit exactly which code is live on a provider in a single call, without
+// a follow-up get-by-id per machine.
 export const GetAllDecisionMachinesResponse = array(
-	DecisionMachineSummarySchema,
+	DecisionMachineSummarySchema.extend({
+		source: string(),
+	}),
 );
 
 export type GetAllDecisionMachinesResponseType = z.infer<


### PR DESCRIPTION
## What

`getAllDecisionMachines` (admin endpoint `/v1/prosopo/provider/admin/decision-machine/get-all`) now returns the full compiled `source` for every decision / routing machine, alongside the existing metadata.

## Why

Previously the get-all response was metadata only — `scope`, `dappAccount`, `kind`, `name`, `version` (just a content hash) and timestamps — with **no code**. Seeing the actual JS running on a provider required a separate `getDecisionMachine(id)` round-trip per machine. Including `source` in the list lets you audit every live machine in a single call — **so that I know what code Chris is putting on prod**.

## Changes

- `@prosopo/types`: `GetAllDecisionMachinesResponse` now extends each item with `source: string` (mirrors the existing `GetDecisionMachineResponse`).
- `@prosopo/provider`: `ClientTaskManager.getAllDecisionMachines()` includes `artifact.source` in its result.
- `decisionMachines.integration.test.ts`: asserts `source` is present and non-empty on every item returned by get-all.
- Changeset added (`patch`: `@prosopo/types`, `@prosopo/provider`).

## Verification

- `npm run -w @prosopo/types build:tsc` and `npm run -w @prosopo/provider build:tsc` — green.
- `biome check` on changed files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)