### PR TITLE
fix(user-access-policy): route non-block strict-match lookups through split-query path

### DIFF
--- a/.changeset/split-restrict-rule-lookup.md
+++ b/.changeset/split-restrict-rule-lookup.md
@@ -1,0 +1,19 @@
+---
+"@prosopo/user-access-policy": patch
+"@prosopo/provider": patch
+---
+
+fix(user-access-policy): route non-block strict-match rule lookups through the split-query path
+
+Live 2026-07-10 Twickets regression: a portal-authored Restrict/image rule scoped to `clientId + numericIp` was silently dropped from the frictionless access-policy lookup even though the rule was correctly stored in Redis and indexed. The DM then fell through to `default_pow` and served POW instead of the configured image challenge.
+
+Root cause: the `findRulesRanked` FT.AGGREGATE ranker used for non-block lookups capped candidates at `SERVER_SIDE_RANK_TOP_N = 20` after a server-side `SORTBY @_rank`. Under Greedy matching with `matchingFieldsOnly=true`, the query is a wide OR that matches every rule missing `headHash`, `coords`, or `headersHash` — for a Twickets-shaped tenant (~860 candidates) the top 20 slots were filled by higher-specificity SIMD_REPLAY and SUDDEN_VOLUME_INCREASE Block rules that didn't actually apply to the request. The specific-IP Restrict rule (specificity 2) was pushed out; Node saw only irrelevant candidates; `rankCandidateRules` filtered them all out via `ruleApplies`; the lookup returned `[]`.
+
+Fix: extend the existing `findBlockRulesSplit` path (previously the hot path for `blockOnly=true` callers) to cover every `matchingFieldsOnly` call. Each sub-query hits a discriminating posting list (exact numericIp, exact ja4Hash, etc.), so the ip:exact probe returns exactly the rules literally matching the request IP — the specific-IP rule can no longer be pushed off the end by irrelevant candidates from other probes. `blockOnly` is now a flag on the sub-query builder that narrows probes to `@type:{block}` when set. Split reader now sorts candidates by (specificity desc, block-first) so direct reader consumers see the same order the old FT.AGGREGATE ranker gave.
+
+Regression coverage added:
+
+- Unit: `buildScopedRulesSubQueries` emits/omits `@type:{block}` correctly per `blockOnly` flag and produces the same probe shape either way.
+- Integration: specific-IP Restrict rule survives when 40 higher-specificity irrelevant Block rules co-exist on the same tenant (mirrors the live Twickets shape).
+
+Benchmarks unchanged: split hot path p50=1.4ms / p99=2.2ms across 19,300 seeded rules; 100×10 concurrent storm holds ~990 req/s.

--- a/packages/user-access-policy/src/redis/reader/redisRulesReader.ts
+++ b/packages/user-access-policy/src/redis/reader/redisRulesReader.ts
@@ -20,7 +20,7 @@ import {
 	REDIS_QUERY_DIALECT,
 	getRulesRedisQuery,
 } from "#policy/redis/reader/redisRulesQuery.js";
-import { buildScopedBlockSubQueries } from "#policy/redis/reader/redisRulesSplitQuery.js";
+import { buildScopedRulesSubQueries } from "#policy/redis/reader/redisRulesSplitQuery.js";
 import {
 	REDIS_BATCH_SIZE,
 	fetchRedisHashRecords,
@@ -137,6 +137,39 @@ const RULE_LOAD_FIELDS = [
 	"@numericIpMaskMax",
 ] as const;
 
+// Populated-field count for reader-level rank (mirrors the JS ranker's
+// specificity semantics without any request-scope dependence — the reader
+// doesn't have the request scope). Enough to preserve the sort the old
+// FT.AGGREGATE ranker imposed on findRules callers.
+const readerSpecificity = (rule: AccessRule): number => {
+	let score = 0;
+	if (rule.clientId !== undefined) score++;
+	if (rule.userId !== undefined) score++;
+	if (rule.ja4Hash !== undefined) score++;
+	if (rule.headersHash !== undefined) score++;
+	if (rule.userAgentHash !== undefined) score++;
+	if (rule.headHash !== undefined) score++;
+	if (rule.coords !== undefined) score++;
+	if (rule.countryCode !== undefined) score++;
+	if (rule.asn !== undefined) score++;
+	if (rule.os !== undefined) score++;
+	if (rule.numericIp !== undefined) score++;
+	if (rule.numericIpMaskMin !== undefined) score++;
+	return score;
+};
+
+// Sort by (specificity desc, block-first). Matches the ranking the old
+// FT.AGGREGATE `RANK_EXPR = (_spec * 2) + _sev` imposed server-side, so
+// callers that consume the reader directly see the same ordering.
+const sortByReaderRank = (rules: AccessRule[]): AccessRule[] =>
+	[...rules].sort((a, b) => {
+		const specDelta = readerSpecificity(b) - readerSpecificity(a);
+		if (specDelta !== 0) return specDelta;
+		const aBlock = a.type === AccessPolicyType.Block ? 1 : 0;
+		const bBlock = b.type === AccessPolicyType.Block ? 1 : 0;
+		return bBlock - aBlock;
+	});
+
 export class RedisRulesReader implements AccessRulesReader {
 	constructor(
 		private readonly client: RedisClientType,
@@ -190,27 +223,24 @@ export class RedisRulesReader implements AccessRulesReader {
 			return [];
 		}
 
-		// Hot path (checkForHardBlock / blockMiddleware): the strict-match
-		// caller passes blockOnly + a userScope, and every field returned
-		// gets JS-side re-ranked by rankCandidateRules anyway. Route it
-		// through the split-query path — one FT probe per populated
-		// request field, each using its own posting list — instead of the
-		// single wide FT.AGGREGATE whose APPLY step scaled linearly in
-		// the tenant's total rule count and tipped over under large
-		// bulk-ban populations.
-		if (
-			matchingFieldsOnly &&
-			filter.blockOnly &&
-			filter.userScope !== undefined
-		) {
-			return this.findBlockRulesSplit(filter);
-		}
-
-		// Non-hot-path matchingFieldsOnly (e.g. Restrict-only lookups):
-		// keep the pre-existing server-side-ranked single query. Not on
-		// the hot path so the APPLY overhead is acceptable.
-		if (matchingFieldsOnly) {
-			return this.findRulesRanked(filter, query);
+		// Hot path (all strict-match lookups): route every
+		// matchingFieldsOnly caller through the split-query path — one FT
+		// probe per populated request field, each using its own posting
+		// list — instead of the single wide FT.AGGREGATE. `blockOnly`
+		// narrows the sub-queries to `@type:{block}` for the hard-block
+		// middleware; every other caller (frictionless access-policy
+		// lookup, verify-time hard-block re-check) fetches both Block
+		// and Restrict rules and lets `rankCandidateRules` pick.
+		//
+		// The previous FT.AGGREGATE ranker used for the non-block path
+		// silently dropped specific-IP Restrict rules from the top-N
+		// when many higher-specificity irrelevant rules matched the
+		// greedy `ismissing(@field)` disjunction — the union-of-probes
+		// shape here can't hit that failure mode because each probe
+		// only returns rules where the probed field is actually
+		// populated with the request's value.
+		if (matchingFieldsOnly && filter.userScope !== undefined) {
+			return this.findRulesSplit(filter);
 		}
 
 		// Admin / internal callers (greedy mode): keep the FT.SEARCH +
@@ -225,7 +255,11 @@ export class RedisRulesReader implements AccessRulesReader {
 	// strict "every populated rule field matches request" semantics —
 	// FT can't express that shape cheaply and the previous server-side
 	// APPLY / SORTBY imposed the linear-per-rule cost we're eliminating.
-	private async findBlockRulesSplit(
+	//
+	// Handles both blockOnly (hard-block middleware) and non-blockOnly
+	// (frictionless access-policy lookup) callers via the `blockOnly`
+	// flag on the sub-query builder.
+	private async findRulesSplit(
 		filter: AccessRulesFilter,
 	): Promise<AccessRule[]> {
 		const userScope = filter.userScope;
@@ -234,7 +268,9 @@ export class RedisRulesReader implements AccessRulesReader {
 		}
 		const clientId = filter.policyScope?.clientId;
 
-		const subQueries = buildScopedBlockSubQueries(userScope, clientId);
+		const subQueries = buildScopedRulesSubQueries(userScope, clientId, {
+			...(filter.blockOnly === true && { blockOnly: true }),
+		});
 
 		try {
 			const keyLists = await Promise.all(
@@ -263,7 +299,7 @@ export class RedisRulesReader implements AccessRulesReader {
 									{ depth: null },
 								),
 							},
-							msg: "failed to execute split block sub-query",
+							msg: "failed to execute split rule sub-query",
 						}));
 						return [];
 					}),
@@ -284,7 +320,7 @@ export class RedisRulesReader implements AccessRulesReader {
 			const ruleKeys = [...uniqueKeys];
 
 			this.logger.debug(() => ({
-				msg: "Executed split block sub-queries",
+				msg: "Executed split rule sub-queries",
 				data: {
 					inspect: util.inspect(
 						{
@@ -311,14 +347,28 @@ export class RedisRulesReader implements AccessRulesReader {
 				(record) => Object.keys(record).length > 0,
 			);
 
-			return parseRedisRecords(nonEmptyRecords, accessRuleInput, this.logger);
+			const parsedRules = parseRedisRecords(
+				nonEmptyRecords,
+				accessRuleInput,
+				this.logger,
+			);
+
+			// Preserve the reader-level (specificity desc, block-first)
+			// ordering the old FT.AGGREGATE ranker gave. Split sub-queries
+			// return keys per-probe (i.e. in insertion order), so without
+			// this sort the caller sees candidates in a shape the previous
+			// implementation never returned. Downstream callers
+			// (`rankCandidateRules` in the provider) do a full re-sort, so
+			// this is purely a defence against silent behaviour changes
+			// for anyone else that consumes the reader directly.
+			return sortByReaderRank(parsedRules);
 		} catch (e) {
 			this.logger.error(() => ({
 				err: e,
 				data: {
 					inspect: util.inspect({ filter }, { depth: null }),
 				},
-				msg: "failed to execute split block query set",
+				msg: "failed to execute split rule query set",
 			}));
 			return [];
 		}

--- a/packages/user-access-policy/src/redis/reader/redisRulesSplitQuery.ts
+++ b/packages/user-access-policy/src/redis/reader/redisRulesSplitQuery.ts
@@ -93,7 +93,7 @@ type SubQuery = {
 
 /**
  * Build the set of FT sub-queries that together cover every rule that
- * could apply to a request for hard-block resolution.
+ * could apply to a request.
  *
  * The single-query design this replaces produced one FT.AGGREGATE whose
  * candidate set was the entire scope's rule pool — the APPLY / SORTBY
@@ -105,19 +105,32 @@ type SubQuery = {
  * instead of forcing a full-set scan.
  *
  * A single fall-through probe covers rules with no user-scope constraint
- * (client-wide block); those are rare so the ismissing()-heavy query is
- * cheap in practice.
+ * (client-wide restriction); those are rare so the ismissing()-heavy
+ * query is cheap in practice.
  *
  * Rank + strict-match filtering happens in JS via `rankCandidateRules`
  * after the union — the FT layer is used purely as a candidate fetcher.
+ *
+ * `blockOnly` narrows the candidate set to rules with `type:{block}` —
+ * used by the hard-block middleware which never needs Restrict rules.
+ * Every other caller passes false so both Block and Restrict rules are
+ * fetched; the JS-side ranker picks the right one via specificity +
+ * severity. Merging the block and restrict paths behind one split-query
+ * fixed the Twickets IP-rule regression: the previous FT.AGGREGATE ranker
+ * used for non-block lookups was truncating specific-IP restrict rules
+ * out of the top-N when many higher-specificity irrelevant rules matched
+ * the greedy `ismissing()` disjunction.
  */
-export const buildScopedBlockSubQueries = (
+export const buildScopedRulesSubQueries = (
 	userScope: UserScope,
 	clientId: string | undefined,
+	options: { blockOnly?: boolean } = {},
 ): SubQuery[] => {
-	const typeClause = `@type:{${AccessPolicyType.Block}}`;
+	const typeClause = options.blockOnly
+		? `@type:{${AccessPolicyType.Block}} `
+		: "";
 	const scopeClause = buildScopeClause(clientId);
-	const prefix = `${typeClause} ${scopeClause}`;
+	const prefix = `${typeClause}${scopeClause}`;
 
 	const subQueries: SubQuery[] = [];
 
@@ -168,3 +181,15 @@ export const buildScopedBlockSubQueries = (
 
 	return subQueries;
 };
+
+/**
+ * Backwards-compatible alias for the previous block-only builder. New
+ * callers should use `buildScopedRulesSubQueries` directly.
+ *
+ * @deprecated use `buildScopedRulesSubQueries(..., { blockOnly: true })`
+ */
+export const buildScopedBlockSubQueries = (
+	userScope: UserScope,
+	clientId: string | undefined,
+): SubQuery[] =>
+	buildScopedRulesSubQueries(userScope, clientId, { blockOnly: true });

--- a/packages/user-access-policy/src/tests/redis/reader/redisRulesSplitQuery.unit.test.ts
+++ b/packages/user-access-policy/src/tests/redis/reader/redisRulesSplitQuery.unit.test.ts
@@ -13,7 +13,10 @@
 // limitations under the License.
 
 import { describe, expect, it } from "vitest";
-import { buildScopedBlockSubQueries } from "#policy/redis/reader/redisRulesSplitQuery.js";
+import {
+	buildScopedBlockSubQueries,
+	buildScopedRulesSubQueries,
+} from "#policy/redis/reader/redisRulesSplitQuery.js";
 
 describe("buildScopedBlockSubQueries", () => {
 	it("emits one sub-query per populated user-scope field", () => {
@@ -128,5 +131,77 @@ describe("buildScopedBlockSubQueries", () => {
 		// Coords hold JSON with brackets and commas — every one must be
 		// backslash-escaped or the TAG query silently returns no matches.
 		expect(coordsSub?.query).toContain("@coords:{\\[\\[\\[100\\,200\\]\\]\\]}");
+	});
+});
+
+describe("buildScopedRulesSubQueries", () => {
+	it("omits @type:{block} when blockOnly is not set", () => {
+		// The non-block path — used by the frictionless access-policy
+		// lookup — must not filter on rule type so both Block and
+		// Restrict rules are returned. JS-side rankCandidateRules then
+		// picks the right one via severity + specificity.
+		const subs = buildScopedRulesSubQueries(
+			{ numericIp: 1376899398n },
+			"client-A",
+		);
+
+		for (const sub of subs) {
+			expect(sub.query).not.toContain("@type:{block}");
+		}
+	});
+
+	it("includes @type:{block} when blockOnly is true", () => {
+		const subs = buildScopedRulesSubQueries(
+			{ numericIp: 1376899398n },
+			"client-A",
+			{ blockOnly: true },
+		);
+
+		for (const sub of subs) {
+			expect(sub.query).toContain("@type:{block}");
+		}
+	});
+
+	it("emits the same probe kinds regardless of blockOnly", () => {
+		// The probe set is driven by populated request scope, not by
+		// rule-type filter. blockOnly only narrows what each probe
+		// returns; the shape of the split stays identical.
+		const withoutBlock = buildScopedRulesSubQueries(
+			{ numericIp: 1376899398n, ja4Hash: "abc" },
+			"client-A",
+		);
+		const withBlock = buildScopedRulesSubQueries(
+			{ numericIp: 1376899398n, ja4Hash: "abc" },
+			"client-A",
+			{ blockOnly: true },
+		);
+
+		expect(withoutBlock.map((s) => s.kind).sort()).toEqual(
+			withBlock.map((s) => s.kind).sort(),
+		);
+	});
+
+	it("produces an ip-exact probe that hits the numericIp posting list", () => {
+		// This is the regression guard for the Twickets rule-lookup bug:
+		// a request with a specific IP must generate a probe that hits
+		// the @numericIp posting list, so a Restrict rule scoped only
+		// to `clientId + numericIp` is fetched even when the tenant has
+		// thousands of higher-specificity irrelevant rules on other
+		// scopes. The previous FT.AGGREGATE ranker capped candidates at
+		// top-20 by populated-field count and truncated the specific-IP
+		// rule below higher-specificity SUDDEN_VOLUME_INCREASE / SIMD
+		// rules that also matched the greedy `ismissing(@field)`
+		// disjunction.
+		const subs = buildScopedRulesSubQueries(
+			{ numericIp: 1376899398n },
+			"5EZVvsHMrKCFKp5NYNoTyDjTjetoVo1Z4UNNbTwJf1GfN6Xm",
+		);
+
+		const ipExact = subs.find((s) => s.kind === "ip:exact");
+		expect(ipExact).toBeDefined();
+		expect(ipExact?.query).toContain("@numericIp:[1376899398 1376899398]");
+		expect(ipExact?.query).toContain(
+			"@clientId:{5EZVvsHMrKCFKp5NYNoTyDjTjetoVo1Z4UNNbTwJf1GfN6Xm}",
+		);
 	});
 });

--- a/packages/user-access-policy/src/tests/redis/redisRulesReaderRank.benchmark.integration.test.ts
+++ b/packages/user-access-policy/src/tests/redis/redisRulesReaderRank.benchmark.integration.test.ts
@@ -247,9 +247,17 @@ describe("redisRulesReader ranked-path benchmark", () => {
 		expect(p99).toBeLessThan(P99_LATENCY_MS);
 	}, 120_000);
 
-	test("ranked findRules result size is bounded by SERVER_SIDE_RANK_TOP_N", async () => {
-		// Fully-populated request that should apply to many seeded rules
-		// — the new path must cap at SERVER_SIDE_RANK_TOP_N (20).
+	test("split findRules returns every applicable candidate (no server-side rank cap)", async () => {
+		// The old FT.AGGREGATE ranker capped candidates at
+		// SERVER_SIDE_RANK_TOP_N=20 which silently dropped
+		// specific-IP Restrict rules when a tenant had many
+		// higher-specificity irrelevant rules — the 2026-07-10
+		// Twickets regression. The split path per-probe uses
+		// discriminating posting lists, so each probe returns only
+		// rules that actually match the probed field. The union of
+		// all probes has no artificial size cap; the only bound is
+		// SPLIT_MAX_CANDIDATES_PER_SUB (500) per sub-query, which
+		// only fires on pathological rule-set shapes.
 		const { clientId, scope } = buildBenchmarkRequest(0);
 		const results = await reader.findRules(
 			{
@@ -260,7 +268,7 @@ describe("redisRulesReader ranked-path benchmark", () => {
 			},
 			true,
 		);
-		expect(results.length).toBeLessThanOrEqual(20);
+		// Must return something for a fully-populated request.
 		expect(results.length).toBeGreaterThan(0);
 	}, 60_000);
 

--- a/packages/user-access-policy/src/tests/redis/redisRulesStorage.integration.test.ts
+++ b/packages/user-access-policy/src/tests/redis/redisRulesStorage.integration.test.ts
@@ -1629,6 +1629,106 @@ describe("redisAccessRulesStorage", () => {
 				),
 			).toBe(true);
 		});
+
+		test("specific-IP Restrict rule survives when many higher-specificity irrelevant rules co-exist (2026-07-10 Twickets regression)", async () => {
+			// Regression guard for the 2026-07-10 Twickets incident: a
+			// portal-authored Restrict rule with scope
+			// `clientId + numericIp` (specificity 2, severity 0) was
+			// silently dropped from the frictionless access-policy lookup
+			// when the tenant had many higher-specificity irrelevant
+			// rules on the same clientId. The old FT.AGGREGATE ranker
+			// used for non-block lookups capped candidates at top-20 by
+			// populated-field count; those 20 slots got filled by rules
+			// with clientId + numericIp + numericIpMaskMin (SIMD_REPLAY
+			// v6 shape, specificity 3, severity 1) or
+			// clientId + ja4Hash + coords (SUDDEN_VOLUME_INCREASE shape,
+			// specificity 3, severity 1) that all matched the greedy
+			// `ismissing(@headHash) | ismissing(@coords) | ismissing(@headersHash)`
+			// disjunction. None of them applied to the request under
+			// `ruleApplies` — they were emitted from other users'
+			// activity — so the JS-side ranker returned [] and the
+			// frictionless decision fell through to `default_pow`.
+			//
+			// The split-query path can't hit that failure: each probe
+			// hits a discriminating posting list, so the ip:exact probe
+			// returns exactly the rules that literally match this IP.
+			const clientId = getUniqueString();
+
+			// The rule that must survive: a portal "Too Many Requests"
+			// Restrict/image rule scoped only to (clientId, numericIp).
+			const targetIp = 1376899398n; // 82.17.209.70 — Twickets rule
+			const targetRule: AccessRule = {
+				type: AccessPolicyType.Restrict,
+				clientId,
+				numericIp: targetIp,
+				description: "Too Many Requests",
+			};
+
+			// 40 irrelevant Block rules with higher specificity than
+			// the target rule. Two shapes drawn from the live Twickets
+			// tenant that dominated the top-20:
+			//
+			//   (a) SIMD_REPLAY v6-style — clientId + numericIp +
+			//       numericIpMaskMin. These have a *different* numericIp
+			//       from the request, so the exact-IP probe skips them.
+			//   (b) SUDDEN_VOLUME_INCREASE-style — clientId + ja4Hash +
+			//       coords. Different ja4Hash from the request so those
+			//       probes miss them too.
+			//
+			// Under the old ranker every one of these would fill the top
+			// slots and push the target rule off the end.
+			const irrelevantRules: AccessRule[] = [];
+			for (let i = 0; i < 20; i++) {
+				irrelevantRules.push({
+					type: AccessPolicyType.Block,
+					clientId,
+					numericIp: BigInt(2000000000 + i),
+					numericIpMaskMin: BigInt(2000000000 + i),
+					numericIpMaskMax: BigInt(2000000000 + i),
+					description: "SIMD_REPLAY",
+				});
+			}
+			for (let i = 0; i < 20; i++) {
+				irrelevantRules.push({
+					type: AccessPolicyType.Block,
+					clientId,
+					ja4Hash: `t13d_other_${i}`,
+					coords: `[[[${100 + i},${200 + i}]]]`,
+					description: "SUDDEN_VOLUME_INCREASE",
+				});
+			}
+
+			await insertRules([targetRule, ...irrelevantRules]);
+
+			// Frictionless access-policy lookup shape — greedy match,
+			// matchingFieldsOnly=true, no blockOnly.
+			const found = await accessRulesReader.findRules(
+				{
+					policyScope: { clientId },
+					policyScopeMatch: FilterScopeMatch.Greedy,
+					userScope: {
+						numericIp: targetIp,
+						ja4Hash: "t13d1516h2_request_ja4",
+						userAgentHash: "sha256:request_ua",
+						userId: getUniqueString(),
+					},
+					userScopeMatch: FilterScopeMatch.Greedy,
+				},
+				true, // matchingFieldsOnly — production hot path
+			);
+
+			// The target rule MUST come back. Under the old ranker it
+			// was truncated; under the split path the ip:exact probe
+			// returns exactly this one rule, so it can't be crowded
+			// out by irrelevant candidates from other probes.
+			const targetFound = found.find(
+				(r) =>
+					r.type === AccessPolicyType.Restrict &&
+					r.numericIp === targetIp &&
+					r.description === "Too Many Requests",
+			);
+			expect(targetFound).toBeDefined();
+		});
 	});
 
 	afterAll(async () => {


### PR DESCRIPTION
## Summary

Root cause and fix for the 2026-07-10 regression where a Restrict/image rule was silently dropped from the frictionless access-policy lookup even though the rule was correctly stored in Redis and indexed on all 10 pronodes. The DM fell through to `default_pow` and served POW instead of the configured image challenge.

## Test plan

- [x] `test:unit` — 75 passed
- [x] `test:integration` — 45 passed (including new Twickets regression test)
- [x] `redisRulesReaderRank.benchmark.integration` — 4 passed
- [x] `redisRulesReaderLoad.benchmark.integration` — 6 passed
- [x] `@prosopo/provider test:unit` — 944 passed
- [ ] Hotfix image built locally and deployed to pronodes for live confirmation

🤖 Generated with [Claude Code](https://claude.com/claude-code)