### PR TITLE
fix(provider): peek before consuming the escalation session on type mismatch

### DIFF
--- a/.changeset/fix-escalation-peek-before-consume.md
+++ b/.changeset/fix-escalation-peek-before-consume.md
@@ -1,0 +1,10 @@
+---
+"@prosopo/database": patch
+"@prosopo/provider": patch
+---
+
+fix(provider): peek (read-only) at the escalation session before consuming on the origin → escalation fallback
+
+Follow-on to the route() escalation NO_SESSION_FOUND fix (#2771). When the widget hit `/captcha/pow` with the origin sessionId after a PoW-submit escalation to image/puzzle, `isValidRequest` resolved the Redis `origin → escalation` mapping and then immediately consumed the escalation session via `checkAndRemoveSession`. Because the escalation session's `captchaType` did not match the requested type, the handler returned `INCORRECT_CAPTCHA_TYPE` — and worse, the escalation session was already gone, so a widget that *did* know to switch to `/captcha/image` with the escalation sessionId from the PoW-submit envelope had nothing left to consume. Production rate jumped from ~4/hour on 3.6.47 to 58/hour on the single 3.6.49 node.
+
+The fix peeks the escalation session read-only first (`getSessionRecordBySessionId`) and only calls `checkAndRemoveSession` when `peeked.captchaType === requestedCaptchaType`. On mismatch the session is left intact, the Redis pointer is still dropped (single-use), and `INCORRECT_CAPTCHA_TYPE` is surfaced. Also extends `getSessionRecordBySessionId`'s projection to include `captchaType` (previously dropped, which would have made every peek look like a mismatch).

--- a/packages/database/src/databases/provider.ts
+++ b/packages/database/src/databases/provider.ts
@@ -1660,6 +1660,13 @@ export class ProviderDatabase
 				userSitekeyIpHash: 1,
 				simdReadings: 1,
 				dnsEvent: 1,
+				// captchaType is required by the peek-before-consume path
+				// in `CaptchaManager.isValidRequest` — without it, every
+				// escalation peek would compare `undefined !== <requested>`
+				// and forcibly return INCORRECT_CAPTCHA_TYPE on the happy
+				// path too. Keep this projection in sync with whatever
+				// fields the read-only callers need.
+				captchaType: 1,
 				"headers.user-agent": 1,
 				"headers.accept": 1,
 				"headers.accept-language": 1,

--- a/packages/provider/src/tasks/captchaManager.ts
+++ b/packages/provider/src/tasks/captchaManager.ts
@@ -334,24 +334,66 @@ export class CaptchaManager {
 				const escalationSessionId =
 					await this.writeQueue.getCachedSessionEscalation(sessionId);
 				if (escalationSessionId && escalationSessionId !== sessionId) {
-					this.logger.info(() => ({
-						msg: "Resolving origin sessionId to escalation",
-						data: {
-							account: clientSettings.account,
-							originSessionId: sessionId,
-							escalationSessionId,
-						},
-					}));
-					const escalationRecord =
-						await this.db.checkAndRemoveSession(escalationSessionId);
-					if (escalationRecord) {
-						sessionRecord = escalationRecord;
-						resolvedSessionId = escalationSessionId;
+					// Peek (read-only) at the escalation session before
+					// consuming. If its captchaType doesn't match what the
+					// widget is asking for, leave the session intact so a
+					// subsequent /captcha/{escalationType} call carrying
+					// the escalation sessionId (returned in the PoW-submit
+					// envelope) can still succeed. Consuming here on
+					// mismatch would surface INCORRECT_CAPTCHA_TYPE *and*
+					// destroy the only remaining route to recovery.
+					const peekedEscalationRecord =
+						await this.db.getSessionRecordBySessionId(escalationSessionId);
+					if (peekedEscalationRecord) {
+						this.logger.info(() => ({
+							msg: "Resolving origin sessionId to escalation",
+							data: {
+								account: clientSettings.account,
+								originSessionId: sessionId,
+								escalationSessionId,
+								escalationCaptchaType: peekedEscalationRecord.captchaType,
+								requestedCaptchaType,
+							},
+						}));
+						if (peekedEscalationRecord.captchaType === requestedCaptchaType) {
+							const consumedEscalationRecord =
+								await this.db.checkAndRemoveSession(escalationSessionId);
+							if (consumedEscalationRecord) {
+								sessionRecord = consumedEscalationRecord;
+								resolvedSessionId = escalationSessionId;
+							}
+						} else {
+							// Type mismatch: do NOT consume the escalation
+							// session, drop the pointer, and surface
+							// INCORRECT_CAPTCHA_TYPE directly. A widget
+							// that knows how to follow the PoW-submit
+							// escalation envelope can still reach
+							// `escalationSessionId` via the correct
+							// /captcha/{type} endpoint.
+							this.logger.warn(() => ({
+								msg: "Escalation captcha type does not match requested type",
+								data: {
+									account: clientSettings.account,
+									originSessionId: sessionId,
+									escalationSessionId,
+									escalationCaptchaType: peekedEscalationRecord.captchaType,
+									requestedCaptchaType,
+								},
+							}));
+							await this.writeQueue.invalidateCachedSessionEscalation(
+								sessionId,
+							);
+							return {
+								valid: false,
+								reason: ResultReason.INCORRECT_CAPTCHA_TYPE,
+								type: requestedCaptchaType,
+							};
+						}
 					}
 					// The escalation mapping is single-use: once we've
 					// followed it (or tried to and the escalation session
-					// is also gone), drop the pointer so subsequent
-					// retries don't keep chasing a dead reference.
+					// is gone), drop the pointer so subsequent retries
+					// don't keep chasing a dead reference.
 					await this.writeQueue.invalidateCachedSessionEscalation(sessionId);
 				}
 			}

--- a/packages/provider/src/tests/integration/escalationPeekBeforeConsume.integration.test.ts
+++ b/packages/provider/src/tests/integration/escalationPeekBeforeConsume.integration.test.ts
@@ -1,0 +1,365 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { Server } from "node:net";
+import { datasetWithSolutionHashes } from "@prosopo/datasets";
+import { ProviderEnvironment } from "@prosopo/env";
+import { generateMnemonic } from "@prosopo/keyring";
+import { Tasks, isTlsAvailable, startProviderApi } from "@prosopo/provider";
+import {
+	CaptchaType,
+	ClientApiPaths,
+	ClientSettingsSchema,
+	DatabaseTypes,
+	type GetPowCaptchaChallengeRequestBodyType,
+	IpAddressType,
+	ProsopoConfigSchema,
+	Tier,
+} from "@prosopo/types";
+import { randomAsHex } from "@prosopo/util-crypto";
+import { GenericContainer, type StartedTestContainer } from "testcontainers";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { testFetch } from "./testUtils.js";
+
+// Reproduces the production NO_SESSION_FOUND → INCORRECT_CAPTCHA_TYPE
+// follow-on bug. The /captcha/pow handler calls `isValidRequest`, which
+// looks up the Redis `cache:session:escalation:{origin}` mapping when
+// the origin session is gone. The fix added here: peek the escalation
+// session read-only first; only consume it when its captchaType matches
+// what the widget is asking for. On mismatch, leave the session intact
+// so a well-behaved widget can still recover via /captcha/{escalationType}
+// with the escalation sessionId returned in the PoW-submit envelope.
+describe("Escalation peek-before-consume integration test", () => {
+	let env: ProviderEnvironment;
+	let mongoContainer: StartedTestContainer;
+	let redisContainer: StartedTestContainer;
+	let server: Server | undefined;
+	let tasks: Tasks;
+	let testPort: number;
+	let baseUrl: string;
+
+	beforeAll(async () => {
+		testPort = 30000 + (process.pid % 10000) + Math.floor(Math.random() * 5000);
+		const protocol = isTlsAvailable() ? "https" : "http";
+		baseUrl = `${protocol}://localhost:${testPort}`;
+
+		// Mongo + Redis are both required: the fix lives in the Redis
+		// origin → escalation pointer + Mongo `getSessionRecordBySessionId`
+		// peek + conditional `checkAndRemoveSession` consume. Skipping Redis
+		// would not exercise the fix at all.
+		mongoContainer = await new GenericContainer("mongo:6.0.28")
+			.withExposedPorts(27017)
+			.withEnvironment({
+				MONGO_INITDB_ROOT_USERNAME: "root",
+				MONGO_INITDB_ROOT_PASSWORD: "root",
+				MONGO_INITDB_DATABASE: "prosopo_test",
+			})
+			.start();
+
+		const mongoHost = mongoContainer.getHost();
+		const mongoPort = mongoContainer.getMappedPort(27017);
+
+		redisContainer = await new GenericContainer("redis/redis-stack:latest")
+			.withExposedPorts(6379)
+			.withEnvironment({ REDIS_ARGS: "--requirepass root" })
+			.start();
+		const redisHost = redisContainer.getHost();
+		const redisPort = redisContainer.getMappedPort(6379);
+
+		const config = ProsopoConfigSchema.parse({
+			defaultEnvironment: "development",
+			host: `${protocol}://localhost:${testPort}`,
+			account: {
+				secret:
+					process.env.PROVIDER_MNEMONIC ||
+					"puppy cream effort carbon despair leg pyramid cotton endorse immense drill peasant",
+			},
+			authAccount: {
+				secret:
+					process.env.ADMIN_MNEMONIC ||
+					"puppy cream effort carbon despair leg pyramid cotton endorse immense drill peasant",
+			},
+			database: {
+				development: {
+					type: DatabaseTypes.enum.provider,
+					endpoint: `mongodb://root:root@${mongoHost}:${mongoPort}`,
+					dbname: "prosopo_test",
+					authSource: "admin",
+				},
+			},
+			redisConnection: {
+				url: `redis://:${encodeURIComponent("root")}@${redisHost}:${redisPort}`,
+				password: "root",
+				indexName: randomAsHex(16),
+			},
+			ipApi: { baseUrl: "https://dummyUrl.com", apiKey: "dummyKey" },
+			server: {
+				baseURL: `${protocol}://localhost`,
+				port: testPort,
+			},
+		});
+
+		env = new ProviderEnvironment(config);
+		await env.isReady();
+
+		tasks = new Tasks(env);
+		await tasks.datasetManager.providerSetDataset(datasetWithSolutionHashes);
+
+		server = await startProviderApi(env, true, testPort);
+		await new Promise<void>((resolve, reject) => {
+			const checkInterval = setInterval(() => {
+				if (server?.listening) {
+					clearInterval(checkInterval);
+					resolve();
+				}
+			}, 100);
+			setTimeout(() => {
+				clearInterval(checkInterval);
+				if (!server?.listening) {
+					reject(new Error("Server failed to start listening within timeout"));
+				}
+			}, 5000);
+		});
+	}, 120_000);
+
+	afterAll(async () => {
+		if (server) {
+			await new Promise<void>((resolve) => {
+				server?.close(() => resolve());
+			});
+			server = undefined;
+		}
+		if (env) {
+			try {
+				await env.getDb().close();
+			} catch {}
+		}
+		if (mongoContainer) {
+			try {
+				await mongoContainer.stop();
+			} catch {}
+		}
+		if (redisContainer) {
+			try {
+				await redisContainer.stop();
+			} catch {}
+		}
+	});
+
+	describe("/captcha/pow with origin sessionId after type-mismatched escalation", () => {
+		let siteKey: string;
+		let userId: string;
+
+		beforeEach(async () => {
+			// Fresh siteKey per test so escalation sessions don't bleed between cases.
+			[, siteKey] = await generateMnemonic();
+			await tasks.clientTaskManager.registerSiteKey(
+				siteKey,
+				Tier.Free,
+				ClientSettingsSchema.parse({
+					// `frictionless` lets us issue both pow and image sessions
+					// against the same siteKey, matching the production setup
+					// where the decision machine routes between them.
+					captchaType: CaptchaType.frictionless,
+					domains: ["localhost", "0.0.0.0", "127.0.0.0", "example.com"],
+					frictionlessThreshold: 0.5,
+					powDifficulty: 1,
+				}),
+			);
+			[, userId] = await generateMnemonic();
+		});
+
+		// Helpers to build the production-shape `origin → escalation` state
+		// without relying on the decision machine actually firing. Mirrors
+		// what `submitPoWCaptchaSolution.buildEscalation` does in prod after
+		// a successful PoW + route()-says-escalate sequence.
+		const seedConsumedOriginPlusLiveEscalation = async (params: {
+			escalationCaptchaType: CaptchaType;
+		}) => {
+			const originSession = await tasks.frictionlessManager.createSession(
+				`token-origin-${Math.random()}`,
+				0.2,
+				0.5,
+				{ baseScore: 0.2 },
+				{ lower: 0n, type: IpAddressType.v4 },
+				CaptchaType.pow,
+				siteKey,
+				undefined,
+				1,
+				`hash-origin-${Math.random()}`,
+				false,
+				false,
+				"head-origin",
+			);
+			// Simulate the preceding /captcha/pow having consumed the origin
+			// session — this is the prod state when the widget retries.
+			const consumed = await env
+				.getDb()
+				.checkAndRemoveSession(originSession.sessionId);
+			expect(consumed?.sessionId).toBe(originSession.sessionId);
+
+			const escalationSession = await tasks.frictionlessManager.createSession(
+				`token-escalation-${Math.random()}`,
+				0.2,
+				0.5,
+				{ baseScore: 0.2 },
+				{ lower: 0n, type: IpAddressType.v4 },
+				params.escalationCaptchaType,
+				siteKey,
+				undefined,
+				undefined,
+				`hash-escalation-${Math.random()}`,
+				false,
+				false,
+				"head-escalation",
+			);
+
+			// Sanity-check that storeSessionRecord actually wrote the
+			// escalation session synchronously — without this, race
+			// conditions in `createSession` would show up as a test-only
+			// failure instead of a fix-level failure.
+			const sanityCheck = await env
+				.getDb()
+				.getSessionRecordBySessionId(escalationSession.sessionId);
+			expect(sanityCheck?.sessionId).toBe(escalationSession.sessionId);
+
+			// Write the production-shape pointer. The widget will keep calling
+			// with `originSession.sessionId`; the fallback in `isValidRequest`
+			// reads this and considers the escalation.
+			if (!tasks.writeQueue) {
+				throw new Error("test requires writeQueue / Redis");
+			}
+			const cached = await tasks.writeQueue.cacheSessionEscalation(
+				originSession.sessionId,
+				escalationSession.sessionId,
+			);
+			expect(cached).toBe(true);
+
+			return {
+				originSessionId: originSession.sessionId,
+				escalationSessionId: escalationSession.sessionId,
+			};
+		};
+
+		it("returns INCORRECT_CAPTCHA_TYPE *and preserves the escalation session* when /captcha/pow is called against an image-typed escalation", async () => {
+			const { originSessionId, escalationSessionId } =
+				await seedConsumedOriginPlusLiveEscalation({
+					escalationCaptchaType: CaptchaType.image,
+				});
+
+			const body: GetPowCaptchaChallengeRequestBodyType = {
+				user: userId,
+				dapp: siteKey,
+				sessionId: originSessionId,
+			};
+			const response = await testFetch(
+				`${baseUrl}${ClientApiPaths.GetPowCaptchaChallenge}`,
+				{
+					method: "POST",
+					headers: {
+						Connection: "close",
+						"Content-Type": "application/json",
+						Origin: "https://localhost",
+						"Prosopo-Site-Key": siteKey,
+						"Prosopo-User": userId,
+					},
+					body: JSON.stringify(body),
+				},
+			);
+			const json = (await response.json()) as {
+				error?: { code?: number; key?: string };
+			};
+
+			// Surface the new behaviour: the widget gets an explicit type
+			// mismatch rather than NO_SESSION_FOUND. The error envelope
+			// places the translation key (matching `ResultReason.INCORRECT_CAPTCHA_TYPE`)
+			// under `.error.key`; `.error.code` carries the HTTP status.
+			expect(response.status).toBe(400);
+			expect(json.error?.key).toBe("API.INCORRECT_CAPTCHA_TYPE");
+
+			// Pin the contract this PR is fixing: the escalation session
+			// must still be present in Mongo AND still consumable. Before
+			// the fix this call would consume the escalation session,
+			// leaving the widget no recovery path. With the fix the
+			// escalation session survives the mismatched /captcha/pow
+			// call so /captcha/image with `escalationSessionId` can
+			// still proceed.
+			const survivor = await env
+				.getDb()
+				.getSessionRecordBySessionId(escalationSessionId);
+			expect(survivor).toBeDefined();
+			expect(survivor?.sessionId).toBe(escalationSessionId);
+			expect(survivor?.captchaType).toBe(CaptchaType.image);
+			// Crucially, a subsequent /captcha/image call would still be
+			// able to consume the escalation session — modelled here by
+			// calling checkAndRemoveSession directly (which is what the
+			// /captcha/image handler reaches through `isValidRequest`).
+			const recoveryConsume = await env
+				.getDb()
+				.checkAndRemoveSession(escalationSessionId);
+			expect(recoveryConsume?.sessionId).toBe(escalationSessionId);
+
+			// Single-use pointer was followed; subsequent retries on the
+			// origin sessionId fall through cleanly to NO_SESSION_FOUND.
+			if (!tasks.writeQueue) throw new Error("writeQueue missing");
+			const pointerAfter =
+				await tasks.writeQueue.getCachedSessionEscalation(originSessionId);
+			expect(pointerAfter).toBeNull();
+		});
+
+		it("still consumes the escalation session when the requested type matches (regression guard for the happy path)", async () => {
+			// Same setup, but the escalation is also a `pow` session so
+			// the existing /captcha/pow path should resolve it through.
+			// This guards against a regression where the peek branch
+			// stops consuming on the match path.
+			const { originSessionId, escalationSessionId } =
+				await seedConsumedOriginPlusLiveEscalation({
+					escalationCaptchaType: CaptchaType.pow,
+				});
+
+			const body: GetPowCaptchaChallengeRequestBodyType = {
+				user: userId,
+				dapp: siteKey,
+				sessionId: originSessionId,
+			};
+			const response = await testFetch(
+				`${baseUrl}${ClientApiPaths.GetPowCaptchaChallenge}`,
+				{
+					method: "POST",
+					headers: {
+						Connection: "close",
+						"Content-Type": "application/json",
+						Origin: "https://localhost",
+						"Prosopo-Site-Key": siteKey,
+						"Prosopo-User": userId,
+					},
+					body: JSON.stringify(body),
+				},
+			);
+			expect(response.status).toBe(200);
+			const challenge = (await response.json()) as { challenge?: string };
+			expect(challenge.challenge).toBeDefined();
+
+			// Escalation session was consumed (match path). `checkAndRemoveSession`
+			// uses Mongo's `findOneAndUpdate({deleted: {$exists: false}}, {deleted: true})`
+			// pattern, so the doc lingers but a second consume attempt
+			// returns undefined — that's the canonical "session is gone"
+			// check throughout the provider.
+			const secondConsume = await env
+				.getDb()
+				.checkAndRemoveSession(escalationSessionId);
+			expect(secondConsume).toBeUndefined();
+		});
+	});
+});

--- a/packages/provider/src/tests/unit/tasks/captchaManager.unit.test.ts
+++ b/packages/provider/src/tests/unit/tasks/captchaManager.unit.test.ts
@@ -77,6 +77,7 @@ describe("CaptchaManager", () => {
 	beforeEach(() => {
 		db = {
 			checkAndRemoveSession: vi.fn(),
+			getSessionRecordBySessionId: vi.fn(),
 		} as unknown as IProviderDatabase;
 
 		pair = {
@@ -354,8 +355,9 @@ describe("CaptchaManager", () => {
 		it("resolves to the escalation session when the origin sessionId is consumed and an escalation mapping exists", async () => {
 			// Origin session was consumed by the earlier /captcha/pow:
 			// checkAndRemoveSession returns undefined for the origin id.
-			// The escalation session is still live: checkAndRemoveSession
-			// returns it for the escalation id.
+			// The escalation session is still live: the peek returns it
+			// and, because its captchaType matches the requested type,
+			// checkAndRemoveSession is then called to consume it.
 			const checkAndRemove = db.checkAndRemoveSession as unknown as ReturnType<
 				typeof vi.fn
 			>;
@@ -369,6 +371,13 @@ describe("CaptchaManager", () => {
 				}
 				return undefined;
 			});
+			(
+				db.getSessionRecordBySessionId as unknown as ReturnType<typeof vi.fn>
+			).mockResolvedValueOnce({
+				sessionId: "escalation-id",
+				captchaType: CaptchaType.image,
+				userSitekeyIpHash: "hash-xyz",
+			} as Pick<Session, "sessionId" | "captchaType" | "userSitekeyIpHash">);
 			(
 				mockWriteQueue.getCachedSessionEscalation as unknown as ReturnType<
 					typeof vi.fn
@@ -417,10 +426,14 @@ describe("CaptchaManager", () => {
 			// user-double-click-the-button case: PoW solved → escalation
 			// minted → user solves escalation → user/widget then retries
 			// PoW submit with the original sessionId, finds neither
-			// alive).
+			// alive). The read-only peek returns undefined so we never
+			// reach the consume step.
 			(
 				db.checkAndRemoveSession as unknown as ReturnType<typeof vi.fn>
 			).mockResolvedValue(undefined);
+			(
+				db.getSessionRecordBySessionId as unknown as ReturnType<typeof vi.fn>
+			).mockResolvedValueOnce(undefined);
 			(
 				mockWriteQueue.getCachedSessionEscalation as unknown as ReturnType<
 					typeof vi.fn
@@ -451,6 +464,64 @@ describe("CaptchaManager", () => {
 			// Even when the escalation can't be resolved, the mapping is
 			// dropped so retries fall through cleanly rather than
 			// repeating the same Redis round-trip.
+			expect(
+				mockWriteQueue.invalidateCachedSessionEscalation,
+			).toHaveBeenCalledWith("origin-id");
+		});
+
+		it("returns INCORRECT_CAPTCHA_TYPE without consuming the escalation session when the type does not match", async () => {
+			// The widget escalated from pow → image but ignored the
+			// PoW-submit envelope and is still calling /captcha/pow with
+			// the origin sessionId. We MUST NOT consume the escalation
+			// session here — it's the user's only path to recovery
+			// (a well-behaved widget can still reach /captcha/image with
+			// the escalation sessionId from the PoW-submit response).
+			const checkAndRemove = db.checkAndRemoveSession as unknown as ReturnType<
+				typeof vi.fn
+			>;
+			checkAndRemove.mockResolvedValue(undefined);
+			(
+				db.getSessionRecordBySessionId as unknown as ReturnType<typeof vi.fn>
+			).mockResolvedValueOnce({
+				sessionId: "escalation-id",
+				captchaType: CaptchaType.image,
+				userSitekeyIpHash: "hash-xyz",
+			} as Pick<Session, "sessionId" | "captchaType" | "userSitekeyIpHash">);
+			(
+				mockWriteQueue.getCachedSessionEscalation as unknown as ReturnType<
+					typeof vi.fn
+				>
+			).mockResolvedValueOnce("escalation-id");
+
+			const result = await captchaManager.isValidRequest(
+				{
+					account: "account",
+					tier: Tier.Free,
+					settings: {
+						...defaultUserSettings,
+						captchaType: CaptchaType.frictionless,
+					},
+				},
+				CaptchaType.pow,
+				mockEnv,
+				"origin-id",
+				undefined,
+				"127.0.0.1",
+			);
+
+			expect(result).toEqual({
+				valid: false,
+				reason: ResultReason.INCORRECT_CAPTCHA_TYPE,
+				type: CaptchaType.pow,
+			});
+			// Crucially: the escalation session must NOT have been consumed.
+			// checkAndRemoveSession was called once for the origin sessionId
+			// (which returned undefined) and must not have been called for
+			// the escalation sessionId.
+			const consumeCalls = checkAndRemove.mock.calls.map((c) => c[0]);
+			expect(consumeCalls).toEqual(["origin-id"]);
+			expect(consumeCalls).not.toContain("escalation-id");
+			// The mapping is single-use and was followed; drop it.
 			expect(
 				mockWriteQueue.invalidateCachedSessionEscalation,
 			).toHaveBeenCalledWith("origin-id");


### PR DESCRIPTION
## Summary
- **Follow-on to prosopo/captcha#2771.** After that PR shipped on 3.6.49 (pronode15), `INCORRECT_CAPTCHA_TYPE` jumped from ~4/hour on 3.6.47 to **58/hour** on the single 3.6.49 node. Same buggy widgets, one layer deeper in the failure mode.
- **Root cause.** When `/captcha/pow` arrived with the origin sessionId after a route() escalation to image/puzzle, `isValidRequest` resolved the Redis `origin → escalation` pointer and immediately called `checkAndRemoveSession` on the escalation session. The session's `captchaType` (image) didn't match the requested type (pow), so the response was `INCORRECT_CAPTCHA_TYPE` — *and* the escalation session was already consumed. A widget that *did* know to switch to `/captcha/image` with the escalation sessionId from the PoW-submit envelope had nothing left to consume.
- **Fix.** Peek the escalation session read-only via `getSessionRecordBySessionId` first; only call `checkAndRemoveSession` when the peeked `captchaType` matches what the widget asked for. On mismatch, leave the session intact (well-behaved widgets can still recover via `/captcha/{escalationType}` with the escalation sessionId) but invalidate the single-use Redis pointer either way.
- **Also** widens `getSessionRecordBySessionId`'s projection to include `captchaType`. The existing projection dropped it, which would have turned every peek into a forced-mismatch on the happy path too.

## Test plan
- [x] **New integration test** `escalationPeekBeforeConsume.integration.test.ts`: real Mongo + Redis testcontainers + real provider API.
  - Type mismatch: `/captcha/pow` with origin sessionId → 400 with `error.key = API.INCORRECT_CAPTCHA_TYPE`, escalation session still consumable by a subsequent `checkAndRemoveSession`.
  - Type match: `/captcha/pow` with origin sessionId where escalation is also `pow` → 200 with challenge, escalation session consumed.
- [x] 1 new unit test for the mismatch path on `captchaManager.unit.test.ts`; existing 4 escalation tests updated to mock the new peek call.
- [x] Full captchaManager suite: 42/42 pass. submitPoWCaptchaSolution.escalation suite: 8/8 pass.
- [x] `npm run -w @prosopo/database build:tsc` + `npm run -w @prosopo/provider build:tsc` clean.
- [x] `npx biome check` clean on all 4 changed/new files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)