### PR TITLE
fix(provider): keep admin endpoints available in maintenance mode

### DIFF
--- a/.changeset/admin-endpoints-in-maintenance-mode.md
+++ b/.changeset/admin-endpoints-in-maintenance-mode.md
@@ -1,0 +1,8 @@
+---
+"@prosopo/env": patch
+"@prosopo/provider": patch
+---
+
+Keep the provider admin endpoints working while `MAINTENANCE_MODE` is on. Previously the admin/access-rule router was skipped entirely at boot in maintenance mode — `Environment.isReady()` never connected the DB, so `env.getDb()` threw and the DB-backed `Tasks` couldn't be constructed — which meant adding/removing site keys (access rules), detector keys and decision machines all 404'd on a node in maintenance mode.
+
+Now, in maintenance mode `Environment.isReady()` creates the `ProviderDatabase` handle and connects in the **background** (without awaiting), so a slow or unavailable Mongo/Redis socket still can't gate boot, but `env.getDb()` returns a usable handle and the admin endpoints register and function. The captcha request path is unchanged — it still short-circuits to a maintenance "pass" before touching the DB. `blockMiddleware` now has an explicit maintenance-mode skip (it previously relied on `env.getDb()` throwing to no-op) so the blocklist/Redis lookup stays off the captcha hot path.

--- a/packages/env/src/env.ts
+++ b/packages/env/src/env.ts
@@ -136,13 +136,21 @@ export class Environment implements ProsopoEnvironment {
 
 			const maintenanceMode = isMaintenanceMode();
 
-			// In maintenance mode we skip the DB connect entirely so a slow
-			// Mongo socket can't gate boot. Handlers short-circuit before
-			// touching the DB while the flag is on.
+			// In maintenance mode the captcha request path is kept DB-free (the
+			// handlers short-circuit before touching the DB), but the admin
+			// endpoints — access rules, detector keys, site keys, decision
+			// machines — still need a DB. So we create the DB handle and connect
+			// in the BACKGROUND: env.getDb() returns a usable handle (admin
+			// routes register and keep working), while a slow or unavailable
+			// Mongo/Redis socket still can't gate boot because we never await
+			// the connection here.
 			if (maintenanceMode) {
 				this.logger.warn(() => ({
-					msg: "MAINTENANCE_MODE=true — skipping DB import on startup",
+					msg: "MAINTENANCE_MODE=true — connecting to DB in the background so admin endpoints stay available; captcha path short-circuits",
 				}));
+				if (!this.db) {
+					this.connectDatabaseInBackground();
+				}
 			} else if (!this.db) {
 				await this.importDatabase();
 			} else if (this.db && !this.db.connected) {
@@ -154,7 +162,9 @@ export class Environment implements ProsopoEnvironment {
 			}
 			// Resolve the default datasetId from the DB. Clients no longer
 			// send one — providers pick from this fallback for image challenges.
-			if (this.db && !this.datasetId) {
+			// Skip in maintenance mode: the connection is still settling in the
+			// background and this is a DB read we don't want to gate boot on.
+			if (!maintenanceMode && this.db && !this.datasetId) {
 				try {
 					this.datasetId = await this.db.getMostRecentDatasetId();
 					if (this.datasetId) {
@@ -185,25 +195,36 @@ export class Environment implements ProsopoEnvironment {
 		}
 	}
 
+	// Build the ProviderDatabase handle from config WITHOUT connecting. Returns
+	// undefined when no database is configured for the current environment.
+	buildDatabase(): ProviderDatabase | undefined {
+		if (!this.config.database) {
+			return undefined;
+		}
+		const dbConfig = this.config.database[this.defaultEnvironment];
+		if (!dbConfig) {
+			return undefined;
+		}
+		return new ProviderDatabase({
+			mongo: {
+				url: dbConfig.endpoint,
+				dbname: dbConfig.dbname,
+				authSource: dbConfig.authSource,
+			},
+			redis: {
+				url: this.config.redisConnection.url,
+				password: this.config.redisConnection.password,
+			},
+			logger: this.logger,
+		});
+	}
+
 	async importDatabase(): Promise<void> {
 		try {
-			if (this.config.database) {
-				const dbConfig = this.config.database[this.defaultEnvironment];
-				if (dbConfig) {
-					this.db = new ProviderDatabase({
-						mongo: {
-							url: dbConfig.endpoint,
-							dbname: dbConfig.dbname,
-							authSource: dbConfig.authSource,
-						},
-						redis: {
-							url: this.config.redisConnection.url,
-							password: this.config.redisConnection.password,
-						},
-						logger: this.logger,
-					});
-					await this.db.connect();
-				}
+			const db = this.buildDatabase();
+			if (db) {
+				this.db = db;
+				await this.db.connect();
 			}
 		} catch (error) {
 			throw new ProsopoEnvError("DATABASE.DATABASE_IMPORT_FAILED", {
@@ -216,6 +237,33 @@ export class Environment implements ProsopoEnvironment {
 						: undefined,
 				},
 			});
+		}
+	}
+
+	// Create the DB handle and kick off the connection WITHOUT awaiting it, so
+	// startup is never gated on the DB socket. Used in maintenance mode: the
+	// captcha request path never touches the DB (it short-circuits), but the
+	// admin endpoints do, so the handle must exist. A failed connection is
+	// logged rather than thrown — admin queries will surface the error (or
+	// succeed once the socket recovers) when they actually run.
+	connectDatabaseInBackground(): void {
+		try {
+			const db = this.buildDatabase();
+			if (!db) {
+				return;
+			}
+			this.db = db;
+			db.connect().catch((error: unknown) => {
+				this.logger.warn(() => ({
+					msg: "Background DB connection failed in maintenance mode; admin endpoints will retry on demand",
+					data: { error },
+				}));
+			});
+		} catch (error) {
+			this.logger.warn(() => ({
+				msg: "Failed to create DB handle in maintenance mode; admin endpoints will be unavailable until restart",
+				data: { error },
+			}));
 		}
 	}
 }

--- a/packages/env/src/tests/env.maintenance.unit.test.ts
+++ b/packages/env/src/tests/env.maintenance.unit.test.ts
@@ -102,16 +102,48 @@ describe("Environment.isReady — maintenance mode startup tolerance", () => {
 		});
 	});
 
-	it("skips DB import entirely when maintenance mode is on", async () => {
+	it("creates the DB handle and connects in the background when maintenance mode is on", async () => {
 		process.env.MAINTENANCE_MODE = "true";
+		const connect = vi.fn().mockResolvedValue(undefined);
+		mockProviderDatabase.mockImplementation(() => ({
+			connect,
+			connected: false,
+			connection: { readyState: 0 },
+		}));
 
 		const env = buildEnv();
 		await env.isReady();
+
 		expect(env.ready).toBe(true);
-		// Importantly: we never even construct ProviderDatabase, so a slow
-		// Mongo socket can't gate boot.
-		expect(mockProviderDatabase).not.toHaveBeenCalled();
+		// The handle IS created (and connecting) so admin endpoints — which need
+		// a DB even during maintenance — keep working. The captcha path stays
+		// DB-free via per-handler short-circuits, not by leaving env.db unset.
+		expect(mockProviderDatabase).toHaveBeenCalledTimes(1);
+		expect(connect).toHaveBeenCalledTimes(1);
+		expect(env.db).toBeDefined();
 		expect(mockIpInfoInit).toHaveBeenCalled();
+	});
+
+	it("does not gate boot when the background DB connect fails in maintenance mode", async () => {
+		process.env.MAINTENANCE_MODE = "true";
+		const connect = vi.fn().mockRejectedValue(new Error("ECONNREFUSED"));
+		mockProviderDatabase.mockImplementation(() => ({
+			connect,
+			connected: false,
+			connection: { readyState: 0 },
+		}));
+
+		const env = buildEnv();
+		// Unlike the maintenance-off path, a failing connect must NOT reject
+		// isReady() — the connection is fire-and-forget in the background.
+		await expect(env.isReady()).resolves.toBeUndefined();
+		expect(env.ready).toBe(true);
+		expect(env.db).toBeDefined();
+		expect(connect).toHaveBeenCalledTimes(1);
+		// Flush the background rejection so its .catch handler runs within the
+		// test rather than surfacing as an unhandled rejection afterwards.
+		await Promise.resolve();
+		expect(env.logger.warn).toHaveBeenCalled();
 	});
 
 	it("still completes the normal connect path when Mongo is up", async () => {

--- a/packages/provider/src/api/block.ts
+++ b/packages/provider/src/api/block.ts
@@ -14,6 +14,7 @@
 
 import type { ProviderEnvironment } from "@prosopo/types-env";
 import type { NextFunction, Request, Response } from "express";
+import { getMaintenanceMode } from "./admin/apiToggleMaintenanceModeEndpoint.js";
 import { BlacklistRequestInspector } from "./blacklistRequestInspector.js";
 
 export const blockMiddleware = (providerEnvironment: ProviderEnvironment) => {
@@ -27,6 +28,15 @@ export const blockMiddleware = (providerEnvironment: ProviderEnvironment) => {
 		providerEnvironment.isReady.bind(providerEnvironment);
 
 	return (req: Request, res: Response, next: NextFunction) => {
+		// In maintenance mode the captcha path short-circuits to a pass and the
+		// access-rules store (Redis) may be unavailable — skip the blocklist
+		// check so a slow or down store can't gate requests. env.getDb() now
+		// returns a handle during maintenance (so the admin endpoints work), so
+		// this explicit guard — not a thrown getDb() — is what keeps the
+		// blocklist check off the hot path.
+		if (getMaintenanceMode()) {
+			return next();
+		}
 		if (!blacklistRequestInspector) {
 			try {
 				const db = providerEnvironment.getDb();

--- a/packages/provider/src/api/startProviderApi.ts
+++ b/packages/provider/src/api/startProviderApi.ts
@@ -147,9 +147,13 @@ export async function startProviderApi(
 	const apiEndpointAdapter = createApiExpressDefaultEndpointAdapter(
 		parseLogLevel(env.config.logLevel),
 	);
-	// Maintenance-mode / DB-down startup: skip the admin/access-rule wiring
-	// since both rely on DB-backed Tasks construction. Captcha endpoints
-	// short-circuit on maintenance-mode at the handler.
+	// Admin + access-rule routes both rely on a DB-backed Tasks/storage. In
+	// maintenance mode the DB handle is created and connected in the background
+	// (see Environment.isReady), so env.getDb() returns a handle and these
+	// routes register and keep working — that's what keeps admin operations
+	// (rules, detector keys, site keys, decision machines) available while the
+	// captcha path short-circuits. The try/catch is a safety net for the case
+	// where no DB is configured at all.
 	let apiRuleRoutesProvider: AccessRuleApiRoutes | undefined;
 	let apiAdminRoutesProvider:
 		| ReturnType<typeof createApiAdminRoutesProvider>

--- a/packages/provider/src/tests/integration/maintenanceModeAdmin.integration.test.ts
+++ b/packages/provider/src/tests/integration/maintenanceModeAdmin.integration.test.ts
@@ -1,0 +1,343 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Why this test exists:
+//
+// A provider can boot with MAINTENANCE_MODE=true (e.g. during a Mongo outage or
+// a maintenance window). The captcha request path short-circuits to a "pass" so
+// the widget keeps rendering, but operators still need the admin endpoints —
+// adding/removing site keys (access rules) and detector keys — to work so they
+// can fix state and recover. Previously the admin router was skipped entirely at
+// boot in maintenance mode (its DB-backed Tasks couldn't be constructed), so
+// every admin call 404'd.
+//
+// This suite boots the real Express app via startProviderApi against a real
+// Mongo + Redis with MAINTENANCE_MODE=true and asserts, over HTTP, that:
+//   - the captcha challenge still returns a maintenance dummy (mode is active),
+//   - site keys can be registered and removed and the change lands in Mongo,
+//   - detector keys can be added and removed,
+//   - admin auth is still enforced (401 without a JWT).
+
+import { generateKeyPairSync } from "node:crypto";
+import type { Server } from "node:net";
+import { ApiEndpointResponseStatus } from "@prosopo/api-route";
+import { ProviderEnvironment } from "@prosopo/env";
+import { generateMnemonic } from "@prosopo/keyring";
+import { isTlsAvailable, startProviderApi } from "@prosopo/provider";
+import {
+	AdminApiPaths,
+	CaptchaType,
+	ClientApiPaths,
+	ClientSettingsSchema,
+	DatabaseTypes,
+	type GetPowCaptchaChallengeRequestBodyType,
+	type GetPowCaptchaResponse,
+	ProsopoConfigSchema,
+	type RegisterSitekeyBodyTypeOutput,
+	Tier,
+} from "@prosopo/types";
+import { randomAsHex } from "@prosopo/util-crypto";
+import { GenericContainer, type StartedTestContainer } from "testcontainers";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+interface AdminResponse {
+	status: ApiEndpointResponseStatus;
+	data?: { activeDetectorKeys?: string[] };
+	error?: string;
+}
+
+// A valid detector key is the base64 of a PEM (pkcs8) private key — that's what
+// ClientTaskManager.updateDetectorKey validates before storing.
+const makeDetectorKey = (): string => {
+	const { privateKey } = generateKeyPairSync("ed25519");
+	const pem = privateKey.export({ format: "pem", type: "pkcs8" }).toString();
+	return Buffer.from(pem).toString("base64");
+};
+
+const waitFor = async (
+	predicate: () => boolean,
+	timeoutMs: number,
+	intervalMs = 100,
+): Promise<void> => {
+	const start = Date.now();
+	while (!predicate()) {
+		if (Date.now() - start > timeoutMs) {
+			throw new Error("Timed out waiting for condition");
+		}
+		await new Promise((resolve) => setTimeout(resolve, intervalMs));
+	}
+};
+
+describe("Maintenance mode — admin endpoints stay available", () => {
+	let env: ProviderEnvironment;
+	let mongoContainer: StartedTestContainer;
+	let redisContainer: StartedTestContainer | undefined;
+	let server: Server | undefined;
+	let testPort: number;
+	let baseUrl: string;
+	let adminAccount: string;
+	let adminJwt: string;
+	let priorTlsReject: string | undefined;
+
+	beforeAll(async () => {
+		// Boot the provider process already in maintenance mode. Read at request
+		// time by the handlers and (now) drives the background DB connect.
+		process.env.MAINTENANCE_MODE = "true";
+		// When local TLS certs are present the provider serves HTTPS with a
+		// self-signed cert; let the in-test fetch client accept it.
+		priorTlsReject = process.env.NODE_TLS_REJECT_UNAUTHORIZED;
+		process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+
+		testPort = 30000 + (process.pid % 10000) + Math.floor(Math.random() * 5000);
+		const protocol = isTlsAvailable() ? "https" : "http";
+		baseUrl = `${protocol}://localhost:${testPort}`;
+
+		mongoContainer = await new GenericContainer("mongo:6.0.28")
+			.withExposedPorts(27017)
+			.withEnvironment({
+				MONGO_INITDB_ROOT_USERNAME: "root",
+				MONGO_INITDB_ROOT_PASSWORD: "root",
+				MONGO_INITDB_DATABASE: "prosopo_test",
+			})
+			.start();
+		const mongoHost = mongoContainer.getHost();
+		const mongoPort = mongoContainer.getMappedPort(27017);
+
+		let redisHost = "localhost";
+		let redisPort = 6379;
+		try {
+			redisContainer = await new GenericContainer("redis/redis-stack:latest")
+				.withExposedPorts(6379)
+				.withEnvironment({ REDIS_ARGS: "--requirepass root" })
+				.start();
+			redisHost = redisContainer.getHost();
+			redisPort = redisContainer.getMappedPort(6379);
+		} catch (error) {
+			console.warn("Failed to start Redis container:", error);
+		}
+
+		const config = ProsopoConfigSchema.parse({
+			defaultEnvironment: "development",
+			host: `${protocol}://localhost:${testPort}`,
+			account: {
+				secret:
+					"puppy cream effort carbon despair leg pyramid cotton endorse immense drill peasant",
+			},
+			authAccount: {
+				secret:
+					"puppy cream effort carbon despair leg pyramid cotton endorse immense drill peasant",
+			},
+			database: {
+				development: {
+					type: DatabaseTypes.enum.provider,
+					endpoint: `mongodb://root:root@${mongoHost}:${mongoPort}`,
+					dbname: "prosopo_test",
+					authSource: "admin",
+				},
+			},
+			...(redisContainer
+				? {
+						redisConnection: {
+							url: `redis://:${encodeURIComponent("root")}@${redisHost}:${redisPort}`,
+							password: "root",
+							indexName: randomAsHex(16),
+						},
+					}
+				: {}),
+			ipApi: { baseUrl: "https://dummyUrl.com", apiKey: "dummyKey" },
+			server: { baseURL: `${protocol}://localhost`, port: testPort },
+		});
+
+		env = new ProviderEnvironment(config);
+		await env.isReady();
+
+		// isReady() kicks off the DB connection in the background in maintenance
+		// mode. Wait for it to settle so the admin writes below are deterministic.
+		await waitFor(() => env.getDb().connected === true, 30_000);
+
+		const pair = env.getPair();
+		adminAccount = pair.address;
+		adminJwt = pair.jwtIssue();
+
+		server = await startProviderApi(env, true, testPort);
+		await waitFor(() => server?.listening === true, 10_000);
+	}, 120_000);
+
+	afterAll(async () => {
+		if (server) {
+			await new Promise<void>((resolve) => server?.close(() => resolve()));
+			server = undefined;
+		}
+		if (env) {
+			try {
+				await env.getDb().close();
+			} catch (error) {
+				console.error("Error closing database:", error);
+			}
+		}
+		if (redisContainer) {
+			try {
+				await redisContainer.stop();
+			} catch (error) {
+				console.error("Error stopping redis container:", error);
+			}
+		}
+		if (mongoContainer) {
+			try {
+				await mongoContainer.stop();
+			} catch (error) {
+				console.error("Error stopping mongo container:", error);
+			}
+		}
+		process.env.MAINTENANCE_MODE = undefined;
+		if (priorTlsReject === undefined) {
+			process.env.NODE_TLS_REJECT_UNAUTHORIZED = undefined;
+		} else {
+			process.env.NODE_TLS_REJECT_UNAUTHORIZED = priorTlsReject;
+		}
+	});
+
+	const adminHeaders = (): Record<string, string> => ({
+		"Content-Type": "application/json",
+		"Prosopo-Site-Key": adminAccount,
+		Authorization: `Bearer ${adminJwt}`,
+	});
+
+	const minimalSettings = () =>
+		ClientSettingsSchema.parse({
+			captchaType: CaptchaType.pow,
+			domains: ["localhost", "example.com"],
+			frictionlessThreshold: 0.5,
+			powDifficulty: 1,
+		});
+
+	it("still serves the captcha challenge as a maintenance dummy", async () => {
+		const [, siteKey] = await generateMnemonic();
+		const [, userId] = await generateMnemonic();
+		const body: GetPowCaptchaChallengeRequestBodyType = {
+			user: userId,
+			dapp: siteKey,
+		};
+
+		const response = await fetch(
+			`${baseUrl}${ClientApiPaths.GetPowCaptchaChallenge}`,
+			{
+				method: "POST",
+				headers: {
+					Connection: "close",
+					"Content-Type": "application/json",
+					Origin: "https://localhost",
+					"Prosopo-Site-Key": siteKey,
+					"Prosopo-User": userId,
+				},
+				body: JSON.stringify(body),
+			},
+		);
+
+		expect(response.status).toBe(200);
+		const data = (await response.json()) as GetPowCaptchaResponse;
+		// The maintenance dummy has difficulty 1 and an empty provider signature.
+		expect(data.difficulty).toBe(1);
+		expect(data.signature.provider.challenge).toBe("");
+	});
+
+	it("registers a site key (access rule) via the admin API and persists it to Mongo", async () => {
+		const [, siteKey] = await generateMnemonic();
+		const registerBody: RegisterSitekeyBodyTypeOutput = {
+			siteKey,
+			tier: Tier.Free,
+			settings: minimalSettings(),
+		};
+
+		const response = await fetch(`${baseUrl}${AdminApiPaths.SiteKeyRegister}`, {
+			method: "POST",
+			headers: adminHeaders(),
+			body: JSON.stringify(registerBody),
+		});
+
+		expect(response.status).toBe(200);
+		const data = (await response.json()) as AdminResponse;
+		expect(data.status).toBe(ApiEndpointResponseStatus.SUCCESS);
+
+		// The write must have reached Mongo — not been silently skipped.
+		const record = await env.getDb().getClientRecord(siteKey);
+		expect(record).toBeDefined();
+		expect(record?.account).toBe(siteKey);
+	});
+
+	it("removes a site key (access rule) via the admin API and deletes it from Mongo", async () => {
+		const [, siteKey] = await generateMnemonic();
+		await fetch(`${baseUrl}${AdminApiPaths.SiteKeyRegister}`, {
+			method: "POST",
+			headers: adminHeaders(),
+			body: JSON.stringify({
+				siteKey,
+				tier: Tier.Free,
+				settings: minimalSettings(),
+			}),
+		});
+		expect(await env.getDb().getClientRecord(siteKey)).toBeDefined();
+
+		const response = await fetch(`${baseUrl}${AdminApiPaths.SiteKeyRemove}`, {
+			method: "POST",
+			headers: adminHeaders(),
+			body: JSON.stringify({ siteKey }),
+		});
+
+		expect(response.status).toBe(200);
+		const data = (await response.json()) as AdminResponse;
+		expect(data.status).toBe(ApiEndpointResponseStatus.SUCCESS);
+		expect(await env.getDb().getClientRecord(siteKey)).toBeUndefined();
+	});
+
+	it("adds and removes a detector key via the admin API", async () => {
+		const detectorKey = makeDetectorKey();
+
+		const addResponse = await fetch(
+			`${baseUrl}${AdminApiPaths.UpdateDetectorKey}`,
+			{
+				method: "POST",
+				headers: adminHeaders(),
+				body: JSON.stringify({ detectorKey }),
+			},
+		);
+		expect(addResponse.status).toBe(200);
+		const addData = (await addResponse.json()) as AdminResponse;
+		expect(addData.status).toBe(ApiEndpointResponseStatus.SUCCESS);
+		expect(addData.data?.activeDetectorKeys).toContain(detectorKey);
+
+		const removeResponse = await fetch(
+			`${baseUrl}${AdminApiPaths.RemoveDetectorKey}`,
+			{
+				method: "POST",
+				headers: adminHeaders(),
+				body: JSON.stringify({ detectorKey }),
+			},
+		);
+		expect(removeResponse.status).toBe(200);
+		const removeData = (await removeResponse.json()) as AdminResponse;
+		expect(removeData.status).toBe(ApiEndpointResponseStatus.SUCCESS);
+	});
+
+	it("still rejects unauthenticated admin requests with 401", async () => {
+		const [, siteKey] = await generateMnemonic();
+		const response = await fetch(`${baseUrl}${AdminApiPaths.SiteKeyRegister}`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ siteKey, tier: Tier.Free }),
+		});
+
+		expect(response.status).toBe(401);
+	});
+});

--- a/packages/provider/src/tests/integration/maintenanceModeAdmin.integration.test.ts
+++ b/packages/provider/src/tests/integration/maintenanceModeAdmin.integration.test.ts
@@ -30,7 +30,10 @@
 //   - admin auth is still enforced (401 without a JWT).
 
 import { generateKeyPairSync } from "node:crypto";
+import { readFileSync } from "node:fs";
 import type { Server } from "node:net";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { ApiEndpointResponseStatus } from "@prosopo/api-route";
 import { ProviderEnvironment } from "@prosopo/env";
 import { generateMnemonic } from "@prosopo/keyring";
@@ -49,6 +52,7 @@ import {
 } from "@prosopo/types";
 import { randomAsHex } from "@prosopo/util-crypto";
 import { GenericContainer, type StartedTestContainer } from "testcontainers";
+import { Agent, fetch } from "undici";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 interface AdminResponse {
@@ -56,6 +60,21 @@ interface AdminResponse {
 	data?: { activeDetectorKeys?: string[] };
 	error?: string;
 }
+
+// The provider serves HTTPS with the repo's self-signed cert when it is present
+// (see startProviderApi/isTlsAvailable). Build a dispatcher that trusts THAT
+// cert as a CA — proper certificate validation, not a bypass. Returns undefined
+// when there is no cert (the server runs over plain HTTP, e.g. in CI).
+const certPath = path.resolve(
+	path.dirname(fileURLToPath(import.meta.url)),
+	"../../../../../certs/server.crt",
+);
+const buildDispatcher = (): Agent | undefined => {
+	if (!isTlsAvailable()) {
+		return undefined;
+	}
+	return new Agent({ connect: { ca: readFileSync(certPath, "utf8") } });
+};
 
 // A valid detector key is the base64 of a PEM (pkcs8) private key — that's what
 // ClientTaskManager.updateDetectorKey validates before storing.
@@ -88,20 +107,20 @@ describe("Maintenance mode — admin endpoints stay available", () => {
 	let baseUrl: string;
 	let adminAccount: string;
 	let adminJwt: string;
-	let priorTlsReject: string | undefined;
+	// undici dispatcher that trusts the provider's own self-signed cert (only
+	// set when the server is serving HTTPS). We pin the cert as a trusted CA
+	// rather than disabling certificate validation.
+	let dispatcher: Agent | undefined;
 
 	beforeAll(async () => {
 		// Boot the provider process already in maintenance mode. Read at request
 		// time by the handlers and (now) drives the background DB connect.
 		process.env.MAINTENANCE_MODE = "true";
-		// When local TLS certs are present the provider serves HTTPS with a
-		// self-signed cert; let the in-test fetch client accept it.
-		priorTlsReject = process.env.NODE_TLS_REJECT_UNAUTHORIZED;
-		process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
 
 		testPort = 30000 + (process.pid % 10000) + Math.floor(Math.random() * 5000);
 		const protocol = isTlsAvailable() ? "https" : "http";
 		baseUrl = `${protocol}://localhost:${testPort}`;
+		dispatcher = buildDispatcher();
 
 		mongoContainer = await new GenericContainer("mongo:6.0.28")
 			.withExposedPorts(27017)
@@ -200,12 +219,10 @@ describe("Maintenance mode — admin endpoints stay available", () => {
 				console.error("Error stopping mongo container:", error);
 			}
 		}
-		process.env.MAINTENANCE_MODE = undefined;
-		if (priorTlsReject === undefined) {
-			process.env.NODE_TLS_REJECT_UNAUTHORIZED = undefined;
-		} else {
-			process.env.NODE_TLS_REJECT_UNAUTHORIZED = priorTlsReject;
+		if (dispatcher) {
+			await dispatcher.close();
 		}
+		process.env.MAINTENANCE_MODE = undefined;
 	});
 
 	const adminHeaders = (): Record<string, string> => ({
@@ -242,6 +259,7 @@ describe("Maintenance mode — admin endpoints stay available", () => {
 					"Prosopo-User": userId,
 				},
 				body: JSON.stringify(body),
+				dispatcher,
 			},
 		);
 
@@ -264,6 +282,7 @@ describe("Maintenance mode — admin endpoints stay available", () => {
 			method: "POST",
 			headers: adminHeaders(),
 			body: JSON.stringify(registerBody),
+			dispatcher,
 		});
 
 		expect(response.status).toBe(200);
@@ -286,6 +305,7 @@ describe("Maintenance mode — admin endpoints stay available", () => {
 				tier: Tier.Free,
 				settings: minimalSettings(),
 			}),
+			dispatcher,
 		});
 		expect(await env.getDb().getClientRecord(siteKey)).toBeDefined();
 
@@ -293,6 +313,7 @@ describe("Maintenance mode — admin endpoints stay available", () => {
 			method: "POST",
 			headers: adminHeaders(),
 			body: JSON.stringify({ siteKey }),
+			dispatcher,
 		});
 
 		expect(response.status).toBe(200);
@@ -310,6 +331,7 @@ describe("Maintenance mode — admin endpoints stay available", () => {
 				method: "POST",
 				headers: adminHeaders(),
 				body: JSON.stringify({ detectorKey }),
+				dispatcher,
 			},
 		);
 		expect(addResponse.status).toBe(200);
@@ -323,6 +345,7 @@ describe("Maintenance mode — admin endpoints stay available", () => {
 				method: "POST",
 				headers: adminHeaders(),
 				body: JSON.stringify({ detectorKey }),
+				dispatcher,
 			},
 		);
 		expect(removeResponse.status).toBe(200);
@@ -336,6 +359,7 @@ describe("Maintenance mode — admin endpoints stay available", () => {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify({ siteKey, tier: Tier.Free }),
+			dispatcher,
 		});
 
 		expect(response.status).toBe(401);

--- a/packages/provider/src/tests/unit/api/adminRoutes.unit.test.ts
+++ b/packages/provider/src/tests/unit/api/adminRoutes.unit.test.ts
@@ -203,4 +203,45 @@ describe("Admin Routes Provider", () => {
 			expect(mockEnv.db.isConnected()).toBe(false);
 		});
 	});
+
+	describe("Maintenance mode", () => {
+		afterEach(() => {
+			process.env.MAINTENANCE_MODE = undefined;
+		});
+
+		// The admin router must stay registered and functional while
+		// MAINTENANCE_MODE is on — that's how operators add/remove access
+		// rules, detector keys, site keys and decision machines during an
+		// outage. env.getDb() returns a background-connecting handle in
+		// maintenance mode, so building the provider must not throw.
+		it("registers all admin routes when maintenance mode is on", () => {
+			process.env.MAINTENANCE_MODE = "true";
+
+			const adminRoutes = createApiAdminRoutesProvider(mockEnv);
+			const routes = adminRoutes.getRoutes();
+
+			expect(routes[AdminApiPaths.SiteKeyRegister]).toBeDefined();
+			expect(routes[AdminApiPaths.SiteKeyRemove]).toBeDefined();
+			expect(routes[AdminApiPaths.UpdateDetectorKey]).toBeDefined();
+			expect(routes[AdminApiPaths.RemoveDetectorKey]).toBeDefined();
+			expect(routes[AdminApiPaths.UpdateDecisionMachine]).toBeDefined();
+			expect(routes[AdminApiPaths.ToggleMaintenanceMode]).toBeDefined();
+		});
+
+		it("still invokes the DB-backed detector-key endpoint in maintenance mode", async () => {
+			process.env.MAINTENANCE_MODE = "true";
+
+			const adminRoutes = createApiAdminRoutesProvider(mockEnv);
+			const routes = adminRoutes.getRoutes();
+
+			const endpoint = routes[AdminApiPaths.RemoveDetectorKey];
+			expect(endpoint).toBeDefined();
+
+			const result = await endpoint?.processRequest(
+				{ detectorKey: "some-detector-key" },
+				mockLogger,
+			);
+			expect(result).toBeDefined();
+		});
+	});
 });

--- a/packages/provider/src/tests/unit/api/block.unit.test.ts
+++ b/packages/provider/src/tests/unit/api/block.unit.test.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import type { ProviderEnvironment } from "@prosopo/types-env";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { BlacklistRequestInspector } from "../../../api/blacklistRequestInspector.js";
 import { blockMiddleware } from "../../../api/block.js";
 
@@ -22,6 +22,11 @@ vi.mock("../../../api/blacklistRequestInspector.js");
 describe("blockMiddleware", () => {
 	beforeEach(() => {
 		vi.mocked(BlacklistRequestInspector).mockClear();
+		process.env.MAINTENANCE_MODE = undefined;
+	});
+
+	afterEach(() => {
+		process.env.MAINTENANCE_MODE = undefined;
 	});
 	const buildMockEnv = (
 		getUserAccessRulesStorageImpl: () => unknown = () => ({
@@ -59,6 +64,21 @@ describe("blockMiddleware", () => {
 		// Lazy phase: inspector built and wired on first hit.
 		expect(BlacklistRequestInspector).toHaveBeenCalledTimes(1);
 		expect(mockAbort).toHaveBeenCalledTimes(1);
+	});
+
+	it("skips the blocklist check entirely when maintenance mode is on", async () => {
+		process.env.MAINTENANCE_MODE = "true";
+		const { env, mockDb } = buildMockEnv();
+
+		const middleware = blockMiddleware(env);
+		const next = vi.fn();
+		await middleware({} as never, {} as never, next);
+
+		// next() invoked directly; the DB/storage is never consulted and no
+		// inspector is built, so a down Redis can't gate maintenance requests.
+		expect(next).toHaveBeenCalledTimes(1);
+		expect(BlacklistRequestInspector).not.toHaveBeenCalled();
+		expect(mockDb.getUserAccessRulesStorage).not.toHaveBeenCalled();
 	});
 
 	it("skips the blocklist check when access-rules storage is unavailable", async () => {


### PR DESCRIPTION
## Problem

When a provider boots with `MAINTENANCE_MODE=true` (e.g. during a Mongo outage or a maintenance window), the captcha path short-circuits to a "pass" so the widget keeps rendering — but the **admin endpoints were unreachable**. `Environment.isReady()` skipped the DB connect entirely, so `env.getDb()` threw and the DB-backed `Tasks` couldn't be constructed. `startProviderApi` therefore skipped the whole admin/access-rule router, and every admin call (add/remove **site keys / access rules**, **detector keys**, **decision machines**) returned `404` — exactly when an operator needs them to fix state and recover.

## Fix

- **`@prosopo/env`** — in maintenance mode, `Environment.isReady()` now creates the `ProviderDatabase` handle and connects **in the background** (without awaiting). A slow/unavailable Mongo/Redis socket still can't gate boot (the original reason for skipping), but `env.getDb()` returns a usable handle, so the admin router registers and functions. The `datasetId` lookup is skipped in maintenance mode to avoid a boot-gating DB read.
- **`@prosopo/provider` `block.ts`** — adds an explicit `getMaintenanceMode()` skip. It previously relied on `env.getDb()` throwing to no-op; now that `getDb()` returns a handle in maintenance mode, this guard keeps the blocklist/Redis lookup off the captcha hot path.
- **`startProviderApi.ts`** — updated the now-stale comment; the existing try/catch stays as a safety net for the no-DB-configured case.

The captcha request path is **unchanged** — it still short-circuits to a maintenance dummy before touching the DB.

## Testing

- **Unit**: `env.maintenance.unit.test.ts` (handle created + background connect in maintenance mode; a failing background connect does not gate boot), `block.unit.test.ts` (maintenance skip), `adminRoutes.unit.test.ts` (router builds + endpoints invoke in maintenance mode).
- **E2E** (`maintenanceModeAdmin.integration.test.ts`, real Mongo + Redis via testcontainers): boots the app with `MAINTENANCE_MODE=true` and asserts over HTTP that the captcha challenge returns a maintenance dummy, site keys register→persist and remove→delete in Mongo, detector keys add/remove, and unauthenticated admin calls still `401`.
- Typecheck (`build:tsc`) and Biome clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)