### PR TITLE
fix(provider): computeDnsAsymmetry respects traffic filter

### DIFF
--- a/.changeset/dns-asymmetry-respect-traffic-filter.md
+++ b/.changeset/dns-asymmetry-respect-traffic-filter.md
@@ -1,0 +1,38 @@
+---
+"@prosopo/provider": patch
+---
+
+fix(provider): `computeDnsAsymmetry` respects the site's traffic filter
+
+The DNS-path scorer previously counted `isDatacenter` and `isAbuser` on the
+resolver / peer IPs unconditionally, so a site with `blockDatacenter=off`,
+`blockVpn=off` (or any of the other category toggles off), or an entry in
+`datacenterNameAllowlist` on the client side could still get a datacenter
+penalty on the DNS side. The client-side `evaluateIpInfo` has honoured
+these knobs for a while — the DNS-side scorer just never got the update.
+
+Changes:
+
+- `computeDnsAsymmetry` now accepts an optional
+  `trafficFilter?: Partial<ITrafficFilter>` and gates its `isDatacenter` /
+  `isAbuser` contributions on the same rules `evaluateIpInfo` uses:
+  `blockDatacenter` opt-in, `providerType !== "isp"` short-circuit,
+  `datacenterNameAllowlist`, `blockAbuser` + `abuserScoreThreshold`.
+- Cross-category suppression mirrored: VPN / proxy / Tor / crawler IPs that
+  also carry `isDatacenter=true` are not counted as datacenter when the
+  operator has left the more specific category unblocked.
+- `pathValid=false` remains unconditional — it's a protocol signal, not a
+  category.
+- `trafficFilter` is threaded through `powTasks`, `imgCaptchaTasks`, and
+  `puzzleTasks`. The admin recompute endpoint (`apiDnsEventEndpoint`)
+  intentionally stays raw with a comment explaining why: diagnostic
+  recompute should not depend on the site's current filter config.
+- `isDatacenterAllowlisted` is exported from `checkTrafficFilter.ts` so
+  `enrichDnsEvent` reuses the same matching rules.
+- When `trafficFilter` is omitted (admin path), the pre-existing scoring
+  behaviour is preserved.
+
+Unit tests cover cross-category suppression for all four categories,
+`blockDatacenter=off`, `providerType==="isp"`, name allowlist,
+`blockAbuser=off`, abuser-score threshold, `pathValid=false` still firing,
+client-ISP compound suppression, and the legacy no-trafficFilter path.

--- a/packages/provider/src/api/admin/apiDnsEventEndpoint.ts
+++ b/packages/provider/src/api/admin/apiDnsEventEndpoint.ts
@@ -119,6 +119,10 @@ class ApiDnsEventEndpoint implements ApiEndpoint<DnsEventBatchSchemaType> {
 				this.ipInfoService,
 				session.ipInfo?.ip,
 			);
+			// Admin recompute path — intentionally omits trafficFilter so the
+			// stored score reflects the raw DNS-path signal, independent of the
+			// site's current filter config. Live captcha decisions pass
+			// trafficFilter (see powTasks / imgCaptchaTasks / puzzleTasks).
 			const dnsAsymmetry = computeDnsAsymmetry(enriched, session.ipInfo);
 			if (dnsAsymmetry > 0) {
 				await this.db.updateSessionRecord(sessionId, {

--- a/packages/provider/src/tasks/dnsEvent/enrichDnsEvent.ts
+++ b/packages/provider/src/tasks/dnsEvent/enrichDnsEvent.ts
@@ -13,7 +13,14 @@
 // limitations under the License.
 
 import type { IIpInfoService } from "@prosopo/ipinfo";
-import type { EnrichedDnsEvent, IPInfoResponse, Session } from "@prosopo/types";
+import type {
+	EnrichedDnsEvent,
+	IPInfoResponse,
+	ITrafficFilter,
+	Session,
+} from "@prosopo/types";
+import { trafficFilterAbuserScoreThresholdDefault } from "@prosopo/types";
+import { isDatacenterAllowlisted } from "../spam/checkTrafficFilter.js";
 
 export type { EnrichedDnsEvent };
 
@@ -67,26 +74,78 @@ export const extraIpInfosFromEnrichedDnsEvent = (
 	return out;
 };
 
+/**
+ * Score the DNS path for asymmetry between the client's DNS resolver / peer
+ * IPs and its connection IP. The score sums four kinds of signal:
+ *
+ *   - `pathValid=false` (protocol-layer failure — always counted)
+ *   - resolver / peer classified `isDatacenter`
+ *   - resolver / peer classified `isAbuser`
+ *   - client IP is a consumer ISP but resolver is datacenter (compound)
+ *
+ * When `trafficFilter` is supplied, the datacenter and abuser contributions
+ * are gated on the same rules `checkTrafficFilter` uses for the client IP:
+ *
+ *   - `blockDatacenter` must be opted in (default off); IPs whose
+ *     `providerType === "isp"` short-circuit; named allowlist skips
+ *   - `blockAbuser` opt-in (default on) with the abuser-score threshold
+ *   - cross-category suppression: VPN / proxy / Tor / crawler IPs that also
+ *     carry `isDatacenter=true` are NOT counted as datacenter when the
+ *     operator hasn't opted into blocking that more specific category —
+ *     mirrors the `datacenterSuppressedByCategory` rule in evaluateIpInfo.
+ *
+ * `pathValid` is a protocol signal, not a category — it always contributes
+ * regardless of trafficFilter. When `trafficFilter` is omitted, all
+ * datacenter / abuser flags count (preserves the pre-gating behaviour for
+ * admin / diagnostic recompute callers).
+ */
 export const computeDnsAsymmetry = (
 	enriched: EnrichedDnsEvent | undefined,
 	clientIpInfo: IPInfoResponse | undefined,
+	trafficFilter?: Partial<ITrafficFilter>,
 ): number => {
 	if (!enriched) return 0;
 	let score = 0;
 	if (enriched.pathValid === false) score += 0.3;
-	if (enriched.resolverIpInfo?.isValid) {
-		if (enriched.resolverIpInfo.isDatacenter) score += 0.3;
-		if (enriched.resolverIpInfo.isAbuser) score += 0.2;
-	}
-	if (enriched.peerIpInfo?.isValid) {
-		if (enriched.peerIpInfo.isDatacenter) score += 0.2;
-		if (enriched.peerIpInfo.isAbuser) score += 0.2;
-	}
+
+	const countDc = (ip: IPInfoResponse | undefined): boolean => {
+		if (!ip?.isValid || !ip.isDatacenter) return false;
+		if (!trafficFilter) return true;
+		// Cross-category suppression: don't penalise datacenter classification
+		// when the operator has left the more specific category unblocked.
+		if (
+			(ip.isVPN && trafficFilter.blockVpn !== true) ||
+			(ip.isProxy && trafficFilter.blockProxy !== true) ||
+			(ip.isTor && trafficFilter.blockTor !== true) ||
+			(ip.isCrawler && trafficFilter.blockCrawler !== true)
+		) {
+			return false;
+		}
+		if (trafficFilter.blockDatacenter !== true) return false;
+		if (ip.providerType === "isp") return false;
+		return !isDatacenterAllowlisted(ip, trafficFilter.datacenterNameAllowlist);
+	};
+
+	const countAbuser = (ip: IPInfoResponse | undefined): boolean => {
+		if (!ip?.isValid || !ip.isAbuser) return false;
+		if (!trafficFilter) return true;
+		if (trafficFilter.blockAbuser === false) return false;
+		const threshold =
+			trafficFilter.abuserScoreThreshold ??
+			trafficFilterAbuserScoreThresholdDefault;
+		const maxScore = Math.max(ip.abuserScore ?? 0, ip.companyAbuserScore ?? 0);
+		return maxScore >= threshold;
+	};
+
+	if (countDc(enriched.resolverIpInfo)) score += 0.3;
+	if (countAbuser(enriched.resolverIpInfo)) score += 0.2;
+	if (countDc(enriched.peerIpInfo)) score += 0.2;
+	if (countAbuser(enriched.peerIpInfo)) score += 0.2;
+
 	if (
 		clientIpInfo?.isValid &&
 		clientIpInfo.providerType === "isp" &&
-		enriched.resolverIpInfo?.isValid &&
-		enriched.resolverIpInfo.isDatacenter
+		countDc(enriched.resolverIpInfo)
 	) {
 		score += 0.2;
 	}

--- a/packages/provider/src/tasks/imgCaptcha/imgCaptchaTasks.ts
+++ b/packages/provider/src/tasks/imgCaptcha/imgCaptchaTasks.ts
@@ -927,6 +927,7 @@ export class ImgCaptchaManager extends CaptchaManager {
 			const dnsAsymmetry = computeDnsAsymmetry(
 				enrichedDnsEvent,
 				solution.ipInfo,
+				trafficFilter,
 			);
 			if (dnsAsymmetry > 0) {
 				sessionRecord.scoreComponents = {

--- a/packages/provider/src/tasks/powCaptcha/powTasks.ts
+++ b/packages/provider/src/tasks/powCaptcha/powTasks.ts
@@ -850,6 +850,7 @@ export class PowCaptchaManager extends CaptchaManager {
 			const dnsAsymmetry = computeDnsAsymmetry(
 				enrichedDnsEvent,
 				challengeRecord.ipInfo,
+				trafficFilter,
 			);
 			if (dnsAsymmetry > 0) {
 				sessionRecord.scoreComponents = {

--- a/packages/provider/src/tasks/puzzleCaptcha/puzzleTasks.ts
+++ b/packages/provider/src/tasks/puzzleCaptcha/puzzleTasks.ts
@@ -690,6 +690,7 @@ export class PuzzleCaptchaManager extends CaptchaManager {
 			const dnsAsymmetry = computeDnsAsymmetry(
 				enrichedDnsEvent,
 				challengeRecord.ipInfo,
+				trafficFilter,
 			);
 			if (dnsAsymmetry > 0) {
 				sessionRecord.scoreComponents = {

--- a/packages/provider/src/tasks/spam/checkTrafficFilter.ts
+++ b/packages/provider/src/tasks/spam/checkTrafficFilter.ts
@@ -40,7 +40,7 @@ export type TrafficCheckResult =
 // curated named ranges, so falling back to providerName and asnOrganization
 // lets the allowlist also catch generic CDN / cloud-provider IPs that come
 // back with `is_datacenter: true` but no datacenter name.
-const isDatacenterAllowlisted = (
+export const isDatacenterAllowlisted = (
 	ipInfo: IPInfoResult,
 	allowlist: ReadonlyArray<string> | undefined,
 ): boolean => {

--- a/packages/provider/src/tests/unit/tasks/dnsEvent/enrichDnsEvent.unit.test.ts
+++ b/packages/provider/src/tests/unit/tasks/dnsEvent/enrichDnsEvent.unit.test.ts
@@ -13,9 +13,15 @@
 // limitations under the License.
 
 import type { IIpInfoService } from "@prosopo/ipinfo";
-import type { IPInfoResponse, Session } from "@prosopo/types";
+import type {
+	EnrichedDnsEvent,
+	IPInfoResponse,
+	ITrafficFilter,
+	Session,
+} from "@prosopo/types";
 import { describe, expect, it, vi } from "vitest";
 import {
+	computeDnsAsymmetry,
 	enrichDnsEvent,
 	extraIpInfosFromEnrichedDnsEvent,
 } from "../../../../tasks/dnsEvent/enrichDnsEvent.js";
@@ -121,6 +127,249 @@ describe("enrichDnsEvent", () => {
 			"1.2.3.4",
 		);
 		expect(result?.peerIpInfo).toBeUndefined();
+	});
+});
+
+describe("computeDnsAsymmetry", () => {
+	const enrichedWith = (
+		overrides: Partial<EnrichedDnsEvent>,
+	): EnrichedDnsEvent => ({
+		peerIp: undefined,
+		resolverIp: undefined,
+		pathValid: true,
+		...overrides,
+	});
+
+	// A resolver/peer IP that ipapi flags as datacenter+VPN — the common
+	// consumer-VPN case (e.g. CDN77, Datacamp, M247).
+	const dcVpn = (overrides: Partial<IPInfoResponse> = {}): IPInfoResponse =>
+		baseInfo({ isDatacenter: true, isVPN: true, ...overrides });
+
+	const filterAllowingVpn: Partial<ITrafficFilter> = {
+		blockVpn: false,
+		blockProxy: false,
+		blockTor: false,
+		blockCrawler: false,
+		blockDatacenter: true,
+		blockAbuser: true,
+	};
+
+	it("returns 0 when the enriched event is undefined", () => {
+		expect(computeDnsAsymmetry(undefined, undefined)).toBe(0);
+	});
+
+	it("adds 0.3 for pathValid=false regardless of trafficFilter", () => {
+		expect(
+			computeDnsAsymmetry(enrichedWith({ pathValid: false }), undefined),
+		).toBeCloseTo(0.3);
+		expect(
+			computeDnsAsymmetry(
+				enrichedWith({ pathValid: false }),
+				undefined,
+				filterAllowingVpn,
+			),
+		).toBeCloseTo(0.3);
+	});
+
+	describe("legacy path (no trafficFilter)", () => {
+		it("counts every datacenter and abuser flag on resolver + peer", () => {
+			const score = computeDnsAsymmetry(
+				enrichedWith({
+					resolverIpInfo: baseInfo({ isDatacenter: true, isAbuser: true }),
+					peerIpInfo: baseInfo({ isDatacenter: true, isAbuser: true }),
+				}),
+				undefined,
+			);
+			// 0.3 (resolver DC) + 0.2 (resolver abuser) + 0.2 (peer DC)
+			// + 0.2 (peer abuser) = 0.9
+			expect(score).toBeCloseTo(0.9);
+		});
+
+		it("adds the client-ISP + resolver-DC compound signal", () => {
+			const score = computeDnsAsymmetry(
+				enrichedWith({
+					resolverIpInfo: baseInfo({ isDatacenter: true }),
+				}),
+				baseInfo({ providerType: "isp" }),
+			);
+			// 0.3 (resolver DC) + 0.2 (client-ISP compound) = 0.5
+			expect(score).toBeCloseTo(0.5);
+		});
+
+		it("caps the score at 1", () => {
+			const score = computeDnsAsymmetry(
+				enrichedWith({
+					pathValid: false,
+					resolverIpInfo: baseInfo({ isDatacenter: true, isAbuser: true }),
+					peerIpInfo: baseInfo({ isDatacenter: true, isAbuser: true }),
+				}),
+				baseInfo({ providerType: "isp" }),
+			);
+			// 0.3 + 0.3 + 0.2 + 0.2 + 0.2 + 0.2 = 1.4 → capped at 1
+			expect(score).toBe(1);
+		});
+	});
+
+	describe("cross-category suppression", () => {
+		it("suppresses datacenter penalty when isVPN and blockVpn is off", () => {
+			const score = computeDnsAsymmetry(
+				enrichedWith({
+					resolverIpInfo: dcVpn(),
+					peerIpInfo: dcVpn(),
+				}),
+				undefined,
+				filterAllowingVpn,
+			);
+			expect(score).toBe(0);
+		});
+
+		it("keeps the datacenter penalty when isVPN but blockVpn is on", () => {
+			const score = computeDnsAsymmetry(
+				enrichedWith({ resolverIpInfo: dcVpn(), peerIpInfo: dcVpn() }),
+				undefined,
+				{ ...filterAllowingVpn, blockVpn: true },
+			);
+			expect(score).toBeCloseTo(0.5);
+		});
+
+		it("suppresses when isProxy and blockProxy off", () => {
+			const score = computeDnsAsymmetry(
+				enrichedWith({
+					resolverIpInfo: baseInfo({ isDatacenter: true, isProxy: true }),
+				}),
+				undefined,
+				filterAllowingVpn,
+			);
+			expect(score).toBe(0);
+		});
+
+		it("suppresses when isTor and blockTor off", () => {
+			const score = computeDnsAsymmetry(
+				enrichedWith({
+					resolverIpInfo: baseInfo({ isDatacenter: true, isTor: true }),
+				}),
+				undefined,
+				filterAllowingVpn,
+			);
+			expect(score).toBe(0);
+		});
+
+		it("suppresses when isCrawler and blockCrawler off", () => {
+			const score = computeDnsAsymmetry(
+				enrichedWith({
+					resolverIpInfo: baseInfo({ isDatacenter: true, isCrawler: true }),
+				}),
+				undefined,
+				filterAllowingVpn,
+			);
+			expect(score).toBe(0);
+		});
+
+		it("does not affect the client-ISP compound when resolver DC is suppressed", () => {
+			const score = computeDnsAsymmetry(
+				enrichedWith({ resolverIpInfo: dcVpn() }),
+				baseInfo({ providerType: "isp" }),
+				filterAllowingVpn,
+			);
+			// resolver DC suppressed by VPN → compound also 0
+			expect(score).toBe(0);
+		});
+	});
+
+	describe("datacenter gating", () => {
+		it("does not count datacenter when blockDatacenter is not opted in", () => {
+			const score = computeDnsAsymmetry(
+				enrichedWith({
+					resolverIpInfo: baseInfo({ isDatacenter: true }),
+					peerIpInfo: baseInfo({ isDatacenter: true }),
+				}),
+				undefined,
+				{ ...filterAllowingVpn, blockDatacenter: false },
+			);
+			expect(score).toBe(0);
+		});
+
+		it("short-circuits datacenter when providerType is isp", () => {
+			const score = computeDnsAsymmetry(
+				enrichedWith({
+					resolverIpInfo: baseInfo({
+						isDatacenter: true,
+						providerType: "isp",
+					}),
+					peerIpInfo: baseInfo({
+						isDatacenter: true,
+						providerType: "isp",
+					}),
+				}),
+				undefined,
+				filterAllowingVpn,
+			);
+			expect(score).toBe(0);
+		});
+
+		it("skips datacenter when the operator has allowlisted its name", () => {
+			const score = computeDnsAsymmetry(
+				enrichedWith({
+					resolverIpInfo: baseInfo({
+						isDatacenter: true,
+						datacenterName: "iCloud Private Relay",
+					}),
+					peerIpInfo: baseInfo({
+						isDatacenter: true,
+						providerName: "iCloud Private Relay",
+					}),
+				}),
+				undefined,
+				{
+					...filterAllowingVpn,
+					datacenterNameAllowlist: ["icloud private relay"],
+				},
+			);
+			expect(score).toBe(0);
+		});
+	});
+
+	describe("abuser gating", () => {
+		it("does not count abuser when blockAbuser is false", () => {
+			const score = computeDnsAsymmetry(
+				enrichedWith({
+					resolverIpInfo: baseInfo({ isAbuser: true, abuserScore: 1 }),
+					peerIpInfo: baseInfo({ isAbuser: true, abuserScore: 1 }),
+				}),
+				undefined,
+				{ ...filterAllowingVpn, blockAbuser: false },
+			);
+			expect(score).toBe(0);
+		});
+
+		it("does not count abuser when the score is below the threshold", () => {
+			const score = computeDnsAsymmetry(
+				enrichedWith({
+					resolverIpInfo: baseInfo({
+						isAbuser: true,
+						abuserScore: 0.02,
+						companyAbuserScore: 0.01,
+					}),
+				}),
+				undefined,
+				{ ...filterAllowingVpn, abuserScoreThreshold: 0.5 },
+			);
+			expect(score).toBe(0);
+		});
+
+		it("counts abuser when the score meets the threshold", () => {
+			const score = computeDnsAsymmetry(
+				enrichedWith({
+					resolverIpInfo: baseInfo({
+						isAbuser: true,
+						abuserScore: 0.6,
+					}),
+				}),
+				undefined,
+				{ ...filterAllowingVpn, abuserScoreThreshold: 0.5 },
+			);
+			expect(score).toBeCloseTo(0.2);
+		});
 	});
 });
 


### PR DESCRIPTION
## Summary
- `computeDnsAsymmetry` now accepts an optional `trafficFilter?: Partial<ITrafficFilter>` and gates its `isDatacenter` / `isAbuser` contributions on the same rules `evaluateIpInfo` already uses for the client IP.
- Includes the same cross-category suppression as `checkTrafficFilter`: VPN / proxy / Tor / crawler IPs that also carry `isDatacenter=true` are not counted as datacenter when the operator has left that more specific category unblocked.
- Threads `trafficFilter` through the three live verify paths (`powTasks`, `imgCaptchaTasks`, `puzzleTasks`). The admin recompute endpoint (`apiDnsEventEndpoint`) intentionally stays raw with a comment explaining why.
- Exports `isDatacenterAllowlisted` from `checkTrafficFilter.ts` so `enrichDnsEvent` reuses the same matching rules (`datacenterName`, `providerName`, `asnOrganization`, case-insensitive, whitespace-trimmed).

## Motivation
The DNS-path scorer was inconsistent with the client-side traffic filter. On a site with `blockDatacenter=off`, `blockVpn=off`, or an entry in `datacenterNameAllowlist`, the client IP passed `checkTrafficFilter` but the DNS-path IPs still incurred datacenter / abuser penalties in `computeDnsAsymmetry`. The `datacenterSuppressedByCategory` rule (see checkTrafficFilter.ts:103-117) and the `providerType === "isp"` short-circuit both existed only on the client side. This PR brings the two subsystems into agreement.

`pathValid=false` remains unconditional — it's a protocol-layer signal, not a category, so the operator's category toggles don't apply.

When `trafficFilter` is omitted (admin diagnostic recompute) the pre-existing scoring behaviour is preserved, so stored diagnostic scores stay independent of the site's current filter config.

## Test plan
- [x] `npm run -w @prosopo/provider build:tsc` clean
- [x] `npx biome check` on all changed files clean
- [x] `npx vitest run src/tests/unit/tasks/dnsEvent/enrichDnsEvent.unit.test.ts` → 24/24 pass
- [x] Neighbouring suites unaffected: `checkTrafficFilter` + `pow` + `img` + `puzzle` unit tests → 172/172 pass
- [x] New coverage: VPN / proxy / Tor / crawler cross-suppression, `blockDatacenter=off`, `providerType==="isp"`, allowlist match by `datacenterName` / `providerName`, `blockAbuser=off`, abuser-score threshold, `pathValid=false` still firing, client-ISP compound suppression, legacy no-trafficFilter path

🤖 Generated with [Claude Code](https://claude.com/claude-code)