### PR TITLE
feat(provider): surface handshake timings + currentUrl to routing machines

### DIFF
--- a/.changeset/routing-timing-currenturl.md
+++ b/.changeset/routing-timing-currenturl.md
@@ -1,0 +1,16 @@
+---
+"@prosopo/provider": patch
+"@prosopo/types": patch
+---
+
+feat(provider): surface handshake timings and currentUrl to routing machines
+
+Extends `RoutingMachineRawSignals` with three optional fields so operator-authored routing machines can read them alongside JA4, headers, UA, and SIMD:
+
+- `tcpToChelloMs?: number`
+- `chelloToHandshakeMs?: number`
+- `currentUrl?: string`
+
+Threaded through every raw-signal construction site — the frictionless hot path, the dedup routing replay, `submitPoWCaptchaSolution`, and the postPow routing context construction. Timing values come from the current request (per-connection, fresh at every entry). `currentUrl` comes from the freshly decrypted frictionless payload at the `route` phase and from the persisted Session at the `postPow` phase, since the submit request's Referer is the captcha iframe rather than the host page.
+
+Follows the earlier PR that added the middleware capture and Session persistence for the two timing fields; this PR completes the surface by making them visible to operator-authored routers.

--- a/packages/provider/src/api/captcha/getFrictionlessCaptchaChallenge/handler.ts
+++ b/packages/provider/src/api/captcha/getFrictionlessCaptchaChallenge/handler.ts
@@ -284,6 +284,21 @@ export default (
 									headers: dedupFlatHeaders,
 									userAgent: dedupUserAgent,
 									...(req.ja4 && { ja4: req.ja4 }),
+									// Timing values are per-connection so they come from
+									// the current request even in the dedup replay path —
+									// dedup.session was created on a different TCP conn.
+									...(req.tcpToChelloMs !== undefined && {
+										tcpToChelloMs: req.tcpToChelloMs,
+									}),
+									...(req.chelloToHandshakeMs !== undefined && {
+										chelloToHandshakeMs: req.chelloToHandshakeMs,
+									}),
+									// currentUrl uses the cached session's value to
+									// match the rest of the dedup routing input (score,
+									// webView, captchaType are all pulled from dedup).
+									...(dedup.session.currentUrl && {
+										currentUrl: dedup.session.currentUrl,
+									}),
 								},
 							},
 						)
@@ -549,6 +564,13 @@ export default (
 					headers: flatHeaders,
 					userAgent: safeUserAgent,
 					...(req.ja4 && { ja4: req.ja4 }),
+					...(req.tcpToChelloMs !== undefined && {
+						tcpToChelloMs: req.tcpToChelloMs,
+					}),
+					...(req.chelloToHandshakeMs !== undefined && {
+						chelloToHandshakeMs: req.chelloToHandshakeMs,
+					}),
+					...(currentUrl && { currentUrl }),
 				},
 			});
 

--- a/packages/provider/src/api/captcha/submitPoWCaptchaSolution.ts
+++ b/packages/provider/src/api/captcha/submitPoWCaptchaSolution.ts
@@ -140,6 +140,12 @@ export default (env: ProviderEnvironment) =>
 					userAgent,
 					...(req.ja4 && { ja4: req.ja4 }),
 					...(fingerprintProof && { fingerprintProof }),
+					...(req.tcpToChelloMs !== undefined && {
+						tcpToChelloMs: req.tcpToChelloMs,
+					}),
+					...(req.chelloToHandshakeMs !== undefined && {
+						chelloToHandshakeMs: req.chelloToHandshakeMs,
+					}),
 				},
 			});
 

--- a/packages/provider/src/tasks/powCaptcha/powTasks.ts
+++ b/packages/provider/src/tasks/powCaptcha/powTasks.ts
@@ -536,6 +536,13 @@ export class PowCaptchaManager extends CaptchaManager {
 				// (decryptAndAttachSimdReadingsIfAbsent) before this re-fetch, so
 				// they are available here in decoded form for the routing machine.
 				...(sessionRecord.simdReadings && { simd: sessionRecord.simdReadings }),
+				// currentUrl was captured at frictionless time from the
+				// widget's payload — the submit request has no equivalent
+				// signal (its Referer is the captcha iframe, not the host
+				// page) so we surface it from the persisted session.
+				...(sessionRecord.currentUrl && {
+					currentUrl: sessionRecord.currentUrl,
+				}),
 			},
 		};
 

--- a/packages/types/src/decisionMachine/index.ts
+++ b/packages/types/src/decisionMachine/index.ts
@@ -227,6 +227,20 @@ export interface RoutingMachineRawSignals {
 	// surfaced here for the post-pow routing machine). Undefined when absent or
 	// unsupported on the client.
 	simd?: SimdReadings;
+	// Server-observed TLS handshake timing deltas forwarded by the chaddy
+	// Caddy plugin (X-TLS-TCP-To-Chello-Ms / X-TLS-Chello-To-Handshake-Ms).
+	// Elevated values indicate the client's ClientHello traversed a proxy
+	// chain before reaching Caddy. Undefined when the request did not
+	// traverse a chaddy-enabled ingress (e.g. dev requests, HTTP/3).
+	tcpToChelloMs?: number;
+	chelloToHandshakeMs?: number;
+	// Full page URL the widget was rendered on (origin + path only; query
+	// string, fragment and any embedded credentials are stripped client- and
+	// server-side). Available on the `route` phase from the freshly decrypted
+	// frictionless payload, and on the `postPow` phase from the persisted
+	// Session record. Undefined when the client omitted it or the session
+	// pre-dates the field.
+	currentUrl?: string;
 }
 
 export type RoutingMachinePhase = "route" | "postPow";


### PR DESCRIPTION
## Summary

Follows #2800 (which added the middleware capture and Session persistence for the two TLS handshake timing deltas) by making the same values, plus the widget's current URL, visible to operator-authored routing decision machines.

Extends \`RoutingMachineRawSignals\` with three optional fields:

- \`tcpToChelloMs?: number\`
- \`chelloToHandshakeMs?: number\`
- \`currentUrl?: string\`

Threads all three through every raw-signal construction site so both the \`route\` phase (frictionless hot path + dedup replay) and the \`postPow\` phase (submit) surface them to the router.

## Where the values come from

| Site | Timing | currentUrl |
|---|---|---|
| \`handler.ts:283\` — dedup routing replay | **request-time** (fresh TCP conn) | cached session (matches score/webView/captchaType which come from dedup) |
| \`handler.ts:548\` — main setRoutingContext | **request-time** | freshly decrypted frictionless payload |
| \`submitPoWCaptchaSolution.ts:138\` — setPostPowContext | **request-time** | deliberately not set here; attached at postPow instead |
| \`powTasks.ts:532\` — postPow routing context | survives via \`...this.postPowContext.raw\` | **from Session** — the submit request's Referer is the captcha iframe, not the host page |

## Rationale

Timing values are per-connection, so we always want the fresh value from the current request rather than a cached one. \`currentUrl\`, by contrast, is a property of the page the widget was mounted on — we capture it at frictionless time (when it's in the decrypted payload) and carry it forward through the session at postPow so operator-authored routers can key on it without depending on the submit Referer.

All three fields are optional throughout so pre-migration sessions and dev requests that skipped TLS still route cleanly.

## Test plan

- [x] \`npm run -w @prosopo/types build:tsc\` clean
- [x] \`npm run -w @prosopo/provider build:tsc\` clean
- [x] \`npx biome check\` on all touched files clean
- [x] \`npm run changesets -- --since main\` shows expected patch bumps for \`@prosopo/provider\` and \`@prosopo/types\`
- [x] Existing unit tests pass (frictionlessTasks, handshakeTimingMiddleware, getFrictionlessCaptchaChallenge)
- [ ] Integration test \`routingDecisionMachines.integration.test.ts\` needs local Mongo + Redis — fails on both this branch and \`main\` without them, so not caused by this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)