### PR TITLE
fix(procaptcha-pow): forward all props through the Suspense wrapper

### DIFF
--- a/.changeset/escalation-prop-dropping.md
+++ b/.changeset/escalation-prop-dropping.md
@@ -1,0 +1,6 @@
+---
+"@prosopo/procaptcha-pow": patch
+"@prosopo/procaptcha-puzzle": patch
+---
+
+fix(procaptcha-pow): forward all props through the Suspense wrapper so `onEscalate` and `autoStart` reach the inner widget. The PoW (and puzzle) wrappers were enumerating props by name and silently dropping `onEscalate`, which meant the Manager closure captured `onEscalate=undefined`. When the provider returned a post-PoW escalation envelope, `onEscalate?.()` no-op'd, the frictionless wrapper was never told to swap in the image widget, and the user was left with a spinning PoW checkbox forever. Both wrappers now spread props, matching the image (`Procaptcha`) sibling.

--- a/demos/cypress-shared/cypress/e2e/escalation.cy.ts
+++ b/demos/cypress-shared/cypress/e2e/escalation.cy.ts
@@ -131,6 +131,15 @@ describe("Post-PoW route() escalation surfaces the image captcha", () => {
 		cy.intercept("POST", "**/prosopo/provider/client/pow/solution").as(
 			"powSubmit",
 		);
+		// `imageChallenge` is the UI contract: it only fires if the frictionless
+		// wrapper's onEscalate handler was actually invoked AND the freshly
+		// loaded Procaptcha image widget mounted and ran its autoStart effect.
+		// A regression in any link of that chain (e.g. the ProcaptchaPow
+		// Suspense wrapper dropping `onEscalate` from its forwarded props)
+		// will block this request from ever leaving the page.
+		cy.intercept("POST", "**/prosopo/provider/client/captcha/image").as(
+			"imageChallenge",
+		);
 
 		// Kick the flow off.
 		getWidgetElement(checkboxClass, { timeout: 12000 }).first().realClick();
@@ -170,19 +179,27 @@ describe("Post-PoW route() escalation surfaces the image captcha", () => {
 				expect(response?.body.verified).to.equal(false);
 			});
 
-		// The escalation envelope above is the server-side contract that
-		// captcha#2771 + #2779 are about. The procaptcha-frictionless
-		// wrapper consumes it and mounts the image widget — that re-mount
-		// + /captcha/image fetch is covered by:
-		//   - procaptcha-pow `Manager` unit tests (onEscalate fired with
-		//     the right type + sessionId)
-		//   - the integration test in #2779 (Mongo + Redis pointer survival,
-		//     escalation session reachable by checkAndRemoveSession)
-		// It does not reliably re-render inside headless Cypress because
-		// the frictionlessState handoff to the freshly-loaded Procaptcha
-		// image module relies on dynamic imports that the test bundle
-		// doesn't always resolve in time — that's a widget bundling
-		// quirk, not a regression in the server-side contract this PR
-		// guards.
+		// UI contract: once the wrapper receives the escalation envelope it
+		// must mount the image widget, whose autoStart effect kicks off
+		// /captcha/image. Asserting the request is the cheapest signal that
+		// the whole client-side handoff actually executed end-to-end. The
+		// real regression we're guarding here is a missing prop on the
+		// Suspense wrapper around ProcaptchaWidget swallowing `onEscalate`
+		// before it reaches Manager — in that case Manager.start silently
+		// no-ops onEscalate?.(), no further request fires, and the user
+		// stares at a spinning checkbox.
+		cy.wait("@imageChallenge", { timeout: 30000 })
+			.its("response")
+			.then((response) => {
+				expect(response?.statusCode).to.equal(200);
+				expect(response?.body).to.have.property("captchas");
+				expect(response?.body.captchas).to.have.length.gte(1);
+			});
+
+		// And the image modal should be visible to the user — same DOM
+		// surface the image-flow tests reach via cy.captchaImages().
+		getWidgetElement(".prosopo-modalInner p", { timeout: 15000 }).should(
+			"be.visible",
+		);
 	});
 });

--- a/packages/procaptcha-pow/src/components/ProcaptchaPoW.tsx
+++ b/packages/procaptcha-pow/src/components/ProcaptchaPoW.tsx
@@ -26,13 +26,14 @@ const ProcaptchaWidget: LazyExoticComponent<ProcaptchaWidgetComponent> = lazy(
 	async () => import("./ProcaptchaWidget.js"),
 );
 
+// Spread props rather than enumerating: the inner ProcaptchaWidget consumes
+// `onEscalate` (passed by ProcaptchaFrictionless so a route()-escalated PoW
+// solve can mount the image widget) and `autoStart`. Listing props by name
+// silently dropped both, so the Manager closure captured
+// `onEscalate=undefined` and the post-PoW escalation envelope no-op'd in the
+// browser — the user just saw the PoW checkbox spin forever.
 export const ProcaptchaPow = (props: ProcaptchaProps) => (
 	<Suspense>
-		<ProcaptchaWidget
-			config={props.config}
-			callbacks={props.callbacks}
-			frictionlessState={props.frictionlessState}
-			i18n={props.i18n}
-		/>
+		<ProcaptchaWidget {...props} />
 	</Suspense>
 );

--- a/packages/procaptcha-puzzle/src/components/ProcaptchaPuzzle.tsx
+++ b/packages/procaptcha-puzzle/src/components/ProcaptchaPuzzle.tsx
@@ -26,14 +26,11 @@ const ProcaptchaWidget: LazyExoticComponent<ProcaptchaWidgetComponent> = lazy(
 	async () => import("./ProcaptchaWidget.js"),
 );
 
+// Spread props rather than enumerating: matches the image (Procaptcha) and
+// PoW (ProcaptchaPow) sibling wrappers so any prop the inner widget consumes
+// can never be silently dropped by this Suspense wrapper.
 export const ProcaptchaPuzzle = (props: ProcaptchaProps) => (
 	<Suspense>
-		<ProcaptchaWidget
-			config={props.config}
-			callbacks={props.callbacks}
-			frictionlessState={props.frictionlessState}
-			i18n={props.i18n}
-			autoStart={props.autoStart}
-		/>
+		<ProcaptchaWidget {...props} />
 	</Suspense>
 );


### PR DESCRIPTION
## Summary

- The `ProcaptchaPow` (and `ProcaptchaPuzzle`) Suspense wrappers enumerated props by name, silently dropping `onEscalate` and `autoStart` before they reached the inner `ProcaptchaWidget`. The `Manager` closure then captured `onEscalate=undefined`, so when the provider's post-PoW `/pow/solution` returned an `escalation: { captchaType, sessionId }` envelope the `onEscalate?.()` invocation no-op'd in the browser. The frictionless wrapper was never told to swap in the image widget and users were left staring at a spinning PoW checkbox forever. This was the staging/Twickets mobile post-PoW hang.
- Fix: spread props in both wrappers (matches the image `Procaptcha` sibling).
- Test: extend the existing `escalation.cy.ts` to assert the image widget actually mounts after the escalation envelope arrives — `cy.wait('@imageChallenge')` plus a visibility check on `.prosopo-modalInner`. This is the regression signal the prop-dropping bug would have tripped.

## Diagnosis trail

Diagnosed via diagnostic `console.log` markers wired through `Manager` → frictionless wrapper → image widget. On staging the marker `[ProcaptchaEscalation] pow Manager: /pow/solution returned {... onEscalateDefined: false}` pinpointed the prop being undefined at Manager construction. Tracing back surfaced the explicit prop enumeration in `ProcaptchaPow.tsx`.

## Test plan

- [ ] `cypress.escalation.config.js` suite runs and the new `@imageChallenge` wait + modal visibility assertion pass
- [ ] Manual staging repro on the dedicated forced-escalation site key (`5CcNvLUdiXFpzKDMjThGLSK9rhWHA1H4EF3zrgkpkjAdqmuP`) on a real mobile device confirms the image captcha mounts after a PoW solve

🤖 Generated with [Claude Code](https://claude.com/claude-code)