### PR TITLE
fix(provider): DNS extras honour traffic filter toggles + extend datacenter suppression

### DIFF
--- a/.changeset/traffic-filter-dns-extras-honour-toggles.md
+++ b/.changeset/traffic-filter-dns-extras-honour-toggles.md
@@ -1,0 +1,15 @@
+---
+"@prosopo/provider": patch
+---
+
+fix(provider): DNS-enriched extras now honour traffic filter toggles
+
+`checkTrafficFilter` previously applied the "VPN on datacenter" suppression only to the primary request IP: the enriched DNS peer/resolver IPs still tripped `DATACENTER_BLOCKED` even when the operator had `blockVpn` off. Real-world impact: Surfshark (and similar) users whose primary IP was a `providerType=isp` datacenter passed the primary check, but their DNS resolver — also on a datacenter range flagged as VPN — was blocked. The extras path silently overrode the operator's toggles.
+
+Changes:
+
+- Extras now go through the same evaluator as the primary IP — the internal `EvaluateOptions` / `suppressVpnDatacenterInteraction` split is gone.
+- Datacenter suppression is extended from VPN to all four overlapping categories: VPN, proxy, Tor, and crawler. If any of those flags is set on the IP and the operator has that specific `block*` toggle off, the datacenter rule is suppressed. Same rationale as the original VPN carve-out — those categories live on datacenter infrastructure by design.
+- Crawler check is skipped entirely on DNS extras. Public DNS resolvers like `8.8.8.8` and `1.1.1.1` share IP ranges with search crawlers, so `is_crawler=true` on a resolver is the resolver, not a crawler visiting the endpoint.
+
+Unit tests updated (`checkTrafficFilter.unit.test.ts`): the "does NOT apply VPN-datacenter suppression to extra IPs" test was flipped to assert the new behaviour, and coverage added for proxy/Tor/crawler suppression on both primary and extras, plus the extras-only crawler-skip.

--- a/packages/provider/src/tasks/spam/checkTrafficFilter.ts
+++ b/packages/provider/src/tasks/spam/checkTrafficFilter.ts
@@ -124,10 +124,7 @@ const evaluateIpInfo = (
 		return { isBlocked: true, reason: ResultReason.SATELLITE_BLOCKED };
 	}
 
-	// Skip the crawler check on DNS extras (peer/resolver). Public DNS
-	// resolvers like 8.8.8.8 (Google) and 1.1.1.1 (Cloudflare) share IP
-	// space with search crawlers, so is_crawler on a resolver is the
-	// resolver itself, not a crawler visiting the captcha endpoint.
+	// Public DNS resolvers share IP space with search crawlers.
 	if (!isDnsExtra && trafficFilter.blockCrawler && ipInfo.isCrawler) {
 		return { isBlocked: true, reason: ResultReason.CRAWLER_BLOCKED };
 	}
@@ -143,22 +140,14 @@ const evaluateIpInfo = (
  * `ipInfo` falls back to "not blocked" so an outage in the upstream
  * service can't block all traffic.
  *
- * One cross-filter rule: "block datacenters" is about scraping and
- * automation traffic, not VPN/proxy/Tor end-users or search crawlers,
- * all of which sit on datacenter infrastructure by design. So the
- * datacenter rule is suppressed for IPs whose more specific category
- * (VPN, proxy, Tor, crawler) the operator has left unblocked. If the
- * operator has opted into blocking that category, the earlier category
- * check fires first and short-circuits before the datacenter rule is
- * reached. This applies uniformly to the primary request IP and to the
- * enriched DNS extras (peer/resolver).
+ * Cross-filter rule: the datacenter rule is suppressed when the IP
+ * carries a more specific category the operator has left unblocked —
+ * VPN, proxy, Tor, or crawler. All four legitimately sit on datacenter
+ * infrastructure, so "block datacenters" (a scraping rule) shouldn't
+ * catch them out the back door. Applies to primary and DNS extras.
  *
- * One extras-specific rule: the crawler check is skipped entirely on
- * DNS extras. Public DNS resolvers (Google `8.8.8.8`, Cloudflare
- * `1.1.1.1`) share IP space with search crawlers, so `is_crawler=true`
- * on a resolver is the resolver itself, not a crawler visiting the
- * captcha endpoint. Applying `blockCrawler` to a resolver would
- * false-positive on ordinary users who resolve via public DoH.
+ * Extras-only rule: the crawler check is skipped on DNS extras. Public
+ * DNS resolvers share IP space with search crawlers.
  *
  * The datacenter rule also honours `datacenterNameAllowlist`: consumer
  * relays route through datacenter ranges and are reported as

--- a/packages/provider/src/tasks/spam/checkTrafficFilter.ts
+++ b/packages/provider/src/tasks/spam/checkTrafficFilter.ts
@@ -34,10 +34,6 @@ export type TrafficCheckResult =
 	| { isBlocked: false }
 	| { isBlocked: true; reason: TrafficBlockReason };
 
-type EvaluateOptions = {
-	suppressVpnDatacenterInteraction: boolean;
-};
-
 // Match the allowlist against `datacenterName`, `providerName`
 // (`company.name`), and `asnOrganization` — case-insensitive, whitespace
 // trimmed. The upstream ipapi only populates `datacenter.datacenter` for
@@ -73,7 +69,7 @@ const isDatacenterAllowlisted = (
 const evaluateIpInfo = (
 	ipInfo: IPInfoResponse | undefined,
 	trafficFilter: Partial<ITrafficFilter>,
-	options: EvaluateOptions,
+	isDnsExtra = false,
 ): TrafficCheckResult => {
 	if (!ipInfo || !ipInfo.isValid) {
 		return { isBlocked: false };
@@ -104,15 +100,17 @@ const evaluateIpInfo = (
 		}
 	}
 
+	const datacenterSuppressedByCategory =
+		(ipInfo.isVPN && !trafficFilter.blockVpn) ||
+		(ipInfo.isProxy && !trafficFilter.blockProxy) ||
+		(ipInfo.isTor && !trafficFilter.blockTor) ||
+		(ipInfo.isCrawler && !trafficFilter.blockCrawler);
+
 	if (
 		trafficFilter.blockDatacenter &&
 		ipInfo.isDatacenter &&
 		ipInfo.providerType !== "isp" &&
-		!(
-			options.suppressVpnDatacenterInteraction &&
-			ipInfo.isVPN &&
-			!trafficFilter.blockVpn
-		) &&
+		!datacenterSuppressedByCategory &&
 		!isDatacenterAllowlisted(ipInfo, trafficFilter.datacenterNameAllowlist)
 	) {
 		return { isBlocked: true, reason: ResultReason.DATACENTER_BLOCKED };
@@ -126,7 +124,11 @@ const evaluateIpInfo = (
 		return { isBlocked: true, reason: ResultReason.SATELLITE_BLOCKED };
 	}
 
-	if (trafficFilter.blockCrawler && ipInfo.isCrawler) {
+	// Skip the crawler check on DNS extras (peer/resolver). Public DNS
+	// resolvers like 8.8.8.8 (Google) and 1.1.1.1 (Cloudflare) share IP
+	// space with search crawlers, so is_crawler on a resolver is the
+	// resolver itself, not a crawler visiting the captcha endpoint.
+	if (!isDnsExtra && trafficFilter.blockCrawler && ipInfo.isCrawler) {
 		return { isBlocked: true, reason: ResultReason.CRAWLER_BLOCKED };
 	}
 
@@ -141,14 +143,22 @@ const evaluateIpInfo = (
  * `ipInfo` falls back to "not blocked" so an outage in the upstream
  * service can't block all traffic.
  *
- * One cross-filter rule: when an operator enables `blockDatacenter` but
- * leaves `blockVpn` off, commercial VPNs that exit from datacenter IPs
- * (which is most of them — Mullvad, NordVPN, ProtonVPN, etc. all run on
- * AWS/OVH/Hetzner) would otherwise be caught by the datacenter rule.
- * Operators almost never intend that: "block data centers" is about
- * scraping/automation traffic, not VPN end-users. So the datacenter
- * rule is suppressed for IPs also flagged as VPN unless the operator
- * has opted in to blocking VPN traffic explicitly.
+ * One cross-filter rule: "block datacenters" is about scraping and
+ * automation traffic, not VPN/proxy/Tor end-users or search crawlers,
+ * all of which sit on datacenter infrastructure by design. So the
+ * datacenter rule is suppressed for IPs whose more specific category
+ * (VPN, proxy, Tor, crawler) the operator has left unblocked. If the
+ * operator has opted into blocking that category, the earlier category
+ * check fires first and short-circuits before the datacenter rule is
+ * reached. This applies uniformly to the primary request IP and to the
+ * enriched DNS extras (peer/resolver).
+ *
+ * One extras-specific rule: the crawler check is skipped entirely on
+ * DNS extras. Public DNS resolvers (Google `8.8.8.8`, Cloudflare
+ * `1.1.1.1`) share IP space with search crawlers, so `is_crawler=true`
+ * on a resolver is the resolver itself, not a crawler visiting the
+ * captcha endpoint. Applying `blockCrawler` to a resolver would
+ * false-positive on ordinary users who resolve via public DoH.
  *
  * The datacenter rule also honours `datacenterNameAllowlist`: consumer
  * relays route through datacenter ranges and are reported as
@@ -175,9 +185,7 @@ export const checkTrafficFilter = (
 	extraIpInfos?: ReadonlyArray<IPInfoResponse | undefined>,
 	dnsPathValid?: boolean,
 ): TrafficCheckResult => {
-	const primary = evaluateIpInfo(ipInfo, trafficFilter, {
-		suppressVpnDatacenterInteraction: true,
-	});
+	const primary = evaluateIpInfo(ipInfo, trafficFilter);
 	if (primary.isBlocked) {
 		return primary;
 	}
@@ -187,9 +195,7 @@ export const checkTrafficFilter = (
 	}
 
 	for (const extra of extraIpInfos ?? []) {
-		const result = evaluateIpInfo(extra, trafficFilter, {
-			suppressVpnDatacenterInteraction: false,
-		});
+		const result = evaluateIpInfo(extra, trafficFilter, true);
 		if (result.isBlocked) {
 			return result;
 		}

--- a/packages/provider/src/tests/unit/tasks/spam/checkTrafficFilter.unit.test.ts
+++ b/packages/provider/src/tests/unit/tasks/spam/checkTrafficFilter.unit.test.ts
@@ -118,6 +118,33 @@ describe("checkTrafficFilter", () => {
 		expect(result).toEqual({ isBlocked: false });
 	});
 
+	it("does not block proxy-on-datacenter IPs when blockDatacenter is on but blockProxy is off", () => {
+		const result = checkTrafficFilter(
+			baseInfo({ isDatacenter: true, isProxy: true }),
+			{ ...allBlocked, blockProxy: false },
+		);
+		expect(result).toEqual({ isBlocked: false });
+	});
+
+	it("does not block Tor-on-datacenter IPs when blockDatacenter is on but blockTor is off", () => {
+		const result = checkTrafficFilter(
+			baseInfo({ isDatacenter: true, isTor: true }),
+			{ ...allBlocked, blockTor: false },
+		);
+		expect(result).toEqual({ isBlocked: false });
+	});
+
+	it("does not block crawler-on-datacenter IPs when blockDatacenter is on but blockCrawler is off", () => {
+		// Search crawlers live on datacenter infra by definition. If the
+		// operator opted crawlers in, the datacenter rule shouldn't catch
+		// them out the back door.
+		const result = checkTrafficFilter(
+			baseInfo({ isDatacenter: true, isCrawler: true }),
+			{ ...allBlocked, blockCrawler: false },
+		);
+		expect(result).toEqual({ isBlocked: false });
+	});
+
 	it("still blocks raw datacenter (non-VPN) IPs when blockDatacenter is on and blockVpn is off", () => {
 		const result = checkTrafficFilter(
 			baseInfo({ isDatacenter: true, isVPN: false }),
@@ -229,12 +256,28 @@ describe("checkTrafficFilter", () => {
 			});
 		});
 
-		it("does NOT apply VPN-datacenter suppression to extra IPs", () => {
+		it("applies VPN-datacenter suppression to extra IPs when blockVpn is off", () => {
+			// A VPN user's DNS resolver typically sits on the VPN provider's
+			// datacenter range. If the operator hasn't opted into blocking
+			// VPN traffic, that resolver shouldn't drop the request either
+			// — the extras must honour the same VPN toggle as the primary.
 			const noVpnBlock: ITrafficFilter = { ...allBlocked, blockVpn: false };
 			const result = checkTrafficFilter(cleanPrimary, noVpnBlock, [
 				baseInfo({
 					ip: "198.51.100.10",
 					isVPN: true,
+					isDatacenter: true,
+				}),
+			]);
+			expect(result).toEqual({ isBlocked: false });
+		});
+
+		it("still blocks a datacenter extra that is not a VPN when blockVpn is off", () => {
+			const noVpnBlock: ITrafficFilter = { ...allBlocked, blockVpn: false };
+			const result = checkTrafficFilter(cleanPrimary, noVpnBlock, [
+				baseInfo({
+					ip: "198.51.100.10",
+					isVPN: false,
 					isDatacenter: true,
 				}),
 			]);
@@ -278,6 +321,67 @@ describe("checkTrafficFilter", () => {
 				baseInfo({ ip: "198.51.100.10", isDatacenter: true }),
 			]);
 			expect(result).toEqual({ isBlocked: true, reason: "API.TOR_BLOCKED" });
+		});
+
+		it("does not check the crawler flag on extra IPs even when blockCrawler is on", () => {
+			// Google 8.8.8.8 and Cloudflare 1.1.1.1 share IP space with
+			// search crawlers, so is_crawler=true on a resolver would
+			// false-positive block ordinary users.
+			const result = checkTrafficFilter(cleanPrimary, allBlocked, [
+				baseInfo({ ip: "8.8.8.8", isCrawler: true }),
+			]);
+			expect(result).toEqual({ isBlocked: false });
+		});
+
+		it("still blocks the crawler flag on the primary IP when an extra is present", () => {
+			const result = checkTrafficFilter(
+				baseInfo({ isCrawler: true }),
+				allBlocked,
+				[baseInfo({ ip: "8.8.8.8" })],
+			);
+			expect(result).toEqual({
+				isBlocked: true,
+				reason: "API.CRAWLER_BLOCKED",
+			});
+		});
+
+		it("applies proxy-datacenter suppression to extra IPs when blockProxy is off", () => {
+			const noProxyBlock: ITrafficFilter = { ...allBlocked, blockProxy: false };
+			const result = checkTrafficFilter(cleanPrimary, noProxyBlock, [
+				baseInfo({
+					ip: "198.51.100.10",
+					isProxy: true,
+					isDatacenter: true,
+				}),
+			]);
+			expect(result).toEqual({ isBlocked: false });
+		});
+
+		it("applies Tor-datacenter suppression to extra IPs when blockTor is off", () => {
+			const noTorBlock: ITrafficFilter = { ...allBlocked, blockTor: false };
+			const result = checkTrafficFilter(cleanPrimary, noTorBlock, [
+				baseInfo({
+					ip: "198.51.100.10",
+					isTor: true,
+					isDatacenter: true,
+				}),
+			]);
+			expect(result).toEqual({ isBlocked: false });
+		});
+
+		it("applies crawler-datacenter suppression to extra IPs when blockCrawler is off", () => {
+			const noCrawlerBlock: ITrafficFilter = {
+				...allBlocked,
+				blockCrawler: false,
+			};
+			const result = checkTrafficFilter(cleanPrimary, noCrawlerBlock, [
+				baseInfo({
+					ip: "198.51.100.10",
+					isCrawler: true,
+					isDatacenter: true,
+				}),
+			]);
+			expect(result).toEqual({ isBlocked: false });
 		});
 	});
 

--- a/packages/provider/src/tests/unit/tasks/spam/checkTrafficFilter.unit.test.ts
+++ b/packages/provider/src/tests/unit/tasks/spam/checkTrafficFilter.unit.test.ts
@@ -135,9 +135,6 @@ describe("checkTrafficFilter", () => {
 	});
 
 	it("does not block crawler-on-datacenter IPs when blockDatacenter is on but blockCrawler is off", () => {
-		// Search crawlers live on datacenter infra by definition. If the
-		// operator opted crawlers in, the datacenter rule shouldn't catch
-		// them out the back door.
 		const result = checkTrafficFilter(
 			baseInfo({ isDatacenter: true, isCrawler: true }),
 			{ ...allBlocked, blockCrawler: false },
@@ -257,10 +254,6 @@ describe("checkTrafficFilter", () => {
 		});
 
 		it("applies VPN-datacenter suppression to extra IPs when blockVpn is off", () => {
-			// A VPN user's DNS resolver typically sits on the VPN provider's
-			// datacenter range. If the operator hasn't opted into blocking
-			// VPN traffic, that resolver shouldn't drop the request either
-			// — the extras must honour the same VPN toggle as the primary.
 			const noVpnBlock: ITrafficFilter = { ...allBlocked, blockVpn: false };
 			const result = checkTrafficFilter(cleanPrimary, noVpnBlock, [
 				baseInfo({
@@ -324,9 +317,6 @@ describe("checkTrafficFilter", () => {
 		});
 
 		it("does not check the crawler flag on extra IPs even when blockCrawler is on", () => {
-			// Google 8.8.8.8 and Cloudflare 1.1.1.1 share IP space with
-			// search crawlers, so is_crawler=true on a resolver would
-			// false-positive block ordinary users.
 			const result = checkTrafficFilter(cleanPrimary, allBlocked, [
 				baseInfo({ ip: "8.8.8.8", isCrawler: true }),
 			]);


### PR DESCRIPTION
## Summary

- **Extras now honour the same VPN/datacenter suppression as the primary IP.** Previously `checkTrafficFilter` passed `suppressVpnDatacenterInteraction: false` for enriched DNS peer/resolver IPs, so a customer with `blockVpn: false` and `blockDatacenter: true` would still see VPN-on-datacenter extras trip `DATACENTER_BLOCKED`. This is the eyematch / mongo1 support ticket — a Surfshark user's primary IP passed (providerType=isp short-circuit) but the resolver was silently blocked.
- **Datacenter suppression extended from VPN-only to all four overlapping categories** — VPN, proxy, Tor, crawler. All live on datacenter infra by design, so if the operator left the specific `block*` toggle off, the datacenter rule no longer catches them through the back door.
- **Crawler check skipped entirely on DNS extras.** `8.8.8.8` and `1.1.1.1` share IP ranges with Googlebot / Cloudflare crawlers, so `is_crawler: true` on a resolver is a false-positive for a captcha visit.

Behaviour that intentionally stays as-is:

- Mobile / satellite checks on extras (rare in the wild; the primary IP would already fire in the realistic case).
- Abuser reputation check on extras (reputation signal, not category classification).
- The soft `dnsAsymmetry` score in `enrichDnsEvent.ts` continues to feed the decision machine; no hard-block on disparity was added — that would false-positive on every residential user who uses public DoH.

## Test plan

- [x] `checkTrafficFilter.unit.test.ts` — 54/54 passing locally. New coverage: proxy/Tor/crawler suppression on primary, proxy/Tor/crawler suppression on extras, crawler-skip on extras, primary crawler still fires when an extra is present.
- [x] Existing behaviour preserved: primary IP block precedence, `providerType=isp` short-circuit, `datacenterNameAllowlist`, `skipExtrasOnValidDnsPath`, abuser-score threshold, mobile/satellite blocks.
- [x] `npm run -w @prosopo/provider build:tsc` — clean.
- [x] `npx biome check` on modified files — clean.
- [ ] Verify CI green on the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)