### PR TITLE
fix(api,procaptcha-frictionless): collapse WKWebView "No session found" mount storm

### DIFF
--- a/.changeset/webview-no-session-found-mount-storm.md
+++ b/.changeset/webview-no-session-found-mount-storm.md
@@ -1,0 +1,9 @@
+---
+"@prosopo/api": patch
+"@prosopo/procaptcha-frictionless": patch
+---
+
+fix(api,procaptcha-frictionless): collapse the WKWebView "No session found" mount storm. Two independent client-side amplifiers were stacking to produce a cascade of `CAPTCHA.NO_SESSION_FOUND` errors during the frictionless → PoW hand-off in iPhone WKWebView.
+
+- `ProcaptchaFrictionless`'s outer `useEffect` depended on `[config, callbacks, detectBot, config.language]`. Host pages that recreate the `callbacks` object on every render (the common React pattern) refired the effect on each parent re-render and triggered a fresh `/frictionless` call each time. Deps are now the primitive widget identity (`config.account?.address`, `config.language`, `config.mode`) plus a `startedForKeyRef` guard, so React StrictMode double-invocation and same-identity re-renders are idempotent. `callbacks` and `detectBot` are still read live via the closure captured by `start()`.
+- `ProviderApi` had no in-flight guard on the three challenge-fetch calls, so a WKWebView duplicate POST (microseconds-apart) would race for the atomic `checkAndRemoveSession` on the same sessionId; the loser saw `NO_SESSION_FOUND`. A per-`(path, sessionId)` in-flight dedupe now attaches duplicate calls to the same Promise. Entry drops on settle, so a genuine retry after a real network error still fires a fresh POST; skipped when there's no sessionId to race on.

--- a/packages/api/src/api/ProviderApi.ts
+++ b/packages/api/src/api/ProviderApi.ts
@@ -108,10 +108,7 @@ export default class ProviderApi
 	//
 	// Skipped when sessionId is absent — those calls carry no shared server
 	// state to race on.
-	private readonly inFlightChallenges = new Map<
-		string,
-		Promise<unknown>
-	>();
+	private readonly inFlightChallenges = new Map<string, Promise<unknown>>();
 
 	private dedupedPost<T, U>(
 		path: string,
@@ -121,9 +118,7 @@ export default class ProviderApi
 	): Promise<T> {
 		if (!sessionId) return this.post<T, U>(path, body, init);
 		const key = `${path}|${sessionId}`;
-		const existing = this.inFlightChallenges.get(key) as
-			| Promise<T>
-			| undefined;
+		const existing = this.inFlightChallenges.get(key) as Promise<T> | undefined;
 		if (existing) return existing;
 		const p = this.post<T, U>(path, body, init).finally(() => {
 			this.inFlightChallenges.delete(key);

--- a/packages/api/src/api/ProviderApi.ts
+++ b/packages/api/src/api/ProviderApi.ts
@@ -85,6 +85,53 @@ export default class ProviderApi
 	extends ApiClient
 	implements ProviderApiInterface
 {
+	// In-flight-only dedupe for the three challenge-fetch endpoints.
+	// Keyed by `${path}|${sessionId}`. If a call for a (path, sessionId)
+	// is already in flight, subsequent calls with the same key attach to
+	// the same Promise instead of sending a second POST.
+	//
+	// Motivation: iPhone WKWebView has been observed firing duplicate POSTs
+	// within microseconds of each other (see the "No session found" incident
+	// on 2026-07-01 07:51:32 — two distinct `/captcha/pow` requests hit the
+	// provider 55 µs apart with the same sessionId). The first call
+	// atomically consumes the session via `checkAndRemoveSession`; the
+	// second lands on a deleted session and returns
+	// `CAPTCHA.NO_SESSION_FOUND`. Deduping in-flight collapses those two
+	// POSTs into one.
+	//
+	// Only in-flight — not resolved-and-cached. Once the request settles we
+	// drop the entry so a legitimate retry after a network error can start
+	// a fresh POST. If the server did consume the sessionId, the retry
+	// will surface the same NO_SESSION_FOUND at that point instead of
+	// being masked here, which is the correct behaviour: the retry needs
+	// a fresh /frictionless.
+	//
+	// Skipped when sessionId is absent — those calls carry no shared server
+	// state to race on.
+	private readonly inFlightChallenges = new Map<
+		string,
+		Promise<unknown>
+	>();
+
+	private dedupedPost<T, U>(
+		path: string,
+		sessionId: string | undefined,
+		body: U,
+		init: RequestInit,
+	): Promise<T> {
+		if (!sessionId) return this.post<T, U>(path, body, init);
+		const key = `${path}|${sessionId}`;
+		const existing = this.inFlightChallenges.get(key) as
+			| Promise<T>
+			| undefined;
+		if (existing) return existing;
+		const p = this.post<T, U>(path, body, init).finally(() => {
+			this.inFlightChallenges.delete(key);
+		});
+		this.inFlightChallenges.set(key, p);
+		return p;
+	}
+
 	public getCaptchaChallenge(
 		userAccount: string,
 		_randomProvider: RandomProvider,
@@ -102,12 +149,17 @@ export default class ProviderApi
 		if (simdReadings) {
 			body[ApiParams.simdReadings] = simdReadings;
 		}
-		return this.post(ClientApiPaths.GetImageCaptchaChallenge, body, {
-			headers: {
-				"Prosopo-Site-Key": this.account,
-				"Prosopo-User": userAccount,
+		return this.dedupedPost<CaptchaResponseBody, CaptchaRequestBodyType>(
+			ClientApiPaths.GetImageCaptchaChallenge,
+			sessionId,
+			body,
+			{
+				headers: {
+					"Prosopo-Site-Key": this.account,
+					"Prosopo-User": userAccount,
+				},
 			},
-		});
+		);
 	}
 
 	public submitCaptchaSolution(
@@ -187,7 +239,10 @@ export default class ProviderApi
 			...(sessionId && { [ApiParams.sessionId]: sessionId }),
 			...(simdReadings && { [ApiParams.simdReadings]: simdReadings }),
 		};
-		return this.post(ClientApiPaths.GetPowCaptchaChallenge, body, {
+		return this.dedupedPost<
+			GetPowCaptchaResponse,
+			GetPowCaptchaChallengeRequestBodyType
+		>(ClientApiPaths.GetPowCaptchaChallenge, sessionId, body, {
 			headers: {
 				"Prosopo-Site-Key": this.account,
 				"Prosopo-User": user,
@@ -249,7 +304,10 @@ export default class ProviderApi
 			...(sessionId && { [ApiParams.sessionId]: sessionId }),
 			...(simdReadings && { [ApiParams.simdReadings]: simdReadings }),
 		};
-		return this.post(ClientApiPaths.GetPuzzleCaptchaChallenge, body, {
+		return this.dedupedPost<
+			GetPuzzleCaptchaResponse,
+			GetPuzzleCaptchaChallengeRequestBodyType
+		>(ClientApiPaths.GetPuzzleCaptchaChallenge, sessionId, body, {
 			headers: {
 				"Prosopo-Site-Key": this.account,
 				"Prosopo-User": user,

--- a/packages/procaptcha-frictionless/src/ProcaptchaFrictionless.tsx
+++ b/packages/procaptcha-frictionless/src/ProcaptchaFrictionless.tsx
@@ -275,14 +275,33 @@ export const ProcaptchaFrictionless = ({
 		});
 	};
 
-	// biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
+	// Track which config identity has already been started for. Host
+	// pages often recreate the `callbacks` object (and sometimes the whole
+	// `config`) on every render, which — before this guard — re-fired
+	// the outer effect on every parent re-render and triggered a fresh
+	// `/frictionless` call each time. On the 2026-07-01 iPhone WKWebView
+	// incident we saw three frictionless calls fan out in 3 ms for the
+	// same user and site key, each carrying its own sessionId, producing
+	// "No session found" cascades and eventually an image-escalation
+	// storm.
+	//
+	// Dep list is now the primitive identity of the widget (site key +
+	// language + mode); the per-identity ref guard makes React StrictMode
+	// double-invocation and same-identity re-renders idempotent.
+	// `callbacks` and `detectBot` intentionally do NOT participate —
+	// they're read via the closure captured by `start()` at call time,
+	// so the latest values are still visible without triggering effect
+	// re-runs.
+	const startedForKeyRef = useRef<string | null>(null);
+	// biome-ignore lint/correctness/useExhaustiveDependencies: intentional — see comment above.
 	useEffect(() => {
-		const detectAndSetComponent = async () => {
-			await start();
-		};
-
-		detectAndSetComponent();
-	}, [config, callbacks, detectBot, config.language]);
+		const key = `${config.account?.address ?? ""}|${config.language ?? ""}|${
+			config.mode ?? ""
+		}`;
+		if (startedForKeyRef.current === key) return;
+		startedForKeyRef.current = key;
+		void start();
+	}, [config.account?.address, config.language, config.mode]);
 
 	return (
 		<>


### PR DESCRIPTION
## Summary

- **`ProcaptchaFrictionless`**: narrow the outer `useEffect` deps from `[config, callbacks, detectBot, config.language]` → `[config.account?.address, config.language, config.mode]` and add a `startedForKeyRef` per-identity guard so parent-side callback churn (host page re-renders that recreate `callbacks`) stops re-firing `/frictionless`.
- **`ProviderApi`**: add an in-flight-only dedupe keyed by `(path, sessionId)` on `getCaptchaChallenge` / `getPowCaptchaChallenge` / `getPuzzleCaptchaChallenge`. Concurrent duplicate POSTs (WKWebView pattern) attach to the same Promise instead of racing for the atomic session-consume. Entry drops on settle so genuine retries after real network errors still work; skipped when there's no sessionId to race on.

## Root cause

`captchaManager.isValidRequest` atomically consumes the session on the first `/captcha/{type}` POST via `checkAndRemoveSession`. When the client sent the same POST twice within microseconds — either because WKWebView duplicated it, or because the frictionless widget mounted twice and both mounts fired a challenge fetch — the second POST landed on the now-deleted session and returned `CAPTCHA.NO_SESSION_FOUND`. That surfaced to the user as the "No session found" placeholder, which then triggered the widget's built-in restart, kicking off further `/frictionless` cascades.

Observed on Twickets (iPhone WKWebView, IP 82.43.214.180, 2026-07-01 07:51:32 UTC):

```
928048  rid=3NKyP2XBu556  sid=pronode15-aba23644  PoW added → 200
928117  rid=uWwzQoxgYufI  sid=pronode15-aba23644  "No session found"
```

Same well-formed sessionId on both requests, 55 µs apart. The sessionId wasn't missing — it was being used twice in parallel, and the atomic consume let only one through.

## Scope

Frontend only. The related decision-machine change (loosening R2 for WebView based on a 7 d cohort study) lives in the private decision-machines repo and is not in this PR.

## Test plan

- [ ] `npm run -w @prosopo/api build:tsc` clean
- [ ] `npm run -w @prosopo/procaptcha-frictionless build:tsc` clean
- [ ] Manual: iPhone WKWebView on Twickets frictionless flow — no `NO_SESSION_FOUND`, no fan-out of `/captcha/pow` calls per sessionId, single `/frictionless` per widget mount.
- [ ] Manual: iPhone Safari on Twickets website — regression check, unchanged.
- [ ] Manual (dev): React StrictMode double-mount still results in at most one `/frictionless` per widget identity.
- [ ] Manual: host page that recreates `callbacks` on every render — verify no repeated frictionless calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)