### PR TITLE
fix(procaptcha): random provider re-selection + backoff on error fallback

### DIFF
--- a/.changeset/frontend-provider-fallback-backoff.md
+++ b/.changeset/frontend-provider-fallback-backoff.md
@@ -1,0 +1,20 @@
+---
+"@prosopo/procaptcha-frictionless": patch
+"@prosopo/procaptcha-common": patch
+"@prosopo/procaptcha-puzzle": patch
+"@prosopo/load-balancer": patch
+"@prosopo/procaptcha-pow": patch
+"@prosopo/procaptcha": patch
+"@prosopo/types": patch
+---
+
+fix(procaptcha): random provider re-selection + backoff on error fallback
+
+When a provider errored, the widget retried the same DNS-routed endpoint immediately and in a tight loop. A fleet of widgets whose provider was unhealthy could therefore accidentally DDoS the provider fleet — retrying the same (possibly-down) endpoint as fast as the event loop allowed.
+
+The error-fallback path now:
+
+- **Re-selects a different provider on retry.** The first attempt still hits the DNS-routed endpoint (unchanged happy path, preserves session stickiness). On a retry the widget picks a random provider straight from the provider list (`getRandomProviderFromList`), weighted by provider capacity and excluding the URL that just failed. In development the list holds only the single local provider, so a retry simply re-targets that provider.
+- **Backs off between retries.** `providerRetry` now waits an exponential-backoff-with-full-jitter delay (0.5s → 1s → 2s → 4s …, capped at 10s) before retrying, so a down provider is no longer hammered and a fleet of clients that all errored at once don't reconverge into a thundering herd.
+
+Applies to the image, PoW and puzzle managers and the frictionless detection flow. New shared `ProviderSelectRetryContext` type; `BotDetectionFunction` gains an optional retry-context argument.

--- a/packages/load-balancer/src/providers.ts
+++ b/packages/load-balancer/src/providers.ts
@@ -152,6 +152,72 @@ export const getRandomActiveProvider = async (
 	};
 };
 
+// Compare two provider URLs ignoring a trailing slash so a stored "failed" URL
+// still matches its list entry regardless of formatting.
+const sameProviderUrl = (a: string, b: string): boolean =>
+	a.replace(/\/$/, "") === b.replace(/\/$/, "");
+
+// Weighted random pick — providers advertise a capacity weight (1-100), so
+// fallback traffic is spread in proportion to capacity rather than uniformly.
+// Returns undefined only for an empty list (callers guard against that).
+const pickWeightedProvider = (
+	providers: HardcodedProvider[],
+	random: () => number,
+): HardcodedProvider | undefined => {
+	const totalWeight = providers.reduce((sum, p) => sum + p.weight, 0);
+	let threshold = random() * totalWeight;
+	let chosen: HardcodedProvider | undefined;
+	for (const provider of providers) {
+		chosen = provider;
+		threshold -= provider.weight;
+		if (threshold < 0) break;
+	}
+	return chosen;
+};
+
+/**
+ * Pick a random provider directly from the provider list, bypassing the
+ * DNS-routed endpoint. This is the error-fallback path: once a provider has
+ * errored, retrying it re-hits the same (possibly-down) endpoint, and a fleet
+ * of widgets doing that in a tight loop can accidentally DDoS the provider — so
+ * instead we spread the retry across the fleet by choosing a random provider
+ * from the list. `excludeUrl` (the provider that just failed) is dropped from
+ * the pool when other providers remain. In development the list holds only the
+ * single local provider, so this naturally degrades to retrying that provider.
+ * `random` is injectable so tests can make the pick deterministic.
+ */
+export const getRandomProviderFromList = async (
+	env: EnvironmentTypes,
+	ipMode?: IpMode,
+	excludeUrl?: string,
+	random: () => number = Math.random,
+): Promise<RandomProvider> => {
+	const providers = await getProviders(env);
+	if (providers.length === 0) {
+		// Nothing to choose from — fall back to the DNS-routed endpoint.
+		return getRandomActiveProvider(env, ipMode);
+	}
+
+	// Only exclude the failed provider when at least one other remains, so we
+	// never end up with an empty pool (e.g. a single-provider environment).
+	const eligible =
+		excludeUrl && providers.length > 1
+			? providers.filter(
+					(p) => !sameProviderUrl(applyIpModeToUrl(p.url, ipMode), excludeUrl),
+				)
+			: providers;
+	const pool = eligible.length > 0 ? eligible : providers;
+
+	const chosen = pickWeightedProvider(pool, random);
+	if (!chosen) {
+		return getRandomActiveProvider(env, ipMode);
+	}
+	return {
+		providerAccount: chosen.address,
+		provider: { url: applyIpModeToUrl(chosen.url, ipMode) },
+	};
+};
+
 // Test-only escape hatch so tests can isolate the healthz cache between
 // cases. Not exported from the package index — internal use only.
 export const _resetPinCache = () => {

--- a/packages/load-balancer/src/tests/productionProviderList.unit.test.ts
+++ b/packages/load-balancer/src/tests/productionProviderList.unit.test.ts
@@ -1,0 +1,230 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// End-to-end coverage that drives the *real* balancer parsing against the shape
+// served by https://provider-list.prosopo.io/ — dual-stack pronode entries at
+// the top level alongside `ipv4` / `ipv6` single-stack sub-lists. Deliberately
+// does NOT mock `../balancer.js` (unlike providers.unit.test.ts) so the raw JSON
+// flows through convertHostedProvider → loadBalancer → getProviders →
+// getRandomProviderFromList exactly as it does in production, with only
+// `fetch` stubbed.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	convertHostedProvider,
+	getProviderHostname,
+	loadBalancer,
+} from "../balancer.js";
+import {
+	_resetPinCache,
+	_resetProviderListCache,
+	getRandomProviderFromList,
+} from "../providers.js";
+
+const DATASET_ID =
+	"0x2e52a1e70f0e0c808972bc04e6fbc8f264b1fbb29c94041fdf01a839b000a40e";
+const ADDRESS = "5FnBurrfqWgSLJFMsojjEP74mLX1vZZ9ASyNXKfA5YXu8FR2";
+
+type ProviderEntry = { url: string; datasetId: string; address: string };
+
+const entry = (host: string): ProviderEntry => ({
+	url: `https://${host}.prosopo.io`,
+	datasetId: DATASET_ID,
+	address: ADDRESS,
+});
+
+// A trimmed but faithful copy of the production provider-list JSON: three
+// pronodes, each present in the ipv4 sub-list, the ipv6 sub-list, and the
+// top-level dual-stack list. Note pronode16 sorts before pronode6 and pronode7
+// under a plain string compare ('1' < '6' < '7').
+const productionJson: Record<string, unknown> = {
+	ipv4: {
+		pronode6: entry("ipv4.pronode6"),
+		pronode7: entry("ipv4.pronode7"),
+		pronode16: entry("ipv4.pronode16"),
+	},
+	ipv6: {
+		pronode6: entry("ipv6.pronode6"),
+		pronode7: entry("ipv6.pronode7"),
+		pronode16: entry("ipv6.pronode16"),
+	},
+	pronode6: entry("pronode6"),
+	pronode7: entry("pronode7"),
+	pronode16: entry("pronode16"),
+};
+
+const originalFetch = globalThis.fetch;
+
+const mockFetchReturning = (payload: unknown) => {
+	const mocked = vi.fn(
+		async () => new Response(JSON.stringify(payload), { status: 200 }),
+	);
+	globalThis.fetch = mocked as typeof fetch;
+	return mocked;
+};
+
+beforeEach(() => {
+	_resetPinCache();
+	_resetProviderListCache();
+});
+
+afterEach(() => {
+	globalThis.fetch = originalFetch;
+	vi.restoreAllMocks();
+});
+
+describe("convertHostedProvider (production.json shape)", () => {
+	it("keeps only the dual-stack pronodes and drops the ipv4/ipv6 sub-lists", () => {
+		const providers = convertHostedProvider(productionJson);
+		expect(providers.map((p) => p.url)).toEqual([
+			// sorted by url.localeCompare — pronode16 first ('1' < '6')
+			"https://pronode16.prosopo.io",
+			"https://pronode6.prosopo.io",
+			"https://pronode7.prosopo.io",
+		]);
+		// Every entry defaults to weight 1 and carries the shared dataset/address.
+		for (const provider of providers) {
+			expect(provider.weight).toBe(1);
+			expect(provider.datasetId).toBe(DATASET_ID);
+			expect(provider.address).toBe(ADDRESS);
+			expect(provider.url).not.toMatch(/ipv[46]\./);
+		}
+	});
+
+	it("returns the ipv4 single-stack sub-list when ipMode=ipv4", () => {
+		const providers = convertHostedProvider(productionJson, "ipv4");
+		expect(providers.map((p) => p.url)).toEqual([
+			"https://ipv4.pronode16.prosopo.io",
+			"https://ipv4.pronode6.prosopo.io",
+			"https://ipv4.pronode7.prosopo.io",
+		]);
+		// The label strips back to the bare pronode hostname for identity.
+		expect(providers.map((p) => getProviderHostname(p))).toEqual([
+			"pronode16.prosopo.io",
+			"pronode6.prosopo.io",
+			"pronode7.prosopo.io",
+		]);
+	});
+
+	it("returns the ipv6 single-stack sub-list when ipMode=ipv6", () => {
+		const providers = convertHostedProvider(productionJson, "ipv6");
+		expect(providers.map((p) => p.url)).toEqual([
+			"https://ipv6.pronode16.prosopo.io",
+			"https://ipv6.pronode6.prosopo.io",
+			"https://ipv6.pronode7.prosopo.io",
+		]);
+	});
+});
+
+describe("loadBalancer (production.json shape)", () => {
+	it("fetches the production list and returns the dual-stack pronodes", async () => {
+		const mocked = mockFetchReturning(productionJson);
+		const providers = await loadBalancer("production");
+		expect(mocked).toHaveBeenCalledWith(
+			"https://provider-list.prosopo.io/",
+			expect.objectContaining({ method: "GET" }),
+		);
+		expect(providers.map((p) => p.url)).toEqual([
+			"https://pronode16.prosopo.io",
+			"https://pronode6.prosopo.io",
+			"https://pronode7.prosopo.io",
+		]);
+	});
+});
+
+describe("getRandomProviderFromList (production.json end-to-end)", () => {
+	const dualStackUrls = [
+		"https://pronode16.prosopo.io",
+		"https://pronode6.prosopo.io",
+		"https://pronode7.prosopo.io",
+	];
+
+	it("picks a dual-stack pronode from the fetched production list", async () => {
+		mockFetchReturning(productionJson);
+		const result = await getRandomProviderFromList(
+			"production",
+			undefined,
+			undefined,
+			() => 0,
+		);
+		// random=0 selects the first entry after the url sort.
+		expect(result.provider.url).toBe("https://pronode16.prosopo.io");
+		expect(result.providerAccount).toBe(ADDRESS);
+	});
+
+	it("labels the chosen pronode with ipv4 when ipMode=ipv4", async () => {
+		mockFetchReturning(productionJson);
+		const result = await getRandomProviderFromList(
+			"production",
+			"ipv4",
+			undefined,
+			() => 0,
+		);
+		// Matches the url found under the production `ipv4` sub-list.
+		expect(result.provider.url).toBe("https://ipv4.pronode16.prosopo.io");
+	});
+
+	it("labels the chosen pronode with ipv6 when ipMode=ipv6", async () => {
+		mockFetchReturning(productionJson);
+		const result = await getRandomProviderFromList(
+			"production",
+			"ipv6",
+			undefined,
+			() => 0.99,
+		);
+		// random≈1 selects the last entry (pronode7) after the sort.
+		expect(result.provider.url).toBe("https://ipv6.pronode7.prosopo.io");
+	});
+
+	it("excludes the pronode that just failed and picks a different one", async () => {
+		mockFetchReturning(productionJson);
+		const result = await getRandomProviderFromList(
+			"production",
+			undefined,
+			"https://pronode16.prosopo.io",
+			() => 0,
+		);
+		expect(result.provider.url).not.toBe("https://pronode16.prosopo.io");
+		expect(dualStackUrls).toContain(result.provider.url);
+		// With pronode16 removed the sorted pool starts at pronode6.
+		expect(result.provider.url).toBe("https://pronode6.prosopo.io");
+	});
+
+	it("excludes by ipv4-labelled url, matching what the widget actually used", async () => {
+		mockFetchReturning(productionJson);
+		// The widget's previous attempt used the ipv4-labelled url; exclusion must
+		// still match the underlying pronode so it is dropped from the pool.
+		const result = await getRandomProviderFromList(
+			"production",
+			"ipv4",
+			"https://ipv4.pronode16.prosopo.io",
+			() => 0,
+		);
+		expect(result.provider.url).not.toBe("https://ipv4.pronode16.prosopo.io");
+		expect(result.provider.url).toBe("https://ipv4.pronode6.prosopo.io");
+	});
+
+	it("serves the cached list across repeat selections (one fetch)", async () => {
+		const mocked = mockFetchReturning(productionJson);
+		await getRandomProviderFromList(
+			"production",
+			undefined,
+			undefined,
+			() => 0,
+		);
+		await getRandomProviderFromList("production", "ipv4", undefined, () => 0);
+		await getRandomProviderFromList("production", "ipv6", undefined, () => 0);
+		expect(mocked).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/load-balancer/src/tests/providers.unit.test.ts
+++ b/packages/load-balancer/src/tests/providers.unit.test.ts
@@ -13,11 +13,13 @@
 // limitations under the License.
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { HardcodedProvider } from "../balancer.js";
 import {
 	_resetPinCache,
 	_resetProviderListCache,
 	getProviders,
 	getRandomActiveProvider,
+	getRandomProviderFromList,
 } from "../providers.js";
 
 // Mock the underlying load balancer so getProviders' caching/failure semantics
@@ -185,5 +187,132 @@ describe("getProviders", () => {
 		const retry = await getProviders("production");
 		expect(retry).toBe(providers);
 		expect(loadBalancer).toHaveBeenCalledTimes(2);
+	});
+});
+
+describe("getRandomProviderFromList", () => {
+	const providerList: HardcodedProvider[] = [
+		{
+			address: "5A",
+			url: "https://provider-a.io",
+			datasetId: "0x0",
+			weight: 1,
+		},
+		{
+			address: "5B",
+			url: "https://provider-b.io",
+			datasetId: "0x0",
+			weight: 1,
+		},
+		{
+			address: "5C",
+			url: "https://provider-c.io",
+			datasetId: "0x0",
+			weight: 1,
+		},
+	];
+
+	beforeEach(() => {
+		_resetProviderListCache();
+		_resetPinCache();
+		loadBalancer.mockReset();
+	});
+
+	it("picks a provider from the list (not the DNS-routed endpoint)", async () => {
+		loadBalancer.mockResolvedValue(providerList);
+		// random just above 1/3 lands in the second bucket (uniform weights).
+		const result = await getRandomProviderFromList(
+			"production",
+			undefined,
+			undefined,
+			() => 0.4,
+		);
+		expect(result.provider.url).toBe("https://provider-b.io");
+		expect(result.providerAccount).toBe("5B");
+	});
+
+	it("excludes the provider that just failed when others remain", async () => {
+		loadBalancer.mockResolvedValue(providerList);
+		// random=0 would normally pick the first entry; excluding provider-a
+		// shifts the pool so index 0 is provider-b.
+		const result = await getRandomProviderFromList(
+			"production",
+			undefined,
+			"https://provider-a.io",
+			() => 0,
+		);
+		expect(result.provider.url).not.toBe("https://provider-a.io");
+		expect(result.provider.url).toBe("https://provider-b.io");
+	});
+
+	it("ignores a trailing slash when matching the excluded url", async () => {
+		loadBalancer.mockResolvedValue(providerList);
+		const result = await getRandomProviderFromList(
+			"production",
+			undefined,
+			"https://provider-a.io/",
+			() => 0,
+		);
+		expect(result.provider.url).toBe("https://provider-b.io");
+	});
+
+	it("still returns the only provider in development even if it is excluded", async () => {
+		const single: HardcodedProvider[] = [
+			{
+				address: "5Local",
+				url: "https://localhost:9229",
+				datasetId: "0x0",
+				weight: 1,
+			},
+		];
+		loadBalancer.mockResolvedValue(single);
+		const result = await getRandomProviderFromList(
+			"development",
+			undefined,
+			"https://localhost:9229",
+			() => 0,
+		);
+		expect(result.provider.url).toBe("https://localhost:9229");
+	});
+
+	it("applies the ipv4 label to the chosen provider url", async () => {
+		loadBalancer.mockResolvedValue(providerList);
+		const result = await getRandomProviderFromList(
+			"production",
+			"ipv4",
+			undefined,
+			() => 0,
+		);
+		expect(result.provider.url).toBe("https://ipv4.provider-a.io");
+	});
+
+	it("weights the pick by provider weight", async () => {
+		const weighted: HardcodedProvider[] = [
+			{ address: "5A", url: "https://a.io", datasetId: "0x0", weight: 1 },
+			{ address: "5B", url: "https://b.io", datasetId: "0x0", weight: 99 },
+		];
+		loadBalancer.mockResolvedValue(weighted);
+		// threshold = 0.5 * 100 = 50 → after subtracting weight 1 (still 49),
+		// lands on the heavy second provider.
+		const result = await getRandomProviderFromList(
+			"production",
+			undefined,
+			undefined,
+			() => 0.5,
+		);
+		expect(result.provider.url).toBe("https://b.io");
+	});
+
+	it("falls back to the DNS-routed endpoint when the list is empty", async () => {
+		loadBalancer.mockResolvedValue([]);
+		const result = await getRandomProviderFromList(
+			"development",
+			undefined,
+			undefined,
+			() => 0,
+		);
+		// Development resolves the local URL without a healthz round-trip.
+		expect(result.provider.url).toBe("https://localhost:9229");
+		expect(result.providerAccount).toBe("dns-routed");
 	});
 });

--- a/packages/procaptcha-common/src/providers.ts
+++ b/packages/procaptcha-common/src/providers.ts
@@ -12,8 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { type IpMode, getRandomActiveProvider } from "@prosopo/load-balancer";
-import type { EnvironmentTypes, RandomProvider } from "@prosopo/types";
+import {
+	type IpMode,
+	getRandomActiveProvider,
+	getRandomProviderFromList,
+} from "@prosopo/load-balancer";
+import type {
+	EnvironmentTypes,
+	ProviderSelectRetryContext,
+	RandomProvider,
+} from "@prosopo/types";
+
+// Inlined rather than importing `sleep` from @prosopo/util so this package
+// doesn't take on @prosopo/util as a dependency for a one-liner.
+const sleep = (ms: number): Promise<void> =>
+	new Promise((resolve) => setTimeout(resolve, ms));
 
 // Translate the user-facing ipv4/ipv6 booleans (set via ProcaptchaRenderOptions
 // or data-ipv4/data-ipv6) into the load-balancer's IpMode selector. ipv4 wins
@@ -26,14 +39,50 @@ export const pickIpMode = (
 	return undefined;
 };
 
-// Thin wrapper over the load-balancer's static-DNS endpoint resolver. Kept as
-// a separate export so widget packages (procaptcha, procaptcha-pow, …) import
-// from procaptcha-common rather than reaching into load-balancer directly.
+// Resolves the provider a widget should talk to. On the first attempt this hits
+// the load-balancer's static-DNS endpoint (the normal, healthy path — keeps
+// session creation and submission pinned to the same backend). On a retry
+// (`retryContext.attempt > 1`) the previous provider errored, so instead of
+// re-hitting the same possibly-down endpoint we pick a random *different*
+// provider straight from the provider list. In development the list holds only
+// the single local provider, so a retry just re-targets that provider.
+//
+// Kept as a separate export so widget packages (procaptcha, procaptcha-pow, …)
+// import from procaptcha-common rather than reaching into load-balancer.
 export const getProcaptchaRandomActiveProvider = async (
 	defaultEnvironment: EnvironmentTypes,
 	ipMode?: IpMode,
+	retryContext?: ProviderSelectRetryContext,
 ): Promise<RandomProvider> => {
-	return getRandomActiveProvider(defaultEnvironment, ipMode);
+	if (!retryContext || retryContext.attempt <= 1) {
+		return getRandomActiveProvider(defaultEnvironment, ipMode);
+	}
+	return getRandomProviderFromList(
+		defaultEnvironment,
+		ipMode,
+		retryContext.excludeUrl,
+	);
+};
+
+// Exponential-backoff-with-jitter bounds for provider retries. The delay grows
+// 0.5s → 1s → 2s → 4s … capped at 10s. Without a delay a widget whose provider
+// is down re-requests as fast as the event loop allows, and a fleet of such
+// widgets can accidentally DDoS the provider fleet. Full jitter (a random point
+// in [0, cap]) desynchronises clients that all errored at once so their retries
+// don't reconverge into a thundering herd.
+const RETRY_BASE_DELAY_MS = 500;
+const RETRY_MAX_DELAY_MS = 10_000;
+
+export const getRetryDelayMs = (
+	attemptCount: number,
+	random: () => number = Math.random,
+): number => {
+	const safeAttempt = Math.max(0, Math.floor(attemptCount));
+	const cappedDelay = Math.min(
+		RETRY_MAX_DELAY_MS,
+		RETRY_BASE_DELAY_MS * 2 ** safeAttempt,
+	);
+	return Math.round(random() * cappedDelay);
 };
 
 export const providerRetry = async (
@@ -42,6 +91,7 @@ export const providerRetry = async (
 	stateReset: () => void,
 	attemptCount: number,
 	retryMax: number,
+	backoffMs: number = getRetryDelayMs(attemptCount),
 ) => {
 	try {
 		await currentFn();
@@ -56,7 +106,10 @@ export const providerRetry = async (
 		console.error(err);
 		// hit an error, disallow user's claim to be human
 		stateReset();
-		// trigger a retry to attempt a new provider until it passes
+		// Back off before retrying so a down provider isn't hammered as fast as
+		// the event loop allows (accidental self-inflicted DDoS).
+		await sleep(backoffMs);
+		// trigger a retry — the managers select a fresh random provider on retry
 		await retryFn();
 	}
 };

--- a/packages/procaptcha-common/src/tests/providers.test.ts
+++ b/packages/procaptcha-common/src/tests/providers.test.ts
@@ -12,9 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	getProcaptchaRandomActiveProvider,
+	getRetryDelayMs,
 	pickIpMode,
 	providerRetry,
 } from "../providers.js";
@@ -29,9 +30,26 @@ vi.mock("@prosopo/load-balancer", () => ({
 					: "http://localhost:9229",
 		},
 	})),
+	getRandomProviderFromList: vi.fn(
+		async (_env: string, _ipMode?: string, excludeUrl?: string) => ({
+			providerAccount: "5FromList",
+			provider: {
+				url: excludeUrl
+					? "https://provider-from-list-b.io"
+					: "https://provider-from-list-a.io",
+			},
+		}),
+	),
 }));
 
 describe("providers", () => {
+	// The load-balancer mock functions are module-level, so their call history
+	// accumulates across tests — clear it between cases to keep call-count
+	// assertions independent.
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
 	describe("getProcaptchaRandomActiveProvider", () => {
 		it("delegates to the load-balancer static-DNS resolver", async () => {
 			const { getRandomActiveProvider } = await import(
@@ -58,6 +76,65 @@ describe("providers", () => {
 				"production",
 				"ipv4",
 			);
+		});
+
+		it("uses the DNS-routed resolver on the first attempt", async () => {
+			const { getRandomActiveProvider, getRandomProviderFromList } =
+				await import("@prosopo/load-balancer");
+
+			const result = await getProcaptchaRandomActiveProvider(
+				"production",
+				undefined,
+				{ attempt: 1 },
+			);
+
+			expect(getRandomActiveProvider).toHaveBeenCalled();
+			expect(getRandomProviderFromList).not.toHaveBeenCalled();
+			expect(result.provider.url).toBe("https://pronode.prosopo.io");
+		});
+
+		it("picks a random provider from the list on a retry", async () => {
+			const { getRandomProviderFromList } = await import(
+				"@prosopo/load-balancer"
+			);
+
+			const result = await getProcaptchaRandomActiveProvider(
+				"production",
+				"ipv4",
+				{ attempt: 2, excludeUrl: "https://pronode.prosopo.io" },
+			);
+
+			expect(getRandomProviderFromList).toHaveBeenCalledWith(
+				"production",
+				"ipv4",
+				"https://pronode.prosopo.io",
+			);
+			// The mock returns a different url when an excludeUrl is supplied.
+			expect(result.provider.url).toBe("https://provider-from-list-b.io");
+		});
+	});
+
+	describe("getRetryDelayMs", () => {
+		it("grows exponentially from the base delay, capped at the max", () => {
+			// random=1 → full jittered value == the (capped) exponential ceiling.
+			expect(getRetryDelayMs(0, () => 1)).toBe(500);
+			expect(getRetryDelayMs(1, () => 1)).toBe(1000);
+			expect(getRetryDelayMs(2, () => 1)).toBe(2000);
+			expect(getRetryDelayMs(3, () => 1)).toBe(4000);
+			// 500 * 2^6 = 32000 → capped at 10000.
+			expect(getRetryDelayMs(6, () => 1)).toBe(10000);
+			expect(getRetryDelayMs(20, () => 1)).toBe(10000);
+		});
+
+		it("applies full jitter — a fraction of the ceiling", () => {
+			// random=0 → no delay; random=0.5 → half the ceiling.
+			expect(getRetryDelayMs(2, () => 0)).toBe(0);
+			expect(getRetryDelayMs(2, () => 0.5)).toBe(1000);
+		});
+
+		it("clamps negative or fractional attempt counts", () => {
+			expect(getRetryDelayMs(-5, () => 1)).toBe(500);
+			expect(getRetryDelayMs(1.9, () => 1)).toBe(1000);
 		});
 	});
 
@@ -95,7 +172,8 @@ describe("providers", () => {
 			const retryFn = vi.fn().mockResolvedValue(undefined);
 			const stateReset = vi.fn();
 
-			await providerRetry(currentFn, retryFn, stateReset, 1, 3);
+			// backoffMs=0 keeps the test fast; timing is covered by getRetryDelayMs.
+			await providerRetry(currentFn, retryFn, stateReset, 1, 3, 0);
 
 			expect(currentFn).toHaveBeenCalledTimes(1);
 			expect(stateReset).toHaveBeenCalledTimes(1);
@@ -152,11 +230,37 @@ describe("providers", () => {
 				.mockImplementation(() => {});
 
 			await expect(
-				providerRetry(currentFn, retryFn, stateReset, 1, 3),
+				providerRetry(currentFn, retryFn, stateReset, 1, 3, 0),
 			).rejects.toThrow("Retry failed");
 
 			expect(currentFn).toHaveBeenCalledTimes(1);
 			expect(stateReset).toHaveBeenCalledTimes(1);
+			expect(retryFn).toHaveBeenCalledTimes(1);
+
+			consoleErrorSpy.mockRestore();
+		});
+
+		it("waits for the backoff delay before retrying", async () => {
+			const error = new Error("Provider failed");
+			const currentFn = vi.fn().mockRejectedValue(error);
+			const order: string[] = [];
+			const retryFn = vi.fn(async () => {
+				order.push("retry");
+			});
+			const stateReset = vi.fn(() => {
+				order.push("reset");
+			});
+			const consoleErrorSpy = vi
+				.spyOn(console, "error")
+				.mockImplementation(() => {});
+
+			const start = Date.now();
+			await providerRetry(currentFn, retryFn, stateReset, 1, 3, 40);
+			const elapsed = Date.now() - start;
+
+			// State is reset before the wait, then the retry fires after the delay.
+			expect(order).toEqual(["reset", "retry"]);
+			expect(elapsed).toBeGreaterThanOrEqual(30);
 			expect(retryFn).toHaveBeenCalledTimes(1);
 
 			consoleErrorSpy.mockRestore();

--- a/packages/procaptcha-frictionless/src/ProcaptchaFrictionless.tsx
+++ b/packages/procaptcha-frictionless/src/ProcaptchaFrictionless.tsx
@@ -280,7 +280,12 @@ export const ProcaptchaFrictionless = ({
 				stateRef.current.attemptCount += 1;
 
 				const configOutput = ProcaptchaConfigSchema.parse(config);
-				const result = await detectBot(configOutput, container, restart);
+				// After the first attempt, tell detection this is a retry so it
+				// re-selects a random provider from the list rather than re-using
+				// the DNS-routed pronode that just failed.
+				const result = await detectBot(configOutput, container, restart, {
+					attempt: stateRef.current.attemptCount,
+				});
 
 				if (result.error?.message) {
 					stateRef.current = {

--- a/packages/procaptcha-frictionless/src/customDetectBot.ts
+++ b/packages/procaptcha-frictionless/src/customDetectBot.ts
@@ -22,6 +22,7 @@ import {
 import type {
 	BotDetectionFunction,
 	ProcaptchaClientConfigOutput,
+	ProviderSelectRetryContext,
 } from "@prosopo/types";
 import type { BotDetectionFunctionResult } from "@prosopo/types";
 import { DetectorLoader } from "./detectorLoader.js";
@@ -73,6 +74,7 @@ const customDetectBot: BotDetectionFunction = async (
 	config: ProcaptchaClientConfigOutput,
 	container: HTMLElement | undefined,
 	restartFn: () => void,
+	retryContext?: ProviderSelectRetryContext,
 ): Promise<BotDetectionFunctionResult> => {
 	const [ExtClass, detect] = await Promise.all([
 		ExtensionLoader(config.web2),
@@ -99,13 +101,17 @@ const customDetectBot: BotDetectionFunction = async (
 		throw new ProsopoEnvError("GENERAL.SITE_KEY_MISSING");
 	}
 
-	// Resolve the static DNS endpoint for this env. No client-side random
-	// selection anymore — the DNS layer load-balances across the pronode fleet.
-	// `pickIpMode(config)` honours the dapp's data-ipv4 / data-ipv6 preference
-	// so frictionless and the subsequent captcha hops stay on the same stack.
+	// On the first attempt this resolves the static DNS endpoint for this env —
+	// the DNS layer load-balances across the pronode fleet. On a retry
+	// (`retryContext.attempt > 1`) the previously used pronode errored, so we
+	// pick a random provider straight from the list instead of re-pinning the
+	// same one. `pickIpMode(config)` honours the dapp's data-ipv4 / data-ipv6
+	// preference so frictionless and the subsequent captcha hops stay on the
+	// same stack.
 	const provider = await getProcaptchaRandomActiveProvider(
 		config.defaultEnvironment,
 		pickIpMode(config),
+		retryContext,
 	);
 
 	const providerApi = new ProviderApi(

--- a/packages/procaptcha-pow/src/services/Manager.ts
+++ b/packages/procaptcha-pow/src/services/Manager.ts
@@ -59,6 +59,10 @@ export const Manager = (
 ) => {
 	const events = getDefaultEvents(callbacks);
 
+	// URL of the provider used on the previous attempt. On a retry we exclude it
+	// from the candidate pool so the fallback lands on a different provider.
+	let previousProviderUrl: string | undefined;
+
 	const defaultState = (): Partial<ProcaptchaState> => {
 		return {
 			// note order matters! see buildUpdateState. These fields are set in order, so disable modal first, then set loading to false, etc.
@@ -222,10 +226,12 @@ export const Manager = (
 					getRandomProviderResponse = await getProcaptchaRandomActiveProvider(
 						currentConfig.defaultEnvironment,
 						pickIpMode(currentConfig),
+						{ attempt: state.attemptCount, excludeUrl: previousProviderUrl },
 					);
 				}
 
 				const providerUrl = getRandomProviderResponse.provider.url;
+				previousProviderUrl = providerUrl;
 
 				const providerApi = new ProviderApi(providerUrl, getDappAccount());
 

--- a/packages/procaptcha-puzzle/src/services/Manager.ts
+++ b/packages/procaptcha-puzzle/src/services/Manager.ts
@@ -75,6 +75,11 @@ export const Manager = (
 	let storedClickX: number | undefined;
 	let storedClickY: number | undefined;
 
+	// URL of the provider used on the previous attempt. Kept outside the
+	// resetState-cleared closure state so a retry can exclude it from the
+	// candidate pool and land on a different provider.
+	let previousProviderUrl: string | undefined;
+
 	const defaultState = (): Partial<ProcaptchaState> => {
 		return {
 			// note order matters! see buildUpdateState. These fields are set in order, so disable modal first, then set loading to false, etc.
@@ -253,10 +258,12 @@ export const Manager = (
 					getRandomProviderResponse = await getProcaptchaRandomActiveProvider(
 						currentConfig.defaultEnvironment,
 						pickIpMode(currentConfig),
+						{ attempt: state.attemptCount, excludeUrl: previousProviderUrl },
 					);
 				}
 
 				const providerUrl = getRandomProviderResponse.provider.url;
+				previousProviderUrl = providerUrl;
 
 				const providerApi = new ProviderApi(providerUrl, getDappAccount());
 

--- a/packages/procaptcha/src/modules/Manager.ts
+++ b/packages/procaptcha/src/modules/Manager.ts
@@ -82,6 +82,9 @@ export function Manager(
 
 	let checkboxClickX = 0;
 	let checkboxClickY = 0;
+	// URL of the provider used on the previous attempt. On a retry we exclude it
+	// from the candidate pool so the fallback lands on a different provider.
+	let previousProviderUrl: string | undefined;
 
 	/**
 	 * Build the config on demand, using the optional config passed in from the outside. State may override various
@@ -148,9 +151,11 @@ export function Manager(
 						await getProcaptchaRandomActiveProvider(
 							currentConfig.defaultEnvironment,
 							pickIpMode(currentConfig),
+							{ attempt: state.attemptCount, excludeUrl: previousProviderUrl },
 						);
 
 					const providerUrl = getRandomProviderResponse.provider.url;
+					previousProviderUrl = providerUrl;
 					// get the provider api inst
 					const providerApi = await loadProviderApi(providerUrl);
 

--- a/packages/types/src/procaptcha-frictionless/props.ts
+++ b/packages/types/src/procaptcha-frictionless/props.ts
@@ -23,6 +23,7 @@ import type { Account } from "../procaptcha/manager.js";
 import type { ProcaptchaProps } from "../procaptcha/props.js";
 import type {
 	GetFrictionlessCaptchaResponse,
+	ProviderSelectRetryContext,
 	RandomProvider,
 } from "../provider/api.js";
 
@@ -58,6 +59,10 @@ export type BotDetectionFunction = (
 	config: ProcaptchaClientConfigOutput,
 	container: HTMLElement | undefined,
 	restartFn: () => void,
+	// Present when the frictionless flow is being retried after an error, so the
+	// detection can re-select a random provider instead of re-using the
+	// DNS-routed one that just failed. Absent on the initial attempt.
+	retryContext?: ProviderSelectRetryContext,
 ) => Promise<BotDetectionFunctionResult>;
 
 /**

--- a/packages/types/src/provider/api.ts
+++ b/packages/types/src/provider/api.ts
@@ -224,6 +224,17 @@ export type RandomProvider = {
 	provider: FrontendProvider;
 };
 
+// Context handed to provider selection when the widget re-selects a provider
+// after an error. `attempt` is the 1-indexed try count (1 = first, healthy
+// try; >1 = a fallback retry). On a retry the widget picks a random provider
+// straight from the provider list instead of the DNS-routed endpoint so a
+// single down provider isn't hammered; `excludeUrl` drops the provider that
+// just failed from the candidate pool when it is known.
+export type ProviderSelectRetryContext = {
+	attempt: number;
+	excludeUrl?: string;
+};
+
 type RateLimitSchemaType = ZodObject<{
 	windowMs: ZodDefault<ZodOptional<ZodNumber>>;
 	limit: ZodDefault<ZodOptional<ZodNumber>>;


### PR DESCRIPTION
## Problem

When a provider errored, the frontend widget retried the **same** DNS-routed endpoint **immediately** and in a tight loop (`providerRetry` re-ran `start`, which re-resolved the same pinned pronode). A fleet of widgets whose provider was unhealthy could therefore accidentally **DDoS our own provider fleet** — hammering a possibly-down endpoint as fast as the event loop allowed. This is the "users DDoS us by accident" failure mode.

## Change

The error-fallback path now does two things:

**1. Re-selects a different provider on retry**
- **First attempt** still hits the DNS-routed endpoint (unchanged happy path — preserves session stickiness across challenge fetch + submission).
- **On a retry** the widget picks a random provider straight from the provider list via the new `getRandomProviderFromList`, weighted by provider capacity and **excluding the URL that just failed**.
- **In development** the list holds only the single local provider (`https://localhost:9229`), so a retry naturally just re-targets that one provider.

**2. Backs off between retries**
- `providerRetry` now waits an **exponential backoff with full jitter** (0.5s → 1s → 2s → 4s …, capped at 10s) before retrying.
- Full jitter desynchronises a fleet of clients that all errored at once, so their retries don't reconverge into a thundering herd.

Applies to the **image**, **PoW** and **puzzle** managers and the **frictionless** detection flow.

## Implementation notes

- New shared type `ProviderSelectRetryContext` (`@prosopo/types`); `getProcaptchaRandomActiveProvider` gains an optional retry-context arg and routes retries to `getRandomProviderFromList`.
- `BotDetectionFunction` gains an optional retry-context arg so the frictionless flow re-selects on retry (each detection run mints a fresh session on the chosen provider, so switching providers mid-fallback is safe).
- Each manager tracks the previously-used provider URL in a closure and passes it as `excludeUrl`.
- Weighted pick + backoff jitter both take an injectable `random` for deterministic tests.

## Tests

- `load-balancer`: `getRandomProviderFromList` — list pick, exclude-failed, trailing-slash match, single-provider (dev) degradation, ipv4 labelling, weighting, empty-list DNS fallback. (20 passing)
- `procaptcha-common`: retry-aware `getProcaptchaRandomActiveProvider` (first-try DNS vs retry-from-list), `getRetryDelayMs` (exponential/cap/jitter/clamp), and `providerRetry` backoff ordering. (65 passing)
- `procaptcha-frictionless`: existing suites pass (18).
- `build:tsc` + `biome check` clean across all touched packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)