### PR TITLE
fix(provider): evict dedup session when routing machine wants a different captchaType

### DIFF
--- a/.changeset/dedup-routing-machine-eviction.md
+++ b/.changeset/dedup-routing-machine-eviction.md
@@ -1,0 +1,5 @@
+---
+"@prosopo/provider": patch
+---
+
+fix(provider): evict dedup session in `/frictionless` when the configured routing machine wants a different captchaType than the cached session. Previously the dedup short-circuit only checked the access policy, so a freshly-published routing machine was invisible to any user with an active dedup pointer — the initial frictionless call returned the stale baseline, the post-PoW router then minted an escalation session the widget couldn't follow, and the next `/captcha/{type}` call surfaced `API.INCORRECT_CAPTCHA_TYPE` with no path forward. Adds `FrictionlessManager.applyRoutingMachine(baseline, ctx)` as the public wrapper used by the handler.

--- a/packages/provider/src/api/captcha/getFrictionlessCaptchaChallenge/handler.ts
+++ b/packages/provider/src/api/captcha/getFrictionlessCaptchaChallenge/handler.ts
@@ -187,15 +187,19 @@ export default (
 			}
 
 			if (dedup) {
-				// A reused session must still honour an active user access policy.
-				// This fast-path returns before handleAccessPolicy / runDecisionMachine
-				// below, so a cached session whose captchaType conflicts with the
-				// policy — e.g. an IP rate-limit rule forcing `image` over a
-				// previously-cached `pow` session — would be served as-is and then
-				// hard-rejected at the /captcha/{type} gate with INCORRECT_CAPTCHA_TYPE.
-				// Re-check the policy here; on conflict evict the stale session and
-				// fall through so the access policy (or decision machine) selects the
-				// correct captcha type.
+				// A reused session must still honour an active user access policy
+				// AND the configured routing machine. This fast-path returns
+				// before handleAccessPolicy / runDecisionMachine below, so a
+				// cached session whose captchaType conflicts with either gate —
+				// e.g. an IP rate-limit rule forcing `image`, or a routing
+				// machine published after this dedup pointer was minted that
+				// now wants `puzzle` — would be served as-is and then either
+				// hard-rejected at the /captcha/{type} gate with
+				// INCORRECT_CAPTCHA_TYPE or escalated by the post-PoW router
+				// into a session the widget can't follow. Re-check both here
+				// and on conflict evict the stale session so the request falls
+				// through to the access policy / decision machine, which will
+				// re-derive the correct captcha type.
 				const dedupCountryCode =
 					req.ipInfo && "isValid" in req.ipInfo && req.ipInfo.isValid
 						? req.ipInfo.countryCode
@@ -204,8 +208,14 @@ export default (
 					req.ipInfo && "isValid" in req.ipInfo && req.ipInfo.isValid
 						? req.ipInfo.asnNumber
 						: undefined;
+				const dedupIsMobile =
+					req.ipInfo && "isValid" in req.ipInfo && req.ipInfo.isValid
+						? req.ipInfo.isMobile
+						: undefined;
+				const dedupFlatHeaders = flatten(req.headers);
+				const dedupUserAgent = String(req.headers["user-agent"] ?? "");
 				const dedupUserScope = getRequestUserScope(
-					flatten(req.headers),
+					dedupFlatHeaders,
 					req.ja4,
 					normalizedIp,
 					user,
@@ -227,15 +237,73 @@ export default (
 						(dedupAccessPolicy.captchaType !== undefined &&
 							dedupAccessPolicy.captchaType !== dedup.captchaType));
 
-				if (dedupConflictsWithPolicy) {
+				// Ask the routing machine (if any) what it would pick now,
+				// using the cached session's signals as the baseline. If it
+				// disagrees with the cached captchaType, evict.
+				//
+				// The router input intentionally mirrors the inputs the cached
+				// session was created under: `score` and `webView` come from
+				// the persisted session, the rest (UA, JA4, country, mobile)
+				// come from the current request. A routing machine that only
+				// reads the captchaType (e.g. blanket-escalate-to-puzzle) will
+				// behave identically. One that mixes per-request signals with
+				// session-derived ones gets the request-time view of every
+				// input that's available without re-decrypting the payload.
+				const cachedCaptchaType = dedup.captchaType as
+					| CaptchaType.image
+					| CaptchaType.pow
+					| CaptchaType.puzzle;
+				const dedupRouted = normalizedIp
+					? await tasks.frictionlessManager.applyRoutingMachine(
+							{
+								captchaType: cachedCaptchaType,
+								...(dedup.session.solvedImagesCount !== undefined && {
+									solvedImagesCount: dedup.session.solvedImagesCount,
+								}),
+								...(dedup.session.powDifficulty !== undefined && {
+									powDifficulty: dedup.session.powDifficulty,
+								}),
+							},
+							{
+								dappAccount: dapp,
+								userAccount: user,
+								ip: normalizedIp,
+								...(dedupCountryCode && { countryCode: dedupCountryCode }),
+								score: dedup.session.score,
+								platform: derivePlatform(
+									dedupUserAgent,
+									dedup.session.webView,
+									{
+										...(typeof dedupIsMobile === "boolean" && {
+											isMobile: dedupIsMobile,
+										}),
+									},
+								),
+								raw: {
+									headers: dedupFlatHeaders,
+									userAgent: dedupUserAgent,
+									...(req.ja4 && { ja4: req.ja4 }),
+								},
+							},
+						)
+					: { captchaType: cachedCaptchaType };
+				const dedupConflictsWithRouting =
+					dedupRouted.captchaType !== cachedCaptchaType;
+
+				if (dedupConflictsWithPolicy || dedupConflictsWithRouting) {
 					req.logger.info(() => ({
-						msg: "Evicting reused session: cached captchaType conflicts with access policy",
+						msg: "Evicting reused session: cached captchaType conflicts with access policy or routing machine",
 						data: {
 							userSitekeyIpHash,
 							sessionId: dedup.sessionId,
 							cachedCaptchaType: dedup.captchaType,
-							policyType: dedupAccessPolicy.type,
-							policyCaptchaType: dedupAccessPolicy.captchaType,
+							...(dedupConflictsWithPolicy && {
+								policyType: dedupAccessPolicy?.type,
+								policyCaptchaType: dedupAccessPolicy?.captchaType,
+							}),
+							...(dedupConflictsWithRouting && {
+								routedCaptchaType: dedupRouted.captchaType,
+							}),
 						},
 					}));
 					// Mongo is authoritative for dedup (see resolveSessionDedup): mark

--- a/packages/provider/src/tasks/frictionless/frictionlessTasks.ts
+++ b/packages/provider/src/tasks/frictionless/frictionlessTasks.ts
@@ -26,6 +26,7 @@ import {
 	type ProsopoConfigOutput,
 	type RequestHeaders,
 	type RoutingMachineBaseline,
+	type RoutingMachineOutput,
 	type ScoreComponents,
 	type Session,
 	SimdReadingsStage,
@@ -96,6 +97,31 @@ export class FrictionlessManager extends CaptchaManager {
 	 */
 	setRoutingContext(ctx: RoutingContext): void {
 		this.routingContext = ctx;
+	}
+
+	/**
+	 * Evaluate the configured routing machine against an arbitrary baseline +
+	 * context, without going through `sendCaptcha`. Used by the dedup
+	 * short-circuit to ask "if we reused this cached session, would the
+	 * current routing machine still pick the same captchaType?" — if not,
+	 * the cached session is evicted and the request falls through into the
+	 * normal decision-machine flow (which will run the router again with
+	 * fully-derived inputs).
+	 *
+	 * Returns the supplied baseline on any failure (no machine, machine
+	 * throws, counter fetch failure, etc.), matching applyRouter's contract.
+	 */
+	async applyRoutingMachine(
+		baseline: RoutingMachineBaseline,
+		ctx: RoutingContext,
+	): Promise<RoutingMachineOutput> {
+		return applyRouter(
+			this.decisionMachineRunner,
+			this.usageCounters,
+			baseline,
+			ctx,
+			this.logger,
+		);
 	}
 
 	setSessionParams(

--- a/packages/provider/src/tests/unit/api/getFrictionlessCaptchaChallenge.unit.test.ts
+++ b/packages/provider/src/tests/unit/api/getFrictionlessCaptchaChallenge.unit.test.ts
@@ -27,6 +27,7 @@ type MockTasks = {
 		checkLangRules: MockFn;
 		setSessionParams: MockFn;
 		setRoutingContext: MockFn;
+		applyRoutingMachine: MockFn;
 		getClientContextEntropy: MockFn;
 		sendImageCaptcha: MockFn;
 		sendPowCaptcha: MockFn;
@@ -152,6 +153,11 @@ vi.mock("../../../tasks/index.js", async () => {
 					checkLangRules: vi.fn().mockReturnValue(0),
 					setSessionParams: vi.fn(),
 					setRoutingContext: vi.fn(),
+					applyRoutingMachine: vi.fn(
+						async (baseline: { captchaType: CaptchaType }) => ({
+							captchaType: baseline.captchaType,
+						}),
+					),
 					getClientContextEntropy: vi.fn(),
 					sendImageCaptcha: vi.fn().mockResolvedValue({ type: "image" }),
 					sendPowCaptcha: vi.fn().mockResolvedValue({ type: "pow" }),
@@ -212,6 +218,11 @@ describe("getFrictionlessCaptchaChallenge - context selection", () => {
 			checkLangRules: vi.fn().mockReturnValue(0),
 			setSessionParams: vi.fn(),
 			setRoutingContext: vi.fn(),
+			applyRoutingMachine: vi.fn(
+				async (baseline: { captchaType: CaptchaType }) => ({
+					captchaType: baseline.captchaType,
+				}),
+			),
 			getClientContextEntropy: vi.fn(),
 			sendImageCaptcha: vi.fn().mockResolvedValue({ type: "image" }),
 			sendPowCaptcha: vi.fn().mockResolvedValue({ type: "pow" }),
@@ -497,6 +508,8 @@ describe("getFrictionlessCaptchaChallenge - context selection", () => {
 		tasksInstance.db.getSessionByuserSitekeyIpHash.mockResolvedValue({
 			sessionId: "stale-pow-session",
 			captchaType: CaptchaType.pow,
+			score: 0,
+			webView: false,
 		});
 
 		// An access rule (e.g. IP rate-limit) now forces image for this scope.
@@ -551,6 +564,8 @@ describe("getFrictionlessCaptchaChallenge - context selection", () => {
 		tasksInstance.db.getSessionByuserSitekeyIpHash.mockResolvedValue({
 			sessionId: "live-pow-session",
 			captchaType: CaptchaType.pow,
+			score: 0,
+			webView: false,
 		});
 		// No matching access policy (default mock returns []) → reuse as-is.
 
@@ -572,6 +587,114 @@ describe("getFrictionlessCaptchaChallenge - context selection", () => {
 		).not.toHaveBeenCalled();
 		expect(res.json).toHaveBeenCalledWith(
 			expect.objectContaining({ sessionId: "live-pow-session" }),
+		);
+	});
+
+	it("evicts the reused session and re-routes when the routing machine returns a different captchaType", async () => {
+		const clientRecord = {
+			account: "siteDedupRoutingConflict",
+			settings: {
+				captchaType: CaptchaType.frictionless,
+				frictionlessThreshold: 0.5,
+				imageMaxRounds: 2,
+				disallowWebView: false,
+			},
+		};
+		tasksInstance.db.getClientRecord.mockResolvedValue(clientRecord);
+
+		// A previously-cached pow session for this user+IP+sitekey, minted
+		// before the routing machine below was published.
+		tasksInstance.db.getSessionByuserSitekeyIpHash.mockResolvedValue({
+			sessionId: "stale-pow-session-routing",
+			captchaType: CaptchaType.pow,
+			score: 0,
+			webView: false,
+		});
+
+		// No access policy in play.
+		tasksInstance.frictionlessManager.getPrioritisedAccessPolicies.mockResolvedValue(
+			[],
+		);
+
+		// Routing machine now wants puzzle for everyone.
+		tasksInstance.frictionlessManager.applyRoutingMachine.mockResolvedValue({
+			captchaType: CaptchaType.puzzle,
+		});
+
+		tasksInstance.frictionlessManager.decryptPayload.mockResolvedValue({
+			baseBotScore: 0,
+			timestamp: Date.now(),
+			userId: "u",
+			userAgent: "844bc172f032bdd2d0baae3536c1d66c",
+			webView: false,
+			iFrame: false,
+			decryptedHeadHash: "abc",
+			decryptionFailed: false,
+		});
+
+		const body = {
+			token: "tRoutingConflict",
+			headHash: "hhRoutingConflict",
+			dapp: "siteDedupRoutingConflict",
+			user: "u",
+		};
+		const { req, res, next } = buildReqRes(body);
+
+		// biome-ignore lint/suspicious/noExplicitAny: mock request
+		await handler(req as any, res as any, next);
+
+		expect(next).not.toHaveBeenCalled();
+		// The stale pow session is evicted before the reuse_session path
+		// can return it.
+		expect(tasksInstance.db.checkAndRemoveSession).toHaveBeenCalledWith(
+			"stale-pow-session-routing",
+		);
+		// Reuse-session response shape is NOT used.
+		expect(res.json).not.toHaveBeenCalledWith(
+			expect.objectContaining({ sessionId: "stale-pow-session-routing" }),
+		);
+	});
+
+	it("reuses the cached session when the routing machine returns the same captchaType", async () => {
+		const clientRecord = {
+			account: "siteDedupRoutingAgrees",
+			settings: {
+				captchaType: CaptchaType.frictionless,
+				frictionlessThreshold: 0.5,
+				disallowWebView: false,
+			},
+		};
+		tasksInstance.db.getClientRecord.mockResolvedValue(clientRecord);
+
+		tasksInstance.db.getSessionByuserSitekeyIpHash.mockResolvedValue({
+			sessionId: "live-pow-session-routing-agrees",
+			captchaType: CaptchaType.pow,
+			score: 0,
+			webView: false,
+		});
+
+		// Routing machine agrees with the cached captchaType — no eviction.
+		tasksInstance.frictionlessManager.applyRoutingMachine.mockResolvedValue({
+			captchaType: CaptchaType.pow,
+		});
+
+		const body = {
+			token: "tRoutingAgrees",
+			headHash: "hhRoutingAgrees",
+			dapp: "siteDedupRoutingAgrees",
+			user: "u",
+		};
+		const { req, res, next } = buildReqRes(body);
+
+		// biome-ignore lint/suspicious/noExplicitAny: mock request
+		await handler(req as any, res as any, next);
+
+		expect(next).not.toHaveBeenCalled();
+		expect(tasksInstance.db.checkAndRemoveSession).not.toHaveBeenCalled();
+		expect(res.json).toHaveBeenCalledWith(
+			expect.objectContaining({
+				sessionId: "live-pow-session-routing-agrees",
+			}),
 		);
 	});
 


### PR DESCRIPTION
## Summary

- The `/frictionless` dedup short-circuit already re-checks the cached session against the current **access policy** and evicts on conflict. It didn't do the equivalent for the **routing machine**, so a freshly-published routing machine was ignored on every dedup-hit (which is the hot path for any returning user).
- Run the routing machine in the dedup block against the cached session's signals. If its `captchaType` disagrees with the cached one, evict and fall through to the normal decision-machine flow.

## Why

Hit this on staging while testing a brand-new routing machine for site key `5CcNvLUd…` that forces puzzle. The initial `/captcha/frictionless` call kept returning `pow` (cached dedup session), then `/pow/solution` ran post-PoW routing and minted a `puzzle` escalation session the widget couldn't follow. End result for the user: `API.INCORRECT_CAPTCHA_TYPE` on the next `/captcha/pow` call, no path forward.

Observed flow from staging OO2 logs (`staging_provider_node`):
- `Frictionless handler entry`
- `Frictionless decision  data_decision: "reuse_session"`  ← never reached the router
- `Frictionless response finished`
- `post-PoW routing decision`  ← router runs here, escalates to puzzle

The dedup pointer was minted before the routing machine was published, so the eviction-on-conflict path (which existed only for access policy) didn't trigger.

## Change

`FrictionlessManager.applyRoutingMachine(baseline, ctx)` is a thin public wrapper around the existing `applyRouter` so the handler can run the router without going through `sendCaptcha`. Used by the dedup block to evaluate the router against:

- baseline: cached session's `captchaType` / `solvedImagesCount` / `powDifficulty`
- score: cached session's `score`
- webView: cached session's `webView`
- everything else (UA, JA4, country, mobile): current request

A router that only reads `captchaType` (e.g. blanket "escalate to puzzle") behaves identically. A router that mixes per-request signals with session-derived ones gets the request-time view of every input that's available without re-decrypting the payload.

Eviction reuses the existing access-policy code path (mark deleted in Mongo, drop Redis pointers), so behaviour for the access-policy case is unchanged.

## Test plan

- [x] `getFrictionlessCaptchaChallenge.unit.test.ts` updated with two new cases:
  - evicts the reused session and re-routes when the routing machine returns a different `captchaType`
  - reuses the cached session when the routing machine agrees
- [x] Existing dedup tests (access-policy conflict / no conflict) still pass
- [x] `tsc --noEmit` clean on `@prosopo/provider` (one pre-existing `prom-client` baseline error, unrelated)
- [ ] Reproduce on staging-pronode4 with the `5CcNvLUd…` puzzle-forcing routing machine after merge: `/frictionless` should now return `captchaType: "puzzle"` on the first call, no escalation needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)