### PR TITLE
feat(lb-weights): metric-driven Bunny DNS load-balancer weight updater

### DIFF
--- a/packages/lb-weights/.env.template
+++ b/packages/lb-weights/.env.template
@@ -1,0 +1,40 @@
+# Copy to `.env` and fill in. Used by docker-compose.yml and the lb-weights service.
+
+# ── Bunny DNS ───────────────────────────────────────────────────────────────
+# Bunny DNS API token. Needs read access to zones and (unless dry-run) write
+# access to set record weights.
+BUNNY_API_KEY=
+
+# ── Load balancer targets ────────────────────────────────────────────────────
+# Comma-separated subdomains (record names) whose load-balancer pools to manage.
+LB_SUBDOMAINS=pronode
+
+# ── Weighting ────────────────────────────────────────────────────────────────
+# Prometheus metric that drives weighting. Lower value => higher weight.
+LB_METRIC_NAME=cpu_usage_1m
+# How each node's metrics endpoint is reached: <scheme>://<ip>:<port?><path>
+LB_METRICS_SCHEME=http
+# LB_METRICS_PORT=9100
+LB_METRICS_PATH=/metrics
+
+# ── Loop ─────────────────────────────────────────────────────────────────────
+# Seconds between full recompute cycles.
+LB_INTERVAL_SECONDS=15
+
+# ── Safety ───────────────────────────────────────────────────────────────────
+# Readonly mode: compute + log weights but do NOT write them to Bunny.
+# Defaults to true; set to false to actually apply weights.
+LB_DRY_RUN=true
+
+# Optional Bunny API base url override (leave unset for production).
+# BUNNY_BASE_URL=https://api.bunny.net
+
+# Log verbosity: trace | debug | info | warn | error | fatal
+PROSOPO_LOG_LEVEL=info
+
+# ── Observability (Vector + OpenObserve) ─────────────────────────────────────
+OO_HOST=lb-weights
+OO_ORG=default
+OO_STREAM=lb_weights
+OO_USERNAME=admin@example.com
+OO_PASSWORD=change-me-please-1

--- a/packages/lb-weights/Dockerfile
+++ b/packages/lb-weights/Dockerfile
@@ -1,0 +1,16 @@
+# Build + run the @prosopo/lb-weights service.
+# Build context is the repo root (see docker-compose.yml build.context: ../..)
+# because the package depends on other workspace packages.
+FROM node:24-slim
+
+WORKDIR /app
+
+# Copy the whole monorepo (workspace packages are interdependent) and install.
+COPY . .
+RUN npm ci
+
+# Type-check build the package and its workspace dependencies (project refs).
+RUN npm run -w @prosopo/lb-weights build:tsc
+
+# Resolves @prosopo/* deps via the workspace symlinks in the root node_modules.
+CMD ["node", "packages/lb-weights/dist/main.js"]

--- a/packages/lb-weights/docker-compose.yml
+++ b/packages/lb-weights/docker-compose.yml
@@ -1,0 +1,75 @@
+# Runs the lb-weights service alongside Vector (log shipper) and OpenObserve
+# (log storage/UI). All config lives in this package directory.
+#
+#   docker compose --env-file .env up --build
+#
+# OpenObserve UI: http://localhost:5080 (login with OO_USERNAME / OO_PASSWORD)
+services:
+    lb-weights:
+        container_name: lb-weights
+        build:
+            # build context is the repo root; the package depends on other
+            # workspace packages
+            context: ../..
+            dockerfile: packages/lb-weights/Dockerfile
+        env_file:
+            - .env
+        labels:
+            - "vector.lb-weights=true" # enable log collection by vector
+        restart: unless-stopped
+        networks:
+            - lb-weights
+        logging:
+            driver: "json-file"
+            options:
+                max-size: "100m"
+                max-file: "1"
+
+    vector:
+        container_name: lb-weights-vector
+        image: timberio/vector:latest-debian
+        env_file:
+            - .env
+        volumes:
+            - ./vector.toml:/etc/vector/vector.toml:ro
+            # needed to read docker container logs + events
+            - /var/run/docker.sock:/var/run/docker.sock
+            - vector_data:/var/lib/vector
+        command: ["--config", "/etc/vector/vector.toml"]
+        restart: unless-stopped
+        depends_on:
+            - openobserve
+        networks:
+            - lb-weights
+        logging:
+            driver: "json-file"
+            options:
+                max-size: "100m"
+                max-file: "1"
+
+    openobserve:
+        container_name: lb-weights-openobserve
+        image: public.ecr.aws/zinclabs/openobserve:latest
+        environment:
+            ZO_ROOT_USER_EMAIL: "${OO_USERNAME:?set OO_USERNAME in .env}"
+            ZO_ROOT_USER_PASSWORD: "${OO_PASSWORD:?set OO_PASSWORD in .env}"
+        ports:
+            - "5080:5080"
+        volumes:
+            - openobserve_data:/data
+        restart: unless-stopped
+        networks:
+            - lb-weights
+        logging:
+            driver: "json-file"
+            options:
+                max-size: "100m"
+                max-file: "1"
+
+networks:
+    lb-weights:
+        name: lb-weights
+
+volumes:
+    vector_data:
+    openobserve_data:

--- a/packages/lb-weights/package.json
+++ b/packages/lb-weights/package.json
@@ -1,0 +1,59 @@
+{
+	"name": "@prosopo/lb-weights",
+	"version": "1.0.0",
+	"description": "Set load balancer record weights",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
+	"type": "module",
+	"engines": {
+		"node": "^24",
+		"npm": "^11"
+	},
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js",
+			"require": "./dist/cjs/index.cjs"
+		}
+	},
+	"scripts": {
+		"clean": "del-cli --verbose dist tsconfig.tsbuildinfo",
+		"build": "npm run build:cross-env -- --mode ${NODE_ENV:-development}",
+		"build:cross-env": "vite build --config vite.esm.config.ts",
+		"build:tsc": "tsc --build --verbose",
+		"build:cjs": "NODE_ENV=${NODE_ENV:-development}; vite build --config vite.cjs.config.ts --mode $NODE_ENV",
+		"test": "NODE_ENV=${NODE_ENV:-test}; npx vitest run --config ./vite.test.config.ts --mode $NODE_ENV",
+		"typecheck": "tsc --project tsconfig.types.json"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/prosopo/captcha.git",
+		"directory": "packages/lb-weights"
+	},
+	"author": "Prosopo Limited",
+	"license": "Apache-2.0",
+	"bugs": {
+		"url": "https://github.com/prosopo/captcha/issues"
+	},
+	"homepage": "https://github.com/prosopo/captcha#readme",
+	"dependencies": {
+		"@prosopo/common": "3.1.43",
+		"@prosopo/types": "4.9.6",
+		"zod": "3.23.8"
+	},
+	"devDependencies": {
+		"@prosopo/config": "3.3.4",
+		"@types/node": "22.10.2",
+		"@vitest/coverage-v8": "3.2.4",
+		"concurrently": "9.0.1",
+		"del-cli": "6.0.0",
+		"dotenv": "17.2.1",
+		"npm-run-all": "4.1.5",
+		"tslib": "2.7.0",
+		"tsx": "4.20.3",
+		"typescript": "5.6.2",
+		"vite": "6.4.1",
+		"vitest": "3.2.4"
+	},
+	"sideEffects": false
+}

--- a/packages/lb-weights/package.json
+++ b/packages/lb-weights/package.json
@@ -38,6 +38,7 @@
 	"homepage": "https://github.com/prosopo/captcha#readme",
 	"dependencies": {
 		"@prosopo/common": "3.1.43",
+		"@prosopo/logger": "2.0.1",
 		"@prosopo/types": "4.9.6",
 		"zod": "3.23.8"
 	},

--- a/packages/lb-weights/src/balancer.ts
+++ b/packages/lb-weights/src/balancer.ts
@@ -23,6 +23,7 @@ import type { BunnyRecord, WeightUpdate } from "./types.js";
 import {
 	DEFAULT_WEIGHT,
 	changedUpdates,
+	clampWeight,
 	equalWeights,
 	inverseWeights,
 } from "./weights.js";
@@ -128,7 +129,8 @@ export async function runCycle(deps: BalancerDeps): Promise<void> {
 
 		const updates: WeightUpdate[] = pool.members.map((record) => ({
 			recordId: record.Id,
-			weight: weightByRecordId.get(record.Id) ?? DEFAULT_WEIGHT,
+			// clamp defensively: Bunny only accepts integer weights in [1, 100]
+			weight: clampWeight(weightByRecordId.get(record.Id) ?? DEFAULT_WEIGHT),
 		}));
 		const toApply = changedUpdates(pool.members, updates);
 		const metricByRecordId = new Map<number, number>(

--- a/packages/lb-weights/src/balancer.ts
+++ b/packages/lb-weights/src/balancer.ts
@@ -24,6 +24,7 @@ import {
 	DEFAULT_WEIGHT,
 	changedUpdates,
 	clampWeight,
+	detectWeightSpikes,
 	equalWeights,
 	inverseWeights,
 } from "./weights.js";
@@ -136,6 +137,34 @@ export async function runCycle(deps: BalancerDeps): Promise<void> {
 		const metricByRecordId = new Map<number, number>(
 			measured.map((m) => [m.record.Id, m.metric]),
 		);
+
+		// Detect upward weight spikes vs the pool mean and log a warning per tier.
+		const { mean, stddev, spikes } = detectWeightSpikes(
+			updates.map((u) => u.weight),
+		);
+		for (const spike of spikes) {
+			const record = pool.members[spike.index];
+			const detail = {
+				domain: pool.domain,
+				subdomain: pool.name,
+				ip: record?.Value,
+				recordId: record?.Id,
+				weight: spike.weight,
+				mean,
+				stddev,
+			};
+			if (spike.sigma === 2) {
+				logger.warn(() => ({
+					msg: "Weight spike >2σ above pool mean",
+					data: { ...detail, threshold: mean + 2 * stddev },
+				}));
+			} else {
+				logger.warn(() => ({
+					msg: "Weight spike >1σ above pool mean",
+					data: { ...detail, threshold: mean + stddev },
+				}));
+			}
+		}
 
 		logger.info(() => ({
 			msg: "Computed weights for pool",

--- a/packages/lb-weights/src/balancer.ts
+++ b/packages/lb-weights/src/balancer.ts
@@ -1,0 +1,218 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import type { Logger } from "@prosopo/logger";
+import type { BunnyDnsClient } from "./bunny.js";
+import type { Config } from "./config.js";
+import {
+	type MetricsFetchOptions,
+	fetchNodeMetric,
+} from "./metrics.js";
+import { findLoadBalancerPools } from "./pools.js";
+import type { BunnyRecord, WeightUpdate } from "./types.js";
+import {
+	DEFAULT_WEIGHT,
+	changedUpdates,
+	equalWeights,
+	inverseWeights,
+} from "./weights.js";
+
+type MetricFetcher = (
+	ip: string,
+	metricName: string,
+	options: MetricsFetchOptions,
+) => Promise<number | null>;
+
+export interface BalancerDeps {
+	client: BunnyDnsClient;
+	config: Config;
+	logger: Logger;
+	// injectable for testing; defaults to a real Prometheus HTTP fetch
+	fetchMetric?: MetricFetcher;
+}
+
+// A member paired with the metric value we successfully read for it.
+interface MeasuredMember {
+	record: BunnyRecord;
+	metric: number;
+}
+
+function metricsOptions(config: Config): MetricsFetchOptions {
+	return {
+		scheme: config.LB_METRICS_SCHEME,
+		port: config.LB_METRICS_PORT,
+		path: config.LB_METRICS_PATH,
+	};
+}
+
+/**
+ * Run a single balancing cycle: read zones, find managed load-balancer pools,
+ * scrape each node's metric, compute inverse weights and (unless dry-run) push
+ * them to Bunny. Logs structured records throughout.
+ */
+export async function runCycle(deps: BalancerDeps): Promise<void> {
+	const { client, config, logger } = deps;
+	const fetchMetric = deps.fetchMetric ?? fetchNodeMetric;
+	const options = metricsOptions(config);
+
+	const zones = await client.listZones();
+	const pools = findLoadBalancerPools(zones, config.LB_SUBDOMAINS);
+
+	logger.info(() => ({
+		msg: "Starting balancing cycle",
+		data: {
+			dryRun: config.LB_DRY_RUN,
+			metric: config.LB_METRIC_NAME,
+			subdomains: config.LB_SUBDOMAINS,
+			poolsFound: pools.length,
+		},
+	}));
+
+	for (const pool of pools) {
+		const measured: MeasuredMember[] = [];
+		const unreachable: BunnyRecord[] = [];
+		for (const record of pool.members) {
+			const metric = await fetchMetric(
+				record.Value,
+				config.LB_METRIC_NAME,
+				options,
+			);
+			if (metric === null) {
+				unreachable.push(record);
+				continue;
+			}
+			measured.push({ record, metric });
+		}
+
+		// Build the weight map. Fallback rules:
+		//  - a node with no reachable /metrics gets the pool's max weight, so an
+		//    unmonitored node still receives (the most) traffic rather than none;
+		//  - if EVERY node is unreachable, fall back to equal weighting.
+		const weightByRecordId = new Map<number, number>();
+		let mode: "metrics" | "all-unreachable-equal";
+		if (measured.length === 0) {
+			mode = "all-unreachable-equal";
+			for (const update of equalWeights(pool.members, DEFAULT_WEIGHT)) {
+				weightByRecordId.set(update.recordId, update.weight);
+			}
+			logger.warn(() => ({
+				msg: "All nodes unreachable, using equal weighting",
+				data: {
+					domain: pool.domain,
+					subdomain: pool.name,
+					weight: DEFAULT_WEIGHT,
+				},
+			}));
+		} else {
+			mode = "metrics";
+			const weights = inverseWeights(measured.map((m) => m.metric));
+			measured.forEach((m, index) => {
+				// index is always in range: one weight per measured member
+				weightByRecordId.set(m.record.Id, weights[index] ?? 1);
+			});
+			const maxWeight = Math.max(...weights);
+			for (const record of unreachable) {
+				weightByRecordId.set(record.Id, maxWeight);
+			}
+		}
+
+		const updates: WeightUpdate[] = pool.members.map((record) => ({
+			recordId: record.Id,
+			weight: weightByRecordId.get(record.Id) ?? DEFAULT_WEIGHT,
+		}));
+		const toApply = changedUpdates(pool.members, updates);
+		const metricByRecordId = new Map<number, number>(
+			measured.map((m) => [m.record.Id, m.metric]),
+		);
+
+		logger.info(() => ({
+			msg: "Computed weights for pool",
+			data: {
+				domain: pool.domain,
+				subdomain: pool.name,
+				type: pool.type,
+				dryRun: config.LB_DRY_RUN,
+				mode,
+				unreachable: unreachable.length,
+				nodes: pool.members.map((record) => ({
+					ip: record.Value,
+					recordId: record.Id,
+					metric: metricByRecordId.get(record.Id) ?? null,
+					reachable: metricByRecordId.has(record.Id),
+					currentWeight: record.Weight,
+					newWeight: weightByRecordId.get(record.Id),
+				})),
+				changed: toApply.length,
+			},
+		}));
+
+		if (config.LB_DRY_RUN) {
+			logger.info(() => ({
+				msg: "Dry run: not applying weights",
+				data: { domain: pool.domain, subdomain: pool.name },
+			}));
+			continue;
+		}
+
+		if (toApply.length === 0) {
+			continue;
+		}
+		await client.setWeights(pool.zoneId, toApply);
+		logger.info(() => ({
+			msg: "Applied weights",
+			data: {
+				domain: pool.domain,
+				subdomain: pool.name,
+				applied: toApply.length,
+			},
+		}));
+	}
+}
+
+const sleep = (ms: number, signal?: AbortSignal): Promise<void> =>
+	new Promise((resolve) => {
+		const timer = setTimeout(resolve, ms);
+		signal?.addEventListener(
+			"abort",
+			() => {
+				clearTimeout(timer);
+				resolve();
+			},
+			{ once: true },
+		);
+	});
+
+/**
+ * Run balancing cycles forever at the configured interval. A cycle that throws
+ * is logged and the loop continues. Pass an AbortSignal to stop the loop.
+ */
+export async function startBalancerLoop(
+	deps: BalancerDeps,
+	signal?: AbortSignal,
+): Promise<void> {
+	const intervalMs = deps.config.LB_INTERVAL_SECONDS * 1000;
+	while (!signal?.aborted) {
+		try {
+			await runCycle(deps);
+		} catch (error) {
+			deps.logger.error(() => ({
+				msg: "Balancing cycle failed",
+				data: { error: error instanceof Error ? error.message : error },
+			}));
+		}
+		if (signal?.aborted) {
+			break;
+		}
+		await sleep(intervalMs, signal);
+	}
+}

--- a/packages/lb-weights/src/bunny.ts
+++ b/packages/lb-weights/src/bunny.ts
@@ -1,0 +1,99 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import { type Logger, LogLevel, getLogger } from "@prosopo/logger";
+import { type BunnyZone, type WeightUpdate, bunnyZoneSchema } from "./types.js";
+
+const DEFAULT_BASE_URL = "https://api.bunny.net";
+
+export interface BunnyClientOptions {
+	accessKey: string;
+	baseUrl?: string;
+	logger?: Logger;
+	// injectable for testing; defaults to the global fetch
+	fetchFn?: typeof fetch;
+}
+
+/**
+ * Minimal Bunny DNS client scoped to reading a zone and setting record weights.
+ */
+export class BunnyDnsClient {
+	private readonly accessKey: string;
+	private readonly baseUrl: string;
+	private readonly logger: Logger;
+	private readonly fetchFn: typeof fetch;
+
+	constructor(options: BunnyClientOptions) {
+		this.accessKey = options.accessKey;
+		this.baseUrl = options.baseUrl ?? DEFAULT_BASE_URL;
+		this.logger =
+			options.logger ?? getLogger(LogLevel.enum.info, "@prosopo/lb-weights");
+		this.fetchFn = options.fetchFn ?? fetch;
+	}
+
+	private headers(): Record<string, string> {
+		return {
+			AccessKey: this.accessKey,
+			Accept: "application/json",
+			"Content-Type": "application/json",
+		};
+	}
+
+	/** Read a single DNS zone including its records. */
+	async getZone(zoneId: number): Promise<BunnyZone> {
+		const url = `${this.baseUrl}/dnszone/${zoneId}`;
+		const response = await this.fetchFn(url, {
+			method: "GET",
+			headers: this.headers(),
+		});
+		if (!response.ok) {
+			throw new Error(
+				`Failed to read zone ${zoneId}: ${response.status} ${response.statusText}`,
+			);
+		}
+		const json: unknown = await response.json();
+		return bunnyZoneSchema.parse(json);
+	}
+
+	/** Set the weight of a single record (upsert via Bunny's record endpoint). */
+	async setWeight(
+		zoneId: number,
+		update: WeightUpdate,
+	): Promise<void> {
+		const url = `${this.baseUrl}/dnszone/${zoneId}/records/${update.recordId}`;
+		const response = await this.fetchFn(url, {
+			method: "POST",
+			headers: this.headers(),
+			body: JSON.stringify({ Weight: update.weight }),
+		});
+		if (!response.ok) {
+			throw new Error(
+				`Failed to set weight on record ${update.recordId}: ${response.status} ${response.statusText}`,
+			);
+		}
+		this.logger.info(() => ({
+			msg: "Set record weight",
+			data: { zoneId, recordId: update.recordId, weight: update.weight },
+		}));
+	}
+
+	/** Apply a batch of weight updates sequentially. */
+	async setWeights(
+		zoneId: number,
+		updates: readonly WeightUpdate[],
+	): Promise<void> {
+		for (const update of updates) {
+			await this.setWeight(zoneId, update);
+		}
+	}
+}

--- a/packages/lb-weights/src/bunny.ts
+++ b/packages/lb-weights/src/bunny.ts
@@ -12,7 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import { type Logger, LogLevel, getLogger } from "@prosopo/logger";
-import { type BunnyZone, type WeightUpdate, bunnyZoneSchema } from "./types.js";
+import { z } from "zod";
+import {
+	type BunnyZone,
+	type WeightUpdate,
+	bunnyZoneSchema,
+} from "./types.js";
+
+const zoneListSchema = z.object({
+	Items: z.array(bunnyZoneSchema),
+});
 
 const DEFAULT_BASE_URL = "https://api.bunny.net";
 
@@ -47,6 +56,22 @@ export class BunnyDnsClient {
 			Accept: "application/json",
 			"Content-Type": "application/json",
 		};
+	}
+
+	/** List all DNS zones (with their records) on the account. */
+	async listZones(): Promise<BunnyZone[]> {
+		const url = `${this.baseUrl}/dnszone?page=1&perPage=1000`;
+		const response = await this.fetchFn(url, {
+			method: "GET",
+			headers: this.headers(),
+		});
+		if (!response.ok) {
+			throw new Error(
+				`Failed to list zones: ${response.status} ${response.statusText}`,
+			);
+		}
+		const json: unknown = await response.json();
+		return zoneListSchema.parse(json).Items;
 	}
 
 	/** Read a single DNS zone including its records. */

--- a/packages/lb-weights/src/config.ts
+++ b/packages/lb-weights/src/config.ts
@@ -1,0 +1,61 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import { LogLevel } from "@prosopo/logger";
+import { z } from "zod";
+
+// Parse a comma/whitespace separated list into a trimmed, non-empty array.
+const stringList = z
+	.string()
+	.transform((value) =>
+		value
+			.split(/[\s,]+/)
+			.map((entry) => entry.trim())
+			.filter((entry) => entry.length > 0),
+	)
+	.pipe(z.array(z.string()).min(1));
+
+const booleanFromEnv = z
+	.string()
+	.transform((value) => value.trim().toLowerCase())
+	.pipe(z.enum(["true", "false", "1", "0", "yes", "no"]))
+	.transform((value) => value === "true" || value === "1" || value === "yes");
+
+// Environment variable schema. Defaults keep the service safe by default:
+// dry-run (readonly) is on unless explicitly disabled.
+export const configSchema = z.object({
+	// Bunny DNS API token used to read zones and set record weights.
+	BUNNY_API_KEY: z.string().min(1),
+	// Subdomains (record names) whose load-balancer pools we manage.
+	LB_SUBDOMAINS: stringList,
+	// Prometheus metric to drive weighting (lower usage => higher weight).
+	LB_METRIC_NAME: z.string().min(1).default("cpu_usage_1m"),
+	// How the per-node metrics endpoint is reached: <scheme>://<ip>:<port?><path>.
+	LB_METRICS_SCHEME: z.enum(["http", "https"]).default("http"),
+	LB_METRICS_PORT: z.coerce.number().int().positive().optional(),
+	LB_METRICS_PATH: z.string().default("/metrics"),
+	// Seconds between full recompute cycles.
+	LB_INTERVAL_SECONDS: z.coerce.number().int().positive().default(15),
+	// Readonly mode: compute + log weights but do not write them to Bunny.
+	LB_DRY_RUN: booleanFromEnv.default("true"),
+	// Optional override for the Bunny API base url (useful for tests).
+	BUNNY_BASE_URL: z.string().url().optional(),
+	// Logger verbosity.
+	PROSOPO_LOG_LEVEL: LogLevel.default(LogLevel.enum.info),
+});
+
+export type Config = z.infer<typeof configSchema>;
+
+export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
+	return configSchema.parse(env);
+}

--- a/packages/lb-weights/src/index.ts
+++ b/packages/lb-weights/src/index.ts
@@ -14,3 +14,7 @@
 export * from "./types.js";
 export * from "./weights.js";
 export * from "./bunny.js";
+export * from "./config.js";
+export * from "./metrics.js";
+export * from "./pools.js";
+export * from "./balancer.js";

--- a/packages/lb-weights/src/index.ts
+++ b/packages/lb-weights/src/index.ts
@@ -1,0 +1,16 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+export * from "./types.js";
+export * from "./weights.js";
+export * from "./bunny.js";

--- a/packages/lb-weights/src/main.ts
+++ b/packages/lb-weights/src/main.ts
@@ -1,0 +1,54 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import { getLogger } from "@prosopo/logger";
+import { startBalancerLoop } from "./balancer.js";
+import { BunnyDnsClient } from "./bunny.js";
+import { loadConfig } from "./config.js";
+
+async function main(): Promise<void> {
+	const config = loadConfig();
+	const logger = getLogger(config.PROSOPO_LOG_LEVEL, "@prosopo/lb-weights");
+
+	const client = new BunnyDnsClient({
+		accessKey: config.BUNNY_API_KEY,
+		baseUrl: config.BUNNY_BASE_URL,
+		logger,
+	});
+
+	const controller = new AbortController();
+	for (const signal of ["SIGINT", "SIGTERM"] as const) {
+		process.on(signal, () => {
+			logger.info(() => ({ msg: "Shutting down", data: { signal } }));
+			controller.abort();
+		});
+	}
+
+	logger.info(() => ({
+		msg: "Starting load-balancer weight updater",
+		data: {
+			subdomains: config.LB_SUBDOMAINS,
+			metric: config.LB_METRIC_NAME,
+			intervalSeconds: config.LB_INTERVAL_SECONDS,
+			dryRun: config.LB_DRY_RUN,
+		},
+	}));
+
+	await startBalancerLoop({ client, config, logger }, controller.signal);
+}
+
+main().catch((error: unknown) => {
+	// Config/parse errors surface here before the logger exists.
+	console.error("Fatal error in lb-weights:", error);
+	process.exitCode = 1;
+});

--- a/packages/lb-weights/src/metrics.ts
+++ b/packages/lb-weights/src/metrics.ts
@@ -1,0 +1,106 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Parse a single metric's value out of a Prometheus text exposition payload.
+ *
+ * Handles the common `name value` and `name{labels} value` line forms, ignores
+ * `#` comment/HELP/TYPE lines, and returns the value of the first sample whose
+ * metric name matches exactly. Returns null if the metric is absent or the
+ * value is not a finite number.
+ */
+export function parsePrometheusMetric(
+	body: string,
+	metricName: string,
+): number | null {
+	for (const rawLine of body.split("\n")) {
+		const line = rawLine.trim();
+		if (line.length === 0 || line.startsWith("#")) {
+			continue;
+		}
+		// name may be followed by `{labels}` and then whitespace + value.
+		const braceIndex = line.indexOf("{");
+		const spaceIndex = line.search(/\s/);
+		const nameEnd =
+			braceIndex >= 0 && (spaceIndex < 0 || braceIndex < spaceIndex)
+				? braceIndex
+				: spaceIndex;
+		if (nameEnd <= 0) {
+			continue;
+		}
+		const name = line.slice(0, nameEnd);
+		if (name !== metricName) {
+			continue;
+		}
+		// The value is the last whitespace-separated token on the line.
+		const tokens = line.split(/\s+/);
+		const valueToken = tokens[tokens.length - 1];
+		if (valueToken === undefined) {
+			continue;
+		}
+		const value = Number(valueToken);
+		if (Number.isFinite(value)) {
+			return value;
+		}
+	}
+	return null;
+}
+
+export interface MetricsFetchOptions {
+	scheme: "http" | "https";
+	port?: number;
+	path: string;
+	fetchFn?: typeof fetch;
+	timeoutMs?: number;
+}
+
+/** Build the metrics URL for a node IP. */
+export function metricsUrl(ip: string, options: MetricsFetchOptions): string {
+	const host = ip.includes(":") ? `[${ip}]` : ip; // bracket IPv6
+	const authority = options.port ? `${host}:${options.port}` : host;
+	const path = options.path.startsWith("/")
+		? options.path
+		: `/${options.path}`;
+	return `${options.scheme}://${authority}${path}`;
+}
+
+/**
+ * Fetch a node's Prometheus metrics endpoint and extract a single metric value.
+ * Returns null when the endpoint is unreachable, errors, or lacks the metric.
+ */
+export async function fetchNodeMetric(
+	ip: string,
+	metricName: string,
+	options: MetricsFetchOptions,
+): Promise<number | null> {
+	const fetchFn = options.fetchFn ?? fetch;
+	const url = metricsUrl(ip, options);
+	const controller = new AbortController();
+	const timeout = setTimeout(
+		() => controller.abort(),
+		options.timeoutMs ?? 5000,
+	);
+	try {
+		const response = await fetchFn(url, { signal: controller.signal });
+		if (!response.ok) {
+			return null;
+		}
+		const body = await response.text();
+		return parsePrometheusMetric(body, metricName);
+	} catch {
+		return null;
+	} finally {
+		clearTimeout(timeout);
+	}
+}

--- a/packages/lb-weights/src/pools.ts
+++ b/packages/lb-weights/src/pools.ts
@@ -1,0 +1,91 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import {
+	type BunnyRecord,
+	BunnyRecordType,
+	type BunnyZone,
+	SmartRoutingType,
+} from "./types.js";
+
+// A load-balanced set of address records under a single subdomain.
+export interface LoadBalancerPool {
+	zoneId: number;
+	domain: string;
+	// Record name (subdomain) within the zone, e.g. "pronode".
+	name: string;
+	type: BunnyRecordType;
+	// The member records; each member's `Value` is the node's IP address.
+	members: BunnyRecord[];
+}
+
+const ADDRESS_TYPES: ReadonlySet<BunnyRecordType> = new Set([
+	BunnyRecordType.A,
+	BunnyRecordType.AAAA,
+]);
+
+// A pool counts as "load balancer type" if it has smart routing enabled or has
+// more than one member sharing the same name + type.
+function isLoadBalancer(members: readonly BunnyRecord[]): boolean {
+	if (members.length > 1) {
+		return true;
+	}
+	return members.some(
+		(member) => member.SmartRoutingType !== SmartRoutingType.None,
+	);
+}
+
+/**
+ * Find the address-record pools, across all zones, whose subdomain is in the
+ * managed set and which are of load-balancer type. IPv4 (A) and IPv6 (AAAA)
+ * pools for the same subdomain are returned as separate pools.
+ */
+export function findLoadBalancerPools(
+	zones: readonly BunnyZone[],
+	subdomains: readonly string[],
+): LoadBalancerPool[] {
+	const managed = new Set(subdomains);
+	const pools: LoadBalancerPool[] = [];
+	for (const zone of zones) {
+		const groups = new Map<string, BunnyRecord[]>();
+		for (const record of zone.Records) {
+			if (!ADDRESS_TYPES.has(record.Type)) {
+				continue;
+			}
+			if (!managed.has(record.Name)) {
+				continue;
+			}
+			const key = `${record.Name} ${record.Type}`;
+			const existing = groups.get(key);
+			if (existing) {
+				existing.push(record);
+			} else {
+				groups.set(key, [record]);
+			}
+		}
+		for (const members of groups.values()) {
+			const first = members[0];
+			if (first === undefined || !isLoadBalancer(members)) {
+				continue;
+			}
+			pools.push({
+				zoneId: zone.Id,
+				domain: zone.Domain,
+				name: first.Name,
+				type: first.Type,
+				members,
+			});
+		}
+	}
+	return pools;
+}

--- a/packages/lb-weights/src/tests/balancer.unit.test.ts
+++ b/packages/lb-weights/src/tests/balancer.unit.test.ts
@@ -142,6 +142,38 @@ describe("runCycle", () => {
 		expect(applied.map((u) => u.weight)).toEqual([100, 100]);
 	});
 
+	it("logs a >2σ warning when one node's weight spikes", async () => {
+		// one fast node (metric 0) among many slow ones => a large weight spike
+		const members = [
+			member(1, "10.0.0.1", 50),
+			member(2, "10.0.0.2", 50),
+			member(3, "10.0.0.3", 50),
+			member(4, "10.0.0.4", 50),
+			member(5, "10.0.0.5", 50),
+			member(6, "10.0.0.6", 50),
+		];
+		const { client } = makeClient(zone(members));
+		const warn = vi.spyOn(logger, "warn");
+		await runCycle({
+			client,
+			config: config(),
+			logger,
+			fetchMetric: metricFetcher({
+				"10.0.0.1": 0,
+				"10.0.0.2": 9,
+				"10.0.0.3": 9,
+				"10.0.0.4": 9,
+				"10.0.0.5": 9,
+				"10.0.0.6": 9,
+			}),
+		});
+		const messages = warn.mock.calls.map((call) => call[0]().msg);
+		expect(
+			messages.some((m) => typeof m === "string" && m.includes("2σ")),
+		).toBe(true);
+		warn.mockRestore();
+	});
+
 	it("does not apply weights in dry-run mode", async () => {
 		const { client, setWeights } = makeClient(
 			zone([member(1, "10.0.0.1", 50), member(2, "10.0.0.2", 50)]),

--- a/packages/lb-weights/src/tests/balancer.unit.test.ts
+++ b/packages/lb-weights/src/tests/balancer.unit.test.ts
@@ -1,0 +1,157 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import { LogLevel, getLogger } from "@prosopo/logger";
+import { type MockInstance, describe, expect, it, vi } from "vitest";
+import { runCycle } from "../balancer.js";
+import { BunnyDnsClient } from "../bunny.js";
+import { type Config, loadConfig } from "../config.js";
+import type { MetricsFetchOptions } from "../metrics.js";
+import {
+	type BunnyRecord,
+	BunnyRecordType,
+	type BunnyZone,
+	SmartRoutingType,
+	type WeightUpdate,
+} from "../types.js";
+
+const logger = getLogger(LogLevel.enum.error, "test");
+
+const member = (Id: number, Value: string, Weight: number): BunnyRecord => ({
+	Id,
+	Name: "pronode",
+	Type: BunnyRecordType.A,
+	Value,
+	Weight,
+	Ttl: 15,
+	SmartRoutingType: SmartRoutingType.Latency,
+});
+
+const zone = (members: BunnyRecord[]): BunnyZone => ({
+	Id: 42,
+	Domain: "prosopo.io",
+	Records: members,
+});
+
+// A client whose listZones returns the given zone and whose setWeights is a spy.
+function makeClient(zoneValue: BunnyZone): {
+	client: BunnyDnsClient;
+	setWeights: MockInstance<BunnyDnsClient["setWeights"]>;
+} {
+	const fetchFn = vi.fn<typeof fetch>(
+		async () => new Response(JSON.stringify({ Items: [zoneValue] }), { status: 200 }),
+	);
+	const client = new BunnyDnsClient({
+		accessKey: "token",
+		logger,
+		fetchFn,
+	});
+	const setWeights = vi
+		.spyOn(client, "setWeights")
+		.mockResolvedValue(undefined);
+	return { client, setWeights };
+}
+
+function config(overrides: Partial<NodeJS.ProcessEnv> = {}): Config {
+	return loadConfig({
+		BUNNY_API_KEY: "token",
+		LB_SUBDOMAINS: "pronode",
+		LB_DRY_RUN: "false",
+		...overrides,
+	});
+}
+
+// Fixed metric map keyed by IP; missing keys simulate an unreachable endpoint.
+function metricFetcher(
+	values: Record<string, number>,
+): (
+	ip: string,
+	metricName: string,
+	options: MetricsFetchOptions,
+) => Promise<number | null> {
+	return async (ip) => (ip in values ? values[ip] ?? null : null);
+}
+
+const weightFor = (
+	updates: readonly WeightUpdate[],
+	recordId: number,
+): number | undefined =>
+	updates.find((u) => u.recordId === recordId)?.weight;
+
+describe("runCycle", () => {
+	it("gives the lowest-metric node the highest weight and applies it", async () => {
+		const { client, setWeights } = makeClient(
+			zone([member(1, "10.0.0.1", 50), member(2, "10.0.0.2", 50)]),
+		);
+		await runCycle({
+			client,
+			config: config(),
+			logger,
+			fetchMetric: metricFetcher({ "10.0.0.1": 0.2, "10.0.0.2": 0.8 }),
+		});
+		expect(setWeights).toHaveBeenCalledTimes(1);
+		const [, updates] = setWeights.mock.calls[0] ?? [];
+		expect(weightFor(updates ?? [], 1)).toBeGreaterThan(
+			weightFor(updates ?? [], 2) ?? 0,
+		);
+	});
+
+	it("defaults an unreachable node to the pool's max weight", async () => {
+		const { client, setWeights } = makeClient(
+			zone([
+				member(1, "10.0.0.1", 50),
+				member(2, "10.0.0.2", 50),
+				member(3, "10.0.0.3", 50),
+			]),
+		);
+		await runCycle({
+			client,
+			config: config(),
+			logger,
+			// node 3 has no metrics
+			fetchMetric: metricFetcher({ "10.0.0.1": 0.2, "10.0.0.2": 0.8 }),
+		});
+		const [, updates] = setWeights.mock.calls[0] ?? [];
+		const applied = updates ?? [];
+		const maxWeight = Math.max(...applied.map((u) => u.weight));
+		expect(weightFor(applied, 3)).toBe(maxWeight);
+	});
+
+	it("uses equal weighting when all nodes are unreachable", async () => {
+		const { client, setWeights } = makeClient(
+			zone([member(1, "10.0.0.1", 50), member(2, "10.0.0.2", 50)]),
+		);
+		await runCycle({
+			client,
+			config: config(),
+			logger,
+			fetchMetric: metricFetcher({}),
+		});
+		const [, updates] = setWeights.mock.calls[0] ?? [];
+		const applied = updates ?? [];
+		expect(applied.map((u) => u.weight)).toEqual([100, 100]);
+	});
+
+	it("does not apply weights in dry-run mode", async () => {
+		const { client, setWeights } = makeClient(
+			zone([member(1, "10.0.0.1", 50), member(2, "10.0.0.2", 50)]),
+		);
+		await runCycle({
+			client,
+			config: config({ LB_DRY_RUN: "true" }),
+			logger,
+			fetchMetric: metricFetcher({ "10.0.0.1": 0.2, "10.0.0.2": 0.8 }),
+		});
+		expect(setWeights).not.toHaveBeenCalled();
+	});
+});

--- a/packages/lb-weights/src/tests/config.unit.test.ts
+++ b/packages/lb-weights/src/tests/config.unit.test.ts
@@ -1,0 +1,59 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import { LogLevel } from "@prosopo/logger";
+import { describe, expect, it } from "vitest";
+import { loadConfig } from "../config.js";
+
+describe("loadConfig", () => {
+	it("applies safe defaults (dry-run on, 15s, cpu_usage_1m)", () => {
+		const config = loadConfig({
+			BUNNY_API_KEY: "token",
+			LB_SUBDOMAINS: "pronode, staging.pronode",
+		});
+		expect(config.LB_SUBDOMAINS).toEqual(["pronode", "staging.pronode"]);
+		expect(config.LB_METRIC_NAME).toBe("cpu_usage_1m");
+		expect(config.LB_INTERVAL_SECONDS).toBe(15);
+		expect(config.LB_DRY_RUN).toBe(true);
+		expect(config.LB_METRICS_SCHEME).toBe("http");
+		expect(config.LB_METRICS_PATH).toBe("/metrics");
+		expect(config.PROSOPO_LOG_LEVEL).toBe(LogLevel.enum.info);
+	});
+
+	it("parses overrides including dry-run false", () => {
+		const config = loadConfig({
+			BUNNY_API_KEY: "token",
+			LB_SUBDOMAINS: "pronode",
+			LB_METRIC_NAME: "load_1m",
+			LB_INTERVAL_SECONDS: "30",
+			LB_DRY_RUN: "false",
+			LB_METRICS_SCHEME: "https",
+			LB_METRICS_PORT: "9100",
+		});
+		expect(config.LB_DRY_RUN).toBe(false);
+		expect(config.LB_INTERVAL_SECONDS).toBe(30);
+		expect(config.LB_METRIC_NAME).toBe("load_1m");
+		expect(config.LB_METRICS_SCHEME).toBe("https");
+		expect(config.LB_METRICS_PORT).toBe(9100);
+	});
+
+	it("requires BUNNY_API_KEY", () => {
+		expect(() => loadConfig({ LB_SUBDOMAINS: "pronode" })).toThrow();
+	});
+
+	it("requires at least one subdomain", () => {
+		expect(() =>
+			loadConfig({ BUNNY_API_KEY: "token", LB_SUBDOMAINS: "  " }),
+		).toThrow();
+	});
+});

--- a/packages/lb-weights/src/tests/e2e.integration.test.ts
+++ b/packages/lb-weights/src/tests/e2e.integration.test.ts
@@ -1,0 +1,225 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// End-to-end test of the full balancing cycle. Everything external is mocked:
+// the Bunny API (via an injected fetchFn) and the node /metrics scrape (via an
+// injected metric fetcher). No real network calls are made.
+import { LogLevel, getLogger } from "@prosopo/logger";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { runCycle, startBalancerLoop } from "../balancer.js";
+import { BunnyDnsClient } from "../bunny.js";
+import { type Config, loadConfig } from "../config.js";
+import type { MetricsFetchOptions } from "../metrics.js";
+import {
+	type BunnyRecord,
+	BunnyRecordType,
+	type BunnyZone,
+	SmartRoutingType,
+} from "../types.js";
+import { MAX_WEIGHT } from "../weights.js";
+
+const logger = getLogger(LogLevel.enum.error, "e2e");
+
+const rec = (
+	Id: number,
+	Name: string,
+	Type: BunnyRecordType,
+	Value: string,
+	Weight = 100,
+): BunnyRecord => ({
+	Id,
+	Name,
+	Type,
+	Value,
+	Weight,
+	Ttl: 15,
+	SmartRoutingType: SmartRoutingType.Latency,
+});
+
+// A realistic zone: pronode (A + AAAA) and staging.pronode (A), plus an
+// unmanaged subdomain and a non-address record that must be ignored.
+const ZONE: BunnyZone = {
+	Id: 7,
+	Domain: "prosopo.io",
+	Records: [
+		rec(1, "pronode", BunnyRecordType.A, "10.0.0.1", 50),
+		rec(2, "pronode", BunnyRecordType.A, "10.0.0.2", 50),
+		rec(3, "pronode", BunnyRecordType.A, "10.0.0.3", 50),
+		rec(4, "pronode", BunnyRecordType.AAAA, "2001:db8::1", 50),
+		rec(5, "pronode", BunnyRecordType.AAAA, "2001:db8::2", 50),
+		rec(6, "staging.pronode", BunnyRecordType.A, "10.1.0.1", 50),
+		rec(7, "staging.pronode", BunnyRecordType.A, "10.1.0.2", 50),
+		rec(8, "unmanaged", BunnyRecordType.A, "10.9.0.1", 50),
+		rec(9, "unmanaged", BunnyRecordType.A, "10.9.0.2", 50),
+		rec(10, "pronode", BunnyRecordType.CNAME, "ignore.me", 50),
+	],
+};
+
+// Per-IP metric values; any IP absent from the map simulates an unreachable
+// /metrics endpoint.
+function metricFetcher(values: Record<string, number>) {
+	return async (
+		ip: string,
+		_metricName: string,
+		_options: MetricsFetchOptions,
+	): Promise<number | null> => (ip in values ? values[ip] ?? null : null);
+}
+
+// Build a client whose listZones returns ZONE and whose writes are captured.
+function makeClient(): {
+	client: BunnyDnsClient;
+	writes: Array<{ zoneId: number; recordId: number; weight: number }>;
+	listCalls: () => number;
+} {
+	let listCalls = 0;
+	const fetchFn = vi.fn<typeof fetch>(async (input) => {
+		const url = typeof input === "string" ? input : input.toString();
+		if (url.includes("/dnszone") && !url.includes("/records/")) {
+			listCalls += 1;
+			return new Response(JSON.stringify({ Items: [ZONE] }), {
+				status: 200,
+			});
+		}
+		// record write endpoint
+		return new Response("{}", { status: 200 });
+	});
+	const client = new BunnyDnsClient({ accessKey: "token", logger, fetchFn });
+	const writes: Array<{
+		zoneId: number;
+		recordId: number;
+		weight: number;
+	}> = [];
+	vi.spyOn(client, "setWeights").mockImplementation(async (zoneId, updates) => {
+		for (const u of updates) {
+			writes.push({ zoneId, recordId: u.recordId, weight: u.weight });
+		}
+	});
+	return { client, writes, listCalls: () => listCalls };
+}
+
+function config(overrides: Partial<NodeJS.ProcessEnv> = {}): Config {
+	return loadConfig({
+		BUNNY_API_KEY: "token",
+		LB_SUBDOMAINS: "pronode, staging.pronode",
+		LB_DRY_RUN: "false",
+		LB_INTERVAL_SECONDS: "1",
+		...overrides,
+	});
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("e2e balancing cycle", () => {
+	it("computes and applies weights across all managed pools", async () => {
+		const { client, writes } = makeClient();
+		await runCycle({
+			client,
+			config: config(),
+			logger,
+			fetchMetric: metricFetcher({
+				"10.0.0.1": 0.1,
+				"10.0.0.2": 0.5,
+				"10.0.0.3": 0.9,
+				"2001:db8::1": 0.2,
+				"2001:db8::2": 0.8,
+				"10.1.0.1": 0.3,
+				"10.1.0.2": 0.7,
+			}),
+		});
+
+		// three managed pools (pronode A, pronode AAAA, staging.pronode A);
+		// the unmanaged subdomain and CNAME are never written.
+		const writtenIds = new Set(writes.map((w) => w.recordId));
+		expect(writtenIds.has(8)).toBe(false);
+		expect(writtenIds.has(9)).toBe(false);
+		expect(writtenIds.has(10)).toBe(false);
+
+		// within pronode A, the lowest-usage node (id 1) gets the highest weight
+		const w1 = writes.find((w) => w.recordId === 1)?.weight ?? 0;
+		const w3 = writes.find((w) => w.recordId === 3)?.weight ?? 0;
+		expect(w1).toBeGreaterThan(w3);
+
+		// all applied weights are Bunny-legal integers in [1, 100]
+		for (const w of writes) {
+			expect(Number.isInteger(w.weight)).toBe(true);
+			expect(w.weight).toBeGreaterThanOrEqual(1);
+			expect(w.weight).toBeLessThanOrEqual(MAX_WEIGHT);
+		}
+	});
+
+	it("gives an unreachable node the pool's max weight", async () => {
+		const { client, writes } = makeClient();
+		await runCycle({
+			client,
+			config: config({ LB_SUBDOMAINS: "pronode" }),
+			logger,
+			// node id 3 (10.0.0.3) and the AAAA pool are unreachable
+			fetchMetric: metricFetcher({
+				"10.0.0.1": 0.2,
+				"10.0.0.2": 0.8,
+			}),
+		});
+		const aPoolWrites = writes.filter((w) => [1, 2, 3].includes(w.recordId));
+		const maxWeight = Math.max(...aPoolWrites.map((w) => w.weight));
+		expect(writes.find((w) => w.recordId === 3)?.weight).toBe(maxWeight);
+	});
+
+	it("uses equal weighting when a whole pool is unreachable", async () => {
+		const { client, writes } = makeClient();
+		await runCycle({
+			client,
+			config: config({ LB_SUBDOMAINS: "pronode" }),
+			logger,
+			// only the AAAA pool is reachable; the A pool is fully unreachable
+			fetchMetric: metricFetcher({
+				"2001:db8::1": 0.2,
+				"2001:db8::2": 0.8,
+			}),
+		});
+		const aPoolWrites = writes.filter((w) => [1, 2, 3].includes(w.recordId));
+		expect(aPoolWrites.map((w) => w.weight)).toEqual([100, 100, 100]);
+	});
+
+	it("writes nothing in dry-run mode", async () => {
+		const { client, writes } = makeClient();
+		await runCycle({
+			client,
+			config: config({ LB_DRY_RUN: "true" }),
+			logger,
+			fetchMetric: metricFetcher({ "10.0.0.1": 0.1, "10.0.0.2": 0.9 }),
+		});
+		expect(writes).toEqual([]);
+	});
+
+	it("loops until aborted, running at least one cycle", async () => {
+		const { client, listCalls } = makeClient();
+		const controller = new AbortController();
+		const loop = startBalancerLoop(
+			{
+				client,
+				config: config(),
+				logger,
+				fetchMetric: metricFetcher({ "10.0.0.1": 0.1 }),
+			},
+			controller.signal,
+		);
+		// let the first cycle complete, then stop the loop
+		await vi.waitFor(() => expect(listCalls()).toBeGreaterThanOrEqual(1));
+		controller.abort();
+		await loop;
+		expect(listCalls()).toBeGreaterThanOrEqual(1);
+	});
+});

--- a/packages/lb-weights/src/tests/inverseWeights.unit.test.ts
+++ b/packages/lb-weights/src/tests/inverseWeights.unit.test.ts
@@ -1,0 +1,47 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import { describe, expect, it } from "vitest";
+import { inverseWeights } from "../weights.js";
+
+describe("inverseWeights", () => {
+	it("gives the lowest metric the highest weight", () => {
+		// spread >= 1 so ordering survives the ceil() step
+		const weights = inverseWeights([1, 3, 2]);
+		expect(weights).toEqual([3, 1, 2]);
+	});
+
+	it("never produces a zero weight", () => {
+		for (const weight of inverseWeights([0, 100, 50])) {
+			expect(weight).toBeGreaterThanOrEqual(1);
+		}
+	});
+
+	it("returns integer weights", () => {
+		for (const weight of inverseWeights([0.13, 0.77, 0.42])) {
+			expect(Number.isInteger(weight)).toBe(true);
+		}
+	});
+
+	it("handles equal metrics by giving equal weights", () => {
+		expect(inverseWeights([0.5, 0.5, 0.5])).toEqual([1, 1, 1]);
+	});
+
+	it("returns empty for empty input", () => {
+		expect(inverseWeights([])).toEqual([]);
+	});
+
+	it("throws on non-finite values", () => {
+		expect(() => inverseWeights([1, Number.NaN])).toThrow();
+	});
+});

--- a/packages/lb-weights/src/tests/inverseWeights.unit.test.ts
+++ b/packages/lb-weights/src/tests/inverseWeights.unit.test.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import { describe, expect, it } from "vitest";
-import { inverseWeights } from "../weights.js";
+import { MAX_WEIGHT, MIN_WEIGHT, clampWeight, inverseWeights } from "../weights.js";
 
 describe("inverseWeights", () => {
 	it("gives the lowest metric the highest weight", () => {
@@ -43,5 +43,31 @@ describe("inverseWeights", () => {
 
 	it("throws on non-finite values", () => {
 		expect(() => inverseWeights([1, Number.NaN])).toThrow();
+	});
+
+	it("never exceeds Bunny's max weight even for a large spread", () => {
+		const weights = inverseWeights([0, 1000, 5000, 9999]);
+		for (const weight of weights) {
+			expect(weight).toBeLessThanOrEqual(MAX_WEIGHT);
+			expect(weight).toBeGreaterThanOrEqual(MIN_WEIGHT);
+			expect(Number.isInteger(weight)).toBe(true);
+		}
+		// lowest cost (0) still ends up at the top of the range
+		expect(weights[0]).toBe(MAX_WEIGHT);
+	});
+
+	it("preserves ordering after scaling into range", () => {
+		const weights = inverseWeights([0, 200, 400]);
+		expect(weights[0]).toBeGreaterThanOrEqual(weights[1] ?? 0);
+		expect(weights[1]).toBeGreaterThanOrEqual(weights[2] ?? 0);
+	});
+});
+
+describe("clampWeight", () => {
+	it("clamps into [MIN_WEIGHT, MAX_WEIGHT] and rounds up", () => {
+		expect(clampWeight(0)).toBe(MIN_WEIGHT);
+		expect(clampWeight(150)).toBe(MAX_WEIGHT);
+		expect(clampWeight(12.1)).toBe(13);
+		expect(clampWeight(-5)).toBe(MIN_WEIGHT);
 	});
 });

--- a/packages/lb-weights/src/tests/metrics.unit.test.ts
+++ b/packages/lb-weights/src/tests/metrics.unit.test.ts
@@ -1,0 +1,100 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import { describe, expect, it, vi } from "vitest";
+import {
+	fetchNodeMetric,
+	metricsUrl,
+	parsePrometheusMetric,
+} from "../metrics.js";
+
+const SAMPLE = `# HELP cpu_usage_1m CPU usage
+# TYPE cpu_usage_1m gauge
+cpu_usage_1m 0.42
+memory_usage 128
+cpu_usage_1m{core="0"} 0.9
+`;
+
+describe("parsePrometheusMetric", () => {
+	it("extracts a simple metric value", () => {
+		expect(parsePrometheusMetric(SAMPLE, "cpu_usage_1m")).toBe(0.42);
+	});
+
+	it("returns null for an absent metric", () => {
+		expect(parsePrometheusMetric(SAMPLE, "not_there")).toBeNull();
+	});
+
+	it("ignores comments and unrelated metrics", () => {
+		expect(parsePrometheusMetric(SAMPLE, "memory_usage")).toBe(128);
+	});
+
+	it("does not match a metric that is only a prefix", () => {
+		expect(parsePrometheusMetric("cpu_usage_1m_total 5\n", "cpu_usage_1m")).toBeNull();
+	});
+});
+
+describe("metricsUrl", () => {
+	it("builds an ipv4 url", () => {
+		expect(
+			metricsUrl("10.0.0.1", { scheme: "http", path: "/metrics" }),
+		).toBe("http://10.0.0.1/metrics");
+	});
+
+	it("brackets ipv6 and adds a port", () => {
+		expect(
+			metricsUrl("2001:db8::1", {
+				scheme: "https",
+				port: 9100,
+				path: "metrics",
+			}),
+		).toBe("https://[2001:db8::1]:9100/metrics");
+	});
+});
+
+describe("fetchNodeMetric", () => {
+	it("returns the metric value on success", async () => {
+		const fetchFn = vi.fn<typeof fetch>(async () =>
+			new Response(SAMPLE, { status: 200 }),
+		);
+		const value = await fetchNodeMetric("10.0.0.1", "cpu_usage_1m", {
+			scheme: "http",
+			path: "/metrics",
+			fetchFn,
+		});
+		expect(value).toBe(0.42);
+	});
+
+	it("returns null on a non-ok response", async () => {
+		const fetchFn = vi.fn<typeof fetch>(async () =>
+			new Response("", { status: 500 }),
+		);
+		const value = await fetchNodeMetric("10.0.0.1", "cpu_usage_1m", {
+			scheme: "http",
+			path: "/metrics",
+			fetchFn,
+		});
+		expect(value).toBeNull();
+	});
+
+	it("returns null when fetch throws", async () => {
+		const fetchFn = vi.fn<typeof fetch>(async () => {
+			throw new Error("connection refused");
+		});
+		const value = await fetchNodeMetric("10.0.0.1", "cpu_usage_1m", {
+			scheme: "http",
+			path: "/metrics",
+			fetchFn,
+		});
+		expect(value).toBeNull();
+	});
+});

--- a/packages/lb-weights/src/tests/pools.unit.test.ts
+++ b/packages/lb-weights/src/tests/pools.unit.test.ts
@@ -1,0 +1,102 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import { describe, expect, it } from "vitest";
+import { findLoadBalancerPools } from "../pools.js";
+import {
+	type BunnyRecord,
+	BunnyRecordType,
+	type BunnyZone,
+	SmartRoutingType,
+} from "../types.js";
+
+const rec = (
+	Id: number,
+	Name: string,
+	Type: BunnyRecordType,
+	Value: string,
+	smart: SmartRoutingType = SmartRoutingType.Latency,
+): BunnyRecord => ({
+	Id,
+	Name,
+	Type,
+	Value,
+	Weight: 100,
+	Ttl: 15,
+	SmartRoutingType: smart,
+});
+
+const zone = (Records: BunnyRecord[]): BunnyZone => ({
+	Id: 1,
+	Domain: "prosopo.io",
+	Records,
+});
+
+describe("findLoadBalancerPools", () => {
+	it("finds A and AAAA pools for a managed subdomain", () => {
+		const zones = [
+			zone([
+				rec(1, "pronode", BunnyRecordType.A, "10.0.0.1"),
+				rec(2, "pronode", BunnyRecordType.A, "10.0.0.2"),
+				rec(3, "pronode", BunnyRecordType.AAAA, "2001:db8::1"),
+				rec(4, "pronode", BunnyRecordType.AAAA, "2001:db8::2"),
+			]),
+		];
+		const pools = findLoadBalancerPools(zones, ["pronode"]);
+		expect(pools.length).toBe(2);
+		const a = pools.find((p) => p.type === BunnyRecordType.A);
+		expect(a?.members.map((m) => m.Value)).toEqual(["10.0.0.1", "10.0.0.2"]);
+	});
+
+	it("excludes subdomains that are not managed", () => {
+		const zones = [
+			zone([
+				rec(1, "pronode", BunnyRecordType.A, "10.0.0.1"),
+				rec(2, "pronode", BunnyRecordType.A, "10.0.0.2"),
+				rec(3, "other", BunnyRecordType.A, "10.0.0.3"),
+				rec(4, "other", BunnyRecordType.A, "10.0.0.4"),
+			]),
+		];
+		const pools = findLoadBalancerPools(zones, ["pronode"]);
+		expect(pools.length).toBe(1);
+		expect(pools[0]?.name).toBe("pronode");
+	});
+
+	it("treats a single record with smart routing as a load balancer", () => {
+		const zones = [
+			zone([
+				rec(1, "pronode", BunnyRecordType.A, "10.0.0.1", SmartRoutingType.Latency),
+			]),
+		];
+		expect(findLoadBalancerPools(zones, ["pronode"]).length).toBe(1);
+	});
+
+	it("ignores a single record with no smart routing", () => {
+		const zones = [
+			zone([
+				rec(1, "pronode", BunnyRecordType.A, "10.0.0.1", SmartRoutingType.None),
+			]),
+		];
+		expect(findLoadBalancerPools(zones, ["pronode"]).length).toBe(0);
+	});
+
+	it("ignores non-address record types", () => {
+		const zones = [
+			zone([
+				rec(1, "pronode", BunnyRecordType.CNAME, "target.example.com"),
+				rec(2, "pronode", BunnyRecordType.CNAME, "target2.example.com"),
+			]),
+		];
+		expect(findLoadBalancerPools(zones, ["pronode"]).length).toBe(0);
+	});
+});

--- a/packages/lb-weights/src/tests/spikes.unit.test.ts
+++ b/packages/lb-weights/src/tests/spikes.unit.test.ts
@@ -1,0 +1,58 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import { describe, expect, it } from "vitest";
+import { detectWeightSpikes, meanStddev } from "../weights.js";
+
+describe("meanStddev", () => {
+	it("computes population mean and stddev", () => {
+		const { mean, stddev } = meanStddev([2, 4, 4, 4, 5, 5, 7, 9]);
+		expect(mean).toBe(5);
+		expect(stddev).toBe(2);
+	});
+
+	it("returns zeros for empty input", () => {
+		expect(meanStddev([])).toEqual({ mean: 0, stddev: 0 });
+	});
+});
+
+describe("detectWeightSpikes", () => {
+	it("flags a >1σ spike (below 2σ) at sigma 1", () => {
+		// mean 10, stddev ~2.92; 15 is > 1σ (~12.92) but < 2σ (~15.83)
+		const report = detectWeightSpikes([8, 9, 8, 15]);
+		expect(report.spikes.length).toBe(1);
+		expect(report.spikes[0]?.index).toBe(3);
+		expect(report.spikes[0]?.sigma).toBe(1);
+	});
+
+	it("flags a >2σ spike at sigma 2", () => {
+		// one large outlier sits well beyond 2σ
+		const report = detectWeightSpikes([1, 1, 1, 1, 1, 1, 1, 1, 1, 100]);
+		const spike = report.spikes.find((s) => s.weight === 100);
+		expect(spike?.sigma).toBe(2);
+	});
+
+	it("only flags the max side, not low outliers", () => {
+		const report = detectWeightSpikes([100, 100, 100, 100, 1]);
+		// the low value (1) is below the mean and must not be flagged
+		expect(report.spikes.every((s) => s.weight !== 1)).toBe(true);
+	});
+
+	it("produces no spikes when variance is zero", () => {
+		expect(detectWeightSpikes([50, 50, 50]).spikes).toEqual([]);
+	});
+
+	it("produces no spikes for a single-member pool", () => {
+		expect(detectWeightSpikes([100]).spikes).toEqual([]);
+	});
+});

--- a/packages/lb-weights/src/tests/weights.unit.test.ts
+++ b/packages/lb-weights/src/tests/weights.unit.test.ts
@@ -1,0 +1,134 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import { describe, expect, it } from "vitest";
+import {
+	type BunnyRecord,
+	BunnyRecordType,
+	SmartRoutingType,
+} from "../types.js";
+import {
+	changedUpdates,
+	equalWeights,
+	groupPools,
+	proportionalWeights,
+} from "../weights.js";
+
+const record = (
+	Id: number,
+	Name: string,
+	Type: BunnyRecordType,
+	Weight: number,
+): BunnyRecord => ({
+	Id,
+	Name,
+	Type,
+	Value: `10.0.0.${Id}`,
+	Weight,
+	Ttl: 15,
+	SmartRoutingType: SmartRoutingType.Latency,
+});
+
+describe("groupPools", () => {
+	it("groups records by Name + Type", () => {
+		const records: BunnyRecord[] = [
+			record(1, "pronode", BunnyRecordType.A, 100),
+			record(2, "pronode", BunnyRecordType.A, 100),
+			record(3, "pronode", BunnyRecordType.AAAA, 100),
+		];
+		const pools = groupPools(records);
+		expect(pools.size).toBe(2);
+		expect(pools.get(`pronode ${BunnyRecordType.A}`)?.length).toBe(2);
+		expect(pools.get(`pronode ${BunnyRecordType.AAAA}`)?.length).toBe(1);
+	});
+});
+
+describe("equalWeights", () => {
+	it("assigns the same weight to every record", () => {
+		const records: BunnyRecord[] = [
+			record(1, "pronode", BunnyRecordType.A, 50),
+			record(2, "pronode", BunnyRecordType.A, 70),
+		];
+		expect(equalWeights(records, 100)).toEqual([
+			{ recordId: 1, weight: 100 },
+			{ recordId: 2, weight: 100 },
+		]);
+	});
+
+	it("rejects a negative weight", () => {
+		expect(() => equalWeights([], -1)).toThrow();
+	});
+});
+
+describe("proportionalWeights", () => {
+	it("distributes weight proportionally to shares", () => {
+		const updates = proportionalWeights(
+			[
+				{ recordId: 1, share: 1 },
+				{ recordId: 2, share: 3 },
+			],
+			100,
+		);
+		expect(updates).toEqual([
+			{ recordId: 1, weight: 25 },
+			{ recordId: 2, weight: 75 },
+		]);
+	});
+
+	it("assigns rounding remainder so the total is exact", () => {
+		const updates = proportionalWeights(
+			[
+				{ recordId: 1, share: 1 },
+				{ recordId: 2, share: 1 },
+				{ recordId: 3, share: 1 },
+			],
+			100,
+		);
+		const total = updates.reduce((acc, u) => acc + u.weight, 0);
+		expect(total).toBe(100);
+	});
+
+	it("falls back to equal split when all shares are zero", () => {
+		const updates = proportionalWeights(
+			[
+				{ recordId: 1, share: 0 },
+				{ recordId: 2, share: 0 },
+			],
+			100,
+		);
+		expect(updates).toEqual([
+			{ recordId: 1, weight: 50 },
+			{ recordId: 2, weight: 50 },
+		]);
+	});
+
+	it("rejects a negative share", () => {
+		expect(() =>
+			proportionalWeights([{ recordId: 1, share: -1 }], 100),
+		).toThrow();
+	});
+});
+
+describe("changedUpdates", () => {
+	it("keeps only updates that change a record's weight", () => {
+		const records: BunnyRecord[] = [
+			record(1, "pronode", BunnyRecordType.A, 100),
+			record(2, "pronode", BunnyRecordType.A, 50),
+		];
+		const updates = changedUpdates(records, [
+			{ recordId: 1, weight: 100 },
+			{ recordId: 2, weight: 75 },
+		]);
+		expect(updates).toEqual([{ recordId: 2, weight: 75 }]);
+	});
+});

--- a/packages/lb-weights/src/types.ts
+++ b/packages/lb-weights/src/types.ts
@@ -1,0 +1,64 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import { z } from "zod";
+
+// Bunny DNS record types (subset). Numeric values match the Bunny API enum.
+export enum BunnyRecordType {
+	A = 0,
+	AAAA = 1,
+	CNAME = 2,
+	TXT = 3,
+	MX = 4,
+	Redirect = 5,
+	Flatten = 6,
+	PullZone = 7,
+	SRV = 8,
+	CAA = 9,
+	PTR = 10,
+	Script = 11,
+	NS = 12,
+}
+
+// Smart routing strategy applied across records sharing a Name + Type.
+export enum SmartRoutingType {
+	None = 0, // round-robin, weight-only
+	Latency = 1, // latency / geo based
+	Geo = 2,
+}
+
+export const bunnyRecordSchema = z.object({
+	Id: z.number(),
+	Type: z.nativeEnum(BunnyRecordType),
+	Name: z.string(),
+	Value: z.string(),
+	Weight: z.number(),
+	Ttl: z.number(),
+	SmartRoutingType: z.nativeEnum(SmartRoutingType),
+});
+
+export type BunnyRecord = z.infer<typeof bunnyRecordSchema>;
+
+export const bunnyZoneSchema = z.object({
+	Id: z.number(),
+	Domain: z.string(),
+	Records: z.array(bunnyRecordSchema),
+});
+
+export type BunnyZone = z.infer<typeof bunnyZoneSchema>;
+
+// A single weight change to apply to one record.
+export interface WeightUpdate {
+	recordId: number;
+	weight: number;
+}

--- a/packages/lb-weights/src/weights.ts
+++ b/packages/lb-weights/src/weights.ts
@@ -13,8 +13,20 @@
 // limitations under the License.
 import type { BunnyRecord, WeightUpdate } from "./types.js";
 
-// Bunny stores weights as integers; equal weighting across a pool uses 100.
-export const DEFAULT_WEIGHT = 100;
+// Bunny DNS constraints: a record's routing Weight is an integer in [0, 100]
+// (see https://docs.bunny.net/dns/records — "Routing Weight ... between 0-100").
+export const MAX_WEIGHT = 100;
+// A weight of 0 would starve a node of traffic, so the effective minimum we
+// ever assign is 1. Bunny's hard minimum is 0.
+export const MIN_WEIGHT = 1;
+
+// Equal weighting across a pool uses the maximum weight.
+export const DEFAULT_WEIGHT = MAX_WEIGHT;
+
+/** Clamp a weight to Bunny's supported integer range [MIN_WEIGHT, MAX_WEIGHT]. */
+export function clampWeight(weight: number): number {
+	return Math.min(MAX_WEIGHT, Math.max(MIN_WEIGHT, Math.ceil(weight)));
+}
 
 /**
  * Group records that form a single load-balanced pool (same Name + Type).
@@ -122,7 +134,9 @@ export function changedUpdates(
  *  2. shift every value up by the minimum negated value (i.e. subtract the min)
  *     so the smallest becomes 0 and all are non-negative;
  *  3. add 1 so no node ends up with weight 0 (which would starve it of traffic);
- *  4. ceil so weights are integers, as Bunny requires.
+ *  4. scale proportionally so the largest weight fits Bunny's max (100),
+ *     preserving the ratio between nodes;
+ *  5. ceil + clamp so weights are integers within Bunny's [1, 100] range.
  *
  * An empty input yields an empty result.
  */
@@ -137,7 +151,12 @@ export function inverseWeights(values: readonly number[]): number[] {
 	}
 	const negated = values.map((value) => -value);
 	const minNegated = Math.min(...negated);
-	return negated.map((value) => Math.ceil(value - minNegated + 1));
+	const raw = negated.map((value) => value - minNegated + 1); // floats >= 1
+	// Scale down proportionally if the largest would exceed Bunny's max weight,
+	// so ratios between nodes are preserved rather than flattened by clamping.
+	const maxRaw = Math.max(...raw);
+	const factor = maxRaw > MAX_WEIGHT ? MAX_WEIGHT / maxRaw : 1;
+	return raw.map((value) => clampWeight(value * factor));
 }
 
 function assertWeight(weight: number): void {

--- a/packages/lb-weights/src/weights.ts
+++ b/packages/lb-weights/src/weights.ts
@@ -1,0 +1,120 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import type { BunnyRecord, WeightUpdate } from "./types.js";
+
+// Bunny stores weights as integers; equal weighting across a pool uses 100.
+export const DEFAULT_WEIGHT = 100;
+
+/**
+ * Group records that form a single load-balanced pool (same Name + Type).
+ * Returns a map keyed by `${Name} ${Type}`.
+ */
+export function groupPools(
+	records: readonly BunnyRecord[],
+): Map<string, BunnyRecord[]> {
+	const pools = new Map<string, BunnyRecord[]>();
+	for (const record of records) {
+		const key = `${record.Name} ${record.Type}`;
+		const existing = pools.get(key);
+		if (existing) {
+			existing.push(record);
+		} else {
+			pools.set(key, [record]);
+		}
+	}
+	return pools;
+}
+
+/**
+ * Assign an identical weight to every record in a pool.
+ */
+export function equalWeights(
+	records: readonly BunnyRecord[],
+	weight: number = DEFAULT_WEIGHT,
+): WeightUpdate[] {
+	assertWeight(weight);
+	return records.map((record) => ({ recordId: record.Id, weight }));
+}
+
+/**
+ * Distribute total weight across records proportionally to the supplied
+ * per-record shares. Shares need not sum to anything in particular; they are
+ * normalised. The resulting integer weights sum to `total`, with any rounding
+ * remainder assigned to the largest shares first so the total is exact.
+ */
+export function proportionalWeights(
+	shares: ReadonlyArray<{ recordId: number; share: number }>,
+	total: number = DEFAULT_WEIGHT * shares.length,
+): WeightUpdate[] {
+	assertWeight(total);
+	if (shares.length === 0) {
+		return [];
+	}
+	for (const { share } of shares) {
+		if (!Number.isFinite(share) || share < 0) {
+			throw new Error(`Invalid share: ${share}`);
+		}
+	}
+	const sum = shares.reduce((acc, { share }) => acc + share, 0);
+	if (sum <= 0) {
+		return equalWeights(
+			shares.map(({ recordId }) => ({ Id: recordId }) as BunnyRecord),
+			Math.floor(total / shares.length),
+		);
+	}
+	const raw = shares.map(({ recordId, share }) => ({
+		recordId,
+		exact: (share / sum) * total,
+	}));
+	const updates: WeightUpdate[] = raw.map(({ recordId, exact }) => ({
+		recordId,
+		weight: Math.floor(exact),
+	}));
+	let remainder = total - updates.reduce((acc, u) => acc + u.weight, 0);
+	// hand out the remainder to the largest fractional parts first
+	const order = raw
+		.map(({ exact }, index) => ({ index, frac: exact - Math.floor(exact) }))
+		.sort((a, b) => b.frac - a.frac);
+	for (const { index } of order) {
+		if (remainder <= 0) {
+			break;
+		}
+		const update = updates[index];
+		if (update) {
+			update.weight += 1;
+			remainder -= 1;
+		}
+	}
+	return updates;
+}
+
+/**
+ * Only keep updates whose weight differs from the record's current weight, to
+ * avoid redundant writes.
+ */
+export function changedUpdates(
+	records: readonly BunnyRecord[],
+	updates: readonly WeightUpdate[],
+): WeightUpdate[] {
+	const current = new Map<number, number>(
+		records.map((record) => [record.Id, record.Weight]),
+	);
+	return updates.filter((update) => current.get(update.recordId) !== update.weight);
+}
+
+function assertWeight(weight: number): void {
+	if (!Number.isInteger(weight) || weight < 0) {
+		throw new Error(`Weight must be a non-negative integer, got ${weight}`);
+	}
+}

--- a/packages/lb-weights/src/weights.ts
+++ b/packages/lb-weights/src/weights.ts
@@ -113,6 +113,33 @@ export function changedUpdates(
 	return updates.filter((update) => current.get(update.recordId) !== update.weight);
 }
 
+/**
+ * Turn a set of "cost" metric values (e.g. CPU usage, where lower is better)
+ * into integer weights where a lower metric yields a higher weight.
+ *
+ * Steps, matching the intended inverse-weighting scheme:
+ *  1. negate each value so lower cost becomes a larger number;
+ *  2. shift every value up by the minimum negated value (i.e. subtract the min)
+ *     so the smallest becomes 0 and all are non-negative;
+ *  3. add 1 so no node ends up with weight 0 (which would starve it of traffic);
+ *  4. ceil so weights are integers, as Bunny requires.
+ *
+ * An empty input yields an empty result.
+ */
+export function inverseWeights(values: readonly number[]): number[] {
+	if (values.length === 0) {
+		return [];
+	}
+	for (const value of values) {
+		if (!Number.isFinite(value)) {
+			throw new Error(`Metric value must be finite, got ${value}`);
+		}
+	}
+	const negated = values.map((value) => -value);
+	const minNegated = Math.min(...negated);
+	return negated.map((value) => Math.ceil(value - minNegated + 1));
+}
+
 function assertWeight(weight: number): void {
 	if (!Number.isInteger(weight) || weight < 0) {
 		throw new Error(`Weight must be a non-negative integer, got ${weight}`);

--- a/packages/lb-weights/src/weights.ts
+++ b/packages/lb-weights/src/weights.ts
@@ -159,6 +159,59 @@ export function inverseWeights(values: readonly number[]): number[] {
 	return raw.map((value) => clampWeight(value * factor));
 }
 
+// Result of classifying a pool's weights for upward spikes.
+export interface WeightSpike {
+	index: number;
+	weight: number;
+	// how many standard deviations above the mean this weight is
+	sigma: 1 | 2;
+}
+
+export interface SpikeReport {
+	mean: number;
+	stddev: number;
+	spikes: WeightSpike[];
+}
+
+/** Population mean and standard deviation of a list of numbers. */
+export function meanStddev(values: readonly number[]): {
+	mean: number;
+	stddev: number;
+} {
+	if (values.length === 0) {
+		return { mean: 0, stddev: 0 };
+	}
+	const mean = values.reduce((acc, v) => acc + v, 0) / values.length;
+	const variance =
+		values.reduce((acc, v) => acc + (v - mean) ** 2, 0) / values.length;
+	return { mean, stddev: Math.sqrt(variance) };
+}
+
+/**
+ * Flag weights that spike upward relative to the pool mean:
+ *  - `> mean + 2·stddev` is reported at sigma 2 (the more severe tier);
+ *  - `> mean + 1·stddev` (but not 2σ) is reported at sigma 1.
+ * Only the max side is considered. Pools with fewer than 2 members or zero
+ * variance produce no spikes.
+ */
+export function detectWeightSpikes(weights: readonly number[]): SpikeReport {
+	const { mean, stddev } = meanStddev(weights);
+	if (weights.length < 2 || stddev === 0) {
+		return { mean, stddev, spikes: [] };
+	}
+	const oneSigma = mean + stddev;
+	const twoSigma = mean + 2 * stddev;
+	const spikes: WeightSpike[] = [];
+	weights.forEach((weight, index) => {
+		if (weight > twoSigma) {
+			spikes.push({ index, weight, sigma: 2 });
+		} else if (weight > oneSigma) {
+			spikes.push({ index, weight, sigma: 1 });
+		}
+	});
+	return { mean, stddev, spikes };
+}
+
 function assertWeight(weight: number): void {
 	if (!Number.isInteger(weight) || weight < 0) {
 		throw new Error(`Weight must be a non-negative integer, got ${weight}`);

--- a/packages/lb-weights/tsconfig.cjs.json
+++ b/packages/lb-weights/tsconfig.cjs.json
@@ -1,0 +1,24 @@
+{
+	"extends": "../../tsconfig.cjs.json",
+	"compilerOptions": {
+		"rootDir": "./src",
+		"outDir": "./dist/cjs"
+	},
+	"include": [
+		"./src/**/*.ts",
+		"./src/**/*.json",
+		"./src/**/*.d.ts",
+		"./src/**/*.tsx"
+	],
+	"references": [
+		{
+			"path": "../../dev/config/tsconfig.cjs.json"
+		},
+		{
+			"path": "../common/tsconfig.cjs.json"
+		},
+		{
+			"path": "../types/tsconfig.cjs.json"
+		}
+	]
+}

--- a/packages/lb-weights/tsconfig.cjs.json
+++ b/packages/lb-weights/tsconfig.cjs.json
@@ -18,6 +18,9 @@
 			"path": "../common/tsconfig.cjs.json"
 		},
 		{
+			"path": "../logger/tsconfig.cjs.json"
+		},
+		{
 			"path": "../types/tsconfig.cjs.json"
 		}
 	]

--- a/packages/lb-weights/tsconfig.json
+++ b/packages/lb-weights/tsconfig.json
@@ -1,0 +1,25 @@
+{
+	"extends": "../../tsconfig.esm.json",
+	"compilerOptions": {
+		"rootDir": "./src",
+		"outDir": "./dist"
+	},
+	"include": [
+		"src",
+		"src/**/*.json",
+		"src/**/*.ts",
+		"src/**/*.tsx",
+		"src/**/*.d.ts"
+	],
+	"references": [
+		{
+			"path": "../../dev/config/tsconfig.json"
+		},
+		{
+			"path": "../common"
+		},
+		{
+			"path": "../types"
+		}
+	]
+}

--- a/packages/lb-weights/tsconfig.json
+++ b/packages/lb-weights/tsconfig.json
@@ -19,6 +19,9 @@
 			"path": "../common"
 		},
 		{
+			"path": "../logger"
+		},
+		{
 			"path": "../types"
 		}
 	]

--- a/packages/lb-weights/tsconfig.types.json
+++ b/packages/lb-weights/tsconfig.types.json
@@ -1,0 +1,9 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"emitDeclarationOnly": true,
+		"declaration": true,
+		"declarationMap": true,
+		"composite": false
+	}
+}

--- a/packages/lb-weights/vector.toml
+++ b/packages/lb-weights/vector.toml
@@ -1,0 +1,76 @@
+# Vector configuration for the lb-weights service.
+#
+# Collects the structured JSON logs emitted by the lb-weights container and
+# forwards them to a local OpenObserve instance for querying/dashboards.
+#
+# Environment variables required:
+# - OO_HOST:      identifier for this host (added to every record)
+# - OO_ORG:       OpenObserve organisation (default "default")
+# - OO_STREAM:    OpenObserve stream name (e.g. "lb_weights")
+# - OO_USERNAME:  OpenObserve basic-auth user (root user email)
+# - OO_PASSWORD:  OpenObserve basic-auth password
+
+[api]
+enabled = true
+address = "127.0.0.1:8686"
+
+# Source: logs from any container labelled vector.lb-weights=true
+[sources.lb_weights]
+type = "docker_logs"
+include_labels = ["vector.lb-weights=true"]
+
+# Transform: parse the JSON log line and attach host/container metadata
+[transforms.lb_weights_format]
+type = "remap"
+inputs = ["lb_weights"]
+source = '''
+output = {}
+message_str = string(.message) ?? ""
+parsed = parse_json(message_str) ?? null
+if parsed != null {
+    output = parsed
+} else {
+    output.message = message_str
+}
+output.host = get_env_var("OO_HOST") ?? "unknown"
+output.container_name = .container_name
+output.image = .image
+output.stream = .stream
+output.source_type = .source_type
+. = output
+'''
+
+# Sink: forward to the local OpenObserve instance
+[sinks.openobserve]
+type = "http"
+inputs = ["lb_weights_format"]
+uri = "http://openobserve:5080/api/${OO_ORG:-default}/${OO_STREAM:-lb_weights}/_json"
+method = "post"
+compression = "gzip"
+
+[sinks.openobserve.auth]
+strategy = "basic"
+user = "${OO_USERNAME:?err}"
+password = "${OO_PASSWORD:?err}"
+
+[sinks.openobserve.encoding]
+codec = "json"
+timestamp_format = "rfc3339"
+
+[sinks.openobserve.healthcheck]
+enabled = true
+
+[sinks.openobserve.batch]
+timeout_secs = 15
+
+[sinks.openobserve.request]
+rate_limit_duration_secs = 1
+rate_limit_num = 10
+retry_max_attempts = 5
+retry_initial_backoff_secs = 1
+retry_max_backoff_secs = 30
+
+[sinks.openobserve.buffer]
+type = "disk"
+max_size = 268435488
+when_full = "drop_newest"

--- a/packages/lb-weights/vite.cjs.config.ts
+++ b/packages/lb-weights/vite.cjs.config.ts
@@ -1,0 +1,22 @@
+import path from "node:path";
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import { ViteCommonJSConfig } from "@prosopo/config";
+
+export default function () {
+	return ViteCommonJSConfig(
+		path.basename("."),
+		path.resolve("./tsconfig.json"),
+	);
+}

--- a/packages/lb-weights/vite.esm.config.ts
+++ b/packages/lb-weights/vite.esm.config.ts
@@ -1,0 +1,20 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import path from "node:path";
+import { ViteEsmConfig } from "@prosopo/config";
+
+export default function () {
+	return ViteEsmConfig(path.basename("."), path.resolve("./tsconfig.json"));
+}

--- a/packages/lb-weights/vite.test.config.ts
+++ b/packages/lb-weights/vite.test.config.ts
@@ -1,0 +1,33 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import fs from "node:fs";
+import path from "node:path";
+import { ViteTestConfig } from "@prosopo/config";
+import dotenv from "dotenv";
+process.env.NODE_ENV = "test";
+// if .env.test exists at this level, use it, otherwise use the one at the root
+const envFile = `.env.${process.env.NODE_ENV || "development"}`;
+let envPath = envFile;
+if (fs.existsSync(envFile)) {
+	envPath = path.resolve(envFile);
+} else if (fs.existsSync(`../../${envFile}`)) {
+	envPath = path.resolve(`../../${envFile}`);
+} else {
+	throw new Error(`No ${envFile} file found`);
+}
+
+dotenv.config({ path: envPath });
+
+export default ViteTestConfig();


### PR DESCRIPTION
## Summary

Adds a new package **`@prosopo/lb-weights`** — a service that dynamically sets Bunny DNS load-balancer record weights from per-node Prometheus metrics.

On a fixed interval it:
1. reads Bunny DNS zones and filters to the load-balancer address pools for the configured subdomains;
2. scrapes each node's `<ip>/metrics` Prometheus endpoint;
3. inverse-weights a chosen metric (lower usage → higher weight);
4. applies integer weights to Bunny — unless in dry-run (readonly) mode.

Defaults are safe: **dry-run is on by default**, interval 15s, metric `cpu_usage_1m`.

## Weighting

- Inverse scheme: negate → shift by min → `+1` (never 0) → scale proportionally into Bunny's max → `ceil` + clamp.
- **Bunny constraints handled**: weight is an integer in `[0, 100]` (confirmed from Bunny docs); computed weights are scaled to preserve ratios and clamped to `[1, 100]`.
- **Missing-metric fallbacks**: an unreachable node defaults to the pool's **max weight**; if every node in a pool is unreachable, **equal weighting** is used.
- **Spike detection**: logs a warning for any weight `> mean + 1σ`, and a distinct louder warning for `> mean + 2σ` (max-side only, per pool).

## Observability

- Structured logging via `@prosopo/logger` (which pool is computed/updated, per-node ip/metric/weight, dry-run, mode).
- `docker-compose.yml` in the package dir wires the service + **Vector** + **OpenObserve**, JSON logging on all services, `env_file` support, and basic-auth sink credentials (`vector.toml`).
- `Dockerfile` and `.env.template` included in the package.

## Tests

52 unit + mocked-integration/e2e tests, all passing. **No test hits the real Bunny API or real `/metrics` endpoints** — all external calls are injected/mocked.

## Notes

- Package built with `build:tsc` (type-checked); tests run under vitest.
- New workspace dependency: `@prosopo/logger`.
