### PR TITLE
chore(types-database): sparse index on isEscalation

### DIFF
--- a/.changeset/session-is-escalation-index.md
+++ b/.changeset/session-is-escalation-index.md
@@ -1,0 +1,7 @@
+---
+"@prosopo/types-database": patch
+"@prosopo/database": patch
+"@prosopo/provider": patch
+---
+
+Add a sparse compound index on `{ isEscalation: 1, createdAt: 1 }` to the Session collection. Sparse so ordinary frictionless sessions (which omit the field) don't add index entries.

--- a/packages/types-database/src/types/provider.ts
+++ b/packages/types-database/src/types/provider.ts
@@ -715,6 +715,13 @@ SessionRecordSchema.index(
 	{ background: true, sparse: true },
 );
 SessionRecordSchema.index({ ruleHash: 1 }, { background: true, sparse: true });
+// Escalation analytics — sparse because ordinary frictionless sessions
+// omit the field, so the index only carries the small subset of records
+// minted by the post-PoW router.
+SessionRecordSchema.index(
+	{ isEscalation: 1, createdAt: 1 },
+	{ background: true, sparse: true },
+);
 // Compound indexes for session aggregation queries
 SessionRecordSchema.index({
 	createdAt: 1,


### PR DESCRIPTION
## Summary
Follow-up to #2815 — adds a sparse compound index on `{ isEscalation: 1, createdAt: 1 }` on the Session collection. Missed the auto-merge on the parent PR.

## Why sparse
Ordinary frictionless sessions omit `isEscalation`, so only the small subset minted by `buildEscalation` shows up in the index. Analytics queries filtering by escalation status hit the index directly instead of a collscan.

## Test plan
- [x] `npm run -w @prosopo/types-database build:tsc` clean.
- [ ] Post-release: verify Mongo has the new index and analytics queries planning use it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)