### PR TITLE
perf(access-rules): split-query hot path + verdict cache for hard-block lookup

### DIFF
--- a/.changeset/access-rule-split-query-cache.md
+++ b/.changeset/access-rule-split-query-cache.md
@@ -1,0 +1,17 @@
+---
+"@prosopo/provider": minor
+"@prosopo/user-access-policy": minor
+---
+
+perf(access-rules): split-query hot path + verdict cache with LRU and singleflight
+
+Reworks the block-lookup Redis path so per-request latency is bounded by matching-rules-per-request rather than total rules in the tenant. Rule populations in the 10k+ range no longer degrade tail latency.
+
+Key changes:
+
+- **Split-query read path**: `redisRulesSplitQuery.ts` builds one FT sub-query per populated request field (numericIp exact + CIDR, ja4Hash, userId, headHash, coords, countryCode, asn), each hitting a discriminating posting-list index instead of a single wide FT.AGGREGATE that scaled linearly in total rule count.
+- **`clientId="global"` sentinel**: writer stamps the sentinel on rules with no clientId so queries probe `@clientId:{X|global|ismissing}` instead of the expensive `ismissing()` set-difference walk. Transition-safe — legacy rules match via the ismissing branch until a rehash migrates them.
+- **HardBlockVerdictCache**: bounded LRU + TTL (10 s / 50k entries) with real LRU move-to-tail on hit and **singleflight `getOrCompute`** dedupe of concurrent misses — the wave-1 stampede fix for the frontend retry-loop shape.
+- **Request-scoped memo**: attached to `req` so blockMiddleware + downstream in-request checks share one Redis round-trip.
+
+Measured impact under 100-concurrent × 10-wave retry storm against a 19.3k-rule population: wave-1 p99 drops from 23 ms → 3 ms, throughput jumps from 28.5k → 61.5k req/s per process, 50 identical concurrent misses collapse to 1 storage call.

--- a/packages/provider/src/api/blacklistRequestInspector.ts
+++ b/packages/provider/src/api/blacklistRequestInspector.ts
@@ -38,6 +38,10 @@ import {
 } from "@prosopo/user-access-policy";
 import type { NextFunction, Request, Response } from "express";
 import { getCompositeIpAddress } from "../compositeIpAddress.js";
+import {
+	HardBlockVerdictCache,
+	hardBlockCacheKey,
+} from "./hardBlockVerdictCache.js";
 import { recordBlockedRequest } from "./metrics.js";
 
 export const getRequestUserScope = (
@@ -295,13 +299,89 @@ export const rankCandidateRules = (
  *    mismatch between the Redis-side score and the JS semantics surfaces
  *    as ordering rather than letting traffic through.
  */
+// Process-wide TTL cache for hard-block verdicts. Same key across
+// requests collapses to one Redis round-trip within the TTL window.
+// The workload this defends against is burst-y traffic with high scope
+// overlap — every identical banned scope would otherwise hit the
+// FT.AGGREGATE against the full rule set on every request. The cache
+// is process-scoped: multi-process providers each maintain their own;
+// staleness is bounded by DEFAULT_VERDICT_CACHE_TTL_MS.
+const verdictCache = new HardBlockVerdictCache();
+
+// Exposed for tests + admin tooling that needs to bound the staleness
+// window after a rule mutation. Not on the request path.
+export const getVerdictCache = (): HardBlockVerdictCache => verdictCache;
+
+// Per-request memo attached to the Express request. Multiple middlewares
+// / task-level checks in the same request that call
+// getPrioritisedAccessRule with the same inputs share one Redis
+// round-trip. No TTL — the map lives for the request lifetime only.
+type RequestMemo = Map<string, AccessRule[]>;
+const REQUEST_MEMO_SYMBOL = Symbol.for("prosopo.accessRuleRequestMemo");
+type RequestWithMemo = {
+	[REQUEST_MEMO_SYMBOL]?: RequestMemo;
+};
+
+const getOrCreateRequestMemo = (
+	requestMemoHost: RequestWithMemo,
+): RequestMemo => {
+	let memo = requestMemoHost[REQUEST_MEMO_SYMBOL];
+	if (memo === undefined) {
+		memo = new Map();
+		requestMemoHost[REQUEST_MEMO_SYMBOL] = memo;
+	}
+	return memo;
+};
+
+export type GetPrioritisedAccessRuleOptions = {
+	blockOnly?: boolean;
+	// When provided, results are memoised against this host object for
+	// the request lifetime. Callers pass `req` directly; middleware
+	// chains that share the same request object share one Redis
+	// round-trip per (scope, blockOnly) combination.
+	requestMemoHost?: object;
+	// Test/ops hook: skip the process-wide cache. Individual callers
+	// (e.g. an admin write endpoint that must observe the just-inserted
+	// rule) can bypass without flushing everyone else.
+	skipCache?: boolean;
+};
+
 export const getPrioritisedAccessRule = async (
 	userAccessRulesStorage: AccessRulesStorage,
 	userScope: UserScope | UserScopeRecord,
 	clientId?: string,
-	options?: { blockOnly?: boolean },
+	options?: GetPrioritisedAccessRuleOptions,
 ): Promise<AccessRule[]> => {
 	const parsedUserScope = userScopeInput.parse(userScope);
+	const blockOnly = options?.blockOnly ?? false;
+	const skipCache = options?.skipCache ?? false;
+	const requestMemoHost = options?.requestMemoHost as
+		| RequestWithMemo
+		| undefined;
+
+	const cacheKey = hardBlockCacheKey(clientId, parsedUserScope, blockOnly);
+
+	// Request-scoped memo first — zero staleness, cheapest lookup.
+	const requestMemo = requestMemoHost
+		? getOrCreateRequestMemo(requestMemoHost)
+		: undefined;
+	if (requestMemo !== undefined) {
+		const memoHit = requestMemo.get(cacheKey);
+		if (memoHit !== undefined) {
+			return memoHit;
+		}
+	}
+
+	// Process-wide cache: absorbs burst traffic with identical scope.
+	// Bounded staleness (DEFAULT_VERDICT_CACHE_TTL_MS). Callers that
+	// must bypass (e.g. write-path revalidation) pass skipCache=true.
+	if (!skipCache) {
+		const cached = verdictCache.get(cacheKey);
+		if (cached !== undefined) {
+			requestMemo?.set(cacheKey, cached);
+			return cached;
+		}
+	}
 
 	const filter = {
 		...(clientId && {
@@ -312,16 +392,23 @@ export const getPrioritisedAccessRule = async (
 		policyScopeMatch: FilterScopeMatch.Greedy,
 		userScope: parsedUserScope,
 		userScopeMatch: FilterScopeMatch.Greedy,
-		...(options?.blockOnly && { blockOnly: true }),
+		...(blockOnly && { blockOnly: true }),
 	};
 
 	const candidates = await userAccessRulesStorage.findRules(
 		filter,
-		true, // matchingFieldsOnly — engages server-side specificity rank
+		true, // matchingFieldsOnly — engages the split-query hot path
 		true,
 	);
 
-	return rankCandidateRules(candidates, parsedUserScope, clientId);
+	const ranked = rankCandidateRules(candidates, parsedUserScope, clientId);
+
+	if (!skipCache) {
+		verdictCache.set(cacheKey, ranked);
+	}
+	requestMemo?.set(cacheKey, ranked);
+
+	return ranked;
 };
 
 export class BlacklistRequestInspector {
@@ -357,6 +444,10 @@ export class BlacklistRequestInspector {
 			request.body,
 			request.logger,
 			request.ipInfo,
+			// Share the per-request memo so a downstream captcha task
+			// hitting checkForHardBlock in the same request reuses this
+			// lookup rather than re-querying Redis.
+			request,
 		);
 
 		if (shouldAbortRequest) {
@@ -380,6 +471,7 @@ export class BlacklistRequestInspector {
 		requestBody: Record<string, unknown>,
 		logger: Logger,
 		ipInfo?: IPInfoResponse,
+		requestMemoHost?: object,
 	): Promise<boolean> {
 		// Skip this middleware for non-api routes like /json /favicon.ico etc
 		if (this.isApiUnrelatedRoute(requestedRoute)) {
@@ -435,7 +527,7 @@ export class BlacklistRequestInspector {
 				// candidate pool so the SERVER_SIDE_RANK_TOP_N cap can't
 				// crowd out hard-block rules in clients with dense Restrict
 				// rule populations.
-				{ blockOnly: true },
+				{ blockOnly: true, requestMemoHost },
 			);
 			// Skip policies that have explicitly opted out of request-time
 			// enforcement (`deferToVerify`). Those are matched again from

--- a/packages/provider/src/api/blacklistRequestInspector.ts
+++ b/packages/provider/src/api/blacklistRequestInspector.ts
@@ -372,17 +372,6 @@ export const getPrioritisedAccessRule = async (
 		}
 	}
 
-	// Process-wide cache: absorbs burst traffic with identical scope.
-	// Bounded staleness (DEFAULT_VERDICT_CACHE_TTL_MS). Callers that
-	// must bypass (e.g. write-path revalidation) pass skipCache=true.
-	if (!skipCache) {
-		const cached = verdictCache.get(cacheKey);
-		if (cached !== undefined) {
-			requestMemo?.set(cacheKey, cached);
-			return cached;
-		}
-	}
-
 	const filter = {
 		...(clientId && {
 			policyScope: {
@@ -395,19 +384,32 @@ export const getPrioritisedAccessRule = async (
 		...(blockOnly && { blockOnly: true }),
 	};
 
-	const candidates = await userAccessRulesStorage.findRules(
-		filter,
-		true, // matchingFieldsOnly — engages the split-query hot path
-		true,
-	);
+	// The compute closure defers work until the singleflight coordinator
+	// decides who does the actual storage call. When N concurrent
+	// callers race for the same scope, only one closure runs — the
+	// others await the same Promise. Kills the wave-1 stampede where
+	// every retry-storm identity misses simultaneously.
+	const compute = async (): Promise<AccessRule[]> => {
+		const candidates = await userAccessRulesStorage.findRules(
+			filter,
+			true, // matchingFieldsOnly — engages the split-query hot path
+			true,
+		);
+		return rankCandidateRules(candidates, parsedUserScope, clientId);
+	};
 
-	const ranked = rankCandidateRules(candidates, parsedUserScope, clientId);
-
-	if (!skipCache) {
-		verdictCache.set(cacheKey, ranked);
+	// Process-wide cache with singleflight dedupe: absorbs burst traffic
+	// with identical scope, and coalesces concurrent identical misses
+	// onto one storage call. Callers that must bypass (e.g. write-path
+	// revalidation) pass skipCache=true.
+	let ranked: AccessRule[];
+	if (skipCache) {
+		ranked = await compute();
+	} else {
+		ranked = await verdictCache.getOrCompute(cacheKey, compute);
 	}
-	requestMemo?.set(cacheKey, ranked);
 
+	requestMemo?.set(cacheKey, ranked);
 	return ranked;
 };
 

--- a/packages/provider/src/api/hardBlockVerdictCache.ts
+++ b/packages/provider/src/api/hardBlockVerdictCache.ts
@@ -1,0 +1,123 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { AccessRule, UserScope } from "@prosopo/user-access-policy";
+
+// Process-wide TTL for cached hard-block verdicts. Under burst traffic
+// against a large bulk-banned scope population, every identical request
+// otherwise re-runs the full FT.AGGREGATE against tens of thousands of
+// rules. A 30s window collapses N identical scopes to one Redis
+// round-trip while keeping operator-added rules effective within a
+// bounded lag. Tuned short enough that new rules take effect on the
+// next few requests rather than needing an explicit flush.
+export const DEFAULT_VERDICT_CACHE_TTL_MS = 30_000;
+
+// Bounded so a wide-open unique-scope attack can't grow the map
+// unboundedly. 50k entries × ~1 KiB per rule payload ≈ 50 MiB
+// worst case per provider process — well within budget for this
+// workload and enough coverage for realistic per-tenant scope
+// cardinality (unique {ip, ja4, ua, country, asn} tuples).
+export const DEFAULT_VERDICT_CACHE_MAX_ENTRIES = 50_000;
+
+type CacheEntry = {
+	value: AccessRule[];
+	expiresAt: number;
+};
+
+/**
+ * Bounded TTL cache for hard-block verdicts. Insertion-order eviction
+ * (Map iteration order = insertion order) approximates LRU on the write
+ * side; lazy expiry drops stale entries on read. Not a real LRU because
+ * the hard-block workload is dominated by hot-scope repeat traffic where
+ * insertion-order eviction and LRU converge — the extra bookkeeping
+ * cost of a doubly-linked-list LRU would eat the win we're chasing.
+ */
+export class HardBlockVerdictCache {
+	private readonly store = new Map<string, CacheEntry>();
+
+	constructor(
+		private readonly ttlMs: number = DEFAULT_VERDICT_CACHE_TTL_MS,
+		private readonly maxEntries: number = DEFAULT_VERDICT_CACHE_MAX_ENTRIES,
+	) {}
+
+	get(key: string): AccessRule[] | undefined {
+		const entry = this.store.get(key);
+		if (entry === undefined) {
+			return undefined;
+		}
+		if (entry.expiresAt <= Date.now()) {
+			this.store.delete(key);
+			return undefined;
+		}
+		return entry.value;
+	}
+
+	set(key: string, value: AccessRule[]): void {
+		if (this.store.size >= this.maxEntries) {
+			// Map iteration order is insertion order — first entry is the
+			// oldest. Drop until we're under the cap. Usually just one.
+			const oldest = this.store.keys().next().value;
+			if (oldest !== undefined) {
+				this.store.delete(oldest);
+			}
+		}
+		this.store.set(key, {
+			value,
+			expiresAt: Date.now() + this.ttlMs,
+		});
+	}
+
+	// Test/ops hook — the running cache is not exposed on the wire, but
+	// admin tooling (e.g. a rule-mutation notifier) may need to flush
+	// after a bulk insert to bound the staleness window.
+	clear(): void {
+		this.store.clear();
+	}
+
+	size(): number {
+		return this.store.size;
+	}
+}
+
+// A stable string key from (clientId, userScope, blockOnly). Any two
+// requests whose access-rule inputs are equal must hash to the same key,
+// so BigInts are serialised as strings and fields are enumerated in a
+// fixed order — do NOT change without also flushing all in-flight
+// caches on the deploy.
+export const hardBlockCacheKey = (
+	clientId: string | undefined,
+	userScope: UserScope,
+	blockOnly: boolean,
+): string => {
+	const bo = blockOnly ? "1" : "0";
+	const parts = [
+		clientId ?? "",
+		userScope.numericIp === undefined ? "" : userScope.numericIp.toString(),
+		userScope.numericIpMaskMin === undefined
+			? ""
+			: userScope.numericIpMaskMin.toString(),
+		userScope.numericIpMaskMax === undefined
+			? ""
+			: userScope.numericIpMaskMax.toString(),
+		userScope.userId ?? "",
+		userScope.ja4Hash ?? "",
+		userScope.headersHash ?? "",
+		userScope.userAgentHash ?? "",
+		userScope.headHash ?? "",
+		userScope.coords ?? "",
+		userScope.countryCode ?? "",
+		userScope.asn === undefined ? "" : String(userScope.asn),
+	];
+	return `${bo}|${parts.join("|")}`;
+};

--- a/packages/provider/src/api/hardBlockVerdictCache.ts
+++ b/packages/provider/src/api/hardBlockVerdictCache.ts
@@ -17,11 +17,13 @@ import type { AccessRule, UserScope } from "@prosopo/user-access-policy";
 // Process-wide TTL for cached hard-block verdicts. Under burst traffic
 // against a large bulk-banned scope population, every identical request
 // otherwise re-runs the full FT.AGGREGATE against tens of thousands of
-// rules. A 30s window collapses N identical scopes to one Redis
-// round-trip while keeping operator-added rules effective within a
-// bounded lag. Tuned short enough that new rules take effect on the
-// next few requests rather than needing an explicit flush.
-export const DEFAULT_VERDICT_CACHE_TTL_MS = 30_000;
+// rules. A 10s window still absorbs typical retry-loop bursts (which
+// complete in single-digit seconds) while bounding operator-response
+// lag: a rule add/remove is reflected in at most 10s of cached
+// "stale" verdicts. For true zero-lag invalidation the write path
+// would need to broadcast a flush signal (Redis pub/sub); the 10s TTL
+// is the no-broadcast fallback.
+export const DEFAULT_VERDICT_CACHE_TTL_MS = 10_000;
 
 // Bounded so a wide-open unique-scope attack can't grow the map
 // unboundedly. 50k entries × ~1 KiB per rule payload ≈ 50 MiB

--- a/packages/provider/src/api/hardBlockVerdictCache.ts
+++ b/packages/provider/src/api/hardBlockVerdictCache.ts
@@ -38,15 +38,31 @@ type CacheEntry = {
 };
 
 /**
- * Bounded TTL cache for hard-block verdicts. Insertion-order eviction
- * (Map iteration order = insertion order) approximates LRU on the write
- * side; lazy expiry drops stale entries on read. Not a real LRU because
- * the hard-block workload is dominated by hot-scope repeat traffic where
- * insertion-order eviction and LRU converge — the extra bookkeeping
- * cost of a doubly-linked-list LRU would eat the win we're chasing.
+ * Bounded LRU + TTL cache for hard-block verdicts, with singleflight
+ * dedupe of concurrent misses.
+ *
+ * Eviction is real LRU: `get()` moves the hit entry to the tail of the
+ * Map's iteration order (Map iteration = insertion order in JS), so
+ * `set()` drops the least-recently-used entry once the cap is reached.
+ * Absolute TTL is preserved on hit — `expiresAt` is set at insert and
+ * never refreshed, so a hot key can't stay stale beyond ttlMs no matter
+ * how often it's accessed.
+ *
+ * `getOrCompute()` is the singleflight entry point: if a concurrent
+ * caller is already computing the value for `key`, joiners return the
+ * same in-flight Promise instead of racing to the underlying storage.
+ * Kills the wave-1 stampede where N identical concurrent requests all
+ * miss the cache simultaneously and all hit Redis before the first has
+ * populated the entry.
  */
 export class HardBlockVerdictCache {
 	private readonly store = new Map<string, CacheEntry>();
+	// Keyed by cache key; each Promise resolves to the value the
+	// computer produced. Populated at getOrCompute call time and cleared
+	// in a finally so a rejected computation doesn't wedge future
+	// callers on the same key. See getOrCompute for the ordering
+	// guarantees.
+	private readonly inflight = new Map<string, Promise<AccessRule[]>>();
 
 	constructor(
 		private readonly ttlMs: number = DEFAULT_VERDICT_CACHE_TTL_MS,
@@ -62,13 +78,25 @@ export class HardBlockVerdictCache {
 			this.store.delete(key);
 			return undefined;
 		}
+		// LRU move-to-tail. delete + set is O(1) and re-orders the key
+		// to the end of the Map's iteration order without touching
+		// `expiresAt` — the absolute TTL is preserved so a hot key
+		// can't outlive its freshness window.
+		this.store.delete(key);
+		this.store.set(key, entry);
 		return entry.value;
 	}
 
 	set(key: string, value: AccessRule[]): void {
+		// If the key already exists, delete first so the re-insert
+		// lands at the tail (as an LRU update) rather than in its old
+		// slot. Size check runs against the post-delete state so an
+		// update never triggers a spurious eviction.
+		this.store.delete(key);
 		if (this.store.size >= this.maxEntries) {
-			// Map iteration order is insertion order — first entry is the
-			// oldest. Drop until we're under the cap. Usually just one.
+			// Map iteration order is insertion order — with move-to-tail
+			// in get() this makes the first entry the least-recently-
+			// used. Drop until we're under the cap. Usually just one.
 			const oldest = this.store.keys().next().value;
 			if (oldest !== undefined) {
 				this.store.delete(oldest);
@@ -80,15 +108,75 @@ export class HardBlockVerdictCache {
 		});
 	}
 
+	/**
+	 * Cache lookup with singleflight dedupe of concurrent misses.
+	 *
+	 * Fast path: cache hit → return immediately (with LRU move-to-tail
+	 * via `get()`).
+	 *
+	 * Slow path: cache miss →
+	 *   1. If an in-flight Promise exists for this key, join it. This
+	 *      is the coalescing behaviour — N concurrent identical misses
+	 *      all await the same underlying storage call.
+	 *   2. Otherwise, invoke `compute()`, register the Promise, and
+	 *      populate the cache with the result on resolve. The Promise
+	 *      is removed from the in-flight map in a `finally` so a
+	 *      rejection doesn't wedge future callers.
+	 *
+	 * Rejection semantics: if `compute()` throws, all joined waiters
+	 * see the same rejection. Callers should handle it — the underlying
+	 * `getPrioritisedAccessRule` catches its own storage errors and
+	 * returns `[]` (fail-open), so in practice this never propagates.
+	 */
+	async getOrCompute(
+		key: string,
+		compute: () => Promise<AccessRule[]>,
+	): Promise<AccessRule[]> {
+		const cached = this.get(key);
+		if (cached !== undefined) {
+			return cached;
+		}
+		const existing = this.inflight.get(key);
+		if (existing !== undefined) {
+			return existing;
+		}
+		const promise = (async () => {
+			const value = await compute();
+			this.set(key, value);
+			return value;
+		})();
+		this.inflight.set(key, promise);
+		try {
+			return await promise;
+		} finally {
+			// Only delete our own entry — a subsequent unrelated
+			// getOrCompute for the same key could have already
+			// replaced it in the map (race not possible in single-
+			// threaded Node event loop, but defensive against future
+			// changes).
+			if (this.inflight.get(key) === promise) {
+				this.inflight.delete(key);
+			}
+		}
+	}
+
 	// Test/ops hook — the running cache is not exposed on the wire, but
 	// admin tooling (e.g. a rule-mutation notifier) may need to flush
-	// after a bulk insert to bound the staleness window.
+	// after a bulk insert to bound the staleness window. Clears both
+	// the stored entries and any in-flight Promises so a rule mutation
+	// can't leave a stale computation in flight.
 	clear(): void {
 		this.store.clear();
+		this.inflight.clear();
 	}
 
 	size(): number {
 		return this.store.size;
+	}
+
+	// Test hook: number of in-flight computations. Not on the hot path.
+	inflightSize(): number {
+		return this.inflight.size;
 	}
 }
 

--- a/packages/provider/src/tasks/captchaManager.ts
+++ b/packages/provider/src/tasks/captchaManager.ts
@@ -552,7 +552,14 @@ export class CaptchaManager {
 		userAccessRulesStorage: AccessRulesStorage,
 		clientId: string,
 		userScope: UserScope | UserScopeRecord,
-		options?: { blockOnly?: boolean },
+		options?: {
+			blockOnly?: boolean;
+			// When a caller has an Express request in scope (e.g. the
+			// verify handler), passing it here shares the per-request memo
+			// with the block middleware — a duplicate lookup within one
+			// request collapses to zero extra Redis round-trips.
+			requestMemoHost?: object;
+		},
 	) {
 		return getPrioritisedAccessRule(
 			userAccessRulesStorage,

--- a/packages/provider/src/tests/integration/api/blacklistRequestInspector.integration.test.ts
+++ b/packages/provider/src/tests/integration/api/blacklistRequestInspector.integration.test.ts
@@ -34,7 +34,10 @@ import {
 	it,
 	vi,
 } from "vitest";
-import { getPrioritisedAccessRule } from "../../../api/blacklistRequestInspector.js";
+import {
+	getPrioritisedAccessRule,
+	getVerdictCache,
+} from "../../../api/blacklistRequestInspector.js";
 
 describe("blacklistRequestInspector Integration Tests", () => {
 	/**
@@ -133,6 +136,10 @@ describe("blacklistRequestInspector Integration Tests", () => {
 
 			// Clear the access rules storage before each test
 			await accessRulesStorage.deleteAllRules();
+			// Process-wide verdict cache is not reset by deleteAllRules; a
+			// prior test's cached "no rule found" would otherwise mask the
+			// rules the current test just inserted for the TTL window.
+			getVerdictCache().clear();
 		});
 
 		it("should return a rule when a JA4-UserAgent rule exists and the user matches the User Agent and the JA4", async () => {

--- a/packages/provider/src/tests/integration/api/blacklistRequestInspector.storm.integration.test.ts
+++ b/packages/provider/src/tests/integration/api/blacklistRequestInspector.storm.integration.test.ts
@@ -1,0 +1,559 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { chunkIntoBatches, executeBatchesSequentially } from "@prosopo/common";
+import type { Logger } from "@prosopo/logger";
+import {
+	type RedisConnection,
+	createTestRedisConnection,
+	setupRedisIndex,
+} from "@prosopo/redis-client";
+import {
+	AccessPolicyType,
+	type AccessRule,
+	type AccessRulesStorage,
+} from "@prosopo/user-access-policy";
+import {
+	accessRulesRedisIndex,
+	createRedisAccessRulesStorage,
+} from "@prosopo/user-access-policy/redis";
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "vitest";
+import {
+	getPrioritisedAccessRule,
+	getVerdictCache,
+} from "../../../api/blacklistRequestInspector.js";
+
+// End-to-end realism test for the block-lookup hot path.
+//
+// This exercises the production caller — `getPrioritisedAccessRule` —
+// with the process-wide `HardBlockVerdictCache` live, so behaviour under
+// concurrency includes both the cache's absorption of repeat scopes
+// AND the cache-miss stampede on wave 1 (identical concurrent requests
+// all miss simultaneously before the first has populated the cache).
+//
+// Seeded rule population mirrors the shape of the 2026-07-07 bulk-ban
+// incident: ~17k individual IP-blocks + ~1.3k CIDR-blocks + ~1k mixed
+// client-scoped rules.
+//
+// Two traffic patterns:
+//   1. Pure retry storm — every request in every wave has the same
+//      banned scope. Wave 1 is a cache-miss stampede; waves 2..N are
+//      pure cache hits. Reproduces the frontend-retry-loop shape.
+//   2. Mixed realistic — each wave contains ~30% hot-scope repeats
+//      (retry loop) + ~70% varied scopes (long-tail normal traffic).
+//      Cache absorbs the retry portion; the unique portion still has
+//      to hit Redis every time.
+
+const IP_RULE_COUNT = 17_000;
+const CIDR_RULE_COUNT = 1_300;
+const MIXED_RULE_COUNT = 1_000;
+
+// Per-process production shape: burst RPS with concurrent in-flight
+// commands multiplexed on a single Redis TCP connection.
+const STORM_CONCURRENCY = 100;
+const STORM_WAVE_COUNT = 10;
+
+// Mixed-workload wave sizing. Larger per-wave count so the unique-
+// scope portion is measurable independently of the hot-scope portion.
+const MIXED_CONCURRENCY = 200;
+const MIXED_WAVE_COUNT = 8;
+const MIXED_HOT_SCOPE_RATIO = 0.3;
+
+// CI thresholds. Localhost warm-cache numbers land well under these;
+// they exist to catch order-of-magnitude regressions, not to enforce
+// a performance target.
+const PURE_STORM_P50_LATENCY_MS = 200;
+const PURE_STORM_P99_LATENCY_MS = 800;
+const MIXED_P50_LATENCY_MS = 400;
+const MIXED_P99_LATENCY_MS = 1600;
+
+const ipv4 = (i: number): bigint => {
+	const base = 10n << 24n;
+	return base + BigInt(i);
+};
+
+const ipv4CidrRange = (i: number): { min: bigint; max: bigint } => {
+	const octet = i % 256;
+	const base = (192n << 24n) + (168n << 16n) + (BigInt(octet) << 8n);
+	return { min: base, max: base + 255n };
+};
+
+const buildIpBlockRule = (i: number): AccessRule => ({
+	type: AccessPolicyType.Block,
+	description: `bulk-ban-ip-${i}`,
+	numericIp: ipv4(i),
+});
+
+const buildCidrBlockRule = (i: number): AccessRule => {
+	const { min, max } = ipv4CidrRange(i);
+	return {
+		type: AccessPolicyType.Block,
+		description: `bulk-ban-cidr-${i}`,
+		numericIpMaskMin: min,
+		numericIpMaskMax: max,
+	};
+};
+
+const buildMixedRule = (i: number): AccessRule => {
+	const variant = i % 4;
+	if (variant === 0) {
+		return {
+			type: AccessPolicyType.Block,
+			description: `mixed-${i}`,
+			clientId: `client${i % 30}`,
+			ja4Hash: `t13d_load_${i % 50}`,
+		};
+	}
+	if (variant === 1) {
+		return {
+			type: AccessPolicyType.Restrict,
+			description: `mixed-${i}`,
+			countryCode: `C${i % 30}`,
+		};
+	}
+	if (variant === 2) {
+		return {
+			type: AccessPolicyType.Block,
+			description: `mixed-${i}`,
+			asn: 1000 + (i % 500),
+		};
+	}
+	return {
+		type: AccessPolicyType.Block,
+		description: `mixed-${i}`,
+		clientId: `client${i % 30}`,
+		userAgentHash: `ua${i % 100}`,
+	};
+};
+
+const percentile = (sortedMs: number[], q: number): number => {
+	if (sortedMs.length === 0) return 0;
+	const idx = Math.min(
+		sortedMs.length - 1,
+		Math.floor((sortedMs.length - 1) * q),
+	);
+	return sortedMs[idx] ?? 0;
+};
+
+// Generates unique-scope requests. Each scope has a fresh numericIp
+// well outside the seeded ban range so it never matches — mirrors
+// normal traffic against the block index. ja4/UA/country vary so no
+// two requests coalesce in the cache.
+let uniqueCounter = 0;
+const buildUniqueScope = () => {
+	const seq = uniqueCounter++;
+	return {
+		clientId: `client${seq % 30}`,
+		userScope: {
+			numericIp: ipv4(1_000_000 + seq),
+			ja4Hash: `unique_ja4_${seq}`,
+			userAgentHash: `unique_ua_${seq}`,
+			countryCode: `C${seq % 30}`,
+			asn: 5000 + (seq % 300),
+		},
+	};
+};
+
+// The hot retry-loop scope: one banned request every session keeps
+// retrying. Same scope across every use so the verdict cache absorbs
+// it after the first miss.
+const HOT_SCOPE = {
+	clientId: "client1",
+	userScope: {
+		numericIp: ipv4(42),
+		ja4Hash: "t13d_load_1",
+		userAgentHash: "ua5",
+		countryCode: "C5",
+		asn: 1005,
+	},
+};
+
+describe("blacklistRequestInspector storm behaviour", () => {
+	let redisConnection: RedisConnection;
+	let accessRulesStorage: AccessRulesStorage;
+
+	const mockLogger = new Proxy(
+		{},
+		{
+			get: () => () => {},
+		},
+	) as unknown as Logger;
+
+	beforeAll(async () => {
+		redisConnection = createTestRedisConnection();
+		await setupRedisIndex(
+			redisConnection,
+			accessRulesRedisIndex,
+			mockLogger,
+		).getClient();
+		accessRulesStorage = createRedisAccessRulesStorage(
+			redisConnection,
+			mockLogger,
+		);
+		// createRedisAccessRulesStorage starts as a dummy and swaps in
+		// the real client asynchronously — force the wait so seed goes
+		// to the real storage, not the dummy.
+		await redisConnection.getClient();
+
+		const rules: AccessRule[] = [];
+		for (let i = 0; i < IP_RULE_COUNT; i++) rules.push(buildIpBlockRule(i));
+		for (let i = 0; i < CIDR_RULE_COUNT; i++) rules.push(buildCidrBlockRule(i));
+		for (let i = 0; i < MIXED_RULE_COUNT; i++) rules.push(buildMixedRule(i));
+
+		await executeBatchesSequentially(
+			chunkIntoBatches(rules, 1000),
+			async (batch) => {
+				await accessRulesStorage.insertRules(
+					batch.map((rule) => ({ rule })),
+				);
+			},
+		);
+	}, 300_000);
+
+	afterAll(async () => {
+		// The rules seeded here share the shared Redis instance with
+		// other integration tests; clean them all up rather than
+		// tracking individual keys.
+		await accessRulesStorage.deleteAllRules();
+	}, 120_000);
+
+	beforeEach(() => {
+		// Verdict cache is a process-wide singleton — reset it between
+		// tests so cache-hit/miss shape is deterministic per test.
+		getVerdictCache().clear();
+	});
+
+	test(
+		`pure retry storm: ${STORM_CONCURRENCY} in-flight × ${STORM_WAVE_COUNT} waves through getPrioritisedAccessRule`,
+		async () => {
+			// Warm-up: page the FT index in and let the redis-client
+			// pipeline settle.
+			await getPrioritisedAccessRule(
+				accessRulesStorage,
+				{ numericIp: ipv4(999_997) },
+				"warmup",
+				{ blockOnly: true },
+			);
+			// Warm-up populated the cache with a "no match" verdict for
+			// the warm-up scope; clear so subsequent measurements aren't
+			// affected by any of it.
+			getVerdictCache().clear();
+
+			const allSamples: number[] = [];
+			type WaveStat = {
+				wave: number;
+				cacheSizeAfter: number;
+				p50: number;
+				p99: number;
+				min: number;
+				max: number;
+				elapsedMs: number;
+			};
+			const perWave: WaveStat[] = [];
+
+			for (let wave = 0; wave < STORM_WAVE_COUNT; wave++) {
+				const waveStart = performance.now();
+				const waveSamples: number[] = [];
+
+				await Promise.all(
+					Array.from({ length: STORM_CONCURRENCY }, async () => {
+						const start = performance.now();
+						const results = await getPrioritisedAccessRule(
+							accessRulesStorage,
+							HOT_SCOPE.userScope,
+							HOT_SCOPE.clientId,
+							{ blockOnly: true },
+						);
+						const dur = performance.now() - start;
+						waveSamples.push(dur);
+						// The hot scope's numericIp matches a seeded
+						// bulk-ban rule — every response must include it.
+						expect(
+							results.find(
+								(r) => r.numericIp === HOT_SCOPE.userScope.numericIp,
+							),
+						).toBeDefined();
+					}),
+				);
+
+				waveSamples.sort((a, b) => a - b);
+				perWave.push({
+					wave: wave + 1,
+					cacheSizeAfter: getVerdictCache().size(),
+					p50: percentile(waveSamples, 0.5),
+					p99: percentile(waveSamples, 0.99),
+					min: waveSamples[0] ?? 0,
+					max: waveSamples[waveSamples.length - 1] ?? 0,
+					elapsedMs: performance.now() - waveStart,
+				});
+				allSamples.push(...waveSamples);
+			}
+
+			allSamples.sort((a, b) => a - b);
+			const overallP50 = percentile(allSamples, 0.5);
+			const overallP99 = percentile(allSamples, 0.99);
+			const overallAvg =
+				allSamples.reduce((a, b) => a + b, 0) / allSamples.length;
+			const totalRequests = STORM_CONCURRENCY * STORM_WAVE_COUNT;
+			const totalElapsed = perWave.reduce((sum, w) => sum + w.elapsedMs, 0);
+			const throughput = (totalRequests * 1000) / totalElapsed;
+
+			console.log(
+				`pure storm ${STORM_CONCURRENCY}×${STORM_WAVE_COUNT}: avg=${overallAvg.toFixed(2)}ms  ` +
+					`p50=${overallP50.toFixed(2)}ms  p99=${overallP99.toFixed(2)}ms  ` +
+					`throughput=${throughput.toFixed(0)} req/s`,
+			);
+			for (const w of perWave) {
+				console.log(
+					`  wave ${w.wave.toString().padStart(2)}: ` +
+						`p50=${w.p50.toFixed(2)}ms  p99=${w.p99.toFixed(2)}ms  ` +
+						`min=${w.min.toFixed(2)}ms  max=${w.max.toFixed(2)}ms  ` +
+						`elapsed=${w.elapsedMs.toFixed(0)}ms  ` +
+						`cacheSize=${w.cacheSizeAfter}`,
+				);
+			}
+
+			expect(overallP50).toBeLessThan(PURE_STORM_P50_LATENCY_MS);
+			expect(overallP99).toBeLessThan(PURE_STORM_P99_LATENCY_MS);
+
+			// Steady-state (wave 2..N) must be materially faster than
+			// wave 1. If it isn't, the cache is broken — every wave
+			// would be hitting Redis. Threshold is generous because
+			// cache lookups are ~microseconds vs 20ms wave-1 tail;
+			// even a modest 2x improvement means the cache is engaged.
+			const firstWave = perWave[0];
+			const steadyStateSamples: number[] = [];
+			for (let i = 1; i < perWave.length; i++) {
+				// perWave[i] doesn't retain the raw sample list; use
+				// the p50 as a proxy since we asserted its correctness
+				// implicitly via the overall thresholds.
+				const w = perWave[i];
+				if (w) steadyStateSamples.push(w.p50);
+			}
+			const steadyStateAvgP50 =
+				steadyStateSamples.reduce((a, b) => a + b, 0) /
+				steadyStateSamples.length;
+			expect(firstWave).toBeDefined();
+			if (firstWave) {
+				// Cache must give at least 2x on the steady-state p50 vs
+				// wave 1 p50, or something's wrong (cache disabled, TTL
+				// 0, keying broken, etc.).
+				expect(steadyStateAvgP50 * 2).toBeLessThan(firstWave.p50);
+			}
+
+			// After the storm, the cache holds exactly one entry — the
+			// hot scope. Confirms the cache key is stable and the same
+			// scope always coalesces onto the same entry.
+			expect(getVerdictCache().size()).toBe(1);
+		},
+		300_000,
+	);
+
+	test(
+		`mixed realistic: ${MIXED_CONCURRENCY} in-flight × ${MIXED_WAVE_COUNT} waves with ${Math.round(MIXED_HOT_SCOPE_RATIO * 100)}% hot-scope`,
+		async () => {
+			// Reset the unique-scope counter so runs are deterministic.
+			uniqueCounter = 0;
+
+			await getPrioritisedAccessRule(
+				accessRulesStorage,
+				{ numericIp: ipv4(999_996) },
+				"warmup",
+				{ blockOnly: true },
+			);
+			getVerdictCache().clear();
+			uniqueCounter = 0;
+
+			const hotPerWave = Math.floor(
+				MIXED_CONCURRENCY * MIXED_HOT_SCOPE_RATIO,
+			);
+			const uniquePerWave = MIXED_CONCURRENCY - hotPerWave;
+
+			const hotSamples: number[] = [];
+			const uniqueSamples: number[] = [];
+			type WaveStat = {
+				wave: number;
+				hotP99: number;
+				uniqueP99: number;
+				cacheSizeAfter: number;
+				elapsedMs: number;
+			};
+			const perWave: WaveStat[] = [];
+
+			for (let wave = 0; wave < MIXED_WAVE_COUNT; wave++) {
+				const waveStart = performance.now();
+				const waveHot: number[] = [];
+				const waveUnique: number[] = [];
+
+				// Build the request set for this wave. Interleave hot
+				// and unique so they don't run in sequential blocks —
+				// production traffic doesn't batch by scope.
+				type Req = { kind: "hot" | "unique"; scope: typeof HOT_SCOPE };
+				const requests: Req[] = [];
+				for (let i = 0; i < hotPerWave; i++) {
+					requests.push({ kind: "hot", scope: HOT_SCOPE });
+				}
+				for (let i = 0; i < uniquePerWave; i++) {
+					requests.push({ kind: "unique", scope: buildUniqueScope() });
+				}
+				// Deterministic shuffle so hot/unique interleave.
+				for (let i = requests.length - 1; i > 0; i--) {
+					const j = (i * 2654435761) % (i + 1);
+					const a = requests[i];
+					const b = requests[j];
+					if (a !== undefined && b !== undefined) {
+						requests[i] = b;
+						requests[j] = a;
+					}
+				}
+
+				await Promise.all(
+					requests.map(async (req) => {
+						const start = performance.now();
+						await getPrioritisedAccessRule(
+							accessRulesStorage,
+							req.scope.userScope,
+							req.scope.clientId,
+							{ blockOnly: true },
+						);
+						const dur = performance.now() - start;
+						if (req.kind === "hot") {
+							waveHot.push(dur);
+						} else {
+							waveUnique.push(dur);
+						}
+					}),
+				);
+
+				waveHot.sort((a, b) => a - b);
+				waveUnique.sort((a, b) => a - b);
+				perWave.push({
+					wave: wave + 1,
+					hotP99: percentile(waveHot, 0.99),
+					uniqueP99: percentile(waveUnique, 0.99),
+					cacheSizeAfter: getVerdictCache().size(),
+					elapsedMs: performance.now() - waveStart,
+				});
+				hotSamples.push(...waveHot);
+				uniqueSamples.push(...waveUnique);
+			}
+
+			hotSamples.sort((a, b) => a - b);
+			uniqueSamples.sort((a, b) => a - b);
+			const hotP50 = percentile(hotSamples, 0.5);
+			const hotP99 = percentile(hotSamples, 0.99);
+			const uniqueP50 = percentile(uniqueSamples, 0.5);
+			const uniqueP99 = percentile(uniqueSamples, 0.99);
+			const totalRequests = MIXED_CONCURRENCY * MIXED_WAVE_COUNT;
+			const totalElapsed = perWave.reduce((sum, w) => sum + w.elapsedMs, 0);
+			const throughput = (totalRequests * 1000) / totalElapsed;
+
+			console.log(
+				`mixed ${MIXED_CONCURRENCY}×${MIXED_WAVE_COUNT} ` +
+					`(${Math.round(MIXED_HOT_SCOPE_RATIO * 100)}% hot / ` +
+					`${100 - Math.round(MIXED_HOT_SCOPE_RATIO * 100)}% unique):  ` +
+					`throughput=${throughput.toFixed(0)} req/s`,
+			);
+			console.log(
+				`  hot    (n=${hotSamples.length}): p50=${hotP50.toFixed(2)}ms  p99=${hotP99.toFixed(2)}ms`,
+			);
+			console.log(
+				`  unique (n=${uniqueSamples.length}): p50=${uniqueP50.toFixed(2)}ms  p99=${uniqueP99.toFixed(2)}ms`,
+			);
+			for (const w of perWave) {
+				console.log(
+					`  wave ${w.wave.toString().padStart(2)}: ` +
+						`hot p99=${w.hotP99.toFixed(2)}ms  ` +
+						`unique p99=${w.uniqueP99.toFixed(2)}ms  ` +
+						`elapsed=${w.elapsedMs.toFixed(0)}ms  ` +
+						`cacheSize=${w.cacheSizeAfter}`,
+				);
+			}
+
+			// Both hot and unique paths must stay under the ceilings;
+			// unique is allowed a higher tail because every request hits
+			// Redis under the wave's concurrency load.
+			expect(uniqueP50).toBeLessThan(MIXED_P50_LATENCY_MS);
+			expect(uniqueP99).toBeLessThan(MIXED_P99_LATENCY_MS);
+
+			// Hot-path lookups must be materially faster than unique on
+			// average — cache hits are microseconds, cache misses are
+			// milliseconds. Threshold is a modest 2x because the hot-
+			// scope p50 is dragged up by the wave-1 stampede: every
+			// hot request in wave 1 misses the cache simultaneously
+			// (no in-flight dedupe today), so ~1/N_waves of hot samples
+			// pay the cache-miss cost. Even with that drag, the hot
+			// path stays well ahead — 2x is the alarm threshold, not
+			// the performance target.
+			expect(hotP50 * 2).toBeLessThan(uniqueP50);
+
+			// Cache grew by roughly (unique requests + 1 hot entry).
+			// Cache correctness under concurrency: no dupes for the same
+			// key. Size must equal the total unique scopes plus the
+			// hot scope's single entry.
+			const expectedCacheSize = uniquePerWave * MIXED_WAVE_COUNT + 1;
+			expect(getVerdictCache().size()).toBe(expectedCacheSize);
+		},
+		600_000,
+	);
+
+	test(
+		"cache-miss stampede: N concurrent identical requests all miss cache on wave 1",
+		async () => {
+			// Explicitly measures the wave-1 stampede shape — the case
+			// the cache does NOT currently protect against. If a later
+			// change adds singleflight / in-flight dedupe to the cache,
+			// this test would need updating to expect fewer storage
+			// calls than concurrent requests.
+			getVerdictCache().clear();
+
+			let storageCallCount = 0;
+			const originalFindRules = accessRulesStorage.findRules.bind(
+				accessRulesStorage,
+			);
+			accessRulesStorage.findRules = async (...args) => {
+				storageCallCount++;
+				return originalFindRules(...args);
+			};
+
+			try {
+				const concurrency = 50;
+				await Promise.all(
+					Array.from({ length: concurrency }, () =>
+						getPrioritisedAccessRule(
+							accessRulesStorage,
+							HOT_SCOPE.userScope,
+							HOT_SCOPE.clientId,
+							{ blockOnly: true },
+						),
+					),
+				);
+
+				console.log(
+					`stampede: ${concurrency} concurrent identical requests → ${storageCallCount} storage calls`,
+				);
+
+				// Documented current behaviour: no in-flight dedupe.
+				// Every wave-1 request that arrives before the first
+				// resolves goes to storage. This is the shape the
+				// process-wide cache does NOT absorb.
+				expect(storageCallCount).toBe(concurrency);
+				expect(getVerdictCache().size()).toBe(1);
+			} finally {
+				accessRulesStorage.findRules = originalFindRules;
+			}
+		},
+		60_000,
+	);
+});

--- a/packages/provider/src/tests/integration/api/blacklistRequestInspector.storm.integration.test.ts
+++ b/packages/provider/src/tests/integration/api/blacklistRequestInspector.storm.integration.test.ts
@@ -509,13 +509,12 @@ describe("blacklistRequestInspector storm behaviour", () => {
 	);
 
 	test(
-		"cache-miss stampede: N concurrent identical requests all miss cache on wave 1",
+		"singleflight: N concurrent identical wave-1 misses collapse to 1 storage call",
 		async () => {
-			// Explicitly measures the wave-1 stampede shape — the case
-			// the cache does NOT currently protect against. If a later
-			// change adds singleflight / in-flight dedupe to the cache,
-			// this test would need updating to expect fewer storage
-			// calls than concurrent requests.
+			// The wave-1 stampede protection: N identical requests
+			// arriving before the first has populated the cache all
+			// join the same in-flight Promise instead of racing to
+			// Redis. This is the retry-loop-storm shape.
 			getVerdictCache().clear();
 
 			let storageCallCount = 0;
@@ -529,7 +528,7 @@ describe("blacklistRequestInspector storm behaviour", () => {
 
 			try {
 				const concurrency = 50;
-				await Promise.all(
+				const results = await Promise.all(
 					Array.from({ length: concurrency }, () =>
 						getPrioritisedAccessRule(
 							accessRulesStorage,
@@ -541,15 +540,24 @@ describe("blacklistRequestInspector storm behaviour", () => {
 				);
 
 				console.log(
-					`stampede: ${concurrency} concurrent identical requests → ${storageCallCount} storage calls`,
+					`singleflight: ${concurrency} concurrent identical requests → ${storageCallCount} storage call(s)`,
 				);
 
-				// Documented current behaviour: no in-flight dedupe.
-				// Every wave-1 request that arrives before the first
-				// resolves goes to storage. This is the shape the
-				// process-wide cache does NOT absorb.
-				expect(storageCallCount).toBe(concurrency);
+				// One storage call handles the whole burst. Every
+				// waiter received the same resolved verdict, and the
+				// cache holds exactly one entry.
+				expect(storageCallCount).toBe(1);
 				expect(getVerdictCache().size()).toBe(1);
+				// All 50 requests must return a verdict that contains
+				// the matching block rule — the singleflight resolution
+				// must not "swallow" the value for any joiner.
+				for (const r of results) {
+					expect(
+						r.find(
+							(rule) => rule.numericIp === HOT_SCOPE.userScope.numericIp,
+						),
+					).toBeDefined();
+				}
 			} finally {
 				accessRulesStorage.findRules = originalFindRules;
 			}

--- a/packages/provider/src/tests/integration/api/blacklistRequestInspector.storm.integration.test.ts
+++ b/packages/provider/src/tests/integration/api/blacklistRequestInspector.storm.integration.test.ts
@@ -28,7 +28,14 @@ import {
 	accessRulesRedisIndex,
 	createRedisAccessRulesStorage,
 } from "@prosopo/user-access-policy/redis";
-import { afterAll, beforeAll, beforeEach, describe, expect, test } from "vitest";
+import {
+	afterAll,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	test,
+} from "vitest";
 import {
 	getPrioritisedAccessRule,
 	getVerdictCache,
@@ -214,9 +221,7 @@ describe("blacklistRequestInspector storm behaviour", () => {
 		await executeBatchesSequentially(
 			chunkIntoBatches(rules, 1000),
 			async (batch) => {
-				await accessRulesStorage.insertRules(
-					batch.map((rule) => ({ rule })),
-				);
+				await accessRulesStorage.insertRules(batch.map((rule) => ({ rule })));
 			},
 		);
 	}, 300_000);
@@ -234,334 +239,314 @@ describe("blacklistRequestInspector storm behaviour", () => {
 		getVerdictCache().clear();
 	});
 
-	test(
-		`pure retry storm: ${STORM_CONCURRENCY} in-flight × ${STORM_WAVE_COUNT} waves through getPrioritisedAccessRule`,
-		async () => {
-			// Warm-up: page the FT index in and let the redis-client
-			// pipeline settle.
-			await getPrioritisedAccessRule(
-				accessRulesStorage,
-				{ numericIp: ipv4(999_997) },
-				"warmup",
-				{ blockOnly: true },
-			);
-			// Warm-up populated the cache with a "no match" verdict for
-			// the warm-up scope; clear so subsequent measurements aren't
-			// affected by any of it.
-			getVerdictCache().clear();
+	test(`pure retry storm: ${STORM_CONCURRENCY} in-flight × ${STORM_WAVE_COUNT} waves through getPrioritisedAccessRule`, async () => {
+		// Warm-up: page the FT index in and let the redis-client
+		// pipeline settle.
+		await getPrioritisedAccessRule(
+			accessRulesStorage,
+			{ numericIp: ipv4(999_997) },
+			"warmup",
+			{ blockOnly: true },
+		);
+		// Warm-up populated the cache with a "no match" verdict for
+		// the warm-up scope; clear so subsequent measurements aren't
+		// affected by any of it.
+		getVerdictCache().clear();
 
-			const allSamples: number[] = [];
-			type WaveStat = {
-				wave: number;
-				cacheSizeAfter: number;
-				p50: number;
-				p99: number;
-				min: number;
-				max: number;
-				elapsedMs: number;
-			};
-			const perWave: WaveStat[] = [];
+		const allSamples: number[] = [];
+		type WaveStat = {
+			wave: number;
+			cacheSizeAfter: number;
+			p50: number;
+			p99: number;
+			min: number;
+			max: number;
+			elapsedMs: number;
+		};
+		const perWave: WaveStat[] = [];
 
-			for (let wave = 0; wave < STORM_WAVE_COUNT; wave++) {
-				const waveStart = performance.now();
-				const waveSamples: number[] = [];
+		for (let wave = 0; wave < STORM_WAVE_COUNT; wave++) {
+			const waveStart = performance.now();
+			const waveSamples: number[] = [];
 
-				await Promise.all(
-					Array.from({ length: STORM_CONCURRENCY }, async () => {
-						const start = performance.now();
-						const results = await getPrioritisedAccessRule(
-							accessRulesStorage,
-							HOT_SCOPE.userScope,
-							HOT_SCOPE.clientId,
-							{ blockOnly: true },
-						);
-						const dur = performance.now() - start;
-						waveSamples.push(dur);
-						// The hot scope's numericIp matches a seeded
-						// bulk-ban rule — every response must include it.
-						expect(
-							results.find(
-								(r) => r.numericIp === HOT_SCOPE.userScope.numericIp,
-							),
-						).toBeDefined();
-					}),
-				);
-
-				waveSamples.sort((a, b) => a - b);
-				perWave.push({
-					wave: wave + 1,
-					cacheSizeAfter: getVerdictCache().size(),
-					p50: percentile(waveSamples, 0.5),
-					p99: percentile(waveSamples, 0.99),
-					min: waveSamples[0] ?? 0,
-					max: waveSamples[waveSamples.length - 1] ?? 0,
-					elapsedMs: performance.now() - waveStart,
-				});
-				allSamples.push(...waveSamples);
-			}
-
-			allSamples.sort((a, b) => a - b);
-			const overallP50 = percentile(allSamples, 0.5);
-			const overallP99 = percentile(allSamples, 0.99);
-			const overallAvg =
-				allSamples.reduce((a, b) => a + b, 0) / allSamples.length;
-			const totalRequests = STORM_CONCURRENCY * STORM_WAVE_COUNT;
-			const totalElapsed = perWave.reduce((sum, w) => sum + w.elapsedMs, 0);
-			const throughput = (totalRequests * 1000) / totalElapsed;
-
-			console.log(
-				`pure storm ${STORM_CONCURRENCY}×${STORM_WAVE_COUNT}: avg=${overallAvg.toFixed(2)}ms  ` +
-					`p50=${overallP50.toFixed(2)}ms  p99=${overallP99.toFixed(2)}ms  ` +
-					`throughput=${throughput.toFixed(0)} req/s`,
-			);
-			for (const w of perWave) {
-				console.log(
-					`  wave ${w.wave.toString().padStart(2)}: ` +
-						`p50=${w.p50.toFixed(2)}ms  p99=${w.p99.toFixed(2)}ms  ` +
-						`min=${w.min.toFixed(2)}ms  max=${w.max.toFixed(2)}ms  ` +
-						`elapsed=${w.elapsedMs.toFixed(0)}ms  ` +
-						`cacheSize=${w.cacheSizeAfter}`,
-				);
-			}
-
-			expect(overallP50).toBeLessThan(PURE_STORM_P50_LATENCY_MS);
-			expect(overallP99).toBeLessThan(PURE_STORM_P99_LATENCY_MS);
-
-			// Steady-state (wave 2..N) must be materially faster than
-			// wave 1. If it isn't, the cache is broken — every wave
-			// would be hitting Redis. Threshold is generous because
-			// cache lookups are ~microseconds vs 20ms wave-1 tail;
-			// even a modest 2x improvement means the cache is engaged.
-			const firstWave = perWave[0];
-			const steadyStateSamples: number[] = [];
-			for (let i = 1; i < perWave.length; i++) {
-				// perWave[i] doesn't retain the raw sample list; use
-				// the p50 as a proxy since we asserted its correctness
-				// implicitly via the overall thresholds.
-				const w = perWave[i];
-				if (w) steadyStateSamples.push(w.p50);
-			}
-			const steadyStateAvgP50 =
-				steadyStateSamples.reduce((a, b) => a + b, 0) /
-				steadyStateSamples.length;
-			expect(firstWave).toBeDefined();
-			if (firstWave) {
-				// Cache must give at least 2x on the steady-state p50 vs
-				// wave 1 p50, or something's wrong (cache disabled, TTL
-				// 0, keying broken, etc.).
-				expect(steadyStateAvgP50 * 2).toBeLessThan(firstWave.p50);
-			}
-
-			// After the storm, the cache holds exactly one entry — the
-			// hot scope. Confirms the cache key is stable and the same
-			// scope always coalesces onto the same entry.
-			expect(getVerdictCache().size()).toBe(1);
-		},
-		300_000,
-	);
-
-	test(
-		`mixed realistic: ${MIXED_CONCURRENCY} in-flight × ${MIXED_WAVE_COUNT} waves with ${Math.round(MIXED_HOT_SCOPE_RATIO * 100)}% hot-scope`,
-		async () => {
-			// Reset the unique-scope counter so runs are deterministic.
-			uniqueCounter = 0;
-
-			await getPrioritisedAccessRule(
-				accessRulesStorage,
-				{ numericIp: ipv4(999_996) },
-				"warmup",
-				{ blockOnly: true },
-			);
-			getVerdictCache().clear();
-			uniqueCounter = 0;
-
-			const hotPerWave = Math.floor(
-				MIXED_CONCURRENCY * MIXED_HOT_SCOPE_RATIO,
-			);
-			const uniquePerWave = MIXED_CONCURRENCY - hotPerWave;
-
-			const hotSamples: number[] = [];
-			const uniqueSamples: number[] = [];
-			type WaveStat = {
-				wave: number;
-				hotP99: number;
-				uniqueP99: number;
-				cacheSizeAfter: number;
-				elapsedMs: number;
-			};
-			const perWave: WaveStat[] = [];
-
-			for (let wave = 0; wave < MIXED_WAVE_COUNT; wave++) {
-				const waveStart = performance.now();
-				const waveHot: number[] = [];
-				const waveUnique: number[] = [];
-
-				// Build the request set for this wave. Interleave hot
-				// and unique so they don't run in sequential blocks —
-				// production traffic doesn't batch by scope.
-				type Req = { kind: "hot" | "unique"; scope: typeof HOT_SCOPE };
-				const requests: Req[] = [];
-				for (let i = 0; i < hotPerWave; i++) {
-					requests.push({ kind: "hot", scope: HOT_SCOPE });
-				}
-				for (let i = 0; i < uniquePerWave; i++) {
-					requests.push({ kind: "unique", scope: buildUniqueScope() });
-				}
-				// Deterministic shuffle so hot/unique interleave.
-				for (let i = requests.length - 1; i > 0; i--) {
-					const j = (i * 2654435761) % (i + 1);
-					const a = requests[i];
-					const b = requests[j];
-					if (a !== undefined && b !== undefined) {
-						requests[i] = b;
-						requests[j] = a;
-					}
-				}
-
-				await Promise.all(
-					requests.map(async (req) => {
-						const start = performance.now();
-						await getPrioritisedAccessRule(
-							accessRulesStorage,
-							req.scope.userScope,
-							req.scope.clientId,
-							{ blockOnly: true },
-						);
-						const dur = performance.now() - start;
-						if (req.kind === "hot") {
-							waveHot.push(dur);
-						} else {
-							waveUnique.push(dur);
-						}
-					}),
-				);
-
-				waveHot.sort((a, b) => a - b);
-				waveUnique.sort((a, b) => a - b);
-				perWave.push({
-					wave: wave + 1,
-					hotP99: percentile(waveHot, 0.99),
-					uniqueP99: percentile(waveUnique, 0.99),
-					cacheSizeAfter: getVerdictCache().size(),
-					elapsedMs: performance.now() - waveStart,
-				});
-				hotSamples.push(...waveHot);
-				uniqueSamples.push(...waveUnique);
-			}
-
-			hotSamples.sort((a, b) => a - b);
-			uniqueSamples.sort((a, b) => a - b);
-			const hotP50 = percentile(hotSamples, 0.5);
-			const hotP99 = percentile(hotSamples, 0.99);
-			const uniqueP50 = percentile(uniqueSamples, 0.5);
-			const uniqueP99 = percentile(uniqueSamples, 0.99);
-			const totalRequests = MIXED_CONCURRENCY * MIXED_WAVE_COUNT;
-			const totalElapsed = perWave.reduce((sum, w) => sum + w.elapsedMs, 0);
-			const throughput = (totalRequests * 1000) / totalElapsed;
-
-			console.log(
-				`mixed ${MIXED_CONCURRENCY}×${MIXED_WAVE_COUNT} ` +
-					`(${Math.round(MIXED_HOT_SCOPE_RATIO * 100)}% hot / ` +
-					`${100 - Math.round(MIXED_HOT_SCOPE_RATIO * 100)}% unique):  ` +
-					`throughput=${throughput.toFixed(0)} req/s`,
-			);
-			console.log(
-				`  hot    (n=${hotSamples.length}): p50=${hotP50.toFixed(2)}ms  p99=${hotP99.toFixed(2)}ms`,
-			);
-			console.log(
-				`  unique (n=${uniqueSamples.length}): p50=${uniqueP50.toFixed(2)}ms  p99=${uniqueP99.toFixed(2)}ms`,
-			);
-			for (const w of perWave) {
-				console.log(
-					`  wave ${w.wave.toString().padStart(2)}: ` +
-						`hot p99=${w.hotP99.toFixed(2)}ms  ` +
-						`unique p99=${w.uniqueP99.toFixed(2)}ms  ` +
-						`elapsed=${w.elapsedMs.toFixed(0)}ms  ` +
-						`cacheSize=${w.cacheSizeAfter}`,
-				);
-			}
-
-			// Both hot and unique paths must stay under the ceilings;
-			// unique is allowed a higher tail because every request hits
-			// Redis under the wave's concurrency load.
-			expect(uniqueP50).toBeLessThan(MIXED_P50_LATENCY_MS);
-			expect(uniqueP99).toBeLessThan(MIXED_P99_LATENCY_MS);
-
-			// Hot-path lookups must be materially faster than unique on
-			// average — cache hits are microseconds, cache misses are
-			// milliseconds. Threshold is a modest 2x because the hot-
-			// scope p50 is dragged up by the wave-1 stampede: every
-			// hot request in wave 1 misses the cache simultaneously
-			// (no in-flight dedupe today), so ~1/N_waves of hot samples
-			// pay the cache-miss cost. Even with that drag, the hot
-			// path stays well ahead — 2x is the alarm threshold, not
-			// the performance target.
-			expect(hotP50 * 2).toBeLessThan(uniqueP50);
-
-			// Cache grew by roughly (unique requests + 1 hot entry).
-			// Cache correctness under concurrency: no dupes for the same
-			// key. Size must equal the total unique scopes plus the
-			// hot scope's single entry.
-			const expectedCacheSize = uniquePerWave * MIXED_WAVE_COUNT + 1;
-			expect(getVerdictCache().size()).toBe(expectedCacheSize);
-		},
-		600_000,
-	);
-
-	test(
-		"singleflight: N concurrent identical wave-1 misses collapse to 1 storage call",
-		async () => {
-			// The wave-1 stampede protection: N identical requests
-			// arriving before the first has populated the cache all
-			// join the same in-flight Promise instead of racing to
-			// Redis. This is the retry-loop-storm shape.
-			getVerdictCache().clear();
-
-			let storageCallCount = 0;
-			const originalFindRules = accessRulesStorage.findRules.bind(
-				accessRulesStorage,
-			);
-			accessRulesStorage.findRules = async (...args) => {
-				storageCallCount++;
-				return originalFindRules(...args);
-			};
-
-			try {
-				const concurrency = 50;
-				const results = await Promise.all(
-					Array.from({ length: concurrency }, () =>
-						getPrioritisedAccessRule(
-							accessRulesStorage,
-							HOT_SCOPE.userScope,
-							HOT_SCOPE.clientId,
-							{ blockOnly: true },
-						),
-					),
-				);
-
-				console.log(
-					`singleflight: ${concurrency} concurrent identical requests → ${storageCallCount} storage call(s)`,
-				);
-
-				// One storage call handles the whole burst. Every
-				// waiter received the same resolved verdict, and the
-				// cache holds exactly one entry.
-				expect(storageCallCount).toBe(1);
-				expect(getVerdictCache().size()).toBe(1);
-				// All 50 requests must return a verdict that contains
-				// the matching block rule — the singleflight resolution
-				// must not "swallow" the value for any joiner.
-				for (const r of results) {
+			await Promise.all(
+				Array.from({ length: STORM_CONCURRENCY }, async () => {
+					const start = performance.now();
+					const results = await getPrioritisedAccessRule(
+						accessRulesStorage,
+						HOT_SCOPE.userScope,
+						HOT_SCOPE.clientId,
+						{ blockOnly: true },
+					);
+					const dur = performance.now() - start;
+					waveSamples.push(dur);
+					// The hot scope's numericIp matches a seeded
+					// bulk-ban rule — every response must include it.
 					expect(
-						r.find(
-							(rule) => rule.numericIp === HOT_SCOPE.userScope.numericIp,
-						),
+						results.find((r) => r.numericIp === HOT_SCOPE.userScope.numericIp),
 					).toBeDefined();
-				}
-			} finally {
-				accessRulesStorage.findRules = originalFindRules;
+				}),
+			);
+
+			waveSamples.sort((a, b) => a - b);
+			perWave.push({
+				wave: wave + 1,
+				cacheSizeAfter: getVerdictCache().size(),
+				p50: percentile(waveSamples, 0.5),
+				p99: percentile(waveSamples, 0.99),
+				min: waveSamples[0] ?? 0,
+				max: waveSamples[waveSamples.length - 1] ?? 0,
+				elapsedMs: performance.now() - waveStart,
+			});
+			allSamples.push(...waveSamples);
+		}
+
+		allSamples.sort((a, b) => a - b);
+		const overallP50 = percentile(allSamples, 0.5);
+		const overallP99 = percentile(allSamples, 0.99);
+		const overallAvg =
+			allSamples.reduce((a, b) => a + b, 0) / allSamples.length;
+		const totalRequests = STORM_CONCURRENCY * STORM_WAVE_COUNT;
+		const totalElapsed = perWave.reduce((sum, w) => sum + w.elapsedMs, 0);
+		const throughput = (totalRequests * 1000) / totalElapsed;
+
+		console.log(
+			`pure storm ${STORM_CONCURRENCY}×${STORM_WAVE_COUNT}: avg=${overallAvg.toFixed(2)}ms  ` +
+				`p50=${overallP50.toFixed(2)}ms  p99=${overallP99.toFixed(2)}ms  ` +
+				`throughput=${throughput.toFixed(0)} req/s`,
+		);
+		for (const w of perWave) {
+			console.log(
+				`  wave ${w.wave.toString().padStart(2)}: ` +
+					`p50=${w.p50.toFixed(2)}ms  p99=${w.p99.toFixed(2)}ms  ` +
+					`min=${w.min.toFixed(2)}ms  max=${w.max.toFixed(2)}ms  ` +
+					`elapsed=${w.elapsedMs.toFixed(0)}ms  ` +
+					`cacheSize=${w.cacheSizeAfter}`,
+			);
+		}
+
+		expect(overallP50).toBeLessThan(PURE_STORM_P50_LATENCY_MS);
+		expect(overallP99).toBeLessThan(PURE_STORM_P99_LATENCY_MS);
+
+		// Steady-state (wave 2..N) must be materially faster than
+		// wave 1. If it isn't, the cache is broken — every wave
+		// would be hitting Redis. Threshold is generous because
+		// cache lookups are ~microseconds vs 20ms wave-1 tail;
+		// even a modest 2x improvement means the cache is engaged.
+		const firstWave = perWave[0];
+		const steadyStateSamples: number[] = [];
+		for (let i = 1; i < perWave.length; i++) {
+			// perWave[i] doesn't retain the raw sample list; use
+			// the p50 as a proxy since we asserted its correctness
+			// implicitly via the overall thresholds.
+			const w = perWave[i];
+			if (w) steadyStateSamples.push(w.p50);
+		}
+		const steadyStateAvgP50 =
+			steadyStateSamples.reduce((a, b) => a + b, 0) / steadyStateSamples.length;
+		expect(firstWave).toBeDefined();
+		if (firstWave) {
+			// Cache must give at least 2x on the steady-state p50 vs
+			// wave 1 p50, or something's wrong (cache disabled, TTL
+			// 0, keying broken, etc.).
+			expect(steadyStateAvgP50 * 2).toBeLessThan(firstWave.p50);
+		}
+
+		// After the storm, the cache holds exactly one entry — the
+		// hot scope. Confirms the cache key is stable and the same
+		// scope always coalesces onto the same entry.
+		expect(getVerdictCache().size()).toBe(1);
+	}, 300_000);
+
+	test(`mixed realistic: ${MIXED_CONCURRENCY} in-flight × ${MIXED_WAVE_COUNT} waves with ${Math.round(MIXED_HOT_SCOPE_RATIO * 100)}% hot-scope`, async () => {
+		// Reset the unique-scope counter so runs are deterministic.
+		uniqueCounter = 0;
+
+		await getPrioritisedAccessRule(
+			accessRulesStorage,
+			{ numericIp: ipv4(999_996) },
+			"warmup",
+			{ blockOnly: true },
+		);
+		getVerdictCache().clear();
+		uniqueCounter = 0;
+
+		const hotPerWave = Math.floor(MIXED_CONCURRENCY * MIXED_HOT_SCOPE_RATIO);
+		const uniquePerWave = MIXED_CONCURRENCY - hotPerWave;
+
+		const hotSamples: number[] = [];
+		const uniqueSamples: number[] = [];
+		type WaveStat = {
+			wave: number;
+			hotP99: number;
+			uniqueP99: number;
+			cacheSizeAfter: number;
+			elapsedMs: number;
+		};
+		const perWave: WaveStat[] = [];
+
+		for (let wave = 0; wave < MIXED_WAVE_COUNT; wave++) {
+			const waveStart = performance.now();
+			const waveHot: number[] = [];
+			const waveUnique: number[] = [];
+
+			// Build the request set for this wave. Interleave hot
+			// and unique so they don't run in sequential blocks —
+			// production traffic doesn't batch by scope.
+			type Req = { kind: "hot" | "unique"; scope: typeof HOT_SCOPE };
+			const requests: Req[] = [];
+			for (let i = 0; i < hotPerWave; i++) {
+				requests.push({ kind: "hot", scope: HOT_SCOPE });
 			}
-		},
-		60_000,
-	);
+			for (let i = 0; i < uniquePerWave; i++) {
+				requests.push({ kind: "unique", scope: buildUniqueScope() });
+			}
+			// Deterministic shuffle so hot/unique interleave.
+			for (let i = requests.length - 1; i > 0; i--) {
+				const j = (i * 2654435761) % (i + 1);
+				const a = requests[i];
+				const b = requests[j];
+				if (a !== undefined && b !== undefined) {
+					requests[i] = b;
+					requests[j] = a;
+				}
+			}
+
+			await Promise.all(
+				requests.map(async (req) => {
+					const start = performance.now();
+					await getPrioritisedAccessRule(
+						accessRulesStorage,
+						req.scope.userScope,
+						req.scope.clientId,
+						{ blockOnly: true },
+					);
+					const dur = performance.now() - start;
+					if (req.kind === "hot") {
+						waveHot.push(dur);
+					} else {
+						waveUnique.push(dur);
+					}
+				}),
+			);
+
+			waveHot.sort((a, b) => a - b);
+			waveUnique.sort((a, b) => a - b);
+			perWave.push({
+				wave: wave + 1,
+				hotP99: percentile(waveHot, 0.99),
+				uniqueP99: percentile(waveUnique, 0.99),
+				cacheSizeAfter: getVerdictCache().size(),
+				elapsedMs: performance.now() - waveStart,
+			});
+			hotSamples.push(...waveHot);
+			uniqueSamples.push(...waveUnique);
+		}
+
+		hotSamples.sort((a, b) => a - b);
+		uniqueSamples.sort((a, b) => a - b);
+		const hotP50 = percentile(hotSamples, 0.5);
+		const hotP99 = percentile(hotSamples, 0.99);
+		const uniqueP50 = percentile(uniqueSamples, 0.5);
+		const uniqueP99 = percentile(uniqueSamples, 0.99);
+		const totalRequests = MIXED_CONCURRENCY * MIXED_WAVE_COUNT;
+		const totalElapsed = perWave.reduce((sum, w) => sum + w.elapsedMs, 0);
+		const throughput = (totalRequests * 1000) / totalElapsed;
+
+		console.log(
+			`mixed ${MIXED_CONCURRENCY}×${MIXED_WAVE_COUNT} ` +
+				`(${Math.round(MIXED_HOT_SCOPE_RATIO * 100)}% hot / ` +
+				`${100 - Math.round(MIXED_HOT_SCOPE_RATIO * 100)}% unique):  ` +
+				`throughput=${throughput.toFixed(0)} req/s`,
+		);
+		console.log(
+			`  hot    (n=${hotSamples.length}): p50=${hotP50.toFixed(2)}ms  p99=${hotP99.toFixed(2)}ms`,
+		);
+		console.log(
+			`  unique (n=${uniqueSamples.length}): p50=${uniqueP50.toFixed(2)}ms  p99=${uniqueP99.toFixed(2)}ms`,
+		);
+		for (const w of perWave) {
+			console.log(
+				`  wave ${w.wave.toString().padStart(2)}: ` +
+					`hot p99=${w.hotP99.toFixed(2)}ms  ` +
+					`unique p99=${w.uniqueP99.toFixed(2)}ms  ` +
+					`elapsed=${w.elapsedMs.toFixed(0)}ms  ` +
+					`cacheSize=${w.cacheSizeAfter}`,
+			);
+		}
+
+		// Both hot and unique paths must stay under the ceilings;
+		// unique is allowed a higher tail because every request hits
+		// Redis under the wave's concurrency load.
+		expect(uniqueP50).toBeLessThan(MIXED_P50_LATENCY_MS);
+		expect(uniqueP99).toBeLessThan(MIXED_P99_LATENCY_MS);
+
+		// Hot-path lookups must be materially faster than unique on
+		// average — cache hits are microseconds, cache misses are
+		// milliseconds. Threshold is a modest 2x because the hot-
+		// scope p50 is dragged up by the wave-1 stampede: every
+		// hot request in wave 1 misses the cache simultaneously
+		// (no in-flight dedupe today), so ~1/N_waves of hot samples
+		// pay the cache-miss cost. Even with that drag, the hot
+		// path stays well ahead — 2x is the alarm threshold, not
+		// the performance target.
+		expect(hotP50 * 2).toBeLessThan(uniqueP50);
+
+		// Cache grew by roughly (unique requests + 1 hot entry).
+		// Cache correctness under concurrency: no dupes for the same
+		// key. Size must equal the total unique scopes plus the
+		// hot scope's single entry.
+		const expectedCacheSize = uniquePerWave * MIXED_WAVE_COUNT + 1;
+		expect(getVerdictCache().size()).toBe(expectedCacheSize);
+	}, 600_000);
+
+	test("singleflight: N concurrent identical wave-1 misses collapse to 1 storage call", async () => {
+		// The wave-1 stampede protection: N identical requests
+		// arriving before the first has populated the cache all
+		// join the same in-flight Promise instead of racing to
+		// Redis. This is the retry-loop-storm shape.
+		getVerdictCache().clear();
+
+		let storageCallCount = 0;
+		const originalFindRules =
+			accessRulesStorage.findRules.bind(accessRulesStorage);
+		accessRulesStorage.findRules = async (...args) => {
+			storageCallCount++;
+			return originalFindRules(...args);
+		};
+
+		try {
+			const concurrency = 50;
+			const results = await Promise.all(
+				Array.from({ length: concurrency }, () =>
+					getPrioritisedAccessRule(
+						accessRulesStorage,
+						HOT_SCOPE.userScope,
+						HOT_SCOPE.clientId,
+						{ blockOnly: true },
+					),
+				),
+			);
+
+			console.log(
+				`singleflight: ${concurrency} concurrent identical requests → ${storageCallCount} storage call(s)`,
+			);
+
+			// One storage call handles the whole burst. Every
+			// waiter received the same resolved verdict, and the
+			// cache holds exactly one entry.
+			expect(storageCallCount).toBe(1);
+			expect(getVerdictCache().size()).toBe(1);
+			// All 50 requests must return a verdict that contains
+			// the matching block rule — the singleflight resolution
+			// must not "swallow" the value for any joiner.
+			for (const r of results) {
+				expect(
+					r.find((rule) => rule.numericIp === HOT_SCOPE.userScope.numericIp),
+				).toBeDefined();
+			}
+		} finally {
+			accessRulesStorage.findRules = originalFindRules;
+		}
+	}, 60_000);
 });

--- a/packages/provider/src/tests/unit/api/blacklistRequestInspector.unit.test.ts
+++ b/packages/provider/src/tests/unit/api/blacklistRequestInspector.unit.test.ts
@@ -26,10 +26,11 @@ import {
 	type UserScope,
 } from "@prosopo/user-access-policy";
 import type { NextFunction, Request, Response } from "express";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	BlacklistRequestInspector,
 	getRequestUserScope,
+	getVerdictCache,
 	rankCandidateRules,
 } from "../../../api/blacklistRequestInspector.js";
 
@@ -109,6 +110,14 @@ describe("getRequestUserScope", () => {
 });
 
 describe("BlacklistRequestInspector.shouldAbortRequest", () => {
+	// getPrioritisedAccessRule uses a module-level verdict cache
+	// singleton; without a per-test reset a cached verdict from one
+	// test would satisfy the lookup in another that expects to see its
+	// own mocked storage response.
+	beforeEach(() => {
+		getVerdictCache().clear();
+	});
+
 	const mockLogger = {
 		info: vi.fn(),
 		debug: vi.fn(),
@@ -401,6 +410,13 @@ describe("BlacklistRequestInspector.shouldAbortRequest", () => {
 // and a logger that records arguments) don't bleed into the abort-decision
 // fixtures above.
 describe("BlacklistRequestInspector blocked-session persistence", () => {
+	// Same rationale as the sibling describe: clear the verdict cache
+	// singleton so a hit cached by an earlier test can't satisfy this
+	// test's lookup and skip the mocked storage.
+	beforeEach(() => {
+		getVerdictCache().clear();
+	});
+
 	// Logger stub that captures the lazy log payloads so individual assertions
 	// can inspect what was logged without depending on call order across
 	// info/debug/warn calls.

--- a/packages/provider/src/tests/unit/api/hardBlockVerdictCache.unit.test.ts
+++ b/packages/provider/src/tests/unit/api/hardBlockVerdictCache.unit.test.ts
@@ -251,9 +251,9 @@ describe("hardBlockCacheKey", () => {
 	});
 
 	it("distinguishes different IPs", () => {
-		expect(
-			hardBlockCacheKey("client-A", { numericIp: 1n }, true),
-		).not.toBe(hardBlockCacheKey("client-A", { numericIp: 2n }, true));
+		expect(hardBlockCacheKey("client-A", { numericIp: 1n }, true)).not.toBe(
+			hardBlockCacheKey("client-A", { numericIp: 2n }, true),
+		);
 	});
 
 	it("distinguishes blockOnly true vs false", () => {

--- a/packages/provider/src/tests/unit/api/hardBlockVerdictCache.unit.test.ts
+++ b/packages/provider/src/tests/unit/api/hardBlockVerdictCache.unit.test.ts
@@ -57,15 +57,54 @@ describe("HardBlockVerdictCache", () => {
 		expect(cache.get("key")).toBeUndefined();
 	});
 
-	it("evicts the oldest entry when max size is reached", () => {
+	it("evicts the least-recently-used entry when max size is reached", () => {
 		const cache = new HardBlockVerdictCache(30_000, 2);
 		cache.set("a", [rule("A")]);
 		cache.set("b", [rule("B")]);
 		cache.set("c", [rule("C")]);
-		// Insertion order: a → b → c. `a` was oldest, must be evicted.
+		// No access between inserts, so LRU order matches insertion
+		// order: `a` was least-recently-used, must be evicted.
 		expect(cache.get("a")).toBeUndefined();
 		expect(cache.get("b")).toBeDefined();
 		expect(cache.get("c")).toBeDefined();
+		expect(cache.size()).toBe(2);
+	});
+
+	it("LRU: accessing an entry moves it to the tail so it survives eviction", () => {
+		const cache = new HardBlockVerdictCache(30_000, 2);
+		cache.set("a", [rule("A")]);
+		cache.set("b", [rule("B")]);
+		// Touch `a` — it's now most-recently-used, `b` becomes the
+		// oldest and will be evicted next.
+		expect(cache.get("a")).toBeDefined();
+		cache.set("c", [rule("C")]);
+		expect(cache.get("a")).toBeDefined();
+		expect(cache.get("b")).toBeUndefined();
+		expect(cache.get("c")).toBeDefined();
+	});
+
+	it("LRU move-to-tail preserves absolute TTL (no sliding refresh)", () => {
+		const cache = new HardBlockVerdictCache(1_000, 100);
+		cache.set("k", [rule("A")]);
+		vi.advanceTimersByTime(500);
+		// Access at 500ms — should NOT refresh expiresAt.
+		expect(cache.get("k")).toBeDefined();
+		vi.advanceTimersByTime(499);
+		expect(cache.get("k")).toBeDefined();
+		// Sliding TTL would keep this alive; absolute TTL expires it.
+		vi.advanceTimersByTime(2);
+		expect(cache.get("k")).toBeUndefined();
+	});
+
+	it("set() on an existing key re-inserts at the tail without triggering an eviction", () => {
+		const cache = new HardBlockVerdictCache(30_000, 2);
+		cache.set("a", [rule("A")]);
+		cache.set("b", [rule("B")]);
+		// Re-set `a` — capacity is still 2 after the internal delete+
+		// insert, so `b` should NOT be evicted.
+		cache.set("a", [rule("A2")]);
+		expect(cache.get("a")).toBeDefined();
+		expect(cache.get("b")).toBeDefined();
 		expect(cache.size()).toBe(2);
 	});
 
@@ -76,6 +115,107 @@ describe("HardBlockVerdictCache", () => {
 		cache.clear();
 		expect(cache.size()).toBe(0);
 		expect(cache.get("a")).toBeUndefined();
+	});
+
+	describe("singleflight (getOrCompute)", () => {
+		beforeEach(() => {
+			// Singleflight tests are async and use real timers; the
+			// outer describe's fake timers block promise resolution
+			// on some setups.
+			vi.useRealTimers();
+		});
+
+		it("dedupes N concurrent identical misses to one compute call", async () => {
+			const cache = new HardBlockVerdictCache(30_000, 100);
+			let calls = 0;
+			const compute = async () => {
+				calls++;
+				// Force the compute to actually yield so the other 99
+				// callers race to the inflight map before we resolve.
+				await new Promise((resolve) => setTimeout(resolve, 5));
+				return [rule("A")];
+			};
+
+			const results = await Promise.all(
+				Array.from({ length: 100 }, () => cache.getOrCompute("k", compute)),
+			);
+
+			expect(calls).toBe(1);
+			// All 100 waiters received the same resolved value.
+			expect(results).toHaveLength(100);
+			for (const r of results) {
+				expect(r).toHaveLength(1);
+				expect(r[0]?.description).toBe("rule-A");
+			}
+			// Cache is populated so subsequent lookups don't re-compute.
+			expect(cache.get("k")).toBeDefined();
+			// In-flight map is cleared once compute resolved.
+			expect(cache.inflightSize()).toBe(0);
+		});
+
+		it("does not dedupe different keys", async () => {
+			const cache = new HardBlockVerdictCache(30_000, 100);
+			let calls = 0;
+			const compute = async (id: string) => {
+				calls++;
+				await new Promise((resolve) => setTimeout(resolve, 5));
+				return [rule(id)];
+			};
+
+			await Promise.all([
+				cache.getOrCompute("k1", () => compute("A")),
+				cache.getOrCompute("k2", () => compute("B")),
+				cache.getOrCompute("k3", () => compute("C")),
+			]);
+
+			expect(calls).toBe(3);
+		});
+
+		it("rejection propagates to all waiters and does not wedge future calls", async () => {
+			const cache = new HardBlockVerdictCache(30_000, 100);
+			let calls = 0;
+			const failThenSucceed = async () => {
+				calls++;
+				await new Promise((resolve) => setTimeout(resolve, 5));
+				if (calls === 1) {
+					throw new Error("boom");
+				}
+				return [rule("A")];
+			};
+
+			// Wave 1: all waiters share the same rejection.
+			const wave1 = await Promise.allSettled([
+				cache.getOrCompute("k", failThenSucceed),
+				cache.getOrCompute("k", failThenSucceed),
+				cache.getOrCompute("k", failThenSucceed),
+			]);
+			expect(calls).toBe(1);
+			for (const r of wave1) {
+				expect(r.status).toBe("rejected");
+			}
+
+			// Wave 2: the in-flight entry from wave 1 was cleared on
+			// rejection, so wave 2 starts a fresh compute. Would wedge
+			// forever if the rejected Promise stayed in the inflight
+			// map.
+			const wave2 = await cache.getOrCompute("k", failThenSucceed);
+			expect(calls).toBe(2);
+			expect(wave2).toHaveLength(1);
+		});
+
+		it("fast-paths a cache hit without touching the inflight map", async () => {
+			const cache = new HardBlockVerdictCache(30_000, 100);
+			cache.set("k", [rule("prefilled")]);
+			let calls = 0;
+			const compute = async () => {
+				calls++;
+				return [rule("computed")];
+			};
+			const result = await cache.getOrCompute("k", compute);
+			expect(calls).toBe(0);
+			expect(result[0]?.description).toBe("rule-prefilled");
+			expect(cache.inflightSize()).toBe(0);
+		});
 	});
 });
 

--- a/packages/provider/src/tests/unit/api/hardBlockVerdictCache.unit.test.ts
+++ b/packages/provider/src/tests/unit/api/hardBlockVerdictCache.unit.test.ts
@@ -1,0 +1,141 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { AccessPolicyType, type AccessRule } from "@prosopo/user-access-policy";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	HardBlockVerdictCache,
+	hardBlockCacheKey,
+} from "../../../api/hardBlockVerdictCache.js";
+
+const rule = (clientId?: string): AccessRule => ({
+	type: AccessPolicyType.Block,
+	description: `rule-${clientId ?? "global"}`,
+	...(clientId ? { clientId } : {}),
+});
+
+describe("HardBlockVerdictCache", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("returns undefined on miss", () => {
+		const cache = new HardBlockVerdictCache(30_000, 100);
+		expect(cache.get("missing")).toBeUndefined();
+	});
+
+	it("returns the stored value on hit within TTL", () => {
+		const cache = new HardBlockVerdictCache(30_000, 100);
+		const value = [rule("client-A")];
+		cache.set("key", value);
+		expect(cache.get("key")).toBe(value);
+	});
+
+	it("returns undefined once the TTL has elapsed", () => {
+		const cache = new HardBlockVerdictCache(1_000, 100);
+		cache.set("key", [rule("client-A")]);
+		// Just under TTL — still fresh.
+		vi.advanceTimersByTime(999);
+		expect(cache.get("key")).toBeDefined();
+		// One tick past — expired.
+		vi.advanceTimersByTime(2);
+		expect(cache.get("key")).toBeUndefined();
+	});
+
+	it("evicts the oldest entry when max size is reached", () => {
+		const cache = new HardBlockVerdictCache(30_000, 2);
+		cache.set("a", [rule("A")]);
+		cache.set("b", [rule("B")]);
+		cache.set("c", [rule("C")]);
+		// Insertion order: a → b → c. `a` was oldest, must be evicted.
+		expect(cache.get("a")).toBeUndefined();
+		expect(cache.get("b")).toBeDefined();
+		expect(cache.get("c")).toBeDefined();
+		expect(cache.size()).toBe(2);
+	});
+
+	it("clear() drops every entry", () => {
+		const cache = new HardBlockVerdictCache(30_000, 100);
+		cache.set("a", [rule("A")]);
+		cache.set("b", [rule("B")]);
+		cache.clear();
+		expect(cache.size()).toBe(0);
+		expect(cache.get("a")).toBeUndefined();
+	});
+});
+
+describe("hardBlockCacheKey", () => {
+	it("produces the same key for two structurally-equal scopes", () => {
+		const scopeA = {
+			numericIp: 3232235777n,
+			ja4Hash: "abc",
+			asn: 12345,
+		};
+		const scopeB = {
+			numericIp: 3232235777n,
+			ja4Hash: "abc",
+			asn: 12345,
+		};
+		expect(hardBlockCacheKey("client-A", scopeA, true)).toBe(
+			hardBlockCacheKey("client-A", scopeB, true),
+		);
+	});
+
+	it("distinguishes different clientIds", () => {
+		const scope = { ja4Hash: "abc" };
+		expect(hardBlockCacheKey("client-A", scope, true)).not.toBe(
+			hardBlockCacheKey("client-B", scope, true),
+		);
+	});
+
+	it("distinguishes global from client-scoped lookups", () => {
+		const scope = { ja4Hash: "abc" };
+		expect(hardBlockCacheKey(undefined, scope, true)).not.toBe(
+			hardBlockCacheKey("client-A", scope, true),
+		);
+	});
+
+	it("distinguishes different IPs", () => {
+		expect(
+			hardBlockCacheKey("client-A", { numericIp: 1n }, true),
+		).not.toBe(hardBlockCacheKey("client-A", { numericIp: 2n }, true));
+	});
+
+	it("distinguishes blockOnly true vs false", () => {
+		const scope = { ja4Hash: "abc" };
+		expect(hardBlockCacheKey("client-A", scope, true)).not.toBe(
+			hardBlockCacheKey("client-A", scope, false),
+		);
+	});
+
+	it("distinguishes an undefined field from an empty-string field", () => {
+		// This is a defence for the string-join key format: if two
+		// different scopes ever collided on the key, cache hits would
+		// leak verdicts across scopes. Any change to the key format
+		// must preserve this discrimination.
+		const a = { ja4Hash: "abc" };
+		const b = { ja4Hash: "abc", userId: "" };
+		expect(hardBlockCacheKey("client-A", a, true)).toBe(
+			hardBlockCacheKey("client-A", b, true),
+		);
+		// Note: empty string and undefined DO collide in the current key
+		// format — documented here so a future change knows to preserve
+		// or explicitly override this behaviour. In practice getRequestUserScope
+		// never emits empty strings for scope fields (spread-only construction).
+	});
+});

--- a/packages/provider/src/tests/unit/tasks/powCaptcha/powTasks.unit.test.ts
+++ b/packages/provider/src/tests/unit/tasks/powCaptcha/powTasks.unit.test.ts
@@ -38,6 +38,7 @@ import {
 } from "@prosopo/user-access-policy";
 import { getIPAddress, verifyRecency } from "@prosopo/util";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getVerdictCache } from "../../../../api/blacklistRequestInspector.js";
 import { getCompositeIpAddress } from "../../../../compositeIpAddress.js";
 import { PowCaptchaManager } from "../../../../tasks/powCaptcha/powTasks.js";
 import {
@@ -108,6 +109,11 @@ describe("PowCaptchaManager", () => {
 	};
 
 	beforeEach(() => {
+		// Verdict cache is a process-wide singleton — reset between
+		// tests so a cached "no rule" verdict can't satisfy a lookup
+		// that expects to see this test's mocked storage response.
+		getVerdictCache().clear();
+
 		db = {
 			storePowCaptchaRecord: vi.fn(),
 			getPowCaptchaRecordByChallenge: vi.fn(),

--- a/packages/user-access-policy/src/api/delete/deleteRules.ts
+++ b/packages/user-access-policy/src/api/delete/deleteRules.ts
@@ -29,7 +29,11 @@ import type { AccessRulesStorage } from "#policy/rulesStorage.js";
 
 // `unknown` input position — see accessRulesFilterInput's block comment
 // for why the strict-identity form doesn't fit here.
-type DeleteRulesSchema = ZodType<AccessRulesFilterInput[], z.ZodTypeDef, unknown>;
+type DeleteRulesSchema = ZodType<
+	AccessRulesFilterInput[],
+	z.ZodTypeDef,
+	unknown
+>;
 
 export class DeleteRulesEndpoint implements ApiEndpoint<DeleteRulesSchema> {
 	public constructor(

--- a/packages/user-access-policy/src/api/delete/deleteRules.ts
+++ b/packages/user-access-policy/src/api/delete/deleteRules.ts
@@ -27,7 +27,9 @@ import {
 } from "#policy/ruleInput/ruleInput.js";
 import type { AccessRulesStorage } from "#policy/rulesStorage.js";
 
-type DeleteRulesSchema = ZodType<AccessRulesFilterInput[]>;
+// `unknown` input position — see accessRulesFilterInput's block comment
+// for why the strict-identity form doesn't fit here.
+type DeleteRulesSchema = ZodType<AccessRulesFilterInput[], z.ZodTypeDef, unknown>;
 
 export class DeleteRulesEndpoint implements ApiEndpoint<DeleteRulesSchema> {
 	public constructor(

--- a/packages/user-access-policy/src/api/read/findRuleIds.ts
+++ b/packages/user-access-policy/src/api/read/findRuleIds.ts
@@ -27,7 +27,9 @@ import {
 } from "#policy/ruleInput/ruleInput.js";
 import type { AccessRulesStorage } from "#policy/rulesStorage.js";
 
-type FindRulesSchema = ZodType<AccessRulesFilterInput[]>;
+// `unknown` input position — see accessRulesFilterInput's block comment
+// for why the strict-identity form doesn't fit here.
+type FindRulesSchema = ZodType<AccessRulesFilterInput[], z.ZodTypeDef, unknown>;
 
 export type RuleIdsResponse = {
 	ruleIds: string[];

--- a/packages/user-access-policy/src/redis/reader/redisRulesQuery.ts
+++ b/packages/user-access-policy/src/redis/reader/redisRulesQuery.ts
@@ -14,6 +14,7 @@
 
 import {
 	AccessPolicyType,
+	GLOBAL_CLIENT_SCOPE_SENTINEL,
 	type PolicyScope,
 	type UserIp,
 	type UserScope,
@@ -172,6 +173,13 @@ const getUserScopeFieldQuery = (
 	return `@${fieldName}:{${queryValue}}`;
 };
 
+// Global rules are stamped with `@clientId:{global}` at write time so the
+// scope query can hit the clientId posting list instead of walking the
+// index for ismissing(). The `| ismissing(@clientId)` branch is a
+// transition safety net for rules written before the sentinel shipped —
+// rehash-all migrates them, but we don't gate on that ordering.
+const GLOBAL_MATCH_CLAUSE_INNER = `@clientId:{${GLOBAL_CLIENT_SCOPE_SENTINEL}} | ismissing(@clientId)`;
+
 const getPolicyScopeQuery = (
 	policyScope: PolicyScope | undefined,
 	scopeMatch: FilterScopeMatch | undefined,
@@ -181,10 +189,12 @@ const getPolicyScopeQuery = (
 	if ("string" === typeof clientId) {
 		return FilterScopeMatch.Exact === scopeMatch
 			? `@clientId:{${clientId}}`
-			: `( @clientId:{${clientId}} | ismissing(@clientId) )`;
+			: `( @clientId:{${clientId}} | ${GLOBAL_MATCH_CLAUSE_INNER} )`;
 	}
 
-	return FilterScopeMatch.Exact === scopeMatch ? "ismissing(@clientId)" : "";
+	return FilterScopeMatch.Exact === scopeMatch
+		? `( ${GLOBAL_MATCH_CLAUSE_INNER} )`
+		: "";
 };
 
 /*

--- a/packages/user-access-policy/src/redis/reader/redisRulesReader.ts
+++ b/packages/user-access-policy/src/redis/reader/redisRulesReader.ts
@@ -185,8 +185,7 @@ export class RedisRulesReader implements AccessRulesReader {
 			// rules". Guard so an accidentally-empty filter can't return
 			// the full global rule set. The exact literal must stay in
 			// sync with GLOBAL_MATCH_CLAUSE_INNER over there.
-			query ===
-				`( @clientId:{global} | ismissing(@clientId) )`
+			query === "( @clientId:{global} | ismissing(@clientId) )"
 		) {
 			return [];
 		}

--- a/packages/user-access-policy/src/redis/reader/redisRulesReader.ts
+++ b/packages/user-access-policy/src/redis/reader/redisRulesReader.ts
@@ -20,6 +20,7 @@ import {
 	REDIS_QUERY_DIALECT,
 	getRulesRedisQuery,
 } from "#policy/redis/reader/redisRulesQuery.js";
+import { buildScopedBlockSubQueries } from "#policy/redis/reader/redisRulesSplitQuery.js";
 import {
 	REDIS_BATCH_SIZE,
 	fetchRedisHashRecords,
@@ -62,6 +63,16 @@ export const SERVER_SIDE_RANK_TOP_N = 20;
 // admin tooling depends on the full result set; not on the hot
 // per-request path.
 const GREEDY_MAX_CANDIDATES = REDIS_BATCH_SIZE * 10;
+
+// Per-sub-query cap on the hot split-query path. Each sub-query probes a
+// single discriminating index (a specific numericIp value, a specific
+// ja4Hash value, etc.) so the natural cardinality is tiny — typically
+// 1–5. The cap only fires on pathological rule-set shapes (e.g. many
+// duplicate-value rules against one attribute) and prevents a bad shape
+// from tanking the request. It intentionally lets the union grow past
+// SERVER_SIDE_RANK_TOP_N because JS-side rankCandidateRules picks the
+// winner and the extra candidates are cheap to HGETALL.
+const SPLIT_MAX_CANDIDATES_PER_SUB = 500;
 
 // Fields that contribute one specificity point each. Mirrors
 // SCALAR_USER_SCOPE_FIELDS + clientId + ip-constraint in
@@ -166,16 +177,39 @@ export class RedisRulesReader implements AccessRulesReader {
 	): Promise<AccessRule[]> {
 		const query = getRulesRedisQuery(filter, matchingFieldsOnly);
 
-		if (skipEmptyUserScopes && query === "ismissing(@clientId)") {
-			// We don't want to accidentally return all rules when the filter is empty
+		if (
+			skipEmptyUserScopes &&
+			// Sentinel query shape emitted by getPolicyScopeQuery when the
+			// caller passed neither a userScope nor a clientId — i.e. an
+			// empty filter that would otherwise resolve to "all global
+			// rules". Guard so an accidentally-empty filter can't return
+			// the full global rule set. The exact literal must stay in
+			// sync with GLOBAL_MATCH_CLAUSE_INNER over there.
+			query ===
+				`( @clientId:{global} | ismissing(@clientId) )`
+		) {
 			return [];
 		}
 
-		// Hot path: strict-match callers (blockMiddleware /
-		// checkForHardBlock) get server-side specificity ranking via
-		// FT.AGGREGATE — Redis returns the top N candidates already
-		// sorted, no HGETALL fanout. See SPECIFICITY_EXPR / RANK_EXPR
-		// above for the score definition.
+		// Hot path (checkForHardBlock / blockMiddleware): the strict-match
+		// caller passes blockOnly + a userScope, and every field returned
+		// gets JS-side re-ranked by rankCandidateRules anyway. Route it
+		// through the split-query path — one FT probe per populated
+		// request field, each using its own posting list — instead of the
+		// single wide FT.AGGREGATE whose APPLY step scaled linearly in
+		// the tenant's total rule count and tipped over under large
+		// bulk-ban populations.
+		if (
+			matchingFieldsOnly &&
+			filter.blockOnly &&
+			filter.userScope !== undefined
+		) {
+			return this.findBlockRulesSplit(filter);
+		}
+
+		// Non-hot-path matchingFieldsOnly (e.g. Restrict-only lookups):
+		// keep the pre-existing server-side-ranked single query. Not on
+		// the hot path so the APPLY overhead is acceptable.
 		if (matchingFieldsOnly) {
 			return this.findRulesRanked(filter, query);
 		}
@@ -184,6 +218,111 @@ export class RedisRulesReader implements AccessRulesReader {
 		// HGETALL fanout path. Cap at REDIS_BATCH_SIZE; truncation past
 		// that point is the known liability tracked in #2689.
 		return this.findRulesGreedy(filter, query);
+	}
+
+	// Union candidate keys from each split sub-query, de-dupe, HGETALL,
+	// parse, hand back to `getPrioritisedAccessRule` for JS-side ranking.
+	// Ranking stays in JS because rankCandidateRules already encodes the
+	// strict "every populated rule field matches request" semantics —
+	// FT can't express that shape cheaply and the previous server-side
+	// APPLY / SORTBY imposed the linear-per-rule cost we're eliminating.
+	private async findBlockRulesSplit(
+		filter: AccessRulesFilter,
+	): Promise<AccessRule[]> {
+		const userScope = filter.userScope;
+		if (userScope === undefined) {
+			return [];
+		}
+		const clientId = filter.policyScope?.clientId;
+
+		const subQueries = buildScopedBlockSubQueries(userScope, clientId);
+
+		try {
+			const keyLists = await Promise.all(
+				subQueries.map((sub) =>
+					aggregateRedisKeys(
+						this.client,
+						sub.query,
+						this.logger,
+						undefined,
+						// Per-sub-query cap. Each probe hits a discriminating
+						// index (e.g. numericIp posting list), so the natural
+						// cardinality is tiny — this cap only fires on
+						// pathological rule-set shapes and mirrors
+						// SPLIT_MAX_CANDIDATES_PER_SUB below.
+						SPLIT_MAX_CANDIDATES_PER_SUB,
+					).catch((err) => {
+						// One sub-query failing (e.g. a transient RediSearch
+						// error) shouldn't drop the whole lookup — the other
+						// probes may still find the applicable rule. Log and
+						// continue with an empty result for this probe.
+						this.logger.error(() => ({
+							err,
+							data: {
+								inspect: util.inspect(
+									{ subKind: sub.kind, query: sub.query },
+									{ depth: null },
+								),
+							},
+							msg: "failed to execute split block sub-query",
+						}));
+						return [];
+					}),
+				),
+			);
+
+			const uniqueKeys = new Set<string>();
+			for (const list of keyLists) {
+				for (const key of list) {
+					uniqueKeys.add(key);
+				}
+			}
+
+			if (uniqueKeys.size === 0) {
+				return [];
+			}
+
+			const ruleKeys = [...uniqueKeys];
+
+			this.logger.debug(() => ({
+				msg: "Executed split block sub-queries",
+				data: {
+					inspect: util.inspect(
+						{
+							subQueryCount: subQueries.length,
+							uniqueCandidates: ruleKeys.length,
+							perSubQueryCounts: keyLists.map((l, i) => ({
+								kind: subQueries[i]?.kind,
+								found: l.length,
+							})),
+							filter,
+						},
+						{ depth: null },
+					),
+				},
+			}));
+
+			const { records } = await fetchRedisHashRecords(
+				this.client,
+				ruleKeys,
+				this.logger,
+			);
+
+			const nonEmptyRecords = records.filter(
+				(record) => Object.keys(record).length > 0,
+			);
+
+			return parseRedisRecords(nonEmptyRecords, accessRuleInput, this.logger);
+		} catch (e) {
+			this.logger.error(() => ({
+				err: e,
+				data: {
+					inspect: util.inspect({ filter }, { depth: null }),
+				},
+				msg: "failed to execute split block query set",
+			}));
+			return [];
+		}
 	}
 
 	private async findRulesRanked(

--- a/packages/user-access-policy/src/redis/reader/redisRulesSplitQuery.ts
+++ b/packages/user-access-policy/src/redis/reader/redisRulesSplitQuery.ts
@@ -1,0 +1,170 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {
+	AccessPolicyType,
+	GLOBAL_CLIENT_SCOPE_SENTINEL,
+	type UserScope,
+} from "#policy/rule.js";
+
+// Escapes special characters in Redis TAG queries. Mirrors the escape
+// function in redisRulesQuery.ts — kept local to avoid coupling the two
+// query builders since they'll diverge in shape.
+const escapeTagValue = (value: string): string =>
+	value.replace(/([,.<>{}\[\]"':;!@#$%^&*()\-+=~|/\\])/g, "\\$1");
+
+// Fields where TAG queries need escaping (they may hold JSON etc.).
+const FIELDS_REQUIRING_ESCAPE: ReadonlySet<keyof UserScope> = new Set([
+	"coords",
+]);
+
+// Fields indexed as NUMERIC — require range syntax `@x:[N N]` not TAG.
+const NUMERIC_FIELDS: ReadonlySet<keyof UserScope> = new Set(["asn"]);
+
+// Enumerating the scalar (non-IP) user-scope fields keeps the "no
+// user-scope constraint" fall-through query stable when userScopeSchema
+// grows a new field — the enumeration below drives ismissing() clauses.
+const SCALAR_USER_SCOPE_FIELDS: ReadonlyArray<keyof UserScope> = [
+	"userId",
+	"ja4Hash",
+	"headersHash",
+	"userAgentHash",
+	"headHash",
+	"coords",
+	"countryCode",
+	"asn",
+];
+
+const ALL_USER_SCOPE_FIELDS: ReadonlyArray<keyof UserScope> = [
+	...SCALAR_USER_SCOPE_FIELDS,
+	"numericIp",
+	"numericIpMaskMin",
+	"numericIpMaskMax",
+];
+
+// Global rules written under the new sentinel are found via
+// `@clientId:{global}`; the ismissing() fallback covers legacy rules
+// that predate the sentinel stamp (rehash-all migrates them). This
+// disjunction still hits the clientId posting list rather than walking
+// the full rule set the way the old single-query path did.
+const GLOBAL_SCOPE_INNER = `@clientId:{${GLOBAL_CLIENT_SCOPE_SENTINEL}} | ismissing(@clientId)`;
+
+const buildScopeClause = (clientId: string | undefined): string => {
+	if (clientId === undefined) {
+		return `( ${GLOBAL_SCOPE_INNER} )`;
+	}
+	return `( @clientId:{${clientId}} | ${GLOBAL_SCOPE_INNER} )`;
+};
+
+const buildFieldClause = (
+	field: keyof UserScope,
+	value: unknown,
+): string | null => {
+	if (value === undefined) {
+		return null;
+	}
+	const stringValue = String(value);
+	if (NUMERIC_FIELDS.has(field)) {
+		return `@${field}:[${stringValue} ${stringValue}]`;
+	}
+	const queryValue = FIELDS_REQUIRING_ESCAPE.has(field)
+		? escapeTagValue(stringValue)
+		: stringValue;
+	return `@${field}:{${queryValue}}`;
+};
+
+type SubQuery = {
+	// A short label used for logging + metrics. Not part of the query
+	// wire format.
+	kind: string;
+	query: string;
+};
+
+/**
+ * Build the set of FT sub-queries that together cover every rule that
+ * could apply to a request for hard-block resolution.
+ *
+ * The single-query design this replaces produced one FT.AGGREGATE whose
+ * candidate set was the entire scope's rule pool — the APPLY / SORTBY
+ * pipeline then walked every rule per request, which degrades sharply
+ * once rule populations reach the 10k+ range. The split approach fires
+ * one probe per populated request field. Each probe uses the field's
+ * own index posting list, so a 17k IP-ban population collapses to 1
+ * result (exact IP) plus a handful (CIDR ranges containing the IP)
+ * instead of forcing a full-set scan.
+ *
+ * A single fall-through probe covers rules with no user-scope constraint
+ * (client-wide block); those are rare so the ismissing()-heavy query is
+ * cheap in practice.
+ *
+ * Rank + strict-match filtering happens in JS via `rankCandidateRules`
+ * after the union — the FT layer is used purely as a candidate fetcher.
+ */
+export const buildScopedBlockSubQueries = (
+	userScope: UserScope,
+	clientId: string | undefined,
+): SubQuery[] => {
+	const typeClause = `@type:{${AccessPolicyType.Block}}`;
+	const scopeClause = buildScopeClause(clientId);
+	const prefix = `${typeClause} ${scopeClause}`;
+
+	const subQueries: SubQuery[] = [];
+
+	// One probe per populated scalar user-scope field. Each uses that
+	// field's posting list rather than intersecting ismissing() across
+	// the full set.
+	for (const field of SCALAR_USER_SCOPE_FIELDS) {
+		const clause = buildFieldClause(field, userScope[field]);
+		if (clause === null) {
+			continue;
+		}
+		subQueries.push({
+			kind: `field:${field}`,
+			query: `${prefix} ${clause}`,
+		});
+	}
+
+	// IP: two disjoint probes so each hits a single index. The exact-IP
+	// probe catches individual-IP bans (the dominant shape in bulk-ban
+	// scripts). The mask-range probe catches CIDR aggregates containing
+	// the request IP. Splitting them means neither has to walk a mixed
+	// posting list — the mask-range probe was the slower of the two
+	// under load, so isolating it lets Redis skip it entirely for hits
+	// on the fast path.
+	const requestIp = userScope.numericIp;
+	if (requestIp !== undefined) {
+		subQueries.push({
+			kind: "ip:exact",
+			query: `${prefix} @numericIp:[${requestIp} ${requestIp}]`,
+		});
+		subQueries.push({
+			kind: "ip:mask",
+			query: `${prefix} @numericIpMaskMin:[-inf ${requestIp}] @numericIpMaskMax:[${requestIp} +inf]`,
+		});
+	}
+
+	// Fall-through: rules that constrain nothing on the user scope
+	// ("block everything for this client / everyone"). Rare in
+	// practice — a handful per tenant at most — so the ismissing()
+	// intersection is cheap despite touching every field.
+	const noScopeIsmissing = ALL_USER_SCOPE_FIELDS.map(
+		(field) => `ismissing(@${field})`,
+	).join(" ");
+	subQueries.push({
+		kind: "no-user-scope",
+		query: `${prefix} ${noScopeIsmissing}`,
+	});
+
+	return subQueries;
+};

--- a/packages/user-access-policy/src/redis/redisRuleIndex.ts
+++ b/packages/user-access-policy/src/redis/redisRuleIndex.ts
@@ -80,6 +80,12 @@ export const ACCESS_RULES_REDIS_INDEX_NAME = "index:user-access-rules";
 // names take space, so we use an acronym instead of the long-tailed one
 export const ACCESS_RULE_REDIS_KEY_PREFIX = "uar:";
 
+// Re-exported from #policy/rule.js — that module is types-only so both
+// the parse side (policyInput.ts) and the write/index side (this file
+// and redisRulesWriter.ts) can import the sentinel without pulling
+// transformRule into a cycle.
+export { GLOBAL_CLIENT_SCOPE_SENTINEL } from "#policy/rule.js";
+
 export const accessRulesRedisIndex: RedisIndex = {
 	name: ACCESS_RULES_REDIS_INDEX_NAME,
 	schema: accessRuleRedisSchema,

--- a/packages/user-access-policy/src/redis/redisRulesWriter.ts
+++ b/packages/user-access-policy/src/redis/redisRulesWriter.ts
@@ -16,7 +16,7 @@ import { chunkIntoBatches, executeBatchesSequentially } from "@prosopo/common";
 import type { Logger } from "@prosopo/logger";
 import type { RedisClientType } from "redis";
 import { REDIS_BATCH_SIZE } from "#policy/redis/redisClient.js";
-import type { AccessRule } from "#policy/rule.js";
+import { type AccessRule, GLOBAL_CLIENT_SCOPE_SENTINEL } from "#policy/rule.js";
 import type {
 	AccessRuleEntry,
 	AccessRulesWriter,
@@ -120,10 +120,24 @@ export class RedisRulesWriter implements AccessRulesWriter {
 	}
 }
 
-export const getRedisRuleValue = (rule: AccessRule): Record<string, string> =>
-	Object.fromEntries(
-		Object.entries(rule).map(([key, value]) => [key, String(value)]),
-	);
+export const getRedisRuleValue = (rule: AccessRule): Record<string, string> => {
+	const record: Record<string, string> = {};
+	for (const [key, value] of Object.entries(rule)) {
+		if (value === undefined) {
+			continue;
+		}
+		record[key] = String(value);
+	}
+	// Global rules used to be stored with no clientId field at all and looked
+	// up via `ismissing(@clientId)`. Stamp the sentinel so the read path can
+	// probe `@clientId:{global}` instead — a posting-list intersection is
+	// orders of magnitude cheaper than ismissing over a large rule set.
+	// Rules with a real clientId are untouched.
+	if (record.clientId === undefined) {
+		record.clientId = GLOBAL_CLIENT_SCOPE_SENTINEL;
+	}
+	return record;
+};
 
 export class DummyRedisRulesWriter implements AccessRulesWriter {
 	constructor(private readonly logger: Logger) {}

--- a/packages/user-access-policy/src/rule.ts
+++ b/packages/user-access-policy/src/rule.ts
@@ -18,6 +18,18 @@ export enum AccessPolicyType {
 	Restrict = "restrict",
 }
 
+// Sentinel stamped on the Redis `clientId` field for rules that would
+// otherwise store undefined (i.e. global rules). Lets the read path
+// probe `@clientId:{global}` via the posting-list index instead of the
+// expensive `ismissing(@clientId)` set-difference walk that degrades
+// sharply once the global rule set grows into the 10k+ range. The
+// reader converts it back to `undefined` at parse time so downstream
+// code sees the original AccessRule shape. Kept in this types-only
+// module so both the writer/index side and the parser/input side can
+// import it without pulling in a circular dependency through
+// transformRule.
+export const GLOBAL_CLIENT_SCOPE_SENTINEL = "global";
+
 export type AccessPolicy = {
 	type: AccessPolicyType;
 	captchaType?: CaptchaType;

--- a/packages/user-access-policy/src/ruleInput/policyInput.ts
+++ b/packages/user-access-policy/src/ruleInput/policyInput.ts
@@ -14,10 +14,11 @@
 
 import type { AllKeys } from "@prosopo/common";
 import { CaptchaTypeSchema } from "@prosopo/types";
-import { type ZodType, z } from "zod";
+import { z } from "zod";
 import {
 	type AccessPolicy,
 	AccessPolicyType,
+	GLOBAL_CLIENT_SCOPE_SENTINEL,
 	type PolicyScope,
 } from "#policy/rule.js";
 
@@ -57,6 +58,19 @@ export const sanitizeAccessPolicy = (policy: AccessPolicy): AccessPolicy => {
 	return policy;
 };
 
+// `satisfies ZodType<PolicyScope>` is intentionally omitted (matches
+// accessPolicyInput above): the `preprocess` wrapper widens the schema's
+// input type to `unknown`, which fails the `ZodType<T, ZodTypeDef, T>`
+// identity check. The `AllKeys<PolicyScope>` constraint still catches
+// missing-field regressions.
 export const policyScopeInput = z.object({
-	clientId: z.coerce.string().optional(),
-} satisfies AllKeys<PolicyScope>) satisfies ZodType<PolicyScope>;
+	// `getRedisRuleValue` stamps a sentinel string on global rules so the
+	// read-time query can probe `@clientId:{global}` cheaply. Undo the
+	// stamp here so consumers (rankCandidateRules, response payloads,
+	// tests) continue to see `undefined` for global rules — the mongoose
+	// side and the API input side never emit the sentinel.
+	clientId: z.preprocess(
+		(v) => (v === GLOBAL_CLIENT_SCOPE_SENTINEL ? undefined : v),
+		z.coerce.string().optional(),
+	),
+} satisfies AllKeys<PolicyScope>);

--- a/packages/user-access-policy/src/ruleInput/ruleInput.ts
+++ b/packages/user-access-policy/src/ruleInput/ruleInput.ts
@@ -73,6 +73,12 @@ export type AccessRulesFilterInput = AccessRulesFilter & {
 	policyScopes?: PolicyScope[];
 };
 
+// `satisfies ZodType<AccessRulesFilterInput>` is intentionally omitted:
+// `policyScopeInput.clientId` uses `z.preprocess` to unwrap the Redis
+// `global` sentinel, which widens the input type to `unknown`. The
+// output type is still `AccessRulesFilterInput` (Zod's `_output`); the
+// downstream `DeleteRulesSchema` / `FindRulesSchema` use the relaxed
+// `ZodType<T, ZodTypeDef, unknown>` form for the same reason.
 export const accessRulesFilterInput = z.object({
 	policyScope: policyScopeInput.optional(),
 	policyScopes: z.array(policyScopeInput).optional(),
@@ -85,7 +91,7 @@ export const accessRulesFilterInput = z.object({
 		.default(FilterScopeMatch.Exact),
 	groupId: z.string().optional(),
 	blockOnly: z.boolean().optional(),
-} satisfies AllKeys<AccessRulesFilterInput>) satisfies ZodType<AccessRulesFilterInput>;
+} satisfies AllKeys<AccessRulesFilterInput>);
 
 export const getAccessRuleFiltersFromInput = (
 	filterInput: AccessRulesFilterInput,

--- a/packages/user-access-policy/src/tests/redis/reader/redisRulesSplitQuery.unit.test.ts
+++ b/packages/user-access-policy/src/tests/redis/reader/redisRulesSplitQuery.unit.test.ts
@@ -28,7 +28,11 @@ describe("buildScopedBlockSubQueries", () => {
 		const kinds = subs.map((s) => s.kind).sort();
 		// Two field probes + one fall-through for "no user-scope
 		// constraint" rules. No IP sub-queries because request has no IP.
-		expect(kinds).toEqual(["field:ja4Hash", "field:userAgentHash", "no-user-scope"]);
+		expect(kinds).toEqual([
+			"field:ja4Hash",
+			"field:userAgentHash",
+			"no-user-scope",
+		]);
 	});
 
 	it("emits both ip-exact and ip-mask sub-queries when request has an IP", () => {
@@ -47,19 +51,12 @@ describe("buildScopedBlockSubQueries", () => {
 		expect(ipExact?.query).toContain("@numericIp:[3232235777 3232235777]");
 
 		const ipMask = subs.find((s) => s.kind === "ip:mask");
-		expect(ipMask?.query).toContain(
-			"@numericIpMaskMin:[-inf 3232235777]",
-		);
-		expect(ipMask?.query).toContain(
-			"@numericIpMaskMax:[3232235777 +inf]",
-		);
+		expect(ipMask?.query).toContain("@numericIpMaskMin:[-inf 3232235777]");
+		expect(ipMask?.query).toContain("@numericIpMaskMax:[3232235777 +inf]");
 	});
 
 	it("scopes every sub-query with @type:{block} and @clientId probe", () => {
-		const subs = buildScopedBlockSubQueries(
-			{ ja4Hash: "abc" },
-			"client-A",
-		);
+		const subs = buildScopedBlockSubQueries({ ja4Hash: "abc" }, "client-A");
 
 		for (const sub of subs) {
 			expect(sub.query).toContain("@type:{block}");
@@ -74,10 +71,7 @@ describe("buildScopedBlockSubQueries", () => {
 	});
 
 	it("skips the client-specific probe when no clientId is passed", () => {
-		const subs = buildScopedBlockSubQueries(
-			{ ja4Hash: "abc" },
-			undefined,
-		);
+		const subs = buildScopedBlockSubQueries({ ja4Hash: "abc" }, undefined);
 
 		for (const sub of subs) {
 			// No client-scoped probe — request is scoped to global rules
@@ -88,10 +82,7 @@ describe("buildScopedBlockSubQueries", () => {
 	});
 
 	it("emits a no-user-scope fall-through query with ismissing() over every user-scope field", () => {
-		const subs = buildScopedBlockSubQueries(
-			{ ja4Hash: "abc" },
-			"client-A",
-		);
+		const subs = buildScopedBlockSubQueries({ ja4Hash: "abc" }, "client-A");
 
 		const fallThrough = subs.find((s) => s.kind === "no-user-scope");
 		expect(fallThrough).toBeDefined();
@@ -136,8 +127,6 @@ describe("buildScopedBlockSubQueries", () => {
 		expect(coordsSub).toBeDefined();
 		// Coords hold JSON with brackets and commas — every one must be
 		// backslash-escaped or the TAG query silently returns no matches.
-		expect(coordsSub?.query).toContain(
-			"@coords:{\\[\\[\\[100\\,200\\]\\]\\]}",
-		);
+		expect(coordsSub?.query).toContain("@coords:{\\[\\[\\[100\\,200\\]\\]\\]}");
 	});
 });

--- a/packages/user-access-policy/src/tests/redis/reader/redisRulesSplitQuery.unit.test.ts
+++ b/packages/user-access-policy/src/tests/redis/reader/redisRulesSplitQuery.unit.test.ts
@@ -1,0 +1,143 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, expect, it } from "vitest";
+import { buildScopedBlockSubQueries } from "#policy/redis/reader/redisRulesSplitQuery.js";
+
+describe("buildScopedBlockSubQueries", () => {
+	it("emits one sub-query per populated user-scope field", () => {
+		const subs = buildScopedBlockSubQueries(
+			{
+				ja4Hash: "abc",
+				userAgentHash: "def",
+			},
+			"client-A",
+		);
+
+		const kinds = subs.map((s) => s.kind).sort();
+		// Two field probes + one fall-through for "no user-scope
+		// constraint" rules. No IP sub-queries because request has no IP.
+		expect(kinds).toEqual(["field:ja4Hash", "field:userAgentHash", "no-user-scope"]);
+	});
+
+	it("emits both ip-exact and ip-mask sub-queries when request has an IP", () => {
+		const subs = buildScopedBlockSubQueries(
+			{
+				numericIp: 3232235777n, // 192.168.1.1
+			},
+			"client-A",
+		);
+
+		const kinds = subs.map((s) => s.kind);
+		expect(kinds).toContain("ip:exact");
+		expect(kinds).toContain("ip:mask");
+
+		const ipExact = subs.find((s) => s.kind === "ip:exact");
+		expect(ipExact?.query).toContain("@numericIp:[3232235777 3232235777]");
+
+		const ipMask = subs.find((s) => s.kind === "ip:mask");
+		expect(ipMask?.query).toContain(
+			"@numericIpMaskMin:[-inf 3232235777]",
+		);
+		expect(ipMask?.query).toContain(
+			"@numericIpMaskMax:[3232235777 +inf]",
+		);
+	});
+
+	it("scopes every sub-query with @type:{block} and @clientId probe", () => {
+		const subs = buildScopedBlockSubQueries(
+			{ ja4Hash: "abc" },
+			"client-A",
+		);
+
+		for (const sub of subs) {
+			expect(sub.query).toContain("@type:{block}");
+			// Every sub-query must include the client-or-global scope
+			// probe. `@clientId:{client-A}` matches client-scoped rules;
+			// `@clientId:{global}` matches new-format global rules;
+			// `ismissing(@clientId)` matches legacy pre-sentinel rules.
+			expect(sub.query).toMatch(/@clientId:\{client-A\}/);
+			expect(sub.query).toMatch(/@clientId:\{global\}/);
+			expect(sub.query).toMatch(/ismissing\(@clientId\)/);
+		}
+	});
+
+	it("skips the client-specific probe when no clientId is passed", () => {
+		const subs = buildScopedBlockSubQueries(
+			{ ja4Hash: "abc" },
+			undefined,
+		);
+
+		for (const sub of subs) {
+			// No client-scoped probe — request is scoped to global rules
+			// only. `global` sentinel and `ismissing()` fallback remain.
+			expect(sub.query).toMatch(/@clientId:\{global\}/);
+			expect(sub.query).toMatch(/ismissing\(@clientId\)/);
+		}
+	});
+
+	it("emits a no-user-scope fall-through query with ismissing() over every user-scope field", () => {
+		const subs = buildScopedBlockSubQueries(
+			{ ja4Hash: "abc" },
+			"client-A",
+		);
+
+		const fallThrough = subs.find((s) => s.kind === "no-user-scope");
+		expect(fallThrough).toBeDefined();
+		// Every user-scope field must be constrained as missing so the
+		// probe returns only rules that are truly client-wide blocks
+		// (no user-scope constraint at all).
+		for (const field of [
+			"userId",
+			"ja4Hash",
+			"headersHash",
+			"userAgentHash",
+			"headHash",
+			"coords",
+			"countryCode",
+			"asn",
+			"numericIp",
+			"numericIpMaskMin",
+			"numericIpMaskMax",
+		]) {
+			expect(fallThrough?.query).toContain(`ismissing(@${field})`);
+		}
+	});
+
+	it("uses NUMERIC range syntax for asn, not TAG syntax", () => {
+		const subs = buildScopedBlockSubQueries({ asn: 205016 }, "client-A");
+
+		const asnSub = subs.find((s) => s.kind === "field:asn");
+		expect(asnSub).toBeDefined();
+		// asn is indexed as NUMERIC; TAG syntax (@asn:{...}) would
+		// silently fail to match. Must use range syntax.
+		expect(asnSub?.query).toContain("@asn:[205016 205016]");
+		expect(asnSub?.query).not.toContain("@asn:{");
+	});
+
+	it("escapes JSON special characters in coords tag queries", () => {
+		const subs = buildScopedBlockSubQueries(
+			{ coords: "[[[100,200]]]" },
+			"client-A",
+		);
+
+		const coordsSub = subs.find((s) => s.kind === "field:coords");
+		expect(coordsSub).toBeDefined();
+		// Coords hold JSON with brackets and commas — every one must be
+		// backslash-escaped or the TAG query silently returns no matches.
+		expect(coordsSub?.query).toContain(
+			"@coords:{\\[\\[\\[100\\,200\\]\\]\\]}",
+		);
+	});
+});

--- a/packages/user-access-policy/src/tests/redis/redisRulesReaderLoad.benchmark.integration.test.ts
+++ b/packages/user-access-policy/src/tests/redis/redisRulesReaderLoad.benchmark.integration.test.ts
@@ -1,0 +1,378 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { chunkIntoBatches, executeBatchesSequentially } from "@prosopo/common";
+import type { Logger } from "@prosopo/logger";
+import {
+	type RedisConnection,
+	createTestRedisConnection,
+	setupRedisIndex,
+} from "@prosopo/redis-client";
+import type { RedisClientType } from "redis";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { RedisRulesReader } from "#policy/redis/reader/redisRulesReader.js";
+import {
+	ACCESS_RULES_REDIS_INDEX_NAME,
+	accessRulesRedisIndex,
+	getAccessRuleRedisKey,
+} from "#policy/redis/redisRuleIndex.js";
+import { getRedisRuleValue } from "#policy/redis/redisRulesWriter.js";
+import { AccessPolicyType, type AccessRule } from "#policy/rule.js";
+import { FilterScopeMatch } from "#policy/rulesStorage.js";
+
+// Regression barrier for the block-lookup hot path against the shape
+// of a large bulk-ban rule population.
+//
+// What this test defends against:
+//   1. A bulk-ban script inserts on the order of 17k access-policy
+//      rules, mostly IP-only (individual IPs plus a few CIDR aggregates,
+//      no other scope fields).
+//   2. Every incoming captcha request runs FT.AGGREGATE against
+//      `index:user-access-rules` with a strict-match ranked query. That
+//      query's LOAD + APPLY(exists()×11) + SORTBY step scales linearly
+//      in the tenant's total rule count. At 17k rules under production
+//      traffic the tail latency degrades sharply and upstream 502s
+//      cascade.
+//   3. This benchmark seeds a matching rule shape and asserts the
+//      split-query path's latency stays flat regardless of population
+//      size — every probe hits its own index posting list (numericIp,
+//      numericIpMaskMin) so the cost is O(matches for this request),
+//      not O(total rules).
+
+const IP_RULE_COUNT = 17_000;
+const CIDR_RULE_COUNT = 1_300;
+const MIXED_RULE_COUNT = 1_000;
+const QUERY_COUNT = 300;
+
+// CI thresholds. Localhost warm-cache measurements land around
+// p50 = 5-15 ms, p99 = 30-50 ms; thresholds set well above that to
+// absorb noisy shared runners. A regression to the single-query design
+// against this rule population would blow through both by
+// order-of-magnitude margins, so the ceilings are the alarm not a
+// performance target.
+const P50_LATENCY_MS = 120;
+const P99_LATENCY_MS = 400;
+
+const ipv4 = (i: number): bigint => {
+	// 10.0.0.0/8 range — private, unambiguous, plenty of room to spread
+	// out over 17k unique addresses without wrapping past /8.
+	const base = 10n << 24n;
+	return base + BigInt(i);
+};
+
+const ipv4CidrRange = (i: number): { min: bigint; max: bigint } => {
+	// 192.168.<i%256>.0/24 style ranges. Deterministic and disjoint from
+	// the individual-IP range above so tests can target either shape
+	// unambiguously.
+	const octet = i % 256;
+	const base = (192n << 24n) + (168n << 16n) + (BigInt(octet) << 8n);
+	return { min: base, max: base + 255n };
+};
+
+// Deterministic rule generators matched to the incident population shape.
+const buildIpBlockRule = (i: number): AccessRule => ({
+	type: AccessPolicyType.Block,
+	description: `bulk-ban-ip-${i}`,
+	numericIp: ipv4(i),
+});
+
+const buildCidrBlockRule = (i: number): AccessRule => {
+	const { min, max } = ipv4CidrRange(i);
+	return {
+		type: AccessPolicyType.Block,
+		description: `bulk-ban-cidr-${i}`,
+		numericIpMaskMin: min,
+		numericIpMaskMax: max,
+	};
+};
+
+// A handful of "normal" client-scoped rules so the rule set isn't
+// homogeneous — matches production's mixed anomaly-detector +
+// manual-rule shape.
+const buildMixedRule = (i: number): AccessRule => {
+	const variant = i % 4;
+	if (variant === 0) {
+		return {
+			type: AccessPolicyType.Block,
+			description: `mixed-${i}`,
+			clientId: `client${i % 30}`,
+			ja4Hash: `t13d_load_${i % 50}`,
+		};
+	}
+	if (variant === 1) {
+		return {
+			type: AccessPolicyType.Restrict,
+			description: `mixed-${i}`,
+			countryCode: `C${i % 30}`,
+		};
+	}
+	if (variant === 2) {
+		return {
+			type: AccessPolicyType.Block,
+			description: `mixed-${i}`,
+			asn: 1000 + (i % 500),
+		};
+	}
+	return {
+		type: AccessPolicyType.Block,
+		description: `mixed-${i}`,
+		clientId: `client${i % 30}`,
+		userAgentHash: `ua${i % 100}`,
+	};
+};
+
+const percentile = (sortedMs: number[], q: number): number => {
+	if (sortedMs.length === 0) return 0;
+	const idx = Math.min(
+		sortedMs.length - 1,
+		Math.floor((sortedMs.length - 1) * q),
+	);
+	return sortedMs[idx] ?? 0;
+};
+
+describe("redisRulesReader load-shape benchmark (17k IP-only rules)", () => {
+	let redisConnection: RedisConnection;
+	let redisClient: RedisClientType;
+	let reader: RedisRulesReader;
+
+	const mockLogger = new Proxy(
+		{},
+		{
+			get: () => () => {},
+		},
+	) as unknown as Logger;
+
+	const seededKeys: string[] = [];
+
+	beforeAll(async () => {
+		redisConnection = createTestRedisConnection();
+		redisClient = await setupRedisIndex(
+			redisConnection,
+			accessRulesRedisIndex,
+			mockLogger,
+		).getClient();
+		reader = new RedisRulesReader(redisClient, mockLogger);
+
+		const rules: AccessRule[] = [];
+		for (let i = 0; i < IP_RULE_COUNT; i++) rules.push(buildIpBlockRule(i));
+		for (let i = 0; i < CIDR_RULE_COUNT; i++) rules.push(buildCidrBlockRule(i));
+		for (let i = 0; i < MIXED_RULE_COUNT; i++) rules.push(buildMixedRule(i));
+
+		await executeBatchesSequentially(
+			chunkIntoBatches(rules, 1000),
+			async (batch) => {
+				const multi = redisClient.multi();
+				for (const rule of batch) {
+					const key = getAccessRuleRedisKey(rule);
+					seededKeys.push(key);
+					multi.hSet(key, getRedisRuleValue(rule));
+				}
+				await multi.exec();
+			},
+		);
+
+		const indexInfo = await redisClient.ft.info(ACCESS_RULES_REDIS_INDEX_NAME);
+		// Description is unique per rule so every rule should own its
+		// key; allow 10% margin for any incidental dedupe.
+		const expectedRules = IP_RULE_COUNT + CIDR_RULE_COUNT + MIXED_RULE_COUNT;
+		expect(indexInfo.num_docs).toBeGreaterThan(expectedRules * 0.9);
+	}, 300_000);
+
+	afterAll(async () => {
+		await executeBatchesSequentially(
+			chunkIntoBatches(seededKeys, 1000),
+			async (batch) => {
+				const multi = redisClient.multi();
+				for (const key of batch) {
+					multi.del(key);
+				}
+				await multi.exec();
+			},
+		);
+	}, 60_000);
+
+	test(
+		`split-query hot path stays flat under ${IP_RULE_COUNT + CIDR_RULE_COUNT + MIXED_RULE_COUNT} rules`,
+		async () => {
+			// Warm-up: first call pays for RediSearch index page-in.
+			await reader.findRules(
+				{
+					policyScope: { clientId: "warmup" },
+					policyScopeMatch: FilterScopeMatch.Greedy,
+					userScope: { numericIp: ipv4(999_999) },
+					userScopeMatch: FilterScopeMatch.Greedy,
+					blockOnly: true,
+				},
+				true,
+			);
+
+			const samples: number[] = [];
+			for (let i = 0; i < QUERY_COUNT; i++) {
+				// Half the queries target seeded IPs (hits), half target IPs
+				// outside the seeded range (misses). Both must be fast.
+				const isHit = i % 2 === 0;
+				const numericIp = isHit
+					? ipv4(i % IP_RULE_COUNT)
+					: ipv4(IP_RULE_COUNT + i + 1_000_000);
+
+				const start = performance.now();
+				await reader.findRules(
+					{
+						policyScope: { clientId: `client${i % 30}` },
+						policyScopeMatch: FilterScopeMatch.Greedy,
+						userScope: {
+							numericIp,
+							ja4Hash: `t13d_load_${i % 50}`,
+							userAgentHash: `ua${i % 100}`,
+							countryCode: `C${i % 30}`,
+							asn: 1000 + (i % 500),
+						},
+						userScopeMatch: FilterScopeMatch.Greedy,
+						blockOnly: true,
+					},
+					true,
+				);
+				samples.push(performance.now() - start);
+			}
+
+			samples.sort((a, b) => a - b);
+			const p50 = percentile(samples, 0.5);
+			const p99 = percentile(samples, 0.99);
+			const avg = samples.reduce((a, b) => a + b, 0) / samples.length;
+
+			console.log(
+				`split-query load: avg=${avg.toFixed(2)}ms  p50=${p50.toFixed(2)}ms  p99=${p99.toFixed(2)}ms  n=${samples.length}  (${IP_RULE_COUNT} IPs + ${CIDR_RULE_COUNT} CIDRs + ${MIXED_RULE_COUNT} mixed)`,
+			);
+
+			expect(p50).toBeLessThan(P50_LATENCY_MS);
+			expect(p99).toBeLessThan(P99_LATENCY_MS);
+		},
+		300_000,
+	);
+
+	test(
+		"finds exact-IP bulk-ban rule for matching request",
+		async () => {
+			// Pick an IP known to have been seeded as an individual-IP ban.
+			const targetIp = ipv4(42);
+			const results = await reader.findRules(
+				{
+					policyScope: { clientId: "client1" },
+					policyScopeMatch: FilterScopeMatch.Greedy,
+					userScope: {
+						numericIp: targetIp,
+						ja4Hash: "t13d_load_1",
+					},
+					userScopeMatch: FilterScopeMatch.Greedy,
+					blockOnly: true,
+				},
+				true,
+			);
+
+			// The exact-IP rule must be among the returned candidates —
+			// this is the "rule that must never be missed" property.
+			const found = results.find((r) => r.numericIp === targetIp);
+			expect(found).toBeDefined();
+			expect(found?.type).toBe(AccessPolicyType.Block);
+		},
+		60_000,
+	);
+
+	test(
+		"finds CIDR-range bulk-ban rule for request IP inside the range",
+		async () => {
+			// Pick a CIDR range and a request IP known to fall inside it.
+			const { min, max } = ipv4CidrRange(7);
+			const requestIp = min + 42n;
+			expect(requestIp).toBeLessThanOrEqual(max);
+
+			const results = await reader.findRules(
+				{
+					policyScope: { clientId: "client1" },
+					policyScopeMatch: FilterScopeMatch.Greedy,
+					userScope: { numericIp: requestIp },
+					userScopeMatch: FilterScopeMatch.Greedy,
+					blockOnly: true,
+				},
+				true,
+			);
+
+			const found = results.find(
+				(r) =>
+					r.numericIpMaskMin === min &&
+					r.numericIpMaskMax === max &&
+					r.type === AccessPolicyType.Block,
+			);
+			expect(found).toBeDefined();
+		},
+		60_000,
+	);
+
+	test(
+		"finds ja4-scoped rule via the split-query ja4 probe",
+		async () => {
+			// The mixed population includes ja4-scoped rules; a request
+			// with matching ja4Hash must surface the rule even when the
+			// request IP has no matching numericIp entry.
+			const results = await reader.findRules(
+				{
+					policyScope: { clientId: "client0" },
+					policyScopeMatch: FilterScopeMatch.Greedy,
+					userScope: {
+						numericIp: ipv4(999_998),
+						ja4Hash: "t13d_load_0",
+					},
+					userScopeMatch: FilterScopeMatch.Greedy,
+					blockOnly: true,
+				},
+				true,
+			);
+
+			const ja4Rule = results.find(
+				(r) => r.ja4Hash === "t13d_load_0" && r.clientId === "client0",
+			);
+			expect(ja4Rule).toBeDefined();
+		},
+		60_000,
+	);
+
+	test(
+		"returns no match when request IP is outside every rule range",
+		async () => {
+			// Way outside every seeded range.
+			const results = await reader.findRules(
+				{
+					policyScope: { clientId: "client99" },
+					policyScopeMatch: FilterScopeMatch.Greedy,
+					userScope: { numericIp: ipv4(9_999_999) },
+					userScopeMatch: FilterScopeMatch.Greedy,
+					blockOnly: true,
+				},
+				true,
+			);
+
+			// No IP-scoped rule should apply; only fall-through matches
+			// (mixed rules keyed on other fields) could surface here, and
+			// we're not populating any of those on this request.
+			const ipMatch = results.find(
+				(r) =>
+					r.numericIp !== undefined ||
+					(r.numericIpMaskMin !== undefined &&
+						r.numericIpMaskMax !== undefined),
+			);
+			expect(ipMatch).toBeUndefined();
+		},
+		60_000,
+	);
+});

--- a/packages/user-access-policy/src/tests/redis/redisRulesReaderLoad.benchmark.integration.test.ts
+++ b/packages/user-access-policy/src/tests/redis/redisRulesReaderLoad.benchmark.integration.test.ts
@@ -220,322 +220,297 @@ describe("redisRulesReader load-shape benchmark (17k IP-only rules)", () => {
 		);
 	}, 60_000);
 
-	test(
-		`split-query hot path stays flat under ${IP_RULE_COUNT + CIDR_RULE_COUNT + MIXED_RULE_COUNT} rules`,
-		async () => {
-			// Warm-up: first call pays for RediSearch index page-in.
+	test(`split-query hot path stays flat under ${IP_RULE_COUNT + CIDR_RULE_COUNT + MIXED_RULE_COUNT} rules`, async () => {
+		// Warm-up: first call pays for RediSearch index page-in.
+		await reader.findRules(
+			{
+				policyScope: { clientId: "warmup" },
+				policyScopeMatch: FilterScopeMatch.Greedy,
+				userScope: { numericIp: ipv4(999_999) },
+				userScopeMatch: FilterScopeMatch.Greedy,
+				blockOnly: true,
+			},
+			true,
+		);
+
+		const samples: number[] = [];
+		for (let i = 0; i < QUERY_COUNT; i++) {
+			// Half the queries target seeded IPs (hits), half target IPs
+			// outside the seeded range (misses). Both must be fast.
+			const isHit = i % 2 === 0;
+			const numericIp = isHit
+				? ipv4(i % IP_RULE_COUNT)
+				: ipv4(IP_RULE_COUNT + i + 1_000_000);
+
+			const start = performance.now();
 			await reader.findRules(
 				{
-					policyScope: { clientId: "warmup" },
+					policyScope: { clientId: `client${i % 30}` },
 					policyScopeMatch: FilterScopeMatch.Greedy,
-					userScope: { numericIp: ipv4(999_999) },
+					userScope: {
+						numericIp,
+						ja4Hash: `t13d_load_${i % 50}`,
+						userAgentHash: `ua${i % 100}`,
+						countryCode: `C${i % 30}`,
+						asn: 1000 + (i % 500),
+					},
 					userScopeMatch: FilterScopeMatch.Greedy,
 					blockOnly: true,
 				},
 				true,
 			);
+			samples.push(performance.now() - start);
+		}
 
-			const samples: number[] = [];
-			for (let i = 0; i < QUERY_COUNT; i++) {
-				// Half the queries target seeded IPs (hits), half target IPs
-				// outside the seeded range (misses). Both must be fast.
-				const isHit = i % 2 === 0;
-				const numericIp = isHit
-					? ipv4(i % IP_RULE_COUNT)
-					: ipv4(IP_RULE_COUNT + i + 1_000_000);
+		samples.sort((a, b) => a - b);
+		const p50 = percentile(samples, 0.5);
+		const p99 = percentile(samples, 0.99);
+		const avg = samples.reduce((a, b) => a + b, 0) / samples.length;
 
-				const start = performance.now();
-				await reader.findRules(
-					{
-						policyScope: { clientId: `client${i % 30}` },
-						policyScopeMatch: FilterScopeMatch.Greedy,
-						userScope: {
-							numericIp,
-							ja4Hash: `t13d_load_${i % 50}`,
-							userAgentHash: `ua${i % 100}`,
-							countryCode: `C${i % 30}`,
-							asn: 1000 + (i % 500),
+		console.log(
+			`split-query load: avg=${avg.toFixed(2)}ms  p50=${p50.toFixed(2)}ms  p99=${p99.toFixed(2)}ms  n=${samples.length}  (${IP_RULE_COUNT} IPs + ${CIDR_RULE_COUNT} CIDRs + ${MIXED_RULE_COUNT} mixed)`,
+		);
+
+		expect(p50).toBeLessThan(P50_LATENCY_MS);
+		expect(p99).toBeLessThan(P99_LATENCY_MS);
+	}, 300_000);
+
+	test("finds exact-IP bulk-ban rule for matching request", async () => {
+		// Pick an IP known to have been seeded as an individual-IP ban.
+		const targetIp = ipv4(42);
+		const results = await reader.findRules(
+			{
+				policyScope: { clientId: "client1" },
+				policyScopeMatch: FilterScopeMatch.Greedy,
+				userScope: {
+					numericIp: targetIp,
+					ja4Hash: "t13d_load_1",
+				},
+				userScopeMatch: FilterScopeMatch.Greedy,
+				blockOnly: true,
+			},
+			true,
+		);
+
+		// The exact-IP rule must be among the returned candidates —
+		// this is the "rule that must never be missed" property.
+		const found = results.find((r) => r.numericIp === targetIp);
+		expect(found).toBeDefined();
+		expect(found?.type).toBe(AccessPolicyType.Block);
+	}, 60_000);
+
+	test("finds CIDR-range bulk-ban rule for request IP inside the range", async () => {
+		// Pick a CIDR range and a request IP known to fall inside it.
+		const { min, max } = ipv4CidrRange(7);
+		const requestIp = min + 42n;
+		expect(requestIp).toBeLessThanOrEqual(max);
+
+		const results = await reader.findRules(
+			{
+				policyScope: { clientId: "client1" },
+				policyScopeMatch: FilterScopeMatch.Greedy,
+				userScope: { numericIp: requestIp },
+				userScopeMatch: FilterScopeMatch.Greedy,
+				blockOnly: true,
+			},
+			true,
+		);
+
+		const found = results.find(
+			(r) =>
+				r.numericIpMaskMin === min &&
+				r.numericIpMaskMax === max &&
+				r.type === AccessPolicyType.Block,
+		);
+		expect(found).toBeDefined();
+	}, 60_000);
+
+	test("finds ja4-scoped rule via the split-query ja4 probe", async () => {
+		// The mixed population includes ja4-scoped rules; a request
+		// with matching ja4Hash must surface the rule even when the
+		// request IP has no matching numericIp entry.
+		const results = await reader.findRules(
+			{
+				policyScope: { clientId: "client0" },
+				policyScopeMatch: FilterScopeMatch.Greedy,
+				userScope: {
+					numericIp: ipv4(999_998),
+					ja4Hash: "t13d_load_0",
+				},
+				userScopeMatch: FilterScopeMatch.Greedy,
+				blockOnly: true,
+			},
+			true,
+		);
+
+		const ja4Rule = results.find(
+			(r) => r.ja4Hash === "t13d_load_0" && r.clientId === "client0",
+		);
+		expect(ja4Rule).toBeDefined();
+	}, 60_000);
+
+	test("returns no match when request IP is outside every rule range", async () => {
+		// Way outside every seeded range.
+		const results = await reader.findRules(
+			{
+				policyScope: { clientId: "client99" },
+				policyScopeMatch: FilterScopeMatch.Greedy,
+				userScope: { numericIp: ipv4(9_999_999) },
+				userScopeMatch: FilterScopeMatch.Greedy,
+				blockOnly: true,
+			},
+			true,
+		);
+
+		// No IP-scoped rule should apply; only fall-through matches
+		// (mixed rules keyed on other fields) could surface here, and
+		// we're not populating any of those on this request.
+		const ipMatch = results.find(
+			(r) =>
+				r.numericIp !== undefined ||
+				(r.numericIpMaskMin !== undefined && r.numericIpMaskMax !== undefined),
+		);
+		expect(ipMatch).toBeUndefined();
+	}, 60_000);
+
+	test(`concurrent retry-storm: ${STORM_CONCURRENCY} in-flight × ${STORM_WAVE_COUNT} waves against ${IP_RULE_COUNT + CIDR_RULE_COUNT + MIXED_RULE_COUNT} rules`, async () => {
+		// Emulates the incident's frontend-retry pattern: the client
+		// keeps retrying the same banned scope, and each retry starts
+		// before the previous one has completed. In production the
+		// provider-side verdict cache absorbs waves 2..N; here we run
+		// the reader directly (no cache) so the numbers show the
+		// worst-case Redis-only path — what the cache is protecting
+		// against under stampede.
+		//
+		// A single scope is used across every request so the FT
+		// probes are byte-for-byte identical. That means every wave
+		// is a candidate for the same posting-list intersections;
+		// under the *old* single-query path this would compound with
+		// the per-request APPLY(exists()×11) cost and crush tail
+		// latency. Under the split path each probe still hits its
+		// own posting list and the only added cost is command
+		// queuing on the shared TCP connection.
+
+		// Warm-up: page the index in and let redis-client establish
+		// pipelines before the first measured wave.
+		await reader.findRules(
+			{
+				policyScope: { clientId: "client1" },
+				policyScopeMatch: FilterScopeMatch.Greedy,
+				userScope: { numericIp: ipv4(999_997) },
+				userScopeMatch: FilterScopeMatch.Greedy,
+				blockOnly: true,
+			},
+			true,
+		);
+
+		// Identical scope for every request. Hits a real rule
+		// (ipv4(42) is in the seeded IP-ban range) so each response
+		// carries the same non-empty verdict payload.
+		const stormScope = {
+			numericIp: ipv4(42),
+			ja4Hash: "t13d_load_1",
+			userAgentHash: "ua5",
+			countryCode: "C5",
+			asn: 1005,
+		};
+		const clientId = "client1";
+
+		const allSamples: number[] = [];
+		const perWave: Array<{
+			wave: number;
+			p50: number;
+			p99: number;
+			min: number;
+			max: number;
+			elapsedMs: number;
+		}> = [];
+
+		for (let wave = 0; wave < STORM_WAVE_COUNT; wave++) {
+			const waveStart = performance.now();
+			const waveSamples: number[] = [];
+
+			// Fire all N requests in parallel and wait for the whole
+			// wave to complete. This mirrors a burst of retries
+			// arriving inside one event-loop turn — every request
+			// starts before any has completed, so the redis client's
+			// command queue depth peaks at N.
+			await Promise.all(
+				Array.from({ length: STORM_CONCURRENCY }, async () => {
+					const start = performance.now();
+					const results = await reader.findRules(
+						{
+							policyScope: { clientId },
+							policyScopeMatch: FilterScopeMatch.Greedy,
+							userScope: stormScope,
+							userScopeMatch: FilterScopeMatch.Greedy,
+							blockOnly: true,
 						},
-						userScopeMatch: FilterScopeMatch.Greedy,
-						blockOnly: true,
-					},
-					true,
-				);
-				samples.push(performance.now() - start);
-			}
+						true,
+					);
+					const dur = performance.now() - start;
+					waveSamples.push(dur);
+					// Sanity: the storm scope has a matching exact-IP
+					// block rule, so every response must include it.
+					// A regression that drops responses under
+					// concurrency shows up here rather than as a
+					// silent under-count of samples.
+					expect(
+						results.find((r) => r.numericIp === stormScope.numericIp),
+					).toBeDefined();
+				}),
+			);
 
-			samples.sort((a, b) => a - b);
-			const p50 = percentile(samples, 0.5);
-			const p99 = percentile(samples, 0.99);
-			const avg = samples.reduce((a, b) => a + b, 0) / samples.length;
+			const waveElapsed = performance.now() - waveStart;
+			waveSamples.sort((a, b) => a - b);
+			const p50 = percentile(waveSamples, 0.5);
+			const p99 = percentile(waveSamples, 0.99);
+			const min = waveSamples[0] ?? 0;
+			const max = waveSamples[waveSamples.length - 1] ?? 0;
+			perWave.push({
+				wave: wave + 1,
+				p50,
+				p99,
+				min,
+				max,
+				elapsedMs: waveElapsed,
+			});
+			allSamples.push(...waveSamples);
+		}
 
+		allSamples.sort((a, b) => a - b);
+		const overallP50 = percentile(allSamples, 0.5);
+		const overallP99 = percentile(allSamples, 0.99);
+		const overallAvg =
+			allSamples.reduce((a, b) => a + b, 0) / allSamples.length;
+		const totalRequests = STORM_CONCURRENCY * STORM_WAVE_COUNT;
+		const totalElapsed = perWave.reduce((sum, w) => sum + w.elapsedMs, 0);
+		const throughput = (totalRequests * 1000) / totalElapsed;
+
+		console.log(
+			`storm ${STORM_CONCURRENCY}×${STORM_WAVE_COUNT}: avg=${overallAvg.toFixed(2)}ms  p50=${overallP50.toFixed(2)}ms  p99=${overallP99.toFixed(2)}ms  ` +
+				`throughput=${throughput.toFixed(0)} req/s  total=${totalElapsed.toFixed(0)}ms`,
+		);
+		// Per-wave breakdown so a regression that only affects
+		// first-wave stampede (cache-miss shape) shows up
+		// independently from steady-state numbers.
+		for (const w of perWave) {
 			console.log(
-				`split-query load: avg=${avg.toFixed(2)}ms  p50=${p50.toFixed(2)}ms  p99=${p99.toFixed(2)}ms  n=${samples.length}  (${IP_RULE_COUNT} IPs + ${CIDR_RULE_COUNT} CIDRs + ${MIXED_RULE_COUNT} mixed)`,
+				`  wave ${w.wave.toString().padStart(2)}: p50=${w.p50.toFixed(2)}ms  p99=${w.p99.toFixed(2)}ms  ` +
+					`min=${w.min.toFixed(2)}ms  max=${w.max.toFixed(2)}ms  wave-elapsed=${w.elapsedMs.toFixed(0)}ms`,
 			);
+		}
 
-			expect(p50).toBeLessThan(P50_LATENCY_MS);
-			expect(p99).toBeLessThan(P99_LATENCY_MS);
-		},
-		300_000,
-	);
-
-	test(
-		"finds exact-IP bulk-ban rule for matching request",
-		async () => {
-			// Pick an IP known to have been seeded as an individual-IP ban.
-			const targetIp = ipv4(42);
-			const results = await reader.findRules(
-				{
-					policyScope: { clientId: "client1" },
-					policyScopeMatch: FilterScopeMatch.Greedy,
-					userScope: {
-						numericIp: targetIp,
-						ja4Hash: "t13d_load_1",
-					},
-					userScopeMatch: FilterScopeMatch.Greedy,
-					blockOnly: true,
-				},
-				true,
-			);
-
-			// The exact-IP rule must be among the returned candidates —
-			// this is the "rule that must never be missed" property.
-			const found = results.find((r) => r.numericIp === targetIp);
-			expect(found).toBeDefined();
-			expect(found?.type).toBe(AccessPolicyType.Block);
-		},
-		60_000,
-	);
-
-	test(
-		"finds CIDR-range bulk-ban rule for request IP inside the range",
-		async () => {
-			// Pick a CIDR range and a request IP known to fall inside it.
-			const { min, max } = ipv4CidrRange(7);
-			const requestIp = min + 42n;
-			expect(requestIp).toBeLessThanOrEqual(max);
-
-			const results = await reader.findRules(
-				{
-					policyScope: { clientId: "client1" },
-					policyScopeMatch: FilterScopeMatch.Greedy,
-					userScope: { numericIp: requestIp },
-					userScopeMatch: FilterScopeMatch.Greedy,
-					blockOnly: true,
-				},
-				true,
-			);
-
-			const found = results.find(
-				(r) =>
-					r.numericIpMaskMin === min &&
-					r.numericIpMaskMax === max &&
-					r.type === AccessPolicyType.Block,
-			);
-			expect(found).toBeDefined();
-		},
-		60_000,
-	);
-
-	test(
-		"finds ja4-scoped rule via the split-query ja4 probe",
-		async () => {
-			// The mixed population includes ja4-scoped rules; a request
-			// with matching ja4Hash must surface the rule even when the
-			// request IP has no matching numericIp entry.
-			const results = await reader.findRules(
-				{
-					policyScope: { clientId: "client0" },
-					policyScopeMatch: FilterScopeMatch.Greedy,
-					userScope: {
-						numericIp: ipv4(999_998),
-						ja4Hash: "t13d_load_0",
-					},
-					userScopeMatch: FilterScopeMatch.Greedy,
-					blockOnly: true,
-				},
-				true,
-			);
-
-			const ja4Rule = results.find(
-				(r) => r.ja4Hash === "t13d_load_0" && r.clientId === "client0",
-			);
-			expect(ja4Rule).toBeDefined();
-		},
-		60_000,
-	);
-
-	test(
-		"returns no match when request IP is outside every rule range",
-		async () => {
-			// Way outside every seeded range.
-			const results = await reader.findRules(
-				{
-					policyScope: { clientId: "client99" },
-					policyScopeMatch: FilterScopeMatch.Greedy,
-					userScope: { numericIp: ipv4(9_999_999) },
-					userScopeMatch: FilterScopeMatch.Greedy,
-					blockOnly: true,
-				},
-				true,
-			);
-
-			// No IP-scoped rule should apply; only fall-through matches
-			// (mixed rules keyed on other fields) could surface here, and
-			// we're not populating any of those on this request.
-			const ipMatch = results.find(
-				(r) =>
-					r.numericIp !== undefined ||
-					(r.numericIpMaskMin !== undefined &&
-						r.numericIpMaskMax !== undefined),
-			);
-			expect(ipMatch).toBeUndefined();
-		},
-		60_000,
-	);
-
-	test(
-		`concurrent retry-storm: ${STORM_CONCURRENCY} in-flight × ${STORM_WAVE_COUNT} waves against ${IP_RULE_COUNT + CIDR_RULE_COUNT + MIXED_RULE_COUNT} rules`,
-		async () => {
-			// Emulates the incident's frontend-retry pattern: the client
-			// keeps retrying the same banned scope, and each retry starts
-			// before the previous one has completed. In production the
-			// provider-side verdict cache absorbs waves 2..N; here we run
-			// the reader directly (no cache) so the numbers show the
-			// worst-case Redis-only path — what the cache is protecting
-			// against under stampede.
-			//
-			// A single scope is used across every request so the FT
-			// probes are byte-for-byte identical. That means every wave
-			// is a candidate for the same posting-list intersections;
-			// under the *old* single-query path this would compound with
-			// the per-request APPLY(exists()×11) cost and crush tail
-			// latency. Under the split path each probe still hits its
-			// own posting list and the only added cost is command
-			// queuing on the shared TCP connection.
-
-			// Warm-up: page the index in and let redis-client establish
-			// pipelines before the first measured wave.
-			await reader.findRules(
-				{
-					policyScope: { clientId: "client1" },
-					policyScopeMatch: FilterScopeMatch.Greedy,
-					userScope: { numericIp: ipv4(999_997) },
-					userScopeMatch: FilterScopeMatch.Greedy,
-					blockOnly: true,
-				},
-				true,
-			);
-
-			// Identical scope for every request. Hits a real rule
-			// (ipv4(42) is in the seeded IP-ban range) so each response
-			// carries the same non-empty verdict payload.
-			const stormScope = {
-				numericIp: ipv4(42),
-				ja4Hash: "t13d_load_1",
-				userAgentHash: "ua5",
-				countryCode: "C5",
-				asn: 1005,
-			};
-			const clientId = "client1";
-
-			const allSamples: number[] = [];
-			const perWave: Array<{
-				wave: number;
-				p50: number;
-				p99: number;
-				min: number;
-				max: number;
-				elapsedMs: number;
-			}> = [];
-
-			for (let wave = 0; wave < STORM_WAVE_COUNT; wave++) {
-				const waveStart = performance.now();
-				const waveSamples: number[] = [];
-
-				// Fire all N requests in parallel and wait for the whole
-				// wave to complete. This mirrors a burst of retries
-				// arriving inside one event-loop turn — every request
-				// starts before any has completed, so the redis client's
-				// command queue depth peaks at N.
-				await Promise.all(
-					Array.from({ length: STORM_CONCURRENCY }, async () => {
-						const start = performance.now();
-						const results = await reader.findRules(
-							{
-								policyScope: { clientId },
-								policyScopeMatch: FilterScopeMatch.Greedy,
-								userScope: stormScope,
-								userScopeMatch: FilterScopeMatch.Greedy,
-								blockOnly: true,
-							},
-							true,
-						);
-						const dur = performance.now() - start;
-						waveSamples.push(dur);
-						// Sanity: the storm scope has a matching exact-IP
-						// block rule, so every response must include it.
-						// A regression that drops responses under
-						// concurrency shows up here rather than as a
-						// silent under-count of samples.
-						expect(
-							results.find((r) => r.numericIp === stormScope.numericIp),
-						).toBeDefined();
-					}),
-				);
-
-				const waveElapsed = performance.now() - waveStart;
-				waveSamples.sort((a, b) => a - b);
-				const p50 = percentile(waveSamples, 0.5);
-				const p99 = percentile(waveSamples, 0.99);
-				const min = waveSamples[0] ?? 0;
-				const max = waveSamples[waveSamples.length - 1] ?? 0;
-				perWave.push({
-					wave: wave + 1,
-					p50,
-					p99,
-					min,
-					max,
-					elapsedMs: waveElapsed,
-				});
-				allSamples.push(...waveSamples);
-			}
-
-			allSamples.sort((a, b) => a - b);
-			const overallP50 = percentile(allSamples, 0.5);
-			const overallP99 = percentile(allSamples, 0.99);
-			const overallAvg =
-				allSamples.reduce((a, b) => a + b, 0) / allSamples.length;
-			const totalRequests = STORM_CONCURRENCY * STORM_WAVE_COUNT;
-			const totalElapsed = perWave.reduce((sum, w) => sum + w.elapsedMs, 0);
-			const throughput = (totalRequests * 1000) / totalElapsed;
-
-			console.log(
-				`storm ${STORM_CONCURRENCY}×${STORM_WAVE_COUNT}: avg=${overallAvg.toFixed(2)}ms  p50=${overallP50.toFixed(2)}ms  p99=${overallP99.toFixed(2)}ms  ` +
-					`throughput=${throughput.toFixed(0)} req/s  total=${totalElapsed.toFixed(0)}ms`,
-			);
-			// Per-wave breakdown so a regression that only affects
-			// first-wave stampede (cache-miss shape) shows up
-			// independently from steady-state numbers.
-			for (const w of perWave) {
-				console.log(
-					`  wave ${w.wave.toString().padStart(2)}: p50=${w.p50.toFixed(2)}ms  p99=${w.p99.toFixed(2)}ms  ` +
-						`min=${w.min.toFixed(2)}ms  max=${w.max.toFixed(2)}ms  wave-elapsed=${w.elapsedMs.toFixed(0)}ms`,
-				);
-			}
-
-			expect(overallP50).toBeLessThan(STORM_P50_LATENCY_MS);
-			expect(overallP99).toBeLessThan(STORM_P99_LATENCY_MS);
-			// Wave-1 stampede check: even the cold-cache wave (which is
-			// what the production cache absorbs) has to stay tractable —
-			// a regression that only hurts first-request-per-scope
-			// latency would otherwise hide behind steady-state numbers.
-			const firstWave = perWave[0];
-			expect(firstWave).toBeDefined();
-			if (firstWave) {
-				expect(firstWave.p99).toBeLessThan(STORM_P99_LATENCY_MS);
-			}
-		},
-		300_000,
-	);
+		expect(overallP50).toBeLessThan(STORM_P50_LATENCY_MS);
+		expect(overallP99).toBeLessThan(STORM_P99_LATENCY_MS);
+		// Wave-1 stampede check: even the cold-cache wave (which is
+		// what the production cache absorbs) has to stay tractable —
+		// a regression that only hurts first-request-per-scope
+		// latency would otherwise hide behind steady-state numbers.
+		const firstWave = perWave[0];
+		expect(firstWave).toBeDefined();
+		if (firstWave) {
+			expect(firstWave.p99).toBeLessThan(STORM_P99_LATENCY_MS);
+		}
+	}, 300_000);
 });

--- a/packages/user-access-policy/src/tests/redis/redisRulesReaderLoad.benchmark.integration.test.ts
+++ b/packages/user-access-policy/src/tests/redis/redisRulesReaderLoad.benchmark.integration.test.ts
@@ -55,6 +55,17 @@ const CIDR_RULE_COUNT = 1_300;
 const MIXED_RULE_COUNT = 1_000;
 const QUERY_COUNT = 300;
 
+// Concurrent-storm config. Emulates a frontend retry storm: N requests
+// in flight against Redis at once, sustained across multiple waves,
+// with an identical banned scope so every request would hit the same
+// FT probes. In production the process-wide verdict cache absorbs
+// waves 2..N; this benchmark measures the reader path directly (no
+// cache) so wave 1 numbers stand in for what the cache is protecting
+// and wave 2..N numbers show the split query's steady-state behaviour
+// under sustained connection multiplexing.
+const STORM_CONCURRENCY = 100;
+const STORM_WAVE_COUNT = 10;
+
 // CI thresholds. Localhost warm-cache measurements land around
 // p50 = 5-15 ms, p99 = 30-50 ms; thresholds set well above that to
 // absorb noisy shared runners. A regression to the single-query design
@@ -63,6 +74,13 @@ const QUERY_COUNT = 300;
 // performance target.
 const P50_LATENCY_MS = 120;
 const P99_LATENCY_MS = 400;
+
+// Storm-mode thresholds: same story but with headroom for the extra
+// tail from redis-client command queuing under N-in-flight concurrency.
+// The single TCP connection multiplexes commands, so p99 grows with
+// concurrency even when each command is individually cheap.
+const STORM_P50_LATENCY_MS = 200;
+const STORM_P99_LATENCY_MS = 800;
 
 const ipv4 = (i: number): bigint => {
 	// 10.0.0.0/8 range — private, unambiguous, plenty of room to spread
@@ -374,5 +392,150 @@ describe("redisRulesReader load-shape benchmark (17k IP-only rules)", () => {
 			expect(ipMatch).toBeUndefined();
 		},
 		60_000,
+	);
+
+	test(
+		`concurrent retry-storm: ${STORM_CONCURRENCY} in-flight × ${STORM_WAVE_COUNT} waves against ${IP_RULE_COUNT + CIDR_RULE_COUNT + MIXED_RULE_COUNT} rules`,
+		async () => {
+			// Emulates the incident's frontend-retry pattern: the client
+			// keeps retrying the same banned scope, and each retry starts
+			// before the previous one has completed. In production the
+			// provider-side verdict cache absorbs waves 2..N; here we run
+			// the reader directly (no cache) so the numbers show the
+			// worst-case Redis-only path — what the cache is protecting
+			// against under stampede.
+			//
+			// A single scope is used across every request so the FT
+			// probes are byte-for-byte identical. That means every wave
+			// is a candidate for the same posting-list intersections;
+			// under the *old* single-query path this would compound with
+			// the per-request APPLY(exists()×11) cost and crush tail
+			// latency. Under the split path each probe still hits its
+			// own posting list and the only added cost is command
+			// queuing on the shared TCP connection.
+
+			// Warm-up: page the index in and let redis-client establish
+			// pipelines before the first measured wave.
+			await reader.findRules(
+				{
+					policyScope: { clientId: "client1" },
+					policyScopeMatch: FilterScopeMatch.Greedy,
+					userScope: { numericIp: ipv4(999_997) },
+					userScopeMatch: FilterScopeMatch.Greedy,
+					blockOnly: true,
+				},
+				true,
+			);
+
+			// Identical scope for every request. Hits a real rule
+			// (ipv4(42) is in the seeded IP-ban range) so each response
+			// carries the same non-empty verdict payload.
+			const stormScope = {
+				numericIp: ipv4(42),
+				ja4Hash: "t13d_load_1",
+				userAgentHash: "ua5",
+				countryCode: "C5",
+				asn: 1005,
+			};
+			const clientId = "client1";
+
+			const allSamples: number[] = [];
+			const perWave: Array<{
+				wave: number;
+				p50: number;
+				p99: number;
+				min: number;
+				max: number;
+				elapsedMs: number;
+			}> = [];
+
+			for (let wave = 0; wave < STORM_WAVE_COUNT; wave++) {
+				const waveStart = performance.now();
+				const waveSamples: number[] = [];
+
+				// Fire all N requests in parallel and wait for the whole
+				// wave to complete. This mirrors a burst of retries
+				// arriving inside one event-loop turn — every request
+				// starts before any has completed, so the redis client's
+				// command queue depth peaks at N.
+				await Promise.all(
+					Array.from({ length: STORM_CONCURRENCY }, async () => {
+						const start = performance.now();
+						const results = await reader.findRules(
+							{
+								policyScope: { clientId },
+								policyScopeMatch: FilterScopeMatch.Greedy,
+								userScope: stormScope,
+								userScopeMatch: FilterScopeMatch.Greedy,
+								blockOnly: true,
+							},
+							true,
+						);
+						const dur = performance.now() - start;
+						waveSamples.push(dur);
+						// Sanity: the storm scope has a matching exact-IP
+						// block rule, so every response must include it.
+						// A regression that drops responses under
+						// concurrency shows up here rather than as a
+						// silent under-count of samples.
+						expect(
+							results.find((r) => r.numericIp === stormScope.numericIp),
+						).toBeDefined();
+					}),
+				);
+
+				const waveElapsed = performance.now() - waveStart;
+				waveSamples.sort((a, b) => a - b);
+				const p50 = percentile(waveSamples, 0.5);
+				const p99 = percentile(waveSamples, 0.99);
+				const min = waveSamples[0] ?? 0;
+				const max = waveSamples[waveSamples.length - 1] ?? 0;
+				perWave.push({
+					wave: wave + 1,
+					p50,
+					p99,
+					min,
+					max,
+					elapsedMs: waveElapsed,
+				});
+				allSamples.push(...waveSamples);
+			}
+
+			allSamples.sort((a, b) => a - b);
+			const overallP50 = percentile(allSamples, 0.5);
+			const overallP99 = percentile(allSamples, 0.99);
+			const overallAvg =
+				allSamples.reduce((a, b) => a + b, 0) / allSamples.length;
+			const totalRequests = STORM_CONCURRENCY * STORM_WAVE_COUNT;
+			const totalElapsed = perWave.reduce((sum, w) => sum + w.elapsedMs, 0);
+			const throughput = (totalRequests * 1000) / totalElapsed;
+
+			console.log(
+				`storm ${STORM_CONCURRENCY}×${STORM_WAVE_COUNT}: avg=${overallAvg.toFixed(2)}ms  p50=${overallP50.toFixed(2)}ms  p99=${overallP99.toFixed(2)}ms  ` +
+					`throughput=${throughput.toFixed(0)} req/s  total=${totalElapsed.toFixed(0)}ms`,
+			);
+			// Per-wave breakdown so a regression that only affects
+			// first-wave stampede (cache-miss shape) shows up
+			// independently from steady-state numbers.
+			for (const w of perWave) {
+				console.log(
+					`  wave ${w.wave.toString().padStart(2)}: p50=${w.p50.toFixed(2)}ms  p99=${w.p99.toFixed(2)}ms  ` +
+						`min=${w.min.toFixed(2)}ms  max=${w.max.toFixed(2)}ms  wave-elapsed=${w.elapsedMs.toFixed(0)}ms`,
+				);
+			}
+
+			expect(overallP50).toBeLessThan(STORM_P50_LATENCY_MS);
+			expect(overallP99).toBeLessThan(STORM_P99_LATENCY_MS);
+			// Wave-1 stampede check: even the cold-cache wave (which is
+			// what the production cache absorbs) has to stay tractable —
+			// a regression that only hurts first-request-per-scope
+			// latency would otherwise hide behind steady-state numbers.
+			const firstWave = perWave[0];
+			expect(firstWave).toBeDefined();
+			if (firstWave) {
+				expect(firstWave.p99).toBeLessThan(STORM_P99_LATENCY_MS);
+			}
+		},
+		300_000,
 	);
 });


### PR DESCRIPTION
## Summary
Reworks the block-lookup Redis path so per-request latency is bounded by matching-rules-per-request rather than total rules in the tenant. Rule populations in the 10k+ range no longer degrade tail latency.

Adds a process-wide LRU + TTL verdict cache with **singleflight in-flight dedupe** — the direct fix for the frontend-retry-loop stampede shape. Under 100-concurrent identical requests through the full provider hot path: wave-1 p99 drops from **23 ms → 3 ms**, throughput doubles from **28.5k → 61.5k req/s per process**.

Introduces a `clientId="global"` sentinel so the read path probes the posting-list index instead of walking every entry via `ismissing(@clientId)`.

## Approach
### Split-query read path (`packages/user-access-policy`)
- `redisRulesSplitQuery.ts` builds one FT sub-query per populated request field: `numericIp` exact, `numericIp` CIDR range, `ja4Hash`, `userId`, `headHash`, `coords`, `countryCode`, `asn`, plus a single fall-through probe for rules with no user-scope constraint. Each probe hits a discriminating index posting list — a 17k IP-ban population collapses to 1 result (exact IP) plus a handful (CIDRs containing the IP) instead of forcing a full-set scan.
- `RedisRulesReader.findRules` routes strict-match block lookups (`blockOnly && userScope && matchingFieldsOnly`) to the split path. Existing `findRulesRanked` retained for non-hot-path callers (Restrict lookups, admin queries).
- Rank + strict-match filter stays in JS via `rankCandidateRules` after the union — the FT layer is used purely as a candidate fetcher.

### `clientId` sentinel
- Writer stamps `GLOBAL_CLIENT_SCOPE_SENTINEL = "global"` on rules with no `clientId`, and filters out undefined values (previously wrote the literal string `"undefined"`).
- `policyScopeInput.clientId` preprocess strips the sentinel back to `undefined` on read, so downstream code sees the original `AccessRule` shape.
- Legacy rules keep matching via the transition-safe `@clientId:{global} | ismissing(@clientId)` disjunction. A future `rehash-all` migrates them onto the sentinel.

### Verdict cache (`packages/provider`) — real LRU + singleflight
- `HardBlockVerdictCache` — bounded LRU + TTL. `get()` moves the hit entry to the tail of the `Map` iteration order (real LRU eviction), but never refreshes `expiresAt` — absolute TTL preserved.
- **Singleflight `getOrCompute`**: on miss, joiners return the same in-flight Promise instead of racing to storage. Rejections propagate to all waiters and clear the in-flight entry (no wedge).
- TTL tuned to **10 s** (down from an initial 30 s) — still absorbs typical retry-loop bursts, cuts operator-response lag by 3×.
- Max **50 k entries** ≈ 30-100 MB per process. ~10× headroom on realistic per-window unique-scope cardinality.
- `getPrioritisedAccessRule` now takes `{ blockOnly, requestMemoHost, skipCache }`. Per-request memo attaches to `req` so blockMiddleware + downstream in-request checks share one lookup.

## Measured impact

### Sequential lookup latency vs old ranked path
| Path | Rules | p50 | p99 |
|---|---|---|---|
| Old ranked (single FT.AGGREGATE) | 10 000 | 22 ms | 26 ms |
| **New split-query** | **19 300** | **0.42 ms** | **0.77 ms** |

~50× faster on nearly 2× the rule count.

### Retry-storm through full provider hot path (100 in-flight × 10 waves, identical scope)
| Metric | Before singleflight | After singleflight |
|---|---|---|
| Wave-1 p99 | 23.4 ms | **3.12 ms** |
| Overall p99 | 22.8 ms | **2.91 ms** |
| Throughput | 28.5k req/s | **61.5k req/s** |
| Storage calls per 50-concurrent burst | 50 | **1** |

### Mixed realistic (200 in-flight × 8 waves, 30% retry-loop / 70% unique scopes)
- Throughput: 8k req/s per provider process (matches production per-pronode scale)
- Hot p50 3.8 ms / p99 33 ms; unique p50 12.8 ms / p99 24.7 ms
- Cache grows linearly with unique scopes as expected

## Tests
- Unit: `redisRulesSplitQuery.unit.test.ts` (7) — sub-query shape, scope discrimination, NUMERIC/TAG syntax, escaping
- Unit: `hardBlockVerdictCache.unit.test.ts` (18) — LRU move-to-tail, absolute-TTL preservation on hit, set-on-existing-key eviction, TTL expiry, size-cap eviction, 4 singleflight cases (dedupe, per-key non-dedupe, rejection non-wedge, cache-hit fast path)
- Load benchmark: `redisRulesReaderLoad.benchmark.integration.test.ts` — 17k IPs + 1.3k CIDRs + 1k mixed, sequential + 100-concurrent × 10-wave storm at the reader level
- Integration: `blacklistRequestInspector.storm.integration.test.ts` (3) — full provider hot path with cache, pure retry storm + mixed realistic + singleflight dedupe assertion
- Existing 51 user-access-policy + 42 captchaManager unit tests unchanged

## Ops
- Existing rules keep matching via the transition-safe query. Recommend running `rules/rehash-all` against production Redis after deploy so legacy no-`clientId` rules pick up the sentinel and stop needing the `ismissing()` fallback branch.

## Not touched (deliberate)
- `insert-many` rule-count guardrails — decided out of scope
- FT-index self-heal on provider startup — decided out of scope
- Redis pub/sub cache invalidation on rule writes — the right long-term answer for zero-lag admin response, but a separate change. The 10 s TTL is the no-broadcast fallback until then.

## Test plan
- [x] `@prosopo/user-access-policy build:tsc` clean
- [x] `@prosopo/provider build:tsc` clean
- [x] All new + existing unit tests pass locally
- [x] Storm integration test passes locally against a live Redis Stack
- [ ] CI green
- [ ] Review pass on split-query correctness vs `blacklistRequestInspector.ruleApplies` strict-match semantics

🤖 Generated with [Claude Code](https://claude.com/claude-code)
