### PR TITLE
fix(procaptcha-frictionless,pow,puzzle,react): auto-recover from CAPTCHA.NO_SESSION_FOUND preserving click coords

### DIFF
--- a/.changeset/session-invalidated-recovery-preserving-coords.md
+++ b/.changeset/session-invalidated-recovery-preserving-coords.md
@@ -1,0 +1,16 @@
+---
+"@prosopo/types": patch
+"@prosopo/procaptcha-frictionless": patch
+"@prosopo/procaptcha-pow": patch
+"@prosopo/procaptcha-puzzle": patch
+"@prosopo/procaptcha-react": patch
+---
+
+fix(procaptcha-frictionless,procaptcha-pow,procaptcha-puzzle,procaptcha-react): auto-recover from `CAPTCHA.NO_SESSION_FOUND` on the inner widget without asking the user to click the checkbox a second time, and without dropping the click coordinates that would otherwise land in the solution salt as `(0, 0)`.
+
+Motivation. The in-flight dedupe added in the previous change only collapses `/captcha/{type}` POSTs that overlap in flight. A duplicate POST that fires ~1 s after the first has already settled (observed on iPhone WKWebView, incident 2026-07-01 21:23 UTC) still lands on a consumed session and returns `NO_SESSION_FOUND`. The pre-existing recovery for that case was a `setTimeout(restart, 100)` that tore the whole widget down and lost the checkbox click position.
+
+- `ProcaptchaProps` gains two optional props: `onSessionInvalidated(x?, y?)` and `startCoords: { x, y }`. Widgets not mounted under a recovery-aware parent still fall back to `frictionlessState.restart()`.
+- `procaptcha-pow`, `procaptcha-puzzle`, and `procaptcha-react` widgets now track the last `manager.start(x, y)` coords in a ref (either from the checkbox click or from `startCoords`) and, on the first `CAPTCHA.NO_SESSION_FOUND`, invoke `onSessionInvalidated(x, y)` instead of calling `restart()`. A per-instance ref makes it strictly one-shot — a second failure falls back to the existing restart path so a persistently broken session doesn't loop.
+- `ProcaptchaFrictionless` wires `onSessionInvalidated` through to each inner widget: it stashes the retry coords in a ref, re-runs its own `start()` (which re-invokes `/frictionless` and mints a fresh sessionId), then re-mounts the inner widget with `autoStart={true}` and `startCoords={x, y}`. The inner widget auto-fires `manager.start(x, y)` on mount so the eventual submit still embeds the real checkbox click position in the salt.
+- The recovery decision (one-shot fire, coord validation — `(0, 0)` and partial pairs are discarded because they're what an `autoStart` mount or an untrusted pointer event emits rather than a real click, and the consume-and-clear pending-coords ref) is extracted into `sessionInvalidatedRecovery.ts` with dedicated unit tests.

--- a/packages/procaptcha-frictionless/src/ProcaptchaFrictionless.tsx
+++ b/packages/procaptcha-frictionless/src/ProcaptchaFrictionless.tsx
@@ -30,6 +30,11 @@ import {
 import { darkTheme, lightTheme } from "@prosopo/widget-skeleton";
 import { useEffect, useRef, useState } from "react";
 import customDetectBot from "./customDetectBot.js";
+import {
+	type RetryCoords,
+	consumeRetryMountProps,
+	handleSessionInvalidated,
+} from "./sessionInvalidatedRecovery.js";
 
 // Each session uses exactly one solver — chosen by the /frictionless response.
 const ProcaptchaLoader = async () =>
@@ -89,6 +94,16 @@ export const ProcaptchaFrictionless = ({
 }: ProcaptchaFrictionlessProps) => {
 	const stateRef = useRef(defaultLoadingState(0));
 	const events = getDefaultEvents(callbacks);
+	// Coords carried over from an `onSessionInvalidated` event on the inner
+	// widget. Consumed once by the next `renderForCaptchaType` — the resumed
+	// widget mounts with `autoStart` + `startCoords` so the user doesn't have
+	// to click the checkbox a second time and the checkbox click position is
+	// preserved in the eventual solution salt.
+	const pendingRetryCoordsRef = useRef<RetryCoords | null>(null);
+	// One-shot outer guard so a persistently broken session doesn't loop.
+	// After we've retried once, a second NO_SESSION_FOUND falls back to the
+	// inner widget's own `frictionlessState.restart()` path.
+	const sessionInvalidatedFiredRef = useRef(false);
 
 	useEffect(() => {
 		if (config.language) {
@@ -175,6 +190,35 @@ export const ProcaptchaFrictionless = ({
 			);
 		};
 
+		// The provider returned NO_SESSION_FOUND on the inner widget's
+		// challenge fetch — the sessionId minted upstream is no longer usable
+		// (usually because a duplicate /captcha/{type} POST from a WebView
+		// mount storm consumed it first). Re-run the frictionless flow to
+		// mint a fresh session, then re-mount the inner widget with the
+		// preserved checkbox click coords so the user is not asked to click a
+		// second time. One-shot per outer widget lifetime — if the retry
+		// also fails, fall through to the inner widget's existing
+		// `frictionlessState.restart()` path.
+		const onSessionInvalidated = (x?: number, y?: number) => {
+			const { shouldRestart } = handleSessionInvalidated(
+				x,
+				y,
+				sessionInvalidatedFiredRef,
+				pendingRetryCoordsRef,
+			);
+			if (!shouldRestart) return;
+			resetState(0);
+			void start();
+		};
+
+		// Consume any pending retry coords now — the resumed widget owns them
+		// for exactly one auto-fired `manager.start(x, y)`. Cleared so a
+		// subsequent escalation/re-render doesn't accidentally re-inject.
+		const { autoStart: resumedAutoStart, startCoords } = consumeRetryMountProps(
+			pendingRetryCoordsRef,
+			autoStart,
+		);
+
 		if (captchaType === CaptchaType.image) {
 			const Procaptcha = await ProcaptchaLoader();
 			setComponentToRender(
@@ -183,7 +227,9 @@ export const ProcaptchaFrictionless = ({
 					callbacks={callbacks}
 					frictionlessState={frictionlessState}
 					i18n={i18n}
-					autoStart={autoStart}
+					autoStart={resumedAutoStart}
+					startCoords={startCoords}
+					onSessionInvalidated={onSessionInvalidated}
 				/>,
 			);
 		} else if (captchaType === CaptchaType.puzzle) {
@@ -194,7 +240,9 @@ export const ProcaptchaFrictionless = ({
 					callbacks={callbacks}
 					frictionlessState={frictionlessState}
 					i18n={i18n}
-					autoStart={autoStart}
+					autoStart={resumedAutoStart}
+					startCoords={startCoords}
+					onSessionInvalidated={onSessionInvalidated}
 				/>,
 			);
 		} else {
@@ -206,6 +254,9 @@ export const ProcaptchaFrictionless = ({
 					frictionlessState={frictionlessState}
 					i18n={i18n}
 					onEscalate={onEscalate}
+					autoStart={resumedAutoStart}
+					startCoords={startCoords}
+					onSessionInvalidated={onSessionInvalidated}
 				/>,
 			);
 		}

--- a/packages/procaptcha-frictionless/src/sessionInvalidatedRecovery.ts
+++ b/packages/procaptcha-frictionless/src/sessionInvalidatedRecovery.ts
@@ -1,0 +1,78 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Shared, unit-testable pieces of the ProcaptchaFrictionless recovery path
+// for CAPTCHA.NO_SESSION_FOUND on the inner widget. The React component
+// mutates refs directly; these helpers isolate the logic that decides how a
+// re-mount should be parameterised so it can be exercised without a renderer.
+
+export type RetryCoords = { x: number; y: number };
+
+/**
+ * Ref-like container used by ProcaptchaFrictionless. Extracted so tests
+ * can pass a plain `{current}` object.
+ */
+export type MutableRef<T> = { current: T };
+
+/**
+ * Semantics of the outer recovery handler. Returns whether the caller
+ * should proceed to re-run the frictionless flow (`start()`), and mutates
+ * the passed refs to record the one-shot fire + pending coords.
+ *
+ * - Second calls are ignored (one-shot per outer widget lifetime) so a
+ *   persistently broken session doesn't loop.
+ * - Coords are recorded only for a real trusted checkbox click. A partial
+ *   pair (only x or only y numeric) is treated as "no coords" so we
+ *   never accidentally embed `NaN` into the solution salt.
+ * - `(0, 0)` is treated as "no coords" too — that's what the widgets
+ *   emit for an `autoStart` mount (post-PoW escalation) or an untrusted
+ *   pointer event on the checkbox, neither of which is a real click. The
+ *   resumed widget re-uses the same default and the outcome on the wire
+ *   is identical; we discard the pair here so future readers can tell
+ *   the two apart.
+ */
+export const handleSessionInvalidated = (
+	x: number | undefined,
+	y: number | undefined,
+	firedRef: MutableRef<boolean>,
+	pendingCoordsRef: MutableRef<RetryCoords | null>,
+): { shouldRestart: boolean } => {
+	if (firedRef.current) return { shouldRestart: false };
+	firedRef.current = true;
+	const bothNumeric = typeof x === "number" && typeof y === "number";
+	const isRealClick = bothNumeric && (x !== 0 || y !== 0);
+	pendingCoordsRef.current = isRealClick ? { x, y } : null;
+	return { shouldRestart: true };
+};
+
+/**
+ * Compute the props a resumed inner widget mounts with. Consumes the
+ * pending coords ref (sets it back to `null`) so the next render doesn't
+ * accidentally re-inject stale coords into a fresh escalation.
+ *
+ * `escalationAutoStart` reflects the caller's own `autoStart` argument to
+ * `renderForCaptchaType` — post-PoW escalations keep the historic
+ * autoStart=true behaviour when no retry coords are pending.
+ */
+export const consumeRetryMountProps = (
+	pendingCoordsRef: MutableRef<RetryCoords | null>,
+	escalationAutoStart: boolean,
+): { autoStart: boolean; startCoords: RetryCoords | undefined } => {
+	const startCoords = pendingCoordsRef.current ?? undefined;
+	pendingCoordsRef.current = null;
+	return {
+		autoStart: escalationAutoStart || Boolean(startCoords),
+		startCoords,
+	};
+};

--- a/packages/procaptcha-frictionless/src/tests/sessionInvalidatedRecovery.test.ts
+++ b/packages/procaptcha-frictionless/src/tests/sessionInvalidatedRecovery.test.ts
@@ -1,0 +1,129 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, expect, it } from "vitest";
+import {
+	type MutableRef,
+	type RetryCoords,
+	consumeRetryMountProps,
+	handleSessionInvalidated,
+} from "../sessionInvalidatedRecovery.js";
+
+const ref = <T>(initial: T): MutableRef<T> => ({ current: initial });
+
+describe("handleSessionInvalidated", () => {
+	it("records both coords and signals a restart on the first fire", () => {
+		const firedRef = ref(false);
+		const coordsRef = ref<RetryCoords | null>(null);
+
+		const result = handleSessionInvalidated(120, 340, firedRef, coordsRef);
+
+		expect(result).toEqual({ shouldRestart: true });
+		expect(firedRef.current).toBe(true);
+		expect(coordsRef.current).toEqual({ x: 120, y: 340 });
+	});
+
+	it("treats (0, 0) as 'no coords' — that's the autoStart / untrusted-event default, not a real click", () => {
+		const firedRef = ref(false);
+		const coordsRef = ref<RetryCoords | null>(null);
+
+		const result = handleSessionInvalidated(0, 0, firedRef, coordsRef);
+
+		expect(result).toEqual({ shouldRestart: true });
+		expect(coordsRef.current).toBeNull();
+	});
+
+	it("carries a real click even if only one axis is at the origin", () => {
+		const firedRef = ref(false);
+		const coordsRef = ref<RetryCoords | null>(null);
+
+		handleSessionInvalidated(0, 340, firedRef, coordsRef);
+
+		expect(coordsRef.current).toEqual({ x: 0, y: 340 });
+	});
+
+	it("stores no coords when x or y is undefined (autoStart / non-trusted event)", () => {
+		const firedRef = ref(false);
+		const coordsRef = ref<RetryCoords | null>(null);
+
+		const result = handleSessionInvalidated(
+			undefined,
+			undefined,
+			firedRef,
+			coordsRef,
+		);
+
+		expect(result).toEqual({ shouldRestart: true });
+		expect(firedRef.current).toBe(true);
+		expect(coordsRef.current).toBeNull();
+	});
+
+	it("stores no coords when only one axis is present — never emit NaN into the salt", () => {
+		const firedRef = ref(false);
+		const coordsRef = ref<RetryCoords | null>(null);
+
+		handleSessionInvalidated(120, undefined, firedRef, coordsRef);
+
+		expect(coordsRef.current).toBeNull();
+	});
+
+	it("is one-shot per outer widget lifetime — a second call is a no-op", () => {
+		const firedRef = ref(false);
+		const coordsRef = ref<RetryCoords | null>(null);
+
+		handleSessionInvalidated(100, 200, firedRef, coordsRef);
+		const second = handleSessionInvalidated(500, 600, firedRef, coordsRef);
+
+		expect(second).toEqual({ shouldRestart: false });
+		// The second call must not overwrite the first attempt's coords.
+		expect(coordsRef.current).toEqual({ x: 100, y: 200 });
+	});
+});
+
+describe("consumeRetryMountProps", () => {
+	it("returns pending retry coords and forces autoStart", () => {
+		const coordsRef = ref<RetryCoords | null>({ x: 42, y: 99 });
+
+		const mount = consumeRetryMountProps(coordsRef, false);
+
+		expect(mount).toEqual({
+			autoStart: true,
+			startCoords: { x: 42, y: 99 },
+		});
+	});
+
+	it("clears the coords ref so a subsequent render doesn't re-inject stale values", () => {
+		const coordsRef = ref<RetryCoords | null>({ x: 42, y: 99 });
+
+		consumeRetryMountProps(coordsRef, false);
+
+		expect(coordsRef.current).toBeNull();
+	});
+
+	it("propagates escalationAutoStart when no retry is pending (post-PoW escalation path)", () => {
+		const coordsRef = ref<RetryCoords | null>(null);
+
+		const mount = consumeRetryMountProps(coordsRef, true);
+
+		expect(mount).toEqual({ autoStart: true, startCoords: undefined });
+	});
+
+	it("returns autoStart=false, startCoords=undefined for the initial checkbox mount", () => {
+		const coordsRef = ref<RetryCoords | null>(null);
+
+		const mount = consumeRetryMountProps(coordsRef, false);
+
+		expect(mount).toEqual({ autoStart: false, startCoords: undefined });
+	});
+});

--- a/packages/procaptcha-pow/src/components/ProcaptchaWidget.tsx
+++ b/packages/procaptcha-pow/src/components/ProcaptchaWidget.tsx
@@ -46,6 +46,15 @@ const Procaptcha = (props: ProcaptchaProps) => {
 			() => hpRef.current?.value || undefined,
 		),
 	);
+	// Coordinates of the last `manager.start(x, y)` invocation from this widget
+	// instance — either the checkbox click, or a `startCoords` handoff from a
+	// prior `onSessionInvalidated` cycle. Held in a ref so the current values
+	// survive re-renders and are readable from the `state.error` effect.
+	const lastCoordsRef = useRef<{ x: number; y: number } | null>(null);
+	// One-shot guard: a widget instance only escalates a single NO_SESSION_FOUND
+	// to `onSessionInvalidated`. If the retry also fails, we fall through to
+	// the pre-existing `frictionlessState.restart()` path instead of looping.
+	const sessionInvalidatedFiredRef = useRef(false);
 
 	useEffect(() => {
 		if (config.language) {
@@ -63,15 +72,37 @@ const Procaptcha = (props: ProcaptchaProps) => {
 	}, [i18n, config.language]);
 
 	useEffect(() => {
-		if (state.error) {
+		if (!props.autoStart) return;
+		setLoading(true);
+		const coords = props.startCoords;
+		lastCoordsRef.current = coords ?? null;
+		manager.current.start(coords?.x ?? 0, coords?.y ?? 0).finally(() => {
 			setLoading(false);
-			if (state.error.key === "CAPTCHA.NO_SESSION_FOUND" && frictionlessState) {
-				setTimeout(() => {
-					frictionlessState.restart();
-				}, 100);
-			}
+		});
+	}, [props.autoStart, props.startCoords]);
+
+	useEffect(() => {
+		if (!state.error) return;
+		setLoading(false);
+		if (state.error.key !== "CAPTCHA.NO_SESSION_FOUND") return;
+		if (props.onSessionInvalidated && !sessionInvalidatedFiredRef.current) {
+			// Preserve the checkbox coords across the retry so the resumed
+			// submit still carries the real entry-point telemetry. The
+			// frictionless wrapper mints a fresh session and re-mounts this
+			// widget with matching `autoStart` + `startCoords`.
+			sessionInvalidatedFiredRef.current = true;
+			const coords = lastCoordsRef.current;
+			props.onSessionInvalidated(coords?.x, coords?.y);
+			return;
 		}
-	}, [state.error, frictionlessState]);
+		if (frictionlessState) {
+			// Fallback for widgets not mounted under a recovery-aware parent,
+			// or a second NO_SESSION_FOUND after we've already retried once.
+			setTimeout(() => {
+				frictionlessState.restart();
+			}, 100);
+		}
+	}, [state.error, frictionlessState, props.onSessionInvalidated]);
 
 	// Add event listener for the execute event (works for invisible mode)
 	useEffect(() => {
@@ -149,6 +180,7 @@ const Procaptcha = (props: ProcaptchaProps) => {
 						y = mouseOrTouchEvent.clientY;
 					}
 
+					lastCoordsRef.current = { x, y };
 					await manager.current.start(x, y);
 					setLoading(false);
 				}}

--- a/packages/procaptcha-puzzle/src/components/ProcaptchaWidget.tsx
+++ b/packages/procaptcha-puzzle/src/components/ProcaptchaWidget.tsx
@@ -57,6 +57,10 @@ const Procaptcha = (props: ProcaptchaProps) => {
 			() => hpRef.current?.value || undefined,
 		),
 	);
+	// See ProcaptchaWidget (procaptcha-pow) — same session-invalidation
+	// recovery contract with coords preservation across a re-mint.
+	const lastCoordsRef = useRef<{ x: number; y: number } | null>(null);
+	const sessionInvalidatedFiredRef = useRef(false);
 
 	useEffect(() => {
 		if (config.language) {
@@ -74,21 +78,22 @@ const Procaptcha = (props: ProcaptchaProps) => {
 	}, [i18n, config.language]);
 
 	useEffect(() => {
-		if (props.autoStart) {
-			setLoading(true);
-			setShowRetry(false);
-			manager.current.start().then(
-				(challenge) => {
-					if (challenge) {
-						setChallengeData(challenge);
-						setPuzzlePhase("dragging");
-					}
-					setLoading(false);
-				},
-				() => setLoading(false),
-			);
-		}
-	}, [props.autoStart]);
+		if (!props.autoStart) return;
+		setLoading(true);
+		setShowRetry(false);
+		const coords = props.startCoords;
+		lastCoordsRef.current = coords ?? null;
+		manager.current.start(coords?.x ?? 0, coords?.y ?? 0).then(
+			(challenge) => {
+				if (challenge) {
+					setChallengeData(challenge);
+					setPuzzlePhase("dragging");
+				}
+				setLoading(false);
+			},
+			() => setLoading(false),
+		);
+	}, [props.autoStart, props.startCoords]);
 
 	useEffect(() => {
 		if (!state.error) return undefined;
@@ -96,14 +101,21 @@ const Procaptcha = (props: ProcaptchaProps) => {
 		setPuzzlePhase("checkbox");
 		setChallengeData(null);
 		setShowRetry(false);
-		if (state.error.key === "CAPTCHA.NO_SESSION_FOUND" && frictionlessState) {
+		if (state.error.key !== "CAPTCHA.NO_SESSION_FOUND") return undefined;
+		if (props.onSessionInvalidated && !sessionInvalidatedFiredRef.current) {
+			sessionInvalidatedFiredRef.current = true;
+			const coords = lastCoordsRef.current;
+			props.onSessionInvalidated(coords?.x, coords?.y);
+			return undefined;
+		}
+		if (frictionlessState) {
 			const timer = setTimeout(() => {
 				frictionlessState.restart();
 			}, 100);
 			return () => clearTimeout(timer);
 		}
 		return undefined;
-	}, [state.error, frictionlessState]);
+	}, [state.error, frictionlessState, props.onSessionInvalidated]);
 
 	// Add event listener for the execute event (works for invisible mode)
 	useEffect(() => {
@@ -256,6 +268,7 @@ const Procaptcha = (props: ProcaptchaProps) => {
 							y = mouseOrTouchEvent.clientY;
 						}
 
+						lastCoordsRef.current = { x, y };
 						const challenge = await manager.current.start(x, y);
 
 						if (challenge) {

--- a/packages/procaptcha-react/src/components/ProcaptchaWidget.tsx
+++ b/packages/procaptcha-react/src/components/ProcaptchaWidget.tsx
@@ -56,6 +56,10 @@ const ProcaptchaWidget = (props: ProcaptchaProps) => {
 			() => hpRef.current?.value || undefined,
 		),
 	);
+	// See procaptcha-pow ProcaptchaWidget — same session-invalidation
+	// recovery contract with coords preservation across a re-mint.
+	const lastCoordsRef = useRef<{ x: number; y: number } | null>(null);
+	const sessionInvalidatedFiredRef = useRef(false);
 	const theme = "light" === props.config.theme ? lightTheme : darkTheme;
 
 	useEffect(() => {
@@ -73,27 +77,33 @@ const ProcaptchaWidget = (props: ProcaptchaProps) => {
 		}
 	}, [i18n, config.language]);
 
-	// biome-ignore lint/correctness/useExhaustiveDependencies: manager.current is stable across renders
 	useEffect(() => {
-		if (props.autoStart) {
-			setLoading(true);
-			manager.current.start().then(
-				() => setLoading(false),
-				() => setLoading(false),
-			);
-		}
-	}, [props.autoStart]);
+		if (!props.autoStart) return;
+		setLoading(true);
+		const coords = props.startCoords;
+		lastCoordsRef.current = coords ?? null;
+		manager.current.start(coords?.x ?? 0, coords?.y ?? 0).then(
+			() => setLoading(false),
+			() => setLoading(false),
+		);
+	}, [props.autoStart, props.startCoords]);
 
 	useEffect(() => {
-		if (state.error) {
-			setLoading(false);
-			if (state.error.key === "CAPTCHA.NO_SESSION_FOUND" && frictionlessState) {
-				setTimeout(() => {
-					frictionlessState.restart();
-				}, 100);
-			}
+		if (!state.error) return;
+		setLoading(false);
+		if (state.error.key !== "CAPTCHA.NO_SESSION_FOUND") return;
+		if (props.onSessionInvalidated && !sessionInvalidatedFiredRef.current) {
+			sessionInvalidatedFiredRef.current = true;
+			const coords = lastCoordsRef.current;
+			props.onSessionInvalidated(coords?.x, coords?.y);
+			return;
 		}
-	}, [state.error, frictionlessState]);
+		if (frictionlessState) {
+			setTimeout(() => {
+				frictionlessState.restart();
+			}, 100);
+		}
+	}, [state.error, frictionlessState, props.onSessionInvalidated]);
 
 	// Add event listener for the execute event
 	useEffect(() => {
@@ -201,6 +211,7 @@ const ProcaptchaWidget = (props: ProcaptchaProps) => {
 						y = nativeEvent.clientY;
 					}
 
+					lastCoordsRef.current = { x, y };
 					await manager.current.start(x, y);
 					setLoading(false);
 				}}

--- a/packages/types/src/procaptcha/props.ts
+++ b/packages/types/src/procaptcha/props.ts
@@ -98,4 +98,17 @@ export interface ProcaptchaProps {
 	// for a checkbox click. Set by ProcaptchaFrictionless after a PoW
 	// escalation so the user doesn't have to click the checkbox a second time.
 	autoStart?: boolean;
+	// Called by the inner widget when the provider returns
+	// CAPTCHA.NO_SESSION_FOUND on the challenge fetch. The frictionless
+	// wrapper re-runs the frictionless flow to mint a new sessionId and
+	// re-mounts the widget in place. Coords are the checkbox click position
+	// the user already made — preserved so the retried submit still carries
+	// real entry-point telemetry instead of (0, 0).
+	onSessionInvalidated?: (x?: number, y?: number) => void;
+	// When provided together with `autoStart`, the widget invokes
+	// `manager.start(x, y)` on mount with these coordinates. Used by
+	// ProcaptchaFrictionless to resume a fresh session after
+	// `onSessionInvalidated` fires without asking the user to click the
+	// checkbox a second time.
+	startCoords?: { x: number; y: number };
 }


### PR DESCRIPTION
## Summary

Follow-up to #2790. That change deduped in-flight `/captcha/{type}` POSTs, but a duplicate that fires ~1 s after the first has already settled (iPhone WKWebView, incident 2026-07-01 21:23 UTC) still lands on a consumed session and returns `CAPTCHA.NO_SESSION_FOUND`. The pre-existing recovery was `setTimeout(frictionlessState.restart, 100)` which tore the whole widget down and dropped the checkbox click coordinates the user had already provided — meaning the retried submit went in with `(0, 0)` in the salt and the server treated it as an autoStart mount.

This PR:

- Adds `onSessionInvalidated(x?, y?)` + `startCoords: { x, y }` to `ProcaptchaProps`.
- `procaptcha-pow`, `procaptcha-puzzle` and `procaptcha-react` widgets track the last `manager.start(x, y)` coords in a ref and, on the first `CAPTCHA.NO_SESSION_FOUND`, invoke `onSessionInvalidated(x, y)` instead of `restart()`. Per-instance ref makes it strictly one-shot; a second failure falls back to the historic restart path so a persistently broken session can't loop.
- `ProcaptchaFrictionless` handles `onSessionInvalidated`: stashes the coords, re-runs its own `start()` (fresh `/frictionless` call → fresh sessionId), then re-mounts the inner widget with `autoStart={true}` and `startCoords={x, y}`. Inner widget auto-fires `manager.start(x, y)` on mount so the eventual submit still carries the real click position.
- `(0, 0)` and partial coord pairs are discarded because they're what an `autoStart` mount (post-PoW escalation) or an untrusted pointer event emits rather than a real click.
- Recovery decision extracted to `sessionInvalidatedRecovery.ts` (`handleSessionInvalidated`, `consumeRetryMountProps`) — pure, framework-free, 100% covered by 10 unit tests.

Widgets not mounted under a recovery-aware parent still fall back to `frictionlessState.restart()`, so this is safe for any dapp that imports `procaptcha-pow` / `procaptcha` / `procaptcha-puzzle` directly.

## Test plan

- [x] `procaptcha-frictionless` test suite passes (18/18, 10 new)
- [x] `sessionInvalidatedRecovery.ts` 100% branch/statement coverage
- [x] `@prosopo/procaptcha-bundle build:tsc` clean
- [x] `biome check` clean on all changed files
- [ ] Manual: iPhone Safari WKWebView on Twickets — click checkbox, observe recovery to fresh session without a full widget teardown; verify submit salt carries real click position via provider logs
- [ ] Manual: regression check on post-PoW escalation (should still auto-fire `manager.start(0, 0)` on image/puzzle without carrying stale retry coords)

🤖 Generated with [Claude Code](https://claude.com/claude-code)