### PR TITLE
fix(database): default to no mongo compression to stop ESM-bundle require crash

### DIFF
--- a/packages/database/src/mongooseOptions.ts
+++ b/packages/database/src/mongooseOptions.ts
@@ -16,12 +16,13 @@ import type { ConnectOptions } from "mongoose";
 
 export type MongoCompressor = "zstd" | "none" | "snappy" | "zlib";
 
-const DEFAULT_COMPRESSORS: MongoCompressor[] = [
-	"zstd",
-	"snappy",
-	"zlib",
-	"none",
-];
+// The default is empty (no compression) because the provider CLI ships as a
+// vite ESM bundle and the mongodb driver loads native compressor modules
+// (@mongodb-js/zstd, @mongodb-js/snappy) via CommonJS `require`, which is
+// undefined in the bundle — any negotiated native compressor crashes the
+// connection with MongoMissingDependencyError. Callers that run unbundled and
+// want compression can pass an explicit list.
+const DEFAULT_COMPRESSORS: MongoCompressor[] = [];
 
 /**
  * Determines MongoDB compression settings based on whether the connection points
@@ -31,7 +32,7 @@ const DEFAULT_COMPRESSORS: MongoCompressor[] = [
  * "database", "db", "mongo") or when no host is present.
  *
  * @param url - The MongoDB connection URL string
- * @param compressors - Optional array of compressor strings. Defaults to ["zstd", "snappy", "zlib", "none"]
+ * @param compressors - Optional array of compressor strings. Defaults to [] (no compression)
  * @returns A new array of compressor strings when compression is enabled, empty array otherwise
  */
 export const getMongoCompressors = (

--- a/packages/database/src/tests/mongooseOptions.unit.test.ts
+++ b/packages/database/src/tests/mongooseOptions.unit.test.ts
@@ -19,7 +19,12 @@ import {
 	getMongoConnectionOptions,
 } from "../mongooseOptions.js";
 
-const DEFAULT_COMPRESSORS: MongoCompressor[] = [
+// The shipped default is empty — the provider CLI is a vite ESM bundle and
+// the mongo driver loads native compressors via `require`, which is undefined
+// in the bundle. Callers can still opt in by passing an explicit compressor
+// list; the host-based gating logic continues to apply to those.
+const DEFAULT_COMPRESSORS: MongoCompressor[] = [];
+const EXPLICIT_COMPRESSORS: MongoCompressor[] = [
 	"zstd",
 	"snappy",
 	"zlib",
@@ -27,7 +32,7 @@ const DEFAULT_COMPRESSORS: MongoCompressor[] = [
 ];
 
 describe("getMongoCompressors", () => {
-	it("returns default compressors for remote domains", () => {
+	it("returns the default (empty) compressors for remote domains", () => {
 		const urls = [
 			"mongodb://user:pass@example.com:27017/db",
 			"mongodb://abc.com/db",
@@ -40,6 +45,19 @@ describe("getMongoCompressors", () => {
 		}
 	});
 
+	it("returns the explicit compressor list for remote domains when provided", () => {
+		const urls = [
+			"mongodb://user:pass@example.com:27017/db",
+			"mongodb://abc.com/db",
+			"mongodb://cluster.mongodb.net/db",
+		];
+		for (const url of urls) {
+			expect(getMongoCompressors(url, EXPLICIT_COMPRESSORS)).toEqual(
+				EXPLICIT_COMPRESSORS,
+			);
+		}
+	});
+
 	it("returns empty array for local hostnames without dots", () => {
 		const urls = [
 			"mongodb://database:27017/db",
@@ -48,7 +66,7 @@ describe("getMongoCompressors", () => {
 			"mongodb://container-name/db",
 		];
 		for (const url of urls) {
-			expect(getMongoCompressors(url)).toEqual([]);
+			expect(getMongoCompressors(url, EXPLICIT_COMPRESSORS)).toEqual([]);
 		}
 	});
 
@@ -59,29 +77,33 @@ describe("getMongoCompressors", () => {
 			"mongodb://[::1]:27017/db",
 		];
 		for (const url of urls) {
-			expect(getMongoCompressors(url)).toEqual([]);
+			expect(getMongoCompressors(url, EXPLICIT_COMPRESSORS)).toEqual([]);
 		}
 	});
 
-	it("returns compressors for IP addresses (treated as remote)", () => {
+	it("returns the explicit list for IP addresses (treated as remote)", () => {
 		const urls = [
 			"mongodb://192.168.1.1:27017/db",
 			"mongodb://10.0.0.1/db",
 			"mongodb://172.16.0.1:27017/db",
 		];
 		for (const url of urls) {
-			expect(getMongoCompressors(url)).toEqual(DEFAULT_COMPRESSORS);
+			expect(getMongoCompressors(url, EXPLICIT_COMPRESSORS)).toEqual(
+				EXPLICIT_COMPRESSORS,
+			);
 		}
 	});
 
-	it("returns compressors for IPv6 addresses (treated as remote)", () => {
+	it("returns the explicit list for IPv6 addresses (treated as remote)", () => {
 		const urls = [
 			"mongodb://[2001:0db8::1]:27017/db",
 			"mongodb://[2001:0db8:85a3::8a2e:0370:7334]/db",
 			"mongodb://[::ffff:192.168.1.1]:27017/db",
 		];
 		for (const url of urls) {
-			expect(getMongoCompressors(url)).toEqual(DEFAULT_COMPRESSORS);
+			expect(getMongoCompressors(url, EXPLICIT_COMPRESSORS)).toEqual(
+				EXPLICIT_COMPRESSORS,
+			);
 		}
 	});
 
@@ -101,15 +123,19 @@ describe("getMongoCompressors", () => {
 
 	it("handles mongodb+srv:// URLs", () => {
 		const url = "mongodb+srv://cluster.mongodb.net/db";
-		expect(getMongoCompressors(url)).toEqual(DEFAULT_COMPRESSORS);
+		expect(getMongoCompressors(url, EXPLICIT_COMPRESSORS)).toEqual(
+			EXPLICIT_COMPRESSORS,
+		);
 	});
 
-	it("returns default compressors when the host cannot be parsed", () => {
+	it("returns the provided list when the host cannot be parsed", () => {
 		// Bare (unbracketed) IPv6 with a port is not a valid URL host, so URL
-		// parsing throws and we fall back to compression.
+		// parsing throws and we fall back to the provided compressors.
 		const unparseableUrls = ["mongodb://::1:27017/db", "mongodb://[bad"];
 		for (const url of unparseableUrls) {
-			expect(getMongoCompressors(url)).toEqual(DEFAULT_COMPRESSORS);
+			expect(getMongoCompressors(url, EXPLICIT_COMPRESSORS)).toEqual(
+				EXPLICIT_COMPRESSORS,
+			);
 		}
 	});
 
@@ -118,19 +144,23 @@ describe("getMongoCompressors", () => {
 		// host, which (like a container name) is treated as local.
 		const urls = ["", "mongodb://", "not-a-url"];
 		for (const url of urls) {
-			expect(getMongoCompressors(url)).toEqual([]);
+			expect(getMongoCompressors(url, EXPLICIT_COMPRESSORS)).toEqual([]);
 		}
 	});
 
 	it("handles URLs with authentication", () => {
 		const url = "mongodb://user:password@example.com:27017/db";
-		expect(getMongoCompressors(url)).toEqual(DEFAULT_COMPRESSORS);
+		expect(getMongoCompressors(url, EXPLICIT_COMPRESSORS)).toEqual(
+			EXPLICIT_COMPRESSORS,
+		);
 	});
 
 	it("handles URLs with query parameters", () => {
 		const url =
 			"mongodb://example.com:27017/db?authSource=admin&retryWrites=true";
-		expect(getMongoCompressors(url)).toEqual(DEFAULT_COMPRESSORS);
+		expect(getMongoCompressors(url, EXPLICIT_COMPRESSORS)).toEqual(
+			EXPLICIT_COMPRESSORS,
+		);
 	});
 });
 
@@ -169,7 +199,7 @@ describe("getMongoConnectionOptions", () => {
 		expect(options.compressors).toEqual([]);
 	});
 
-	it("uses default compressors for a remote host", () => {
+	it("uses no compressors for a remote host (default is no compression)", () => {
 		const options = getMongoConnectionOptions({
 			url: "mongodb://cluster.mongodb.net/db",
 			appName,


### PR DESCRIPTION
## Summary
- Default `DEFAULT_COMPRESSORS` in `packages/database/src/mongooseOptions.ts` to `[]` (was `["zstd","snappy","zlib","none"]`).
- Update unit tests: the host-based gating logic is now exercised against an explicit caller-supplied list rather than the shipped default.

## Why
On pronode15 (and any node running 3.6.50 with `PROSOPO_MONGO_CAPTCHA_URI` set), `CentralDbStreamer` was failing every record write with:

```
err: "CentralDbStreamer reconnect cooldown"
err: "Optional module \`@mongodb-js/zstd\` not found. ..."
cause: "require is not defined"
```

The provider CLI ships as a vite ESM bundle (`provider.cli.bundle.js`). The mongodb driver loads native compressor modules (`@mongodb-js/zstd`, `@mongodb-js/snappy`) via CommonJS `require`, which is undefined in the bundle. As soon as the server negotiates a native compressor, the driver throws `MongoMissingDependencyError`, `connect()` rejects, and the streamer enters a 5s reconnect cooldown — repeating forever.

`zstd` is what bit us this time; `snappy` would bite next via the same code path. The shipped default now offers no compressors at all, so the driver never tries to load a native module. Callers running unbundled (e.g. tests, scripts) can opt in by passing an explicit compressor list.

## Hotfix image
For the running fleet, image `prosopo/provider:3.6.50-hotfix1` was built from this branch.

## Test plan
- [x] `npm run -w @prosopo/database build:tsc` clean
- [x] `npx vitest run src/tests/mongooseOptions.unit.test.ts` — 19/19 pass
- [x] `npm run -w @prosopo/cli bundle` succeeds; `provider.cli.bundle.js` no longer contains `["zstd","snappy","zlib","none"]` as a default literal
- [x] Hotfix docker image builds and tags as `prosopo/provider:3.6.50-hotfix1`
- [ ] Smoke-test on pronode15: pull the hotfix image, restart `provider1`, confirm no `CentralDbStreamer reconnect cooldown` / `MongoMissingDependencyError` entries appear in OpenObserve

🤖 Generated with [Claude Code](https://claude.com/claude-code)