### PR TITLE
feat(provider): persist isEscalation flag on post-PoW routed sessions

### DIFF
--- a/.changeset/session-is-escalation.md
+++ b/.changeset/session-is-escalation.md
@@ -1,0 +1,12 @@
+---
+"@prosopo/types": patch
+"@prosopo/types-database": patch
+"@prosopo/database": patch
+"@prosopo/provider": patch
+---
+
+Persist `isEscalation: true` on Session records minted by the post-PoW routing machine.
+
+The escalation path in `submitPoWCaptchaSolution.buildEscalation` creates a follow-up session (image or puzzle) whenever the router decides the PoW-verified user still needs a stronger challenge. Analytics couldn't previously separate those escalated sessions from cold frictionless sessions since both shared the same shape — every downstream count that wanted to reason about "did we escalate this user?" had to reverse-engineer the origin/escalation link from the redis cache mapping.
+
+The field is optional on the schema and only written when true, so ordinary frictionless sessions stay slim and older records still parse.

--- a/packages/database/src/databases/provider.ts
+++ b/packages/database/src/databases/provider.ts
@@ -1652,6 +1652,7 @@ export class ProviderDatabase
 				ipInfo: 1,
 				webView: 1,
 				iFrame: 1,
+				isEscalation: 1,
 				decryptedHeadHash: 1,
 				siteKey: 1,
 				reason: 1,

--- a/packages/provider/src/api/captcha/submitPoWCaptchaSolution.ts
+++ b/packages/provider/src/api/captcha/submitPoWCaptchaSolution.ts
@@ -298,6 +298,7 @@ export const buildEscalation = async (
 		originSession.currentUrl,
 		handshakeTiming?.tcpToChelloUs,
 		handshakeTiming?.chelloToHandshakeUs,
+		true,
 	);
 
 	// Record the origin → escalation sessionId mapping so a /captcha/*

--- a/packages/provider/src/tasks/frictionless/frictionlessTasks.ts
+++ b/packages/provider/src/tasks/frictionless/frictionlessTasks.ts
@@ -190,6 +190,7 @@ export class FrictionlessManager extends CaptchaManager {
 		currentUrl?: Session["currentUrl"],
 		tcpToChelloUs?: Session["tcpToChelloUs"],
 		chelloToHandshakeUs?: Session["chelloToHandshakeUs"],
+		isEscalation?: Session["isEscalation"],
 	): Promise<Session> {
 		const sessionRecord: Session = {
 			sessionId: `${getSessionIDPrefix(this.config.host)}-${uuidv4()}`,
@@ -206,6 +207,10 @@ export class FrictionlessManager extends CaptchaManager {
 			userSitekeyIpHash,
 			webView,
 			iFrame,
+			// Only persist the escalation flag when it's actually true —
+			// avoids polluting analytics with `false` on every plain
+			// frictionless session.
+			...(isEscalation && { isEscalation: true }),
 			decryptedHeadHash,
 			reason,
 			siteKey,

--- a/packages/types-database/src/types/provider.ts
+++ b/packages/types-database/src/types/provider.ts
@@ -623,6 +623,10 @@ export const SessionRecordSchema = new Schema<SessionRecord>({
 	userSitekeyIpHash: { type: String, required: false },
 	webView: { type: Boolean, required: true, default: false },
 	iFrame: { type: Boolean, required: true, default: false },
+	// True when this session was created by the post-PoW routing machine as
+	// an escalation of an earlier session. Optional so ordinary
+	// frictionless-created sessions can omit it and stay slim.
+	isEscalation: { type: Boolean, required: false },
 	decryptedHeadHash: { type: String, required: false, default: "" },
 	siteKey: { type: String, required: false },
 	// Full page URL the widget was rendered on (origin + path only; query

--- a/packages/types/src/provider/database.ts
+++ b/packages/types/src/provider/database.ts
@@ -401,6 +401,13 @@ export const SessionSchema = object({
 	userSitekeyIpHash: string().optional(),
 	webView: boolean(),
 	iFrame: boolean(),
+	// True when this session was minted by the post-PoW routing machine
+	// as an escalation of a prior session (see `buildEscalation` in
+	// submitPoWCaptchaSolution). Absent / false on ordinary
+	// frictionless-created sessions. Persisted so analytics can separate
+	// "user hit the widget cold" from "user got escalated into a
+	// stronger captcha after a low-confidence PoW".
+	isEscalation: boolean().optional(),
 	decryptedHeadHash: string(),
 	siteKey: string().optional(),
 	// Full page URL the widget was rendered on (origin + path only — query
@@ -487,6 +494,9 @@ export type Session = {
 	userSitekeyIpHash?: string;
 	webView: boolean;
 	iFrame: boolean;
+	// True when this session was minted by the post-PoW routing machine
+	// as an escalation. Undefined / false on ordinary frictionless sessions.
+	isEscalation?: boolean;
 	decryptedHeadHash: string;
 	siteKey?: string;
 	// Full page URL the widget was rendered on (origin + path only — query


### PR DESCRIPTION
## Summary
- `buildEscalation` in `submitPoWCaptchaSolution` mints a follow-up session whenever the routing machine decides a PoW-verified user needs a stronger challenge, but the follow-up looked identical to a cold frictionless session in Mongo.
- Adds a `isEscalation?: boolean` field to the `Session` schema (Zod + Mongoose) and threads it through `createSession`; only written when `true` so cold sessions stay slim.
- Widens the peek projection so the flag round-trips into the read path.

## Why cut a patch here
Ships alongside the top-frame `currentUrl` fix (captcha#2813 / 3.6.58) that only bumped procaptcha-frictionless — the release didn't cascade a version bump into the CLI's transitive graph, so nothing published. This change touches `@prosopo/provider`, which `@prosopo/cli` depends on, so a new patch release will actually reach npm.

## Test plan
- [x] `npm run -w @prosopo/types build:tsc`
- [x] `npm run -w @prosopo/types-database build:tsc`
- [x] `npm run -w @prosopo/database build:tsc`
- [x] `npm run -w @prosopo/provider build:tsc`
- [ ] Post-release: verify escalated PoW sessions carry `isEscalation: true` in Mongo and cold frictionless sessions omit the field entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)