### PR TITLE
test(cli): unit tests for RateLimiter + validator helpers (triggers cli patch)

### DIFF
--- a/.changeset/cli-ratelimiter-validators-unit-tests.md
+++ b/.changeset/cli-ratelimiter-validators-unit-tests.md
@@ -1,0 +1,29 @@
+---
+"@prosopo/cli": patch
+---
+
+test(cli): unit-test coverage for `RateLimiter.getRateLimitConfig` and `commands/validators`
+
+Adds two new vitest files under `@prosopo/cli/src/tests/`:
+
+- `RateLimiter.unit.test.ts` — 7 tests covering `getRateLimitConfig`:
+  every ClientApiPaths / AdminApiPaths / PublicApiPaths route referenced in
+  the source has a mapped entry (regression guard against silently dropping
+  routes on refactor); env vars are propagated verbatim to `windowMs` /
+  `limit`; no WINDOW/LIMIT crossover; and the config is re-read on every
+  invocation rather than cached at module load (so ops can hot-toggle a
+  rate window without restarting the provider). Snapshots and restores
+  every `PROSOPO_*` env var it touches so the suite doesn't leak state.
+
+- `commands/validators.unit.test.ts` — 14 tests covering the four
+  argv validators: `validateAddress`, `validateSiteKey`, `validateValue`,
+  `validateScheduleExpression`. Verifies SS58 ↔ hex address round-tripping
+  through `encodeStringAddress`; `ProsopoContractError` with
+  `CONTRACT.INVALID_ADDRESS` on garbage address input;
+  `ProsopoEnvError` with `CLI.PARAMETER_ERROR` for non-numeric values
+  (string, boolean, object, null, undefined); and cron parsing across a
+  spread of standard schedule expressions.
+
+No behaviour change — pure test additions. Fills a coverage gap in a
+package that previously had a single integration-style bundle test and
+no unit tests for these pure helpers.

--- a/packages/cli/src/tests/RateLimiter.unit.test.ts
+++ b/packages/cli/src/tests/RateLimiter.unit.test.ts
@@ -1,0 +1,202 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import { AdminApiPaths, ClientApiPaths, PublicApiPaths } from "@prosopo/types";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { getRateLimitConfig } from "../RateLimiter.js";
+
+// getRateLimitConfig reads process.env at call time (not module load), so
+// mutating env between calls exercises the branch used at runtime.
+const RATE_ENV_KEYS: readonly string[] = [
+	"PROSOPO_GET_IMAGE_CAPTCHA_CHALLENGE_WINDOW",
+	"PROSOPO_GET_IMAGE_CAPTCHA_CHALLENGE_LIMIT",
+	"PROSOPO_GET_POW_CAPTCHA_CHALLENGE_WINDOW",
+	"PROSOPO_GET_POW_CAPTCHA_CHALLENGE_LIMIT",
+	"PROSOPO_SUBMIT_IMAGE_CAPTCHA_SOLUTION_WINDOW",
+	"PROSOPO_SUBMIT_IMAGE_CAPTCHA_SOLUTION_LIMIT",
+	"PROSOPO_SUBMIT_POW_CAPTCHA_SOLUTION_WINDOW",
+	"PROSOPO_SUBMIT_POW_CAPTCHA_SOLUTION_LIMIT",
+	"PROSOPO_VERIFY_POW_CAPTCHA_SOLUTION_WINDOW",
+	"PROSOPO_VERIFY_POW_CAPTCHA_SOLUTION_LIMIT",
+	"PROSOPO_VERIFY_IMAGE_CAPTCHA_SOLUTION_DAPP_WINDOW",
+	"PROSOPO_VERIFY_IMAGE_CAPTCHA_SOLUTION_DAPP_LIMIT",
+	"PROSOPO_CHECK_SPAM_EMAIL_WINDOW",
+	"PROSOPO_CHECK_SPAM_EMAIL_LIMIT",
+	"PROSOPO_GET_PROVIDER_STATUS_WINDOW",
+	"PROSOPO_GET_PROVIDER_STATUS_LIMIT",
+	"PROSOPO_GET_PROVIDER_DETAILS_WINDOW",
+	"PROSOPO_GET_PROVIDER_DETAILS_LIMIT",
+	"PROSOPO_SUBMIT_USER_EVENTS_WINDOW",
+	"PROSOPO_SUBMIT_USER_EVENTS_LIMIT",
+	"PROSOPO_SITE_KEY_REGISTER_WINDOW",
+	"PROSOPO_SITE_KEY_REGISTER_LIMIT",
+	"PROSOPO_SITE_KEYS_REGISTER_WINDOW",
+	"PROSOPO_SITE_KEYS_REGISTER_LIMIT",
+	"PROSOPO_SITE_KEY_REMOVE_WINDOW",
+	"PROSOPO_SITE_KEY_REMOVE_LIMIT",
+	"PROSOPO_SITE_KEYS_REMOVE_WINDOW",
+	"PROSOPO_SITE_KEYS_REMOVE_LIMIT",
+	"PROSOPO_UPDATE_DETECTOR_KEY_WINDOW",
+	"PROSOPO_UPDATE_DETECTOR_KEY_LIMIT",
+	"PROSOPO_REMOVE_DETECTOR_KEY_WINDOW",
+	"PROSOPO_REMOVE_DETECTOR_KEY_LIMIT",
+	"PROSOPO_TOGGLE_MAINTENANCE_MODE_WINDOW",
+	"PROSOPO_TOGGLE_MAINTENANCE_MODE_LIMIT",
+	"PROSOPO_UPDATE_DECISION_MACHINE_WINDOW",
+	"PROSOPO_UPDATE_DECISION_MACHINE_LIMIT",
+	"PROSOPO_GET_FR_CAPTCHA_CHALLENGE_WINDOW",
+	"PROSOPO_GET_FR_CAPTCHA_CHALLENGE_LIMIT",
+	"PROSOPO_GET_DECISION_MACHINE_WINDOW",
+	"PROSOPO_GET_DECISION_MACHINE_LIMIT",
+	"PROSOPO_GET_ALL_DECISION_MACHINES_WINDOW",
+	"PROSOPO_GET_ALL_DECISION_MACHINES_LIMIT",
+	"PROSOPO_REMOVE_ALL_DECISION_MACHINES_WINDOW",
+	"PROSOPO_REMOVE_ALL_DECISION_MACHINES_LIMIT",
+	"PROSOPO_REMOVE_DECISION_MACHINE_WINDOW",
+	"PROSOPO_REMOVE_DECISION_MACHINE_LIMIT",
+	"PROSOPO_CLEAR_ALL_COUNTERS_WINDOW",
+	"PROSOPO_CLEAR_ALL_COUNTERS_LIMIT",
+	"PROSOPO_GET_PUZZLE_CAPTCHA_CHALLENGE_WINDOW",
+	"PROSOPO_GET_PUZZLE_CAPTCHA_CHALLENGE_LIMIT",
+	"PROSOPO_SUBMIT_PUZZLE_CAPTCHA_SOLUTION_WINDOW",
+	"PROSOPO_SUBMIT_PUZZLE_CAPTCHA_SOLUTION_LIMIT",
+	"PROSOPO_VERIFY_PUZZLE_CAPTCHA_SOLUTION_WINDOW",
+	"PROSOPO_VERIFY_PUZZLE_CAPTCHA_SOLUTION_LIMIT",
+	"PROSOPO_DNS_EVENT_WINDOW",
+	"PROSOPO_DNS_EVENT_LIMIT",
+];
+
+describe("RateLimiter.getRateLimitConfig", () => {
+	// Snapshot every env we touch so the suite doesn't leak state into other
+	// tests that read the same PROSOPO_* vars (e.g. an integration test that
+	// spins up a real limiter).
+	const originalEnv: Record<string, string | undefined> = {};
+
+	beforeEach(() => {
+		for (const key of RATE_ENV_KEYS) {
+			originalEnv[key] = process.env[key];
+			delete process.env[key];
+		}
+	});
+
+	afterEach(() => {
+		for (const key of RATE_ENV_KEYS) {
+			if (originalEnv[key] === undefined) {
+				delete process.env[key];
+			} else {
+				process.env[key] = originalEnv[key];
+			}
+		}
+	});
+
+	it("returns undefined windowMs/limit for every route when no env vars are set", () => {
+		const cfg = getRateLimitConfig();
+		for (const [route, entry] of Object.entries(cfg)) {
+			expect(
+				entry.windowMs,
+				`${route}.windowMs should be undefined when env missing`,
+			).toBeUndefined();
+			expect(
+				entry.limit,
+				`${route}.limit should be undefined when env missing`,
+			).toBeUndefined();
+		}
+	});
+
+	it("exposes an entry for every ClientApiPaths route referenced in the source", () => {
+		const cfg = getRateLimitConfig();
+		const expected = [
+			ClientApiPaths.GetImageCaptchaChallenge,
+			ClientApiPaths.GetPowCaptchaChallenge,
+			ClientApiPaths.SubmitImageCaptchaSolution,
+			ClientApiPaths.SubmitPowCaptchaSolution,
+			ClientApiPaths.VerifyPowCaptchaSolution,
+			ClientApiPaths.VerifyImageCaptchaSolutionDapp,
+			ClientApiPaths.CheckSpamEmail,
+			ClientApiPaths.GetProviderStatus,
+			ClientApiPaths.SubmitUserEvents,
+			ClientApiPaths.GetFrictionlessCaptchaChallenge,
+			ClientApiPaths.GetPuzzleCaptchaChallenge,
+			ClientApiPaths.SubmitPuzzleCaptchaSolution,
+			ClientApiPaths.VerifyPuzzleCaptchaSolution,
+		];
+		for (const route of expected) {
+			expect(cfg).toHaveProperty(route);
+		}
+	});
+
+	it("exposes an entry for every AdminApiPaths route referenced in the source", () => {
+		const cfg = getRateLimitConfig();
+		const expected = [
+			AdminApiPaths.SiteKeyRegister,
+			AdminApiPaths.SiteKeysRegister,
+			AdminApiPaths.SiteKeyRemove,
+			AdminApiPaths.SiteKeysRemove,
+			AdminApiPaths.UpdateDetectorKey,
+			AdminApiPaths.RemoveDetectorKey,
+			AdminApiPaths.ToggleMaintenanceMode,
+			AdminApiPaths.UpdateDecisionMachine,
+			AdminApiPaths.GetDecisionMachine,
+			AdminApiPaths.GetAllDecisionMachines,
+			AdminApiPaths.RemoveAllDecisionMachines,
+			AdminApiPaths.RemoveDecisionMachine,
+			AdminApiPaths.ClearAllCounters,
+			AdminApiPaths.DnsEvent,
+		];
+		for (const route of expected) {
+			expect(cfg).toHaveProperty(route);
+		}
+	});
+
+	it("exposes an entry for every PublicApiPaths route referenced in the source", () => {
+		const cfg = getRateLimitConfig();
+		expect(cfg).toHaveProperty(PublicApiPaths.GetProviderDetails);
+	});
+
+	it("propagates env vars verbatim to the mapped route (strings)", () => {
+		process.env.PROSOPO_GET_IMAGE_CAPTCHA_CHALLENGE_WINDOW = "60000";
+		process.env.PROSOPO_GET_IMAGE_CAPTCHA_CHALLENGE_LIMIT = "10";
+		const cfg = getRateLimitConfig();
+		expect(cfg[ClientApiPaths.GetImageCaptchaChallenge]).toEqual({
+			windowMs: "60000",
+			limit: "10",
+		});
+		// Other routes untouched.
+		expect(cfg[ClientApiPaths.CheckSpamEmail].windowMs).toBeUndefined();
+		expect(cfg[ClientApiPaths.CheckSpamEmail].limit).toBeUndefined();
+	});
+
+	it("wires WINDOW and LIMIT env vars to distinct fields (no crossover)", () => {
+		process.env.PROSOPO_CHECK_SPAM_EMAIL_WINDOW = "WINDOW_MARKER";
+		process.env.PROSOPO_CHECK_SPAM_EMAIL_LIMIT = "LIMIT_MARKER";
+		const entry = getRateLimitConfig()[ClientApiPaths.CheckSpamEmail];
+		expect(entry.windowMs).toBe("WINDOW_MARKER");
+		expect(entry.limit).toBe("LIMIT_MARKER");
+	});
+
+	it("re-reads process.env on every invocation (no module-load caching)", () => {
+		process.env.PROSOPO_DNS_EVENT_WINDOW = "first";
+		expect(getRateLimitConfig()[AdminApiPaths.DnsEvent].windowMs).toBe("first");
+		process.env.PROSOPO_DNS_EVENT_WINDOW = "second";
+		expect(getRateLimitConfig()[AdminApiPaths.DnsEvent].windowMs).toBe(
+			"second",
+		);
+		// Real delete — assigning undefined to process.env coerces to the
+		// literal string "undefined", which would defeat the test.
+		// biome-ignore lint/performance/noDelete: intentional — test needs the key removed
+		delete process.env.PROSOPO_DNS_EVENT_WINDOW;
+		expect(
+			getRateLimitConfig()[AdminApiPaths.DnsEvent].windowMs,
+		).toBeUndefined();
+	});
+});

--- a/packages/cli/src/tests/commands/validators.unit.test.ts
+++ b/packages/cli/src/tests/commands/validators.unit.test.ts
@@ -1,0 +1,144 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { ProsopoContractError, ProsopoEnvError } from "@prosopo/common";
+import { describe, expect, it } from "vitest";
+import type { ArgumentsCamelCase } from "yargs";
+import {
+	validateAddress,
+	validateScheduleExpression,
+	validateSiteKey,
+	validateValue,
+} from "../../commands/validators.js";
+
+// Well-formed Substrate SS58 test address (Alice's dev key). `encodeStringAddress`
+// round-trips this through util-crypto's decode+encode, so a valid input maps to
+// a canonical SS58 string.
+const VALID_SS58_ADDRESS = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+// Corresponding public-key hex.
+const VALID_HEX_ADDRESS =
+	"0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d";
+const INVALID_ADDRESS = "not-a-real-address";
+
+// Minimal ArgumentsCamelCase-shaped object. Yargs adds `_` and `$0`; the
+// validators only touch the specific keys they care about, so keeping this
+// object tight isolates the field-under-test.
+const argv = (extras: Record<string, unknown>): ArgumentsCamelCase => ({
+	_: [],
+	$0: "test",
+	...extras,
+});
+
+describe("validateAddress", () => {
+	it("returns the encoded SS58 form of a valid SS58 input", () => {
+		const { address } = validateAddress(argv({ address: VALID_SS58_ADDRESS }));
+		expect(typeof address).toBe("string");
+		// Same key, so re-encoded output matches the input.
+		expect(address).toBe(VALID_SS58_ADDRESS);
+	});
+
+	it("returns the encoded SS58 form when given a hex address", () => {
+		const { address } = validateAddress(argv({ address: VALID_HEX_ADDRESS }));
+		// Hex input for the same public key round-trips to the same SS58 string.
+		expect(address).toBe(VALID_SS58_ADDRESS);
+	});
+
+	it("throws ProsopoContractError with INVALID_ADDRESS code on garbage input", () => {
+		expect(() => validateAddress(argv({ address: INVALID_ADDRESS }))).toThrow(
+			ProsopoContractError,
+		);
+		expect(() => validateAddress(argv({ address: INVALID_ADDRESS }))).toThrow(
+			"CONTRACT.INVALID_ADDRESS",
+		);
+	});
+});
+
+describe("validateSiteKey", () => {
+	it("returns the encoded SS58 form of a valid SS58 input", () => {
+		const { sitekey } = validateSiteKey(argv({ sitekey: VALID_SS58_ADDRESS }));
+		expect(sitekey).toBe(VALID_SS58_ADDRESS);
+	});
+
+	it("returns the encoded SS58 form when given a hex site key", () => {
+		const { sitekey } = validateSiteKey(argv({ sitekey: VALID_HEX_ADDRESS }));
+		expect(sitekey).toBe(VALID_SS58_ADDRESS);
+	});
+
+	it("throws ProsopoContractError with INVALID_ADDRESS code on garbage input", () => {
+		expect(() => validateSiteKey(argv({ sitekey: INVALID_ADDRESS }))).toThrow(
+			ProsopoContractError,
+		);
+		expect(() => validateSiteKey(argv({ sitekey: INVALID_ADDRESS }))).toThrow(
+			"CONTRACT.INVALID_ADDRESS",
+		);
+	});
+});
+
+describe("validateValue", () => {
+	it("returns the numeric value wrapped as Compact<u128> when input is a number", () => {
+		const result = validateValue(argv({ value: 42 }));
+		// The validator casts through unknown without normalising, so the value
+		// object is the same reference we passed in.
+		expect(result.value).toBe(42);
+	});
+
+	it("accepts zero", () => {
+		const result = validateValue(argv({ value: 0 }));
+		expect(result.value).toBe(0);
+	});
+
+	it("throws ProsopoEnvError with PARAMETER_ERROR on string input", () => {
+		expect(() => validateValue(argv({ value: "42" }))).toThrow(ProsopoEnvError);
+		expect(() => validateValue(argv({ value: "42" }))).toThrow(
+			"CLI.PARAMETER_ERROR",
+		);
+	});
+
+	it("throws ProsopoEnvError on undefined value", () => {
+		expect(() => validateValue(argv({}))).toThrow(ProsopoEnvError);
+	});
+
+	it("throws ProsopoEnvError on boolean / object / null inputs", () => {
+		expect(() => validateValue(argv({ value: true }))).toThrow(ProsopoEnvError);
+		expect(() => validateValue(argv({ value: null }))).toThrow(ProsopoEnvError);
+		expect(() => validateValue(argv({ value: {} }))).toThrow(ProsopoEnvError);
+	});
+});
+
+describe("validateScheduleExpression", () => {
+	it("returns the cron string when it parses cleanly", () => {
+		const result = validateScheduleExpression(argv({ schedule: "0 0 * * *" }));
+		expect(result.schedule).toBe("0 0 * * *");
+	});
+
+	it("returns null schedule when argv.schedule is not a string", () => {
+		expect(validateScheduleExpression(argv({}))).toEqual({ schedule: null });
+		expect(validateScheduleExpression(argv({ schedule: 42 }))).toEqual({
+			schedule: null,
+		});
+		expect(validateScheduleExpression(argv({ schedule: undefined }))).toEqual({
+			schedule: null,
+		});
+	});
+
+	it("accepts a variety of valid cron expressions", () => {
+		const valid = ["*/5 * * * *", "30 3 * * 1", "0 12 1 * *", "15 14 1 * *"];
+		for (const expr of valid) {
+			expect(
+				validateScheduleExpression(argv({ schedule: expr })).schedule,
+				`cron expression ${expr} should parse`,
+			).toBe(expr);
+		}
+	});
+});


### PR DESCRIPTION
## Summary

Adds unit-test coverage for `@prosopo/cli` — previously had only one integration-style bundle test and zero unit tests for its pure helpers.

**`packages/cli/src/tests/RateLimiter.unit.test.ts`** — 7 tests, `getRateLimitConfig`:
- every ClientApiPaths / AdminApiPaths / PublicApiPaths route referenced in source has a mapped entry
- env vars propagate verbatim to `windowMs` / `limit`, no WINDOW↔LIMIT crossover
- config re-read every invocation (not cached at module load — ops can hot-toggle a rate window without restart)
- snapshots + restores every touched `PROSOPO_*` env var

**`packages/cli/src/tests/commands/validators.unit.test.ts`** — 14 tests, all four argv validators:
- `validateAddress` / `validateSiteKey`: SS58 ↔ hex round-trip; `ProsopoContractError` `CONTRACT.INVALID_ADDRESS` on garbage
- `validateValue`: `ProsopoEnvError` `CLI.PARAMETER_ERROR` for string / boolean / object / null / undefined; accepts 0 and positives
- `validateScheduleExpression`: parses standard cron; returns `{schedule: null}` for non-string

## Why

Recent frictionless perf PR (#2837) only bumped `@prosopo/procaptcha-frictionless`. The release workflow's root-version tracks `@prosopo/cli`, so a frictionless-only changeset doesn't cut a release. This PR's `@prosopo/cli: patch` is a real coverage win *and* unblocks the release for the healthz-parallel fix.

## Test plan

- [x] `npm run -w @prosopo/cli build:tsc` clean
- [x] `npm run -w @prosopo/cli test` — 22 pass (7 new RateLimiter + 14 new validators + 1 pre-existing bundle)
- [x] `npx biome check` clean on both new files
- [x] Pure test additions — no source changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)