### PR TITLE
perf(frictionless): fire provider-pin /healthz in parallel with detect()

### DIFF
--- a/.changeset/frictionless-prefetch-provider-pin.md
+++ b/.changeset/frictionless-prefetch-provider-pin.md
@@ -1,0 +1,16 @@
+---
+"@prosopo/procaptcha-frictionless": patch
+---
+
+perf(frictionless): fire provider-pin `/healthz` in parallel with `detect()` instead of serial after
+
+`customDetectBot` was resolving the provider pin (`getProcaptchaRandomActiveProvider`, which hits `/healthz` on the load-balancer DNS endpoint) only after `detect()` returned — so the healthz round-trip was fully serial with the detector suite's ~seconds of worker + fingerprint work. On the network waterfall this showed up as `index-*.js → blob → blob → healthz → frictionless`, with `healthz` blocking the `frictionless` POST from firing.
+
+Fire the pin resolution fire-and-forget at the very top of `customDetectBot`, before the `ExtensionLoader` / `DetectorLoader` dynamic imports even start. `getProcaptchaRandomActiveProvider` is memoised via `pinPromiseCache` keyed on `(env, ipMode)`, so:
+
+- catcher's internal `randomProviderSelectorFn` (called during `detect()`) hits the in-flight promise instead of firing its own healthz
+- the awaited `getProcaptchaRandomActiveProvider(...)` after `detect()` reuses the resolved promise
+
+Both cache keys are prewarmed — one for catcher's selector (no `ipMode`) and one matching the dapp's `data-ipv4`/`data-ipv6` if set. Same-key when the dapp is dual-stack (the common case), which is one healthz request total instead of two.
+
+Net effect: the healthz round-trip (~100–200 ms on cold DNS/TLS) now overlaps with detector work instead of following it. The `frictionless` POST becomes the next hop on the wire immediately after the workers post their scores back.

--- a/packages/procaptcha-frictionless/src/customDetectBot.ts
+++ b/packages/procaptcha-frictionless/src/customDetectBot.ts
@@ -129,6 +129,34 @@ const customDetectBot: BotDetectionFunction = async (
 	restartFn: () => void,
 	retryContext?: ProviderSelectRetryContext,
 ): Promise<BotDetectionFunctionResult> => {
+	// Kick off the provider-pin resolution (which hits `/healthz` on the
+	// load-balancer DNS endpoint) in parallel with the module loaders and
+	// the whole `detect()` flow. `getProcaptchaRandomActiveProvider` is
+	// memoised via `pinPromiseCache` keyed on `(env, ipMode)`, so the
+	// in-flight promise is reused when catcher's internal provider selector
+	// and the awaited `getProcaptchaRandomActiveProvider(...)` below reach
+	// for it — no duplicate healthz request. Before this ordering change
+	// the healthz round-trip was fully serial with `detect()`, adding
+	// ~100–200ms to the frictionless critical path on cold DNS/TLS.
+	//
+	// We warm both cache keys because the catcher-internal selector call
+	// (line ~145 below) passes no ipMode, while the awaited call further
+	// down passes `pickIpMode(config)`. Same key when the dapp opts into
+	// neither ipv4 nor ipv6 (dual stack — the common case); different
+	// keys when the dapp is pinned to a single stack. Fire-and-forget on
+	// both — the real synchronisation happens at the awaits below.
+	const ipMode = pickIpMode(config);
+	void getProcaptchaRandomActiveProvider(config.defaultEnvironment).catch(
+		() => undefined,
+	);
+	if (ipMode !== undefined) {
+		void getProcaptchaRandomActiveProvider(
+			config.defaultEnvironment,
+			ipMode,
+			retryContext,
+		).catch(() => undefined);
+	}
+
 	const [ExtClass, detect] = await Promise.all([
 		ExtensionLoader(config.web2),
 		DetectorLoader(),
@@ -161,9 +189,12 @@ const customDetectBot: BotDetectionFunction = async (
 	// same one. `pickIpMode(config)` honours the dapp's data-ipv4 / data-ipv6
 	// preference so frictionless and the subsequent captcha hops stay on the
 	// same stack.
+	//
+	// This await usually hits the in-flight/resolved promise warmed at the
+	// top of this function — see the prefetch call there.
 	const provider = await getProcaptchaRandomActiveProvider(
 		config.defaultEnvironment,
-		pickIpMode(config),
+		ipMode,
 		retryContext,
 	);
 


### PR DESCRIPTION
## Summary

- `customDetectBot` was resolving the provider pin (`getProcaptchaRandomActiveProvider` → `/healthz`) only after `detect()` returned. On the network waterfall this looked like: \`index-*.js → blob → blob → healthz → frictionless\`, with healthz blocking the frictionless POST behind ~seconds of detector work.
- This PR fires `getProcaptchaRandomActiveProvider(env, ipMode)` fire-and-forget at the very top of `customDetectBot`, before the `ExtensionLoader` / `DetectorLoader` imports even start. `pinPromiseCache` memoisation means both catcher's internal selector call and the awaited call further down reuse the in-flight promise — one healthz request, running in parallel with detector work.
- Both cache keys prewarmed — one for catcher's selector (no `ipMode`) and one matching the dapp's `data-ipv4`/`data-ipv6` if set. Same key when dual-stack (the common case).

## Impact

Healthz round-trip (~100–200 ms on cold DNS/TLS) now overlaps with detector work instead of following it. The `frictionless` POST becomes the next hop on the wire immediately after the workers post their scores back.

## Test plan

- [x] `npm run -w @prosopo/procaptcha-frictionless build:tsc` clean
- [x] `npx biome check packages/procaptcha-frictionless/src/customDetectBot.ts` clean
- [ ] Verify on staging after merge: network waterfall should show \`healthz\` firing alongside \`index-*.js\`, not after the blobs
- [ ] No behaviour change on retry path (`retryContext.attempt > 1`) — the retry selector still bypasses the pin cache via `getRandomProviderFromList`

## Notes

- Fire-and-forget `.catch(() => undefined)` prevents unhandled-rejection warnings if healthz is transiently down. The awaited calls below still get the real error/success — nothing swallows retries or hides failures from the caller.
- No API surface change; downstream widget code doesn't need to know about this optimisation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)