### PR TITLE
fix(provider): on equal specificity, pick the harshest matching access rule

### DIFF
--- a/.changeset/access-rule-harshest-wins.md
+++ b/.changeset/access-rule-harshest-wins.md
@@ -2,4 +2,4 @@
 "@prosopo/provider": patch
 ---
 
-fix(provider): pick the harshest matching access rule, not the first. When multiple access rules match a request, ranking now sorts by harshness first (Block > Restrict[image, rounds DESC] > Restrict[puzzle] > Restrict[pow]) with specificity as a tiebreaker. Block always beats Restrict regardless of specificity — closes a gap where a more-specific Restrict could be picked over a less-specific Block. `deferToVerify` is preserved on the chosen rule and continues to control request-time vs verify-time enforcement.
+fix(provider): on equal specificity, pick the harshest matching access rule. Specificity remains the primary criterion (a more-specific rule still wins), but the equal-specificity tiebreaker is extended from the previous Block-vs-Restrict-only severity check to a full harshness ordering: Block > Restrict[image, rounds DESC] > Restrict[puzzle] > Restrict[pow]. `deferToVerify` continues to control request-time vs verify-time enforcement and doesn't affect ranking.

--- a/.changeset/access-rule-harshest-wins.md
+++ b/.changeset/access-rule-harshest-wins.md
@@ -1,0 +1,5 @@
+---
+"@prosopo/provider": patch
+---
+
+fix(provider): pick the harshest matching access rule, not the first. When multiple access rules match a request, ranking now sorts by harshness first (Block > Restrict[image, rounds DESC] > Restrict[puzzle] > Restrict[pow]) with specificity as a tiebreaker. Block always beats Restrict regardless of specificity — closes a gap where a more-specific Restrict could be picked over a less-specific Block. `deferToVerify` is preserved on the chosen rule and continues to control request-time vs verify-time enforcement.

--- a/packages/provider/src/api/blacklistRequestInspector.ts
+++ b/packages/provider/src/api/blacklistRequestInspector.ts
@@ -196,11 +196,11 @@ const ruleSpecificity = (
 	return score;
 };
 
-// Per-captcha-type harshness ranks for Restrict rules (issue #3713).
-// Gaps of 10 between tiers leave room for `solvedImagesCount` (image rule
-// rounds) to break ties within the image tier without crossing into the
-// puzzle tier. A misconfigured rule with rounds >= 10 still ranks above
-// puzzle/pow — which is correct: a 12-round image is harsher than puzzle.
+// Per-captcha-type harshness ranks for Restrict rules. Used as the
+// equal-specificity tiebreaker (issue #3713). Gaps of 10 between tiers
+// leave room for `solvedImagesCount` to break ties within the image
+// tier without crossing into the puzzle tier — a 12-round image still
+// ranks above puzzle/pow, which is the intended ordering.
 const CAPTCHA_TYPE_HARSHNESS: Record<CaptchaType, number> = {
 	[CaptchaType.image]: 30,
 	[CaptchaType.puzzle]: 20,
@@ -212,16 +212,17 @@ const CAPTCHA_TYPE_HARSHNESS: Record<CaptchaType, number> = {
 	[CaptchaType.frictionless]: 0,
 };
 
-// Harshness ordering across all matching rules (issue #3713):
+// Harshness within an equal-specificity tier (issue #3713). On equal
+// specificity, the harshest matching rule wins:
 //   Block  >  Restrict[image, rounds DESC]  >  Restrict[puzzle]  >  Restrict[pow]
-// Block beats every Restrict regardless of specificity — a request matched
-// by both must be blocked, not routed to a captcha. This is a strict change
-// from the prior "specificity, then severity-as-tiebreaker" rule, and
-// supersedes the historical safety comment about equal-specificity ties.
+// Specificity still dominates — a more-specific Restrict[pow] beats a
+// less-specific Block, because the operator deliberately narrowed scope
+// for that combination. Harshness only decides ties between rules at the
+// same specificity, replacing the prior Block-vs-Restrict-only tiebreaker.
 //
 // `deferToVerify` doesn't affect this ordering: it controls *when* a Block
-// fires (request-time vs verify-time), not how severe it is. The flag rides
-// on the chosen rule and downstream consumers (`findHardBlockPolicy`,
+// fires (request-time vs verify-time), not how severe it is. The flag
+// rides on the chosen rule and downstream consumers (`findHardBlockPolicy`,
 // blockMiddleware's `enforceable` filter) read it after ranking.
 const ruleHarshness = (rule: AccessRule): number => {
 	if (rule.type === AccessPolicyType.Block) {
@@ -240,11 +241,11 @@ const ruleHarshness = (rule: AccessRule): number => {
  * every populated field on the rule equals the corresponding request field
  * (IP fields use range semantics).
  *
- * Ordering (issue #3713): harshness DESC, then specificity DESC as tiebreaker.
- * Block always wins over Restrict regardless of specificity. Within Restrict,
- * image (with `solvedImagesCount` DESC) beats puzzle beats pow. Client-scoped
- * rules outrank global rules of equal user-scope specificity within the same
- * harshness tier.
+ * Ordering: specificity DESC primary, harshness DESC as the equal-specificity
+ * tiebreaker (issue #3713). The most specific applicable rule wins; on tie,
+ * the harshest matching rule wins — Block > Restrict[image, rounds DESC] >
+ * Restrict[puzzle] > Restrict[pow]. Client-scoped rules outrank global rules
+ * of equal user-scope specificity.
  */
 export const rankCandidateRules = (
 	rules: AccessRule[],
@@ -254,14 +255,13 @@ export const rankCandidateRules = (
 	rules
 		.filter((rule) => ruleApplies(rule, request, requestClientId))
 		.sort((a, b) => {
-			const harshDelta = ruleHarshness(b) - ruleHarshness(a);
-			if (harshDelta !== 0) {
-				return harshDelta;
-			}
-			return (
+			const specDelta =
 				ruleSpecificity(b, requestClientId) -
-				ruleSpecificity(a, requestClientId)
-			);
+				ruleSpecificity(a, requestClientId);
+			if (specDelta !== 0) {
+				return specDelta;
+			}
+			return ruleHarshness(b) - ruleHarshness(a);
 		});
 
 /**

--- a/packages/provider/src/api/blacklistRequestInspector.ts
+++ b/packages/provider/src/api/blacklistRequestInspector.ts
@@ -196,18 +196,55 @@ const ruleSpecificity = (
 	return score;
 };
 
-// On equal specificity, the more severe outcome wins. This is a safety
-// property: a request that matches both a Block rule and a Restrict rule
-// of equal specificity must be blocked, never restricted-but-let-through.
-const policySeverity = (rule: AccessRule): number =>
-	rule.type === AccessPolicyType.Block ? 1 : 0;
+// Per-captcha-type harshness ranks for Restrict rules (issue #3713).
+// Gaps of 10 between tiers leave room for `solvedImagesCount` (image rule
+// rounds) to break ties within the image tier without crossing into the
+// puzzle tier. A misconfigured rule with rounds >= 10 still ranks above
+// puzzle/pow — which is correct: a 12-round image is harsher than puzzle.
+const CAPTCHA_TYPE_HARSHNESS: Record<CaptchaType, number> = {
+	[CaptchaType.image]: 30,
+	[CaptchaType.puzzle]: 20,
+	[CaptchaType.pow]: 10,
+	// Frictionless isn't a routing target for Restrict rules but include it
+	// so the Record is total over CaptchaType — keeps the type-checker honest
+	// if the enum grows. Restrict-with-frictionless wouldn't make operational
+	// sense and ranks at the bottom of the captcha tiers if it ever appears.
+	[CaptchaType.frictionless]: 0,
+};
+
+// Harshness ordering across all matching rules (issue #3713):
+//   Block  >  Restrict[image, rounds DESC]  >  Restrict[puzzle]  >  Restrict[pow]
+// Block beats every Restrict regardless of specificity — a request matched
+// by both must be blocked, not routed to a captcha. This is a strict change
+// from the prior "specificity, then severity-as-tiebreaker" rule, and
+// supersedes the historical safety comment about equal-specificity ties.
+//
+// `deferToVerify` doesn't affect this ordering: it controls *when* a Block
+// fires (request-time vs verify-time), not how severe it is. The flag rides
+// on the chosen rule and downstream consumers (`findHardBlockPolicy`,
+// blockMiddleware's `enforceable` filter) read it after ranking.
+const ruleHarshness = (rule: AccessRule): number => {
+	if (rule.type === AccessPolicyType.Block) {
+		return Number.MAX_SAFE_INTEGER;
+	}
+	if (rule.captchaType === undefined) {
+		return 0;
+	}
+	const base = CAPTCHA_TYPE_HARSHNESS[rule.captchaType];
+	const rounds = rule.solvedImagesCount ?? 0;
+	return base + rounds;
+};
 
 /**
  * Rank the candidate rules a single Redis query returned. A rule "applies" iff
  * every populated field on the rule equals the corresponding request field
- * (IP fields use range semantics). The most specific applicable rule wins;
- * on tie, the more severe (Block over Restrict) wins. Client-scoped rules
- * outrank global rules of equal user-scope specificity.
+ * (IP fields use range semantics).
+ *
+ * Ordering (issue #3713): harshness DESC, then specificity DESC as tiebreaker.
+ * Block always wins over Restrict regardless of specificity. Within Restrict,
+ * image (with `solvedImagesCount` DESC) beats puzzle beats pow. Client-scoped
+ * rules outrank global rules of equal user-scope specificity within the same
+ * harshness tier.
  */
 export const rankCandidateRules = (
 	rules: AccessRule[],
@@ -217,13 +254,14 @@ export const rankCandidateRules = (
 	rules
 		.filter((rule) => ruleApplies(rule, request, requestClientId))
 		.sort((a, b) => {
-			const specDelta =
-				ruleSpecificity(b, requestClientId) -
-				ruleSpecificity(a, requestClientId);
-			if (specDelta !== 0) {
-				return specDelta;
+			const harshDelta = ruleHarshness(b) - ruleHarshness(a);
+			if (harshDelta !== 0) {
+				return harshDelta;
 			}
-			return policySeverity(b) - policySeverity(a);
+			return (
+				ruleSpecificity(b, requestClientId) -
+				ruleSpecificity(a, requestClientId)
+			);
 		});
 
 /**

--- a/packages/provider/src/tests/unit/api/blacklistRequestInspector.unit.test.ts
+++ b/packages/provider/src/tests/unit/api/blacklistRequestInspector.unit.test.ts
@@ -906,7 +906,7 @@ describe("rankCandidateRules", () => {
 		expect(ranked).toEqual([]);
 	});
 
-	it("on equal specificity, Block wins over Restrict", () => {
+	it("on equal specificity, Block wins over Restrict (safety tiebreaker)", () => {
 		const restrict: AccessRule = {
 			type: AccessPolicyType.Restrict,
 			ja4Hash: "ja4-A",
@@ -921,10 +921,10 @@ describe("rankCandidateRules", () => {
 		expect(ranked[1]).toEqual(restrict);
 	});
 
-	// Issue #3713: harshness now dominates specificity. Block always wins
-	// over Restrict — even a less-specific Block beats a more-specific
-	// Restrict.
-	it("Block beats Restrict regardless of specificity", () => {
+	it("specificity still beats severity (a more-specific Restrict beats a less-specific Block)", () => {
+		// A Restrict matching ja4 + asn (2 fields) outranks a Block matching
+		// only ja4 (1 field) — the operator intentionally narrowed the policy
+		// for this combination.
 		const broadBlock: AccessRule = {
 			type: AccessPolicyType.Block,
 			ja4Hash: "ja4-A",
@@ -933,19 +933,21 @@ describe("rankCandidateRules", () => {
 			type: AccessPolicyType.Restrict,
 			ja4Hash: "ja4-A",
 			asn: 205016,
-			captchaType: CaptchaType.image,
-			solvedImagesCount: 4,
 		};
 		const ranked = rankCandidateRules(
-			[specificRestrict, broadBlock],
+			[broadBlock, specificRestrict],
 			request,
 			undefined,
 		);
-		expect(ranked[0]).toEqual(broadBlock);
-		expect(ranked[1]).toEqual(specificRestrict);
+		expect(ranked[0]).toEqual(specificRestrict);
 	});
 
-	it("ranks Restrict tiers as image > puzzle > pow", () => {
+	// Issue #3713: at equal specificity, harshness picks the winner.
+	// Ordering: Block > Restrict[image, rounds DESC] > Restrict[puzzle] >
+	// Restrict[pow]. Specificity stays the primary criterion — these tests
+	// use equal-specificity setups to isolate the new tiebreaker.
+
+	it("on equal specificity, ranks Restrict tiers as image > puzzle > pow", () => {
 		const powRule: AccessRule = {
 			type: AccessPolicyType.Restrict,
 			ja4Hash: "ja4-A",
@@ -969,7 +971,7 @@ describe("rankCandidateRules", () => {
 		expect(ranked).toEqual([imageRule, puzzleRule, powRule]);
 	});
 
-	it("among image rules, more solvedImagesCount is harsher", () => {
+	it("on equal specificity, image with more solvedImagesCount is harsher", () => {
 		const twoRounds: AccessRule = {
 			type: AccessPolicyType.Restrict,
 			ja4Hash: "ja4-A",
@@ -991,32 +993,26 @@ describe("rankCandidateRules", () => {
 		expect(ranked[1]).toEqual(twoRounds);
 	});
 
-	it("an image rule beats a puzzle rule even when puzzle is more specific", () => {
-		const broadImage: AccessRule = {
+	it("on equal specificity, Block beats every Restrict captcha tier", () => {
+		const block: AccessRule = {
+			type: AccessPolicyType.Block,
+			ja4Hash: "ja4-A",
+		};
+		const image: AccessRule = {
 			type: AccessPolicyType.Restrict,
 			ja4Hash: "ja4-A",
 			captchaType: CaptchaType.image,
-			solvedImagesCount: 2,
+			solvedImagesCount: 9,
 		};
-		const specificPuzzle: AccessRule = {
-			type: AccessPolicyType.Restrict,
-			ja4Hash: "ja4-A",
-			asn: 205016,
-			captchaType: CaptchaType.puzzle,
-		};
-		const ranked = rankCandidateRules(
-			[specificPuzzle, broadImage],
-			request,
-			undefined,
-		);
-		expect(ranked[0]).toEqual(broadImage);
+		const ranked = rankCandidateRules([image, block], request, undefined);
+		expect(ranked[0]).toEqual(block);
 	});
 
 	// `deferToVerify` is a fire-time flag, not a harshness signal — a
-	// deferred Block still ranks ahead of any Restrict so the verify-time
-	// hard-block lookup (which iterates the same ranked array) still finds
-	// the Block first.
-	it("a deferToVerify Block still outranks a non-deferred Restrict", () => {
+	// deferred Block at equal specificity still ranks ahead of a Restrict so
+	// downstream verify-time consumers (which iterate the same ranked array)
+	// still see the Block first.
+	it("on equal specificity, a deferToVerify Block still outranks a Restrict", () => {
 		const deferredBlock: AccessRule = {
 			type: AccessPolicyType.Block,
 			ja4Hash: "ja4-A",
@@ -1025,7 +1021,6 @@ describe("rankCandidateRules", () => {
 		const restrict: AccessRule = {
 			type: AccessPolicyType.Restrict,
 			ja4Hash: "ja4-A",
-			asn: 205016,
 			captchaType: CaptchaType.image,
 			solvedImagesCount: 4,
 		};
@@ -1037,26 +1032,26 @@ describe("rankCandidateRules", () => {
 		expect(ranked[0]).toEqual(deferredBlock);
 	});
 
-	it("breaks harshness ties by specificity", () => {
+	it("a more-specific pow Restrict still beats a less-specific image Restrict", () => {
+		// Harshness is only the equal-specificity tiebreaker. A narrower
+		// pow rule (ja4 + asn) still wins over a broader image rule (ja4).
 		const broadImage: AccessRule = {
 			type: AccessPolicyType.Restrict,
 			ja4Hash: "ja4-A",
 			captchaType: CaptchaType.image,
-			solvedImagesCount: 2,
+			solvedImagesCount: 4,
 		};
-		const specificImage: AccessRule = {
+		const specificPow: AccessRule = {
 			type: AccessPolicyType.Restrict,
 			ja4Hash: "ja4-A",
 			asn: 205016,
-			captchaType: CaptchaType.image,
-			solvedImagesCount: 2,
+			captchaType: CaptchaType.pow,
 		};
 		const ranked = rankCandidateRules(
-			[broadImage, specificImage],
+			[broadImage, specificPow],
 			request,
 			undefined,
 		);
-		expect(ranked[0]).toEqual(specificImage);
-		expect(ranked[1]).toEqual(broadImage);
+		expect(ranked[0]).toEqual(specificPow);
 	});
 });

--- a/packages/provider/src/tests/unit/api/blacklistRequestInspector.unit.test.ts
+++ b/packages/provider/src/tests/unit/api/blacklistRequestInspector.unit.test.ts
@@ -13,7 +13,11 @@
 // limitations under the License.
 
 import type { Logger } from "@prosopo/logger";
-import { FrictionlessReason, type IPInfoResponse } from "@prosopo/types";
+import {
+	CaptchaType,
+	FrictionlessReason,
+	type IPInfoResponse,
+} from "@prosopo/types";
 import type { IProviderDatabase } from "@prosopo/types-database";
 import {
 	AccessPolicyType,
@@ -902,7 +906,7 @@ describe("rankCandidateRules", () => {
 		expect(ranked).toEqual([]);
 	});
 
-	it("on equal specificity, Block wins over Restrict (safety tiebreaker)", () => {
+	it("on equal specificity, Block wins over Restrict", () => {
 		const restrict: AccessRule = {
 			type: AccessPolicyType.Restrict,
 			ja4Hash: "ja4-A",
@@ -917,10 +921,10 @@ describe("rankCandidateRules", () => {
 		expect(ranked[1]).toEqual(restrict);
 	});
 
-	it("specificity still beats severity (a more-specific Restrict beats a less-specific Block)", () => {
-		// A Restrict matching ja4 + asn (2 fields) outranks a Block matching
-		// only ja4 (1 field) — the operator intentionally narrowed the policy
-		// for this combination.
+	// Issue #3713: harshness now dominates specificity. Block always wins
+	// over Restrict — even a less-specific Block beats a more-specific
+	// Restrict.
+	it("Block beats Restrict regardless of specificity", () => {
 		const broadBlock: AccessRule = {
 			type: AccessPolicyType.Block,
 			ja4Hash: "ja4-A",
@@ -929,12 +933,130 @@ describe("rankCandidateRules", () => {
 			type: AccessPolicyType.Restrict,
 			ja4Hash: "ja4-A",
 			asn: 205016,
+			captchaType: CaptchaType.image,
+			solvedImagesCount: 4,
 		};
 		const ranked = rankCandidateRules(
-			[broadBlock, specificRestrict],
+			[specificRestrict, broadBlock],
 			request,
 			undefined,
 		);
-		expect(ranked[0]).toEqual(specificRestrict);
+		expect(ranked[0]).toEqual(broadBlock);
+		expect(ranked[1]).toEqual(specificRestrict);
+	});
+
+	it("ranks Restrict tiers as image > puzzle > pow", () => {
+		const powRule: AccessRule = {
+			type: AccessPolicyType.Restrict,
+			ja4Hash: "ja4-A",
+			captchaType: CaptchaType.pow,
+		};
+		const puzzleRule: AccessRule = {
+			type: AccessPolicyType.Restrict,
+			ja4Hash: "ja4-A",
+			captchaType: CaptchaType.puzzle,
+		};
+		const imageRule: AccessRule = {
+			type: AccessPolicyType.Restrict,
+			ja4Hash: "ja4-A",
+			captchaType: CaptchaType.image,
+		};
+		const ranked = rankCandidateRules(
+			[powRule, puzzleRule, imageRule],
+			request,
+			undefined,
+		);
+		expect(ranked).toEqual([imageRule, puzzleRule, powRule]);
+	});
+
+	it("among image rules, more solvedImagesCount is harsher", () => {
+		const twoRounds: AccessRule = {
+			type: AccessPolicyType.Restrict,
+			ja4Hash: "ja4-A",
+			captchaType: CaptchaType.image,
+			solvedImagesCount: 2,
+		};
+		const fourRounds: AccessRule = {
+			type: AccessPolicyType.Restrict,
+			ja4Hash: "ja4-A",
+			captchaType: CaptchaType.image,
+			solvedImagesCount: 4,
+		};
+		const ranked = rankCandidateRules(
+			[twoRounds, fourRounds],
+			request,
+			undefined,
+		);
+		expect(ranked[0]).toEqual(fourRounds);
+		expect(ranked[1]).toEqual(twoRounds);
+	});
+
+	it("an image rule beats a puzzle rule even when puzzle is more specific", () => {
+		const broadImage: AccessRule = {
+			type: AccessPolicyType.Restrict,
+			ja4Hash: "ja4-A",
+			captchaType: CaptchaType.image,
+			solvedImagesCount: 2,
+		};
+		const specificPuzzle: AccessRule = {
+			type: AccessPolicyType.Restrict,
+			ja4Hash: "ja4-A",
+			asn: 205016,
+			captchaType: CaptchaType.puzzle,
+		};
+		const ranked = rankCandidateRules(
+			[specificPuzzle, broadImage],
+			request,
+			undefined,
+		);
+		expect(ranked[0]).toEqual(broadImage);
+	});
+
+	// `deferToVerify` is a fire-time flag, not a harshness signal — a
+	// deferred Block still ranks ahead of any Restrict so the verify-time
+	// hard-block lookup (which iterates the same ranked array) still finds
+	// the Block first.
+	it("a deferToVerify Block still outranks a non-deferred Restrict", () => {
+		const deferredBlock: AccessRule = {
+			type: AccessPolicyType.Block,
+			ja4Hash: "ja4-A",
+			deferToVerify: true,
+		};
+		const restrict: AccessRule = {
+			type: AccessPolicyType.Restrict,
+			ja4Hash: "ja4-A",
+			asn: 205016,
+			captchaType: CaptchaType.image,
+			solvedImagesCount: 4,
+		};
+		const ranked = rankCandidateRules(
+			[restrict, deferredBlock],
+			request,
+			undefined,
+		);
+		expect(ranked[0]).toEqual(deferredBlock);
+	});
+
+	it("breaks harshness ties by specificity", () => {
+		const broadImage: AccessRule = {
+			type: AccessPolicyType.Restrict,
+			ja4Hash: "ja4-A",
+			captchaType: CaptchaType.image,
+			solvedImagesCount: 2,
+		};
+		const specificImage: AccessRule = {
+			type: AccessPolicyType.Restrict,
+			ja4Hash: "ja4-A",
+			asn: 205016,
+			captchaType: CaptchaType.image,
+			solvedImagesCount: 2,
+		};
+		const ranked = rankCandidateRules(
+			[broadImage, specificImage],
+			request,
+			undefined,
+		);
+		expect(ranked[0]).toEqual(specificImage);
+		expect(ranked[1]).toEqual(broadImage);
 	});
 });


### PR DESCRIPTION
## Summary
- Extends today's equal-specificity severity tiebreaker (Block vs Restrict) into a full harshness ordering: `Block > Restrict[image, rounds DESC] > Restrict[puzzle] > Restrict[pow]`.
- **Specificity is unchanged as the primary criterion** — a more-specific Restrict still beats a less-specific Block. Harshness only decides between rules at the same specificity.
- `deferToVerify` is preserved on the chosen rule and continues to control request-time vs verify-time enforcement (no semantic change to the verify-deferred path).

Closes prosopo/captcha-private#3713

## Where it changes
- `rankCandidateRules` in `packages/provider/src/api/blacklistRequestInspector.ts` — `policySeverity` replaced by `ruleHarshness` (Block, then captcha-tier with rounds). Sort body still does `specificity DESC` first, then harshness; only the tiebreaker function changed.
- Downstream call sites consume the same ordered array, no other handler edits are needed:
  - `getFrictionlessCaptchaChallenge/handler.ts` — `accessPolicies[0]` picks the harshest rule within the top specificity tier.
  - `captchaManager.checkForHardBlock` / `findHardBlockPolicy` — `.find()` still locates Blocks first because Block sorts before Restrict on equal specificity.
  - `blacklistRequestInspector.shouldAbortRequest` — `enforceable[0]` still picks the same rule the prior logic would have on specificity, with the harshness tiebreaker applied within tier.

## Notes
- The server-side Redis rank (`FT.AGGREGATE` in `redisRulesReader`) is unchanged. It returns the top-N=20 candidates by `spec*2 + sev`, and the JS-side `rankCandidateRules` is authoritative for harshest-wins among those. The 20-cap has comfortable headroom for realistic rule populations.

## Test plan
- [x] `npx vitest run src/tests/unit/api/blacklistRequestInspector.unit.test.ts` → 40/40 passing.
- [x] `npm run -w @prosopo/provider build:tsc` → clean.
- [ ] CI passes.
- The existing assertion that specificity beats severity (a more-specific Restrict beats a less-specific Block) is retained — that contract is unchanged.
- New unit tests cover:
  - On equal specificity, image > puzzle > pow.
  - On equal specificity, image with more `solvedImagesCount` is harsher.
  - On equal specificity, Block beats every Restrict captcha tier (including a maxed-out image).
  - On equal specificity, a `deferToVerify` Block still outranks a Restrict.
  - A more-specific pow Restrict still beats a less-specific image Restrict (specificity dominates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
