### PR TITLE
fix(provider): skip datacenter block when provider is a consumer ISP

### DIFF
--- a/.changeset/datacenter-block-skip-isp.md
+++ b/.changeset/datacenter-block-skip-isp.md
@@ -1,0 +1,11 @@
+---
+"@prosopo/provider": patch
+---
+
+fix(provider): skip the datacenter traffic-filter block when upstream classifies the provider as a consumer ISP (`providerType === "isp"`).
+
+Motivation. Consumer ISPs like Afrihost (AS37611), Comcast, and BT are occasionally flagged `is_datacenter=true` by the upstream classifier because part of their ASN hosts B2B or hosting services, but the eyeball ranges behind those ASNs carry ordinary end-users. Observed on prod at commitment `0xd3f919c0…fa03` (provider `pronode15`): a real user in Johannesburg on `165.73.62.88` was rejected with `API.DATACENTER_BLOCKED` despite the same payload reporting `providerType: "isp"` and `asnOrganization: "AFRIHOST SP (PTY) LTD"`. The `providerType` categorisation is stronger evidence of consumer traffic than the `isDatacenter` boolean.
+
+- `checkTrafficFilter` short-circuits the datacenter rule when `ipInfo.providerType === "isp"`. Missing `providerType` preserves the previous behaviour.
+- Earlier rules (VPN, Tor, proxy, abuser) still fire first, so the ISP flag cannot be used to bypass those checks.
+- Suppression applies to both the primary IP and the extras list.

--- a/packages/provider/src/tasks/spam/checkTrafficFilter.ts
+++ b/packages/provider/src/tasks/spam/checkTrafficFilter.ts
@@ -107,6 +107,7 @@ const evaluateIpInfo = (
 	if (
 		trafficFilter.blockDatacenter &&
 		ipInfo.isDatacenter &&
+		ipInfo.providerType !== "isp" &&
 		!(
 			options.suppressVpnDatacenterInteraction &&
 			ipInfo.isVPN &&
@@ -154,6 +155,14 @@ const evaluateIpInfo = (
  * `is_datacenter=true` by upstream but the exiting users are real humans.
  * Operators can list the datacenter, provider, or ASN organisation names
  * they want to allow through — see `isDatacenterAllowlisted`.
+ *
+ * The datacenter rule also short-circuits when upstream classifies the
+ * provider as an ISP (`providerType === "isp"`). Consumer ISPs like
+ * Afrihost, Comcast, or BT are sometimes flagged `is_datacenter=true` by
+ * upstream heuristics — usually because part of the ASN hosts B2B or
+ * hosting services — but the eyeball ranges behind those ASNs carry
+ * ordinary end-users. The ISP categorisation is stronger evidence of
+ * consumer traffic than the datacenter boolean.
  *
  * When `trafficFilter.skipExtrasOnValidDnsPath` is on and the catcher
  * confirmed the DNS path matched the connection path (`pathValid: true`),

--- a/packages/provider/src/tests/unit/tasks/spam/checkTrafficFilter.unit.test.ts
+++ b/packages/provider/src/tests/unit/tasks/spam/checkTrafficFilter.unit.test.ts
@@ -444,6 +444,94 @@ describe("checkTrafficFilter", () => {
 		});
 	});
 
+	describe("providerType ISP suppression", () => {
+		it("does not block datacenter IPs whose providerType is 'isp'", () => {
+			// Consumer ISPs (e.g. Afrihost, Comcast) are sometimes flagged
+			// is_datacenter=true by upstream but their eyeball ranges carry
+			// real end-users.
+			const result = checkTrafficFilter(
+				baseInfo({
+					isDatacenter: true,
+					providerType: "isp",
+					providerName: "afrihost.co.za",
+					asnOrganization: "AFRIHOST SP (PTY) LTD",
+				}),
+				allBlocked,
+			);
+			expect(result).toEqual({ isBlocked: false });
+		});
+
+		it("still blocks datacenter IPs when providerType is 'hosting'", () => {
+			const result = checkTrafficFilter(
+				baseInfo({ isDatacenter: true, providerType: "hosting" }),
+				allBlocked,
+			);
+			expect(result).toEqual({
+				isBlocked: true,
+				reason: "API.DATACENTER_BLOCKED",
+			});
+		});
+
+		it("still blocks datacenter IPs when providerType is missing", () => {
+			// Preserves the pre-fix behavior for upstream responses that
+			// don't carry providerType at all.
+			const result = checkTrafficFilter(
+				baseInfo({ isDatacenter: true }),
+				allBlocked,
+			);
+			expect(result).toEqual({
+				isBlocked: true,
+				reason: "API.DATACENTER_BLOCKED",
+			});
+		});
+
+		it("does not let ISP classification bypass earlier rules", () => {
+			// The ISP suppression only affects the datacenter rule. A Tor
+			// exit or VPN that also reports providerType='isp' must still
+			// trip whichever earlier rule fires first.
+			const torResult = checkTrafficFilter(
+				baseInfo({
+					isTor: true,
+					isDatacenter: true,
+					providerType: "isp",
+				}),
+				allBlocked,
+			);
+			expect(torResult).toEqual({
+				isBlocked: true,
+				reason: "API.TOR_BLOCKED",
+			});
+
+			const vpnResult = checkTrafficFilter(
+				baseInfo({
+					isVPN: true,
+					isDatacenter: true,
+					providerType: "isp",
+				}),
+				allBlocked,
+			);
+			expect(vpnResult).toEqual({
+				isBlocked: true,
+				reason: "API.VPN_BLOCKED",
+			});
+		});
+
+		it("applies ISP suppression to extra IPs as well", () => {
+			const result = checkTrafficFilter(
+				baseInfo({ ip: "192.0.2.1" }),
+				allBlocked,
+				[
+					baseInfo({
+						ip: "198.51.100.10",
+						isDatacenter: true,
+						providerType: "isp",
+					}),
+				],
+			);
+			expect(result).toEqual({ isBlocked: false });
+		});
+	});
+
 	describe("skipExtrasOnValidDnsPath", () => {
 		it("skips the extras evaluation when the catcher confirmed a valid DNS path and the setting is on", () => {
 			const result = checkTrafficFilter(


### PR DESCRIPTION
## Summary

- Adds `providerType !== "isp"` to the datacenter block condition in `checkTrafficFilter`.
- Consumer ISPs (Afrihost, Comcast, BT, etc.) are sometimes flagged `is_datacenter=true` by upstream because part of their ASN also hosts B2B services, but the eyeball ranges carry real end-users. `providerType` is stronger evidence than the datacenter boolean.
- Adds unit tests covering: ISP + datacenter → allowed; `hosting` still blocked; missing `providerType` preserves prior behavior; earlier rules (Tor, VPN) still fire; suppression applies to extras.

🤖 Generated with [Claude Code](https://claude.com/claude-code)