### PR TITLE
feat(provider): treat Restrict + deferToVerify:true as a verify-time hard block

### DIFF
--- a/.changeset/restrict-defer-to-verify.md
+++ b/.changeset/restrict-defer-to-verify.md
@@ -1,0 +1,20 @@
+---
+"@prosopo/provider": patch
+---
+
+feat(provider): support `deferToVerify: true` on Restrict rules — serve the challenge, fail at verify
+
+Extends `findHardBlockPolicy` in `captchaManager.ts` so that a Restrict rule with `deferToVerify: true` is treated as a hard-block at verify time.
+
+Behaviour:
+
+- **Frictionless**: the Restrict rule fires as normal — the client is served the configured `captchaType` and `solvedImagesCount` (e.g. `image` / 8 rounds). Compute burden of the challenge is imposed on the caller.
+- **Verify**: `checkForHardBlock` matches the same rule and marks the commitment `Disapproved` with `ACCESS_POLICY_BLOCK`, so the dApp's `verify()` returns `{verified: false}` regardless of whether the client's solution was correct.
+
+Motivation: PROXY_POOL_TLS_NARROW targets solving-farm-backed residential proxy pools that solve image captchas at ~100% (they use human solvers), so we can't stop them by demanding correctness — only by wasting their compute. The existing Restrict/image/8-rounds shape imposes the cost but still lets them through if they solve. Layering `deferToVerify: true` closes that loop: they burn 8 image rounds per session AND fail verify.
+
+Test coverage updated in `captchaManager.unit.test.ts`:
+
+- Restrict + deferToVerify → returns the policy (new behaviour).
+- Restrict without deferToVerify → returns undefined (routing rule, unchanged).
+- All existing Block cases (Block+deferToVerify, Block+no-captchaType, Block+captchaType-without-defer) continue to behave as before.

--- a/packages/provider/src/tasks/captchaManager.ts
+++ b/packages/provider/src/tasks/captchaManager.ts
@@ -62,25 +62,33 @@ import {
 /**
  * Finds a hard block policy from access policies.
  *
- * A hard block is a Block policy that either (a) has no captchaType (the
- * historical "block all challenge types" case) or (b) has the
- * `deferToVerify` flag set. The deferred case is also caught here so a
- * Block policy that opted out of the request-time middleware still
- * disapproves the commitment at verify and the dApp's verify call returns
- * `{verified:false}`.
+ * A hard block is either:
+ *   (a) A Block policy with no captchaType (the historical "block all
+ *       challenge types" case).
+ *   (b) A Block policy with `deferToVerify: true` — request-time
+ *       middleware skips these, so verify-time is the only place they
+ *       can reject the commitment.
+ *   (c) A Restrict policy with `deferToVerify: true` — the frictionless
+ *       flow serves the rule's captchaType/solvedImagesCount normally
+ *       (imposing the compute burden of the challenge), then verify
+ *       marks the commitment disapproved regardless of solve outcome.
+ *       Used by PROXY_POOL_TLS_NARROW to force a solving farm to burn
+ *       8 image rounds per session while still failing verify — bots
+ *       solve at 100% so we can't stop them by demanding correctness,
+ *       only by wasting their compute.
  *
- * Policies with captchaType (but without deferToVerify) are still routing
- * rules, not hard blocks — they pick which challenge type to serve, not
- * whether to reject.
+ * Policies with captchaType and without `deferToVerify` are pure routing
+ * rules — they pick which challenge type to serve, not whether to reject.
  */
 const findHardBlockPolicy = (
 	accessPolicies: AccessPolicy[],
 ): AccessPolicy | undefined => {
-	return accessPolicies.find(
-		(policy) =>
-			policy.type === AccessPolicyType.Block &&
-			(policy.deferToVerify || !policy.captchaType),
-	);
+	return accessPolicies.find((policy) => {
+		if (policy.deferToVerify === true) {
+			return true;
+		}
+		return policy.type === AccessPolicyType.Block && !policy.captchaType;
+	});
 };
 
 export class CaptchaManager {

--- a/packages/provider/src/tests/unit/tasks/captchaManager.unit.test.ts
+++ b/packages/provider/src/tests/unit/tasks/captchaManager.unit.test.ts
@@ -1282,20 +1282,48 @@ describe("CaptchaManager", () => {
 			expect(result).toEqual(deferBlockNoType);
 		});
 
-		// Restrict + deferToVerify is non-sensical for hard-block purposes
-		// (deferToVerify on Restrict has its own meaning at middleware
-		// time, see blacklistRequestInspector tests). The hard-block
-		// matcher must stay Block-only — accidentally letting a Restrict
-		// pass through here would deny-list any restrict-throttled user.
-		it("should return undefined for Restrict + deferToVerify (hard block is Block-only)", async () => {
+		// Restrict + deferToVerify: the frictionless flow serves the
+		// rule's captchaType (image / N rounds) as normal — imposing the
+		// compute burden — and verify hard-blocks regardless of solve
+		// outcome. Used by PROXY_POOL_TLS_NARROW to force a solving farm
+		// to burn N image rounds per session while still failing verify.
+		// Bots solve at 100%, so correctness gating doesn't stop them —
+		// wasting their compute does.
+		it("should return the policy for Restrict + deferToVerify=true (verify-time hard block after serving captcha)", async () => {
 			const restrictDefer: AccessPolicy = {
 				type: AccessPolicyType.Restrict,
+				captchaType: CaptchaType.image,
+				solvedImagesCount: 8,
 				deferToVerify: true,
 			};
 			vi.spyOn(
 				captchaManager,
 				"getPrioritisedAccessPolicies",
 			).mockResolvedValue([restrictDefer]);
+
+			const result = await captchaManager.checkForHardBlock(
+				{} as AccessRulesStorage,
+				mockChallengeRecord,
+				"userAccount",
+				mockHeaders,
+			);
+			expect(result).toEqual(restrictDefer);
+		});
+
+		// Restrict rules WITHOUT deferToVerify are pure routing rules —
+		// they pick which challenge type to serve, not whether to reject.
+		// The hard-block matcher must NOT return them, or every
+		// image-throttled user would be denied outright.
+		it("should return undefined for Restrict without deferToVerify (routing rules are not hard blocks)", async () => {
+			const restrictRoute: AccessPolicy = {
+				type: AccessPolicyType.Restrict,
+				captchaType: CaptchaType.image,
+				solvedImagesCount: 4,
+			};
+			vi.spyOn(
+				captchaManager,
+				"getPrioritisedAccessPolicies",
+			).mockResolvedValue([restrictRoute]);
 
 			const result = await captchaManager.checkForHardBlock(
 				{} as AccessRulesStorage,


### PR DESCRIPTION
## Summary

Extends \`findHardBlockPolicy\` in \`captchaManager.ts\` so that a **Restrict rule with \`deferToVerify: true\`** is treated as a verify-time hard block.

### Behaviour

- **Frictionless**: rule fires as normal — client is served the configured \`captchaType\` / \`solvedImagesCount\` (e.g. \`image\` / 8 rounds). Compute burden imposed.
- **Verify**: \`checkForHardBlock\` picks up the same rule, marks the commitment \`Disapproved\` with \`ACCESS_POLICY_BLOCK\`, dApp's \`verify()\` returns \`{verified: false}\` regardless of solve correctness.

## Motivation

PROXY_POOL_TLS_NARROW targets solving-farm-backed residential proxy pools that solve image captchas at ~100% because they use human solvers. Correctness gating doesn't stop them — wasting their compute does. Today's Restrict/image/8-rounds shape imposes the cost but still lets them through if they solve. Layering \`deferToVerify: true\` closes that loop: 8 image rounds per session AND verify fails.

Live baseline (24h on Twickets, current behaviour): 44 sessions across 9 IPs on the PROXY_POOL_TLS_NARROW rule, 38% pass rate on finished sessions. With this PR the pass rate on same-shape traffic drops to 0% while compute cost stays at 8 rounds per attempt.

## Compatibility

Fully backwards compatible. Restrict rules without \`deferToVerify\` remain pure routing rules — they pick the challenge type, they don't reject. Only rules that opt in via \`deferToVerify: true\` change behaviour.

## Test plan

- [x] \`checkForHardBlock\` unit tests updated:
  - Restrict + deferToVerify → returns policy (new)
  - Restrict without deferToVerify → returns undefined (unchanged)
  - Block + deferToVerify (with or without captchaType) → still returns policy (unchanged)
  - Block + captchaType without deferToVerify → still returns undefined (unchanged)
- [x] All 945 provider unit tests pass
- [ ] Deploy → verify PROXY_POOL_TLS_NARROW rules cause verify-time disapproval once the paired captcha-private detector change ships

🤖 Generated with [Claude Code](https://claude.com/claude-code)