### PR TITLE
fix(procaptcha-frictionless): report top-frame URL as currentUrl in iframes

### DIFF
--- a/.changeset/frictionless-top-url.md
+++ b/.changeset/frictionless-top-url.md
@@ -1,0 +1,15 @@
+---
+"@prosopo/procaptcha-frictionless": patch
+---
+
+Report the top-frame URL as `currentUrl` when the widget runs inside an iframe.
+
+Previously the frictionless client always sent `window.location.origin + pathname`, which is the iframe's own URL — so every session loaded through Protect's site-wide iframe (`protect.<tenant>.live/...`) reported the same widget endpoint regardless of which page the user was actually on. Downstream detectors (HEAD_HASH_OUTLIER's proxy-pool signal in particular) then saw diverse-geography traffic on one URL+UA fingerprint and treated our own iframe as a bot cluster.
+
+Resolution order for `currentUrl`:
+1. Top window → local `location.href` (widget is the top frame).
+2. Same-origin iframe → `window.top.location.href`.
+3. Cross-origin iframe → `document.referrer` (browser fills it subject to Referrer-Policy).
+4. Fallback → the iframe's own `location.href` so the field is never empty.
+
+Origin+path sanitisation is preserved across all paths — the query string, fragment and any embedded credentials are still stripped before the URL leaves the browser.

--- a/packages/procaptcha-frictionless/src/customDetectBot.ts
+++ b/packages/procaptcha-frictionless/src/customDetectBot.ts
@@ -34,15 +34,55 @@ import { DetectorLoader } from "./detectorLoader.js";
 // Returns undefined in non-browser contexts (SSR / tests) or for opaque
 // origins; the provider then treats the session as having no page URL and
 // forces an image captcha.
+//
+// When we're loaded inside an iframe (Protect's site-wide embed) the local
+// `window.location` is the iframe URL, which conveys nothing about the page
+// the user is actually on — every session across the tenant ends up
+// reporting the same widget endpoint. Same-origin iframes let us read the
+// top frame directly; cross-origin iframes fall through to `document.referrer`,
+// which the browser fills with the embedding page URL subject to
+// Referrer-Policy. Only when both are unavailable do we fall back to the
+// iframe's own URL, matching the previous behaviour.
+const sanitiseHref = (href: string): string | undefined => {
+	try {
+		const u = new URL(href);
+		if (!u.origin || u.origin === "null") return undefined;
+		return `${u.origin}${u.pathname || ""}`;
+	} catch {
+		return undefined;
+	}
+};
+
 const getCurrentPageUrl = (): string | undefined => {
 	if (typeof window === "undefined" || !window.location) {
 		return undefined;
 	}
-	const { origin, pathname } = window.location;
-	if (!origin || origin === "null") {
-		return undefined;
+	const local = (() => {
+		const { origin, pathname } = window.location;
+		if (!origin || origin === "null") return undefined;
+		return `${origin}${pathname || ""}`;
+	})();
+
+	// Top window — the iframe path doesn't apply.
+	if (window === window.top) return local;
+
+	// Same-origin iframe — read the top URL directly.
+	try {
+		const topHref = window.top?.location?.href;
+		const sanitised = topHref ? sanitiseHref(topHref) : undefined;
+		if (sanitised) return sanitised;
+	} catch {
+		/* cross-origin — fall through */
 	}
-	return `${origin}${pathname || ""}`;
+
+	// Cross-origin iframe — the embedding page URL comes via referrer,
+	// subject to the parent's Referrer-Policy header.
+	if (typeof document !== "undefined" && document.referrer) {
+		const fromReferrer = sanitiseHref(document.referrer);
+		if (fromReferrer) return fromReferrer;
+	}
+
+	return local;
 };
 
 export const withTimeout = async <T>(


### PR DESCRIPTION
## Summary
- Every Protect-iframe session was reporting `protect.<tenant>.live/api/protect/challenge` (the widget endpoint) as `currentUrl`, not the actual page the user was on.
- Downstream detectors then saw diverse-geography traffic on one URL+UA fingerprint and treated our own iframe as a proxy pool — the root cause of the ~950/hr `API.ACCESS_POLICY_BLOCK` regression observed on Twickets after HEAD_HASH_OUTLIER shipped.

## Change
`getCurrentPageUrl()` now resolves in order:
1. Top window → local `location.href` (widget is the top frame).
2. Same-origin iframe → `window.top.location.href`.
3. Cross-origin iframe → `document.referrer` (browser-populated subject to Referrer-Policy).
4. Fallback → the iframe's own `location.href` so the field is never empty.

Origin+path sanitisation preserved across all paths — query string, fragment and any embedded credentials are stripped before the URL leaves the browser.

## Test plan
- [x] `npm run -w @prosopo/procaptcha-frictionless build:tsc` clean.
- [ ] Post-merge: verify sessions on `www.<tenant>.com/page/...` load through Protect iframe and `currentUrl` matches the app-block URL, not the iframe URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)