### PR TITLE
fix(database): forward currentUrl and iframeUrl through session projection

### DIFF
--- a/.changeset/session-projection-current-iframe-url.md
+++ b/.changeset/session-projection-current-iframe-url.md
@@ -1,0 +1,5 @@
+---
+"@prosopo/database": patch
+---
+
+Include `currentUrl` and `iframeUrl` in the `getSessionRecordBySessionId` projection so `buildEscalation` forwards them onto the escalated session. Without this, every post-PoW routed session was persisted with `currentUrl: undefined`, dropping URL attribution on the PoW → image/puzzle hop.

--- a/packages/database/src/databases/provider.ts
+++ b/packages/database/src/databases/provider.ts
@@ -1661,6 +1661,8 @@ export class ProviderDatabase
 				userSitekeyIpHash: 1,
 				simdReadings: 1,
 				dnsEvent: 1,
+				currentUrl: 1,
+				iframeUrl: 1,
 				// captchaType is required by the peek-before-consume path
 				// in `CaptchaManager.isValidRequest` — without it, every
 				// escalation peek would compare `undefined !== <requested>`

--- a/packages/database/src/tests/integration/sessionRecordProjection.integration.test.ts
+++ b/packages/database/src/tests/integration/sessionRecordProjection.integration.test.ts
@@ -115,6 +115,8 @@ describe("getSessionRecordBySessionId projection", () => {
 			decryptedHeadHash: "head-hash-xyz",
 			siteKey: "site-key-1",
 			reason: "user-passed",
+			currentUrl: "https://example.com/checkout",
+			iframeUrl: "https://widget.example.com/embed",
 			headers: {
 				"user-agent": "Mozilla/5.0",
 				"accept-language": "en-GB",
@@ -151,6 +153,13 @@ describe("getSessionRecordBySessionId projection", () => {
 		expect(got.iFrame).toBe(false);
 		expect(got.decryptedHeadHash).toBe("head-hash-xyz");
 		expect(got.reason).toBe("user-passed");
+		// currentUrl / iframeUrl are forwarded onto the escalation session so
+		// downstream analytics (attack attribution, per-URL routing) survive
+		// the PoW → image/puzzle hop. Missed on the original projection
+		// (2026-07-09): 100% of escalation sessions were storing
+		// `currentUrl: undefined` in prod.
+		expect(got.currentUrl).toBe("https://example.com/checkout");
+		expect(got.iframeUrl).toBe("https://widget.example.com/embed");
 
 		// Headers come back so `buildEscalation` can forward them onto the
 		// escalation session, but the multi-KB `x-tls-clienthello` is


### PR DESCRIPTION
## Summary

- `getSessionRecordBySessionId` projected only a hand-picked list of session fields; `currentUrl` and `iframeUrl` were not on the list.
- `buildEscalation` in `submitPoWCaptchaSolution` reads the origin session via this method and forwards the URLs into `createSession` — so every escalation session was persisted with `undefined` URLs.
- Add both fields to the projection and extend the existing regression test.

## Prod evidence (captchastorage, 2026-07-09, 30-minute window)

| Cohort | Sessions | With `currentUrl` |
|---|---:|---:|
| Client origin PoW sessions | 1,786 | 1,786 (100%) |
| Client escalation sessions | 384 | 0 (0%) |

The origin sessions correctly stored `currentUrl` (e.g. `https://www.client.com/…`). Every escalation minted from those origins came out `undefined`, so downstream analytics (attack attribution, per-URL routing) lost the URL on the PoW → image/puzzle hop.

## Scope

- `sessions` collection only. `powcaptchas` and `usercommitments` schemas do not have `currentUrl` and are intentionally left alone — attribute via `sessionId` join.
- Only `currentUrl` and `iframeUrl` are added; other fields also missing from the projection (`isProtect`, entropy fields, handshake timings) are out of scope for this PR.

## Test plan

- [x] `npx vitest run src/tests/integration/sessionRecordProjection.integration.test.ts` — 3/3 pass
- [x] `npm run -w @prosopo/database build:tsc`
- [x] `npm run -w @prosopo/provider build:tsc`
- [ ] After merge: verify Client escalation sessions in prod start populating `currentUrl`

🤖 Generated with [Claude Code](https://claude.com/claude-code)