### PR TITLE
feat(provider): escalate verified PoW solves with missing coords to an image captcha

### DIFF
--- a/.changeset/pow-escalate-missing-coords.md
+++ b/.changeset/pow-escalate-missing-coords.md
@@ -1,0 +1,6 @@
+---
+"@prosopo/provider": patch
+"@prosopo/types": patch
+---
+
+feat(provider): escalate verified PoW solves with missing coordinates to an image captcha. Every current widget embeds the checkbox click position in the solution salt, so a verified solve that arrives without coordinates didn't come through the official widget path. Such session-linked solves are now escalated to an image captcha via the existing post-PoW routing/escalation mechanism instead of being approved outright. Adds the `MISSING_COORDINATES` FrictionlessReason.

--- a/packages/provider/src/tasks/powCaptcha/powTasks.ts
+++ b/packages/provider/src/tasks/powCaptcha/powTasks.ts
@@ -29,6 +29,7 @@ import {
 	CaptchaStatus,
 	type ClientMetaData,
 	type DecisionMachineBehavioralDataPacked,
+	FrictionlessReason,
 	type IPAddress,
 	type ISpamFilterRules,
 	type ITrafficFilter,
@@ -432,19 +433,47 @@ export class PowCaptchaManager extends CaptchaManager {
 
 		await Promise.all(writePromises);
 
+		if (!correct) {
+			return { verified: correct };
+		}
+
+		// A verified solve that arrived without click coordinates didn't come
+		// through the official widget's checkbox/salt path — every current
+		// widget embeds the click position in the salt (see procaptcha-pow
+		// Manager). Treat absent coords as a weak bot signal and escalate to an
+		// image captcha rather than approving outright. Escalation carries the
+		// originating session's risk profile forward, so it only applies when a
+		// session is linked; without one buildEscalation can't mint a follow-up
+		// and the solve falls through to a normal pass.
+		const escalateForMissingCoords =
+			!coords && Boolean(challengeRecord.sessionId);
+
 		// Post-pow routing: only meaningful on a verified solution. The routing
 		// machine re-examines the (now richer) signals — score from the original
 		// session, decrypted behavioural data, counters — and may escalate the
 		// user to an image/puzzle captcha. Returning baseline (pow) means "done".
-		if (!correct || !this.postPowContext) {
-			return { verified: correct };
+		let routingOutput = this.postPowContext
+			? await this.runPostPowRouting({
+					challengeRecord,
+					challengeSplit,
+					behavioralDataPacked: decryptedBehavioralDataPacked,
+				})
+			: undefined;
+
+		// Missing coords forces at least an image escalation, unless the routing
+		// machine already escalated to a visual challenge (image/puzzle) that we
+		// would keep anyway.
+		if (
+			escalateForMissingCoords &&
+			routingOutput?.captchaType !== CaptchaType.image &&
+			routingOutput?.captchaType !== CaptchaType.puzzle
+		) {
+			routingOutput = {
+				captchaType: CaptchaType.image,
+				reason: FrictionlessReason.MISSING_COORDINATES,
+			};
 		}
 
-		const routingOutput = await this.runPostPowRouting({
-			challengeRecord,
-			challengeSplit,
-			behavioralDataPacked: decryptedBehavioralDataPacked,
-		});
 		return { verified: correct, routingOutput };
 	}
 

--- a/packages/provider/src/tests/unit/tasks/powCaptcha/powTasks.unit.test.ts
+++ b/packages/provider/src/tests/unit/tasks/powCaptcha/powTasks.unit.test.ts
@@ -27,7 +27,10 @@ import {
 	ResultReason,
 	type Session,
 } from "@prosopo/types";
-import type { IProviderDatabase } from "@prosopo/types-database";
+import type {
+	IProviderDatabase,
+	PoWCaptchaRecord,
+} from "@prosopo/types-database";
 import type { ProviderEnvironment } from "@prosopo/types-env";
 import {
 	AccessPolicyType,
@@ -407,6 +410,113 @@ describe("PowCaptchaManager", () => {
 			);
 			expect(verifyRecency).not.toHaveBeenCalled();
 			expect(validateSolution).not.toHaveBeenCalled();
+		});
+
+		it("escalates a verified solve to an image captcha when coords are missing and a session is linked", async () => {
+			const requestedAtTimestamp = 123456789;
+			const userAccount = "testUserAccount";
+			const challenge: PoWChallengeId = `${requestedAtTimestamp}${POW_SEPARATOR}${userAccount}${POW_SEPARATOR}${pair.address}`;
+			const difficulty = 4;
+			const providerSignature = "testSignature";
+			const userSignature = "testTimestampSignature";
+			const nonce = 12345;
+			const timeout = 1000;
+			const ipAddress = getIPAddress("1.1.1.1");
+			const headers: RequestHeaders = { a: "1", b: "2", c: "3" };
+			const challengeRecord: PoWCaptchaStored = {
+				challenge,
+				difficulty,
+				dappAccount: pair.address,
+				userAccount,
+				requestedAtTimestamp: new Date(requestedAtTimestamp),
+				submittedAtTimestamp: new Date(),
+				result: { status: CaptchaStatus.pending },
+				userSubmitted: false,
+				serverChecked: false,
+				ipAddress: getCompositeIpAddress(ipAddress),
+				headers,
+				ja4: "ja4",
+				providerSignature,
+				lastUpdatedTimestamp: new Date(),
+				sessionId: "linked-session-id",
+			};
+			vi.mocked(verifyRecency).mockReturnValue(true);
+			vi.mocked(checkPowSignature).mockImplementation(() => undefined);
+			vi.mocked(validateSolution).mockReturnValue(true);
+			vi.mocked(db.getPowCaptchaRecordByChallenge).mockResolvedValue(
+				challengeRecord as unknown as PoWCaptchaRecord,
+			);
+			vi.mocked(db.updatePowCaptchaRecordResult).mockResolvedValue(undefined);
+			vi.mocked(db.getSessionRecordBySessionId).mockResolvedValue(undefined);
+
+			const result = await powCaptchaManager.verifyPowCaptchaSolution(
+				challenge,
+				providerSignature,
+				nonce,
+				timeout,
+				userSignature,
+				ipAddress,
+				headers,
+				undefined, // behavioralData
+				undefined, // salt — no coords supplied
+			);
+
+			expect(result.verified).toBe(true);
+			expect(result.routingOutput).toEqual({
+				captchaType: CaptchaType.image,
+				reason: FrictionlessReason.MISSING_COORDINATES,
+			});
+		});
+
+		it("does not escalate a verified solve with missing coords when no session is linked", async () => {
+			const requestedAtTimestamp = 123456789;
+			const userAccount = "testUserAccount";
+			const challenge: PoWChallengeId = `${requestedAtTimestamp}${POW_SEPARATOR}${userAccount}${POW_SEPARATOR}${pair.address}`;
+			const difficulty = 4;
+			const providerSignature = "testSignature";
+			const userSignature = "testTimestampSignature";
+			const nonce = 12345;
+			const timeout = 1000;
+			const ipAddress = getIPAddress("1.1.1.1");
+			const headers: RequestHeaders = { a: "1", b: "2", c: "3" };
+			const challengeRecord: PoWCaptchaStored = {
+				challenge,
+				difficulty,
+				dappAccount: pair.address,
+				userAccount,
+				requestedAtTimestamp: new Date(requestedAtTimestamp),
+				submittedAtTimestamp: new Date(),
+				result: { status: CaptchaStatus.pending },
+				userSubmitted: false,
+				serverChecked: false,
+				ipAddress: getCompositeIpAddress(ipAddress),
+				headers,
+				ja4: "ja4",
+				providerSignature,
+				lastUpdatedTimestamp: new Date(),
+			};
+			vi.mocked(verifyRecency).mockReturnValue(true);
+			vi.mocked(checkPowSignature).mockImplementation(() => undefined);
+			vi.mocked(validateSolution).mockReturnValue(true);
+			vi.mocked(db.getPowCaptchaRecordByChallenge).mockResolvedValue(
+				challengeRecord as unknown as PoWCaptchaRecord,
+			);
+			vi.mocked(db.updatePowCaptchaRecordResult).mockResolvedValue(undefined);
+
+			const result = await powCaptchaManager.verifyPowCaptchaSolution(
+				challenge,
+				providerSignature,
+				nonce,
+				timeout,
+				userSignature,
+				ipAddress,
+				headers,
+				undefined, // behavioralData
+				undefined, // salt — no coords supplied
+			);
+
+			expect(result.verified).toBe(true);
+			expect(result.routingOutput).toBeUndefined();
 		});
 	});
 

--- a/packages/types/src/provider/reasons.ts
+++ b/packages/types/src/provider/reasons.ts
@@ -30,6 +30,12 @@ export enum FrictionlessReason {
 	AUTO_BAN_SCORE = "AUTO_BAN_SCORE",
 	FINGERPRINT_PROOF_INVALID = "FINGERPRINT_PROOF_INVALID",
 	MISSING_CURRENT_URL = "MISSING_CURRENT_URL",
+	// A verified PoW solve arrived without click coordinates encoded in its
+	// salt. Every current widget embeds the checkbox click position, so absent
+	// coords mean the solve didn't come through the official widget path; such
+	// solves are escalated to an image captcha rather than approved outright
+	// (see verifyPowCaptchaSolution in @prosopo/provider).
+	MISSING_COORDINATES = "MISSING_COORDINATES",
 }
 
 /**


### PR DESCRIPTION
## What

A verified PoW solve that arrives **without click coordinates** is now escalated to an image captcha instead of being approved outright.

## Why

Every current widget embeds the checkbox click position in the solution `salt` (see `procaptcha-pow/src/services/Manager.ts` — `start(x = 0, y = 0)` always builds a salt, even the frictionless auto-start path which sends `[0,0]`). So a verified solve that arrives with **no coords at all** did not come through the official widget path.

Production data backs this up (`captchastorage.powcaptchas`, last 24h): of **244,999** submitted PoW records, **0** were missing the `coords` field and only **29** had empty coords (10 of them approved) — i.e. ~99.99% of legit submissions carry coords. Pure `[[[0,0]]]` (frictionless auto-start) is rare (334), and real solves cluster tightly at the checkbox location (e.g. `[867,60]`, `[866,61]` …) as expected for genuine human clicks. Absent coords is therefore a strong "not the official widget" signal.

Escalating (rather than blocking) is deliberate: a few legit edge cases can still arrive without coords (stale cached bundles from before the salt/coords feature shipped ~2025-09-16, or direct non-browser API integrations), so they get a solvable image challenge rather than a hard fail.

## How

Reuses the existing post-PoW routing/escalation mechanism — no new client or transport work:

- `verifyPowCaptchaSolution` now sets `routingOutput = { captchaType: image, reason: MISSING_COORDINATES }` for a **verified, session-linked** solve with no coords, **unless** the routing machine already escalated to a visual challenge (image/puzzle), which we keep.
- `buildEscalation` does the rest (mints the follow-up image session, caches the origin→escalation mapping). It already requires a linked session, so a sessionless solve with no coords falls through to a normal pass — escalation needs a session to carry the originating risk profile forward.
- Adds `FrictionlessReason.MISSING_COORDINATES` as the selection reason.

### Safety / blast radius

- The official widget **always** sends a salt (real click or `[0,0]`), so legit widget traffic — including the Cypress E2E specs, which drive the real widget — always has coords and is **never** escalated by this change. Only salt-less submissions (bots / very old bundles / direct API) with a session are affected.
- `[0,0]` counts as present coords, so frictionless auto-start is unaffected.
- Only caller of `verifyPowCaptchaSolution` is the client submit handler; the server-to-server `/verify` path (`serverVerifyPowCaptchaSolution`) is untouched.

## Tests

- New unit tests in `powTasks.unit.test.ts`: verified solve + no coords + linked session → escalates to image with `MISSING_COORDINATES`; verified solve + no coords + no session → no escalation (normal pass).
- Full provider unit suite green locally (71 files / 892 tests), incl. the existing escalation tests. `@prosopo/types` and `@prosopo/provider` `build:tsc` pass; biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
