### PR TITLE
test(account): unit tests for CryptoWorker + ExtensionWeb2 keypair-derivation paths

### DIFF
--- a/.changeset/account-crypto-worker-tests.md
+++ b/.changeset/account-crypto-worker-tests.md
@@ -1,0 +1,22 @@
+---
+"@prosopo/account": patch
+"@prosopo/cli": patch
+---
+
+test(account): unit tests for CryptoWorker + ExtensionWeb2 keypair-derivation paths
+
+Adds unit coverage for the code changed in the sr25519-in-worker perf PR (#2830):
+
+- `cryptoWorker.unit.test.ts` — exercises the primitives (`entropyToMnemonic`, `mnemonicToMiniSecret`, `sr25519FromSeed`) the CryptoWorker's task dispatch calls into, and asserts the composed `entropyToKeypair` pipeline produces:
+  - a keypair byte-equivalent (address + publicKey) to `keyring.addFromMnemonic(mnemonic)`
+  - signatures that verify cross-instance (`addFromPair`-derived sig verifies against `addFromMnemonic`'s public key, and vice-versa)
+  - deterministic output for identical entropy input
+  - proper input-validation rejection for non-BIP39 entropy sizes
+- `ExtensionWeb2.unit.test.ts` — mocks `getCryptoWorkerManager` + `getFingerprint` to lock down both branches of `createAccount`:
+  - **worker branch** — `entropyToKeypair` resolves with raw bytes, `addFromPair` produces the expected address
+  - **fallback branch** — `entropyToKeypair` rejects (worker unavailable), falls through to `entropyToMnemonic` + `addFromMnemonic` on main thread, produces the *same* address
+  - A/B check confirming worker and fallback branches derive identical addresses for the same fingerprint — the invariant that lets us swap the paths without breaking session identity for users whose worker fails
+
+Also wires up a `test` script and `vite.test.config.ts` in `@prosopo/account`, which had none previously.
+
+**cli patch**: sync bump so the release cuts a new tag (root version follows `@prosopo/cli`) and the tag-triggered `publish_release` + downstream `deploy-procaptcha-bundle` republishes the CDN bundle with the sr25519-in-worker perf improvements from #2830. Without this, the `test(account)` bump alone leaves cli at its current version, the release script computes the same root version as the previous tag, and no new `v*.*.*` tag → no publish → no CDN republish.

--- a/package-lock.json
+++ b/package-lock.json
@@ -38842,6 +38842,7 @@
 				"@vitest/coverage-v8": "3.2.4",
 				"concurrently": "9.0.1",
 				"del-cli": "6.0.0",
+				"dotenv": "16.4.5",
 				"npm-run-all": "4.1.5",
 				"tslib": "2.7.0",
 				"tsx": "4.20.3",
@@ -38862,6 +38863,19 @@
 			"license": "MIT",
 			"dependencies": {
 				"undici-types": "~6.20.0"
+			}
+		},
+		"packages/account/node_modules/dotenv": {
+			"version": "16.4.5",
+			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+			"integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://dotenvx.com"
 			}
 		},
 		"packages/api": {

--- a/packages/account/package.json
+++ b/packages/account/package.json
@@ -65,6 +65,7 @@
 		"@vitest/coverage-v8": "3.2.4",
 		"concurrently": "9.0.1",
 		"del-cli": "6.0.0",
+		"dotenv": "16.4.5",
 		"npm-run-all": "4.1.5",
 		"tslib": "2.7.0",
 		"tsx": "4.20.3",

--- a/packages/account/package.json
+++ b/packages/account/package.json
@@ -32,6 +32,7 @@
 		"build:cross-env": "vite build --config vite.esm.config.ts",
 		"build:tsc": "npm run typecheck && npm run build",
 		"build:cjs": "NODE_ENV=${NODE_ENV:-development}; vite build --config vite.cjs.config.ts --mode $NODE_ENV",
+		"test": "NODE_ENV=${NODE_ENV:-test}; npx vitest run --config ./vite.test.config.ts",
 		"typecheck": "tsc --project tsconfig.types.json"
 	},
 	"repository": {

--- a/packages/account/src/tests/ExtensionWeb2.unit.test.ts
+++ b/packages/account/src/tests/ExtensionWeb2.unit.test.ts
@@ -1,0 +1,172 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Tests for ExtensionWeb2.createAccount. The interesting behaviour to lock
+// down is the two-branch account-derivation path:
+//
+//   1. Worker branch (preferred): `workerManager.entropyToKeypair(...)` →
+//      `keyring.addFromPair({publicKey, secretKey})` — the sr25519 scalar-
+//      mul runs off the main thread, main thread just packages the bytes.
+//   2. Fallback branch: worker throws (CSP block, task timeout, etc.) →
+//      dynamic-import `entropyToMnemonic` → `keyring.addFromMnemonic(...)`
+//      on the main thread.
+//
+// Both branches must produce the same account address for a given fingerprint
+// or session identity breaks between the two paths — a repeat visitor whose
+// worker fails would look like a different user to the provider.
+
+import { stringToU8a } from "@polkadot/util";
+import { getFingerprint } from "@prosopo/fingerprint";
+import { Keyring } from "@prosopo/keyring";
+import { entropyToMnemonic, hexHash } from "@prosopo/util-crypto";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// vi.hoisted() makes these accessible from within vi.mock factories, which
+// run before the module's own imports at collection time.
+const mocks = vi.hoisted(() => {
+	const entropyToKeypair = vi.fn();
+	return {
+		entropyToKeypair,
+		getCryptoWorkerManager: vi.fn(() => ({
+			prewarm: vi.fn(),
+			entropyToKeypair,
+			entropyToMnemonic: vi.fn(),
+		})),
+	};
+});
+
+vi.mock("@prosopo/fingerprint", async (importOriginal) => {
+	const actual =
+		(await importOriginal()) as typeof import("@prosopo/fingerprint");
+	return {
+		...actual,
+		getFingerprint: vi.fn(),
+		prefetchFingerprint: vi.fn(),
+	};
+});
+
+vi.mock("../workers/CryptoWorkerManager.js", () => ({
+	getCryptoWorkerManager: mocks.getCryptoWorkerManager,
+	// Types re-exported at runtime aren't needed for the tests but keep the
+	// mock shape aligned with the module's actual named exports.
+	CryptoWorkerManager: class {},
+}));
+
+// Imported after mocks so the module picks up the mocked getFingerprint and
+// worker manager during its top-level side effects (prefetchFingerprint,
+// getCryptoWorkerManager().prewarm()).
+const { default: ExtensionWeb2 } = await import(
+	"../extension/ExtensionWeb2.js"
+);
+
+// Fixed browser-fingerprint hex the mocked getFingerprint always returns.
+// The real code hashes this to 128 bits, hex-encodes it, and passes the ASCII
+// hex bytes as entropy to the mnemonic derivation — so both branches under
+// test see the same input regardless of the underlying fingerprint.
+const FIXED_FINGERPRINT_HEX = "0x1234567890abcdef1234567890abcdef";
+
+// Config placeholder — ExtensionWeb2.createAccount ignores fields other than
+// what the fingerprint hash + keyring type need.
+const config = {
+	account: { address: "" },
+	web2: true,
+	defaultEnvironment: "test",
+} as unknown as Parameters<InstanceType<typeof ExtensionWeb2>["getAccount"]>[0];
+
+describe("ExtensionWeb2.createAccount", () => {
+	beforeEach(() => {
+		vi.mocked(getFingerprint).mockReset();
+		mocks.entropyToKeypair.mockReset();
+		vi.mocked(getFingerprint).mockResolvedValue(FIXED_FINGERPRINT_HEX);
+	});
+
+	it("worker branch: derives account from worker-returned keypair bytes", async () => {
+		// Compute the expected keypair the same way ExtensionWeb2 would — we
+		// need to feed the mock the exact bytes the worker would produce for
+		// this fingerprint, otherwise the reconstructed address won't match.
+		const entropyHex = hexHash(FIXED_FINGERPRINT_HEX, 128).slice(2);
+		const u8Entropy = stringToU8a(entropyHex);
+		const mnemonic = entropyToMnemonic(u8Entropy);
+		const keyring = new Keyring({ type: "sr25519" });
+		const expectedPair = keyring.addFromMnemonic(mnemonic);
+
+		mocks.entropyToKeypair.mockResolvedValue({
+			publicKey: expectedPair.publicKey,
+			secretKey:
+				// Fish the secret out of the reference pair — this is what the
+				// real CryptoWorker returns from sr25519FromSeed(seed).
+				(expectedPair as unknown as { secretKey: Uint8Array }).secretKey ??
+				new Uint8Array(64),
+			mnemonic,
+		});
+
+		const ext = new ExtensionWeb2();
+		const { account } = await ext.getAccount(config);
+
+		expect(mocks.entropyToKeypair).toHaveBeenCalledTimes(1);
+		// The worker got called with the entropy ExtensionWeb2 hashed from the
+		// fingerprint — verifies the argument-shaping code isn't broken.
+		const [entropyArg] = mocks.entropyToKeypair.mock.calls[0] ?? [];
+		expect(entropyArg).toBeInstanceOf(Uint8Array);
+		expect(entropyArg).toEqual(u8Entropy);
+		// Account address matches the addFromMnemonic-derived one — proves the
+		// addFromPair wrapping preserves account identity.
+		expect(account.address).toBe(expectedPair.address);
+	});
+
+	it("fallback branch: derives account on main thread when worker throws", async () => {
+		// Simulate a worker failure — CSP block, worker script parse failure,
+		// task timeout — anything that surfaces as a rejection from
+		// entropyToKeypair. Fallback path must reach the same account address.
+		mocks.entropyToKeypair.mockRejectedValue(new Error("Worker unavailable"));
+
+		const entropyHex = hexHash(FIXED_FINGERPRINT_HEX, 128).slice(2);
+		const u8Entropy = stringToU8a(entropyHex);
+		const mnemonic = entropyToMnemonic(u8Entropy);
+		const keyring = new Keyring({ type: "sr25519" });
+		const expectedPair = keyring.addFromMnemonic(mnemonic);
+
+		const ext = new ExtensionWeb2();
+		const { account } = await ext.getAccount(config);
+
+		expect(mocks.entropyToKeypair).toHaveBeenCalledTimes(1);
+		// Fallback still gives us a working keypair with the same address —
+		// this is the invariant that lets us safely swap in the worker path.
+		expect(account.address).toBe(expectedPair.address);
+	});
+
+	it("worker and fallback branches derive the same account address", async () => {
+		// Direct A/B: one call goes through the worker mock, the next through
+		// the fallback. Assert the addresses match.
+		const entropyHex = hexHash(FIXED_FINGERPRINT_HEX, 128).slice(2);
+		const u8Entropy = stringToU8a(entropyHex);
+		const mnemonic = entropyToMnemonic(u8Entropy);
+		const refKeyring = new Keyring({ type: "sr25519" });
+		const refPair = refKeyring.addFromMnemonic(mnemonic);
+
+		mocks.entropyToKeypair.mockResolvedValueOnce({
+			publicKey: refPair.publicKey,
+			secretKey:
+				(refPair as unknown as { secretKey: Uint8Array }).secretKey ??
+				new Uint8Array(64),
+			mnemonic,
+		});
+		const workerAccount = await new ExtensionWeb2().getAccount(config);
+
+		mocks.entropyToKeypair.mockRejectedValueOnce(new Error("worker down"));
+		const fallbackAccount = await new ExtensionWeb2().getAccount(config);
+
+		expect(workerAccount.account.address).toBe(fallbackAccount.account.address);
+	});
+});

--- a/packages/account/src/tests/cryptoWorker.unit.test.ts
+++ b/packages/account/src/tests/cryptoWorker.unit.test.ts
@@ -1,0 +1,146 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Unit tests for the CryptoWorker task implementations. The worker itself
+// bootstraps under `?worker&inline` in the browser build and can't easily be
+// spun up in a Node vitest env, so these tests exercise the same primitives
+// the worker's message handler dispatches to (entropyToMnemonic,
+// mnemonicToMiniSecret, sr25519FromSeed) and prove they produce a keypair
+// equivalent to `keyring.addFromMnemonic` — the shipped-blob invariant that
+// `ExtensionWeb2.createAccount`'s worker path relies on.
+
+import { stringToU8a } from "@polkadot/util";
+import { Keyring } from "@prosopo/keyring";
+import {
+	entropyToMnemonic,
+	mnemonicToMiniSecret,
+	sr25519FromSeed,
+} from "@prosopo/util-crypto";
+import { describe, expect, it } from "vitest";
+
+// Mirrors ExtensionWeb2.createAccount: browserEntropy → hexHash(., 128) →
+// slice(2) → 32 ASCII-hex characters → stringToU8a → 32 bytes. Fixed value
+// so tests are deterministic (real code path uses the browser fingerprint).
+const FIXED_ENTROPY_HEX = "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6";
+
+const entropyBytes = (hex: string): Uint8Array => stringToU8a(hex);
+
+describe("CryptoWorker task primitives", () => {
+	describe("entropyToKeypair pipeline", () => {
+		it("derives an sr25519 keypair from entropy deterministically", () => {
+			const entropy = entropyBytes(FIXED_ENTROPY_HEX);
+
+			const mnemonic = entropyToMnemonic(entropy);
+			const seed = mnemonicToMiniSecret(mnemonic);
+			const { publicKey, secretKey } = sr25519FromSeed(seed);
+
+			expect(publicKey).toBeInstanceOf(Uint8Array);
+			expect(secretKey).toBeInstanceOf(Uint8Array);
+			expect(publicKey.length).toBe(32);
+			expect(secretKey.length).toBe(64);
+
+			// Re-running with the same entropy must yield the same keys —
+			// otherwise the CryptoWorker cache would be poisoned by a
+			// non-deterministic derivation.
+			const again = sr25519FromSeed(
+				mnemonicToMiniSecret(entropyToMnemonic(entropy)),
+			);
+			expect(again.publicKey).toEqual(publicKey);
+			expect(again.secretKey).toEqual(secretKey);
+		});
+
+		it("produces the same address as keyring.addFromMnemonic (worker/main-thread parity)", () => {
+			const entropy = entropyBytes(FIXED_ENTROPY_HEX);
+			const mnemonic = entropyToMnemonic(entropy);
+
+			// Worker path: entropy → mnemonic → miniSecret → sr25519 → addFromPair
+			const seed = mnemonicToMiniSecret(mnemonic);
+			const { publicKey, secretKey } = sr25519FromSeed(seed);
+			const workerKeyring = new Keyring({ type: "sr25519" });
+			const workerPair = workerKeyring.addFromPair(
+				{ publicKey, secretKey },
+				{},
+				"sr25519",
+			);
+
+			// Legacy main-thread path: keyring.addFromMnemonic
+			const mainKeyring = new Keyring({ type: "sr25519" });
+			const mainPair = mainKeyring.addFromMnemonic(mnemonic);
+
+			// Addresses must match exactly — this is the invariant that guarantees
+			// swapping addFromMnemonic → addFromPair(entropyToKeypair(...)) is a
+			// behavioural no-op for account identity.
+			expect(workerPair.address).toBe(mainPair.address);
+			expect(workerPair.publicKey).toEqual(mainPair.publicKey);
+			expect(workerPair.type).toBe(mainPair.type);
+		});
+
+		it("signatures produced by addFromPair verify against the addFromMnemonic public key", () => {
+			const entropy = entropyBytes(FIXED_ENTROPY_HEX);
+			const mnemonic = entropyToMnemonic(entropy);
+			const seed = mnemonicToMiniSecret(mnemonic);
+			const { publicKey, secretKey } = sr25519FromSeed(seed);
+
+			const workerKeyring = new Keyring({ type: "sr25519" });
+			const workerPair = workerKeyring.addFromPair(
+				{ publicKey, secretKey },
+				{},
+				"sr25519",
+			);
+			const mainKeyring = new Keyring({ type: "sr25519" });
+			const mainPair = mainKeyring.addFromMnemonic(mnemonic);
+
+			const message = stringToU8a("prosopo-test-message");
+			const workerSig = workerPair.sign(message);
+			const mainSig = mainPair.sign(message);
+
+			expect(workerSig.length).toBe(64);
+			expect(mainSig.length).toBe(64);
+			// sr25519 signatures are non-deterministic, so we can't byte-compare;
+			// but each signature must verify against BOTH pairs' public keys.
+			expect(mainPair.verify(message, workerSig, mainPair.publicKey)).toBe(
+				true,
+			);
+			expect(workerPair.verify(message, mainSig, workerPair.publicKey)).toBe(
+				true,
+			);
+		});
+	});
+
+	describe("entropyToMnemonic (existing worker task, unchanged)", () => {
+		it("produces a 24-word BIP39 mnemonic from 32 bytes of entropy", () => {
+			const entropy = entropyBytes(FIXED_ENTROPY_HEX);
+			const mnemonic = entropyToMnemonic(entropy);
+			const words = mnemonic.split(" ");
+			// 32 bytes of entropy = 256 bits → 24 BIP39 words.
+			expect(words.length).toBe(24);
+			for (const w of words) {
+				expect(w).toMatch(/^[a-z]+$/);
+			}
+		});
+
+		it("is deterministic for a given entropy", () => {
+			const entropy = entropyBytes(FIXED_ENTROPY_HEX);
+			expect(entropyToMnemonic(entropy)).toBe(entropyToMnemonic(entropy));
+		});
+
+		it("rejects entropy that isn't 16/20/24/28/32 bytes", () => {
+			// bip39 accepts only these sizes — CryptoWorker relies on the caller
+			// passing valid entropy (already-hashed to 32 bytes in ExtensionWeb2).
+			expect(() => entropyToMnemonic(new Uint8Array(15))).toThrow();
+			expect(() => entropyToMnemonic(new Uint8Array(17))).toThrow();
+			expect(() => entropyToMnemonic(new Uint8Array(33))).toThrow();
+		});
+	});
+});

--- a/packages/account/vite.test.config.ts
+++ b/packages/account/vite.test.config.ts
@@ -1,0 +1,28 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import fs from "node:fs";
+import path from "node:path";
+import { ViteTestConfig } from "@prosopo/config";
+import dotenv from "dotenv";
+process.env.NODE_ENV = "test";
+const envFile = `.env.${process.env.NODE_ENV || "development"}`;
+let envPath = envFile;
+if (fs.existsSync(envFile)) {
+	envPath = path.resolve(envFile);
+} else if (fs.existsSync(`../../${envFile}`)) {
+	envPath = path.resolve(`../../${envFile}`);
+}
+dotenv.config({ path: envPath });
+
+export default ViteTestConfig();


### PR DESCRIPTION
## Summary

Adds vitest coverage for the code changed in the sr25519-in-worker perf PR (#2830). Two test files under `packages/account/src/tests/`, plus the missing `test` script + `vite.test.config.ts` (`@prosopo/account` had none before).

## What's tested

- **`cryptoWorker.unit.test.ts`** — exercises the primitives the CryptoWorker's task dispatch calls into (`entropyToMnemonic`, `mnemonicToMiniSecret`, `sr25519FromSeed`):
  - `entropyToKeypair` pipeline produces a keypair address-equal to `keyring.addFromMnemonic(mnemonic)` — the parity invariant that makes the worker-path swap a behavioural no-op
  - Signatures from `addFromPair`-derived pair verify against the `addFromMnemonic`-derived public key and vice-versa
  - Deterministic derivation for identical entropy input
  - Rejects non-BIP39-valid entropy sizes (guards the CryptoWorker input contract)
- **`ExtensionWeb2.unit.test.ts`** — mocks `getCryptoWorkerManager` + `getFingerprint` and asserts both branches of `createAccount`:
  - **Worker branch** — `entropyToKeypair` resolves with raw bytes → `addFromPair` produces the expected address
  - **Fallback branch** — `entropyToKeypair` rejects (worker unavailable) → dynamic-import `entropyToMnemonic` → `addFromMnemonic` on main thread → same address
  - A/B — worker vs fallback yield identical addresses for the same fingerprint (session-identity invariant across paths)

## Why the `@prosopo/cli` patch bump

Root repo version follows `@prosopo/cli`'s version (see `create_release_pr.yml`'s ``root_version=$(npm -w @prosopo/cli pkg get version | jq …)`` step). The previous perf PR's changeset bumped `@prosopo/account` + `@prosopo/procaptcha-frictionless` but not `cli`, so the release script computed the same root version as the pre-existing v3.6.63 tag, `tag_release` printed "Tag already exists, skipping", and `publish_release` + downstream `deploy-procaptcha-bundle` never fired — the CDN never picked up the sr25519-in-worker perf.

A `cli: patch` bump paired with the test bump gets us a fresh root version → new tag → publish → CDN republish.

## Test plan

- [x] `cd packages/account && npm run test` → 9/9 pass, 2 files
- [x] `npx turbo run build:tsc --filter=@prosopo/account` → clean
- [x] `npx biome check` on all new files → clean
- [ ] CI green
- [ ] Release PR opens with @prosopo/cli in the bump list

🤖 Generated with [Claude Code](https://claude.com/claude-code)