### PR TITLE
fix(widget): enforce single language across widget, kill browser/config race

### DIFF
--- a/.changeset/widget-single-language-enforcement.md
+++ b/.changeset/widget-single-language-enforcement.md
@@ -1,0 +1,24 @@
+---
+"@prosopo/locale": patch
+"@prosopo/procaptcha-bundle": patch
+"@prosopo/procaptcha-react": patch
+"@prosopo/procaptcha-pow": patch
+"@prosopo/procaptcha-puzzle": patch
+"@prosopo/procaptcha-frictionless": patch
+---
+
+fix(widget): enforce single language across widget, kill browser/config race
+
+`WidgetFactory.getCaptchaRenderer()` booted the i18n singleton with the
+browser-detected language before the site-owner `renderOptions.language` /
+`data-language` had been resolved, and each widget then called
+`i18n.changeLanguage(config.language)` from a post-mount effect. Any child
+component that read `useTranslation()` between first render and the async
+`changeLanguage` resolution rendered in the browser language, then re-rendered
+in the site-owner language — the multi-language flash customers reported.
+
+Resolve the site-owner language in `WidgetFactory.createWidget()` before the
+lazy renderer load and thread it into `loadI18next(false, lng)`, so the
+singleton boots (or reconciles via `changeLanguage` + await) with the correct
+language before React mounts. Site-owner language wins; falls back to browser
+detection only when no `language` / `data-language` is set.

--- a/packages/locale/src/i18nFrontend.ts
+++ b/packages/locale/src/i18nFrontend.ts
@@ -37,6 +37,7 @@ const getLoadPath = (language: string, namespace: string) => {
 
 export function initializeI18n(
 	i18nLoadedCallback?: (value: typeof i18n) => void,
+	lng?: string,
 ) {
 	if (!i18n.isInitialized) {
 		i18n
@@ -54,6 +55,13 @@ export function initializeI18n(
 			.use(initReactI18next)
 			.init({
 				...i18nSharedOptions,
+				// When the site owner has resolved a language upfront (via widget
+				// config or data-language) we set `lng` explicitly so i18next skips
+				// browser detection. This is the single source of truth for the
+				// widget language and prevents the flash-of-wrong-language race
+				// where child components read the browser-detected language on
+				// first render before an effect can call changeLanguage().
+				...(lng ? { lng } : {}),
 				backend: {
 					backends: [
 						HttpBackend, // if a namespace can't be loaded via normal http-backend loadPath, then the inMemoryLocalBackend will try to return the correct resources

--- a/packages/locale/src/loadI18next.ts
+++ b/packages/locale/src/loadI18next.ts
@@ -14,7 +14,18 @@
 
 import type { i18n } from "i18next";
 let i18nInstance: i18n;
-async function loadI18next(backend: boolean): Promise<i18n> {
+
+const reconcileLanguage = async (
+	instance: i18n,
+	lng: string | undefined,
+): Promise<i18n> => {
+	if (lng && instance.language !== lng) {
+		await instance.changeLanguage(lng);
+	}
+	return instance;
+};
+
+async function loadI18next(backend: boolean, lng?: string): Promise<i18n> {
 	return new Promise((resolve, reject) => {
 		try {
 			if (backend) {
@@ -30,11 +41,20 @@ async function loadI18next(backend: boolean): Promise<i18n> {
 			} else {
 				import("./i18nFrontend.js").then(({ default: initializeI18n }) => {
 					if (!i18nInstance) {
-						// pass the resolver into the i18 init fn which will resolve after i18 connected fires
-						i18nInstance = initializeI18n(resolve);
+						// Pass `lng` in on first init so browser detection is skipped
+						// entirely when the site owner has supplied a language. The
+						// resolver only fires on the `loaded` event, so at resolve
+						// time the target-language resources are guaranteed present.
+						i18nInstance = initializeI18n((instance) => {
+							void reconcileLanguage(instance, lng).then(resolve);
+						}, lng);
 					} else {
-						// we've already initialised i18n so just return it
-						resolve(i18nInstance);
+						// Singleton already exists (e.g. a prior widget mounted with a
+						// different language, or a React consumer initialised earlier).
+						// Reconcile before resolving so callers can render synchronously
+						// against the requested language instead of seeing a flash of
+						// the previous one.
+						void reconcileLanguage(i18nInstance, lng).then(resolve);
 					}
 				});
 			}

--- a/packages/procaptcha-bundle/src/util/language.ts
+++ b/packages/procaptcha-bundle/src/util/language.ts
@@ -35,12 +35,29 @@ export const setLanguage = (
 	element: Element,
 	config: ProcaptchaClientConfigInput,
 ) => {
+	const resolved = resolveLanguage(renderOptions, element);
+
+	if (resolved) {
+		config.language = resolved;
+	}
+};
+
+// Resolves the site-owner language before an i18n singleton has been created,
+// so the widget can boot i18n with the correct language on first init instead
+// of having to run a post-mount changeLanguage() effect. Returning `undefined`
+// preserves the existing "fall back to browser detection" behaviour.
+export const resolveLanguage = (
+	renderOptions: ProcaptchaRenderOptions | undefined,
+	element: Element,
+): string | undefined => {
 	const languageAttribute =
 		renderOptions?.language || element.getAttribute("data-language");
 
-	if (languageAttribute) {
-		config.language = validateLanguage(languageAttribute);
+	if (!languageAttribute) {
+		return undefined;
 	}
+
+	return validateLanguage(languageAttribute);
 };
 
 const validateLanguage = (languageAttribute: string | typeof Languages) => {

--- a/packages/procaptcha-bundle/src/util/widgetFactory.ts
+++ b/packages/procaptcha-bundle/src/util/widgetFactory.ts
@@ -26,6 +26,7 @@ import {
 } from "@prosopo/widget-skeleton";
 import type { Root } from "react-dom/client";
 import type { CaptchaRenderer } from "./captcha/captchaRenderer.js";
+import { resolveLanguage } from "./language.js";
 import type { WidgetThemeResolver } from "./widgetThemeResolver.js";
 
 class WidgetFactory {
@@ -99,9 +100,16 @@ class WidgetFactory {
 			widgetContainer = widgetResult.webComponent;
 		}
 
+		// Resolve the site-owner language BEFORE lazy-loading the renderer so
+		// i18n can boot (or reconcile) with the correct language on first init,
+		// rather than starting in the browser-detected language and swapping to
+		// the site-owner language via a post-mount effect (which caused mixed-
+		// language flashes visible to end users).
+		const language = resolveLanguage(renderOptions, container);
+
 		// all the captcha-rendering logic is lazy-loaded, to avoid react & zod delay the initial widget creation.
 
-		const captchaRenderer = await this.getCaptchaRenderer();
+		const captchaRenderer = await this.getCaptchaRenderer(language);
 
 		const captchaRoot = captchaRenderer.renderCaptcha(
 			{
@@ -122,9 +130,16 @@ class WidgetFactory {
 		return captchaRoot;
 	}
 
-	protected async getCaptchaRenderer(): Promise<CaptchaRenderer> {
+	protected async getCaptchaRenderer(
+		language?: string,
+	): Promise<CaptchaRenderer> {
 		if (this._i18n === null) {
-			this._i18n = await loadI18next(false);
+			this._i18n = await loadI18next(false, language);
+		} else if (language && this._i18n.language !== language) {
+			// A subsequent widget on the same page requested a different
+			// language than the cached singleton — reconcile before rendering
+			// so all widgets on the page share one consistent language state.
+			await this._i18n.changeLanguage(language);
 		}
 
 		if (this.captchaRenderer === null) {

--- a/packages/procaptcha-frictionless/src/ProcaptchaFrictionless.tsx
+++ b/packages/procaptcha-frictionless/src/ProcaptchaFrictionless.tsx
@@ -106,18 +106,18 @@ export const ProcaptchaFrictionless = ({
 	const sessionInvalidatedFiredRef = useRef(false);
 
 	useEffect(() => {
-		if (config.language) {
-			if (i18n) {
-				if (i18n.language !== config.language) {
-					i18n.changeLanguage(config.language).then((r) => r);
-				}
-			} else {
-				loadI18next(false).then((i18n) => {
-					if (i18n.language !== config.language)
-						i18n.changeLanguage(config.language).then((r) => r);
-				});
+		if (!config.language) return;
+		if (i18n) {
+			if (i18n.language !== config.language) {
+				void i18n.changeLanguage(config.language);
 			}
+			return;
 		}
+		// Direct-React consumers don't go through WidgetFactory, so pass the
+		// language into loadI18next — first init boots with the right language
+		// (skipping browser detection), and subsequent calls reconcile via
+		// changeLanguage inside loadI18next.
+		void loadI18next(false, config.language);
 	}, [i18n, config.language]);
 
 	const [componentToRender, setComponentToRender] = useState(

--- a/packages/procaptcha-pow/src/components/ProcaptchaWidget.tsx
+++ b/packages/procaptcha-pow/src/components/ProcaptchaWidget.tsx
@@ -57,18 +57,18 @@ const Procaptcha = (props: ProcaptchaProps) => {
 	const sessionInvalidatedFiredRef = useRef(false);
 
 	useEffect(() => {
-		if (config.language) {
-			if (i18n) {
-				if (i18n.language !== config.language) {
-					i18n.changeLanguage(config.language).then((r) => r);
-				}
-			} else {
-				loadI18next(false).then((i18n) => {
-					if (i18n.language !== config.language)
-						i18n.changeLanguage(config.language).then((r) => r);
-				});
+		if (!config.language) return;
+		if (i18n) {
+			if (i18n.language !== config.language) {
+				void i18n.changeLanguage(config.language);
 			}
+			return;
 		}
+		// Direct-React consumers don't go through WidgetFactory, so pass the
+		// language into loadI18next — first init boots with the right language
+		// (skipping browser detection), and subsequent calls reconcile via
+		// changeLanguage inside loadI18next.
+		void loadI18next(false, config.language);
 	}, [i18n, config.language]);
 
 	useEffect(() => {

--- a/packages/procaptcha-puzzle/src/components/ProcaptchaWidget.tsx
+++ b/packages/procaptcha-puzzle/src/components/ProcaptchaWidget.tsx
@@ -63,18 +63,18 @@ const Procaptcha = (props: ProcaptchaProps) => {
 	const sessionInvalidatedFiredRef = useRef(false);
 
 	useEffect(() => {
-		if (config.language) {
-			if (i18n) {
-				if (i18n.language !== config.language) {
-					i18n.changeLanguage(config.language).then((r) => r);
-				}
-			} else {
-				loadI18next(false).then((i18n) => {
-					if (i18n.language !== config.language)
-						i18n.changeLanguage(config.language).then((r) => r);
-				});
+		if (!config.language) return;
+		if (i18n) {
+			if (i18n.language !== config.language) {
+				void i18n.changeLanguage(config.language);
 			}
+			return;
 		}
+		// Direct-React consumers don't go through WidgetFactory, so pass the
+		// language into loadI18next — first init boots with the right language
+		// (skipping browser detection), and subsequent calls reconcile via
+		// changeLanguage inside loadI18next.
+		void loadI18next(false, config.language);
 	}, [i18n, config.language]);
 
 	useEffect(() => {

--- a/packages/procaptcha-react/src/components/ProcaptchaWidget.tsx
+++ b/packages/procaptcha-react/src/components/ProcaptchaWidget.tsx
@@ -63,18 +63,18 @@ const ProcaptchaWidget = (props: ProcaptchaProps) => {
 	const theme = "light" === props.config.theme ? lightTheme : darkTheme;
 
 	useEffect(() => {
-		if (config.language) {
-			if (i18n) {
-				if (i18n.language !== config.language) {
-					i18n.changeLanguage(config.language).then((r) => r);
-				}
-			} else {
-				loadI18next(false).then((i18n) => {
-					if (i18n.language !== config.language)
-						i18n.changeLanguage(config.language).then((r) => r);
-				});
+		if (!config.language) return;
+		if (i18n) {
+			if (i18n.language !== config.language) {
+				void i18n.changeLanguage(config.language);
 			}
+			return;
 		}
+		// Direct-React consumers don't go through WidgetFactory, so pass the
+		// language into loadI18next — first init boots with the right language
+		// (skipping browser detection), and subsequent calls reconcile via
+		// changeLanguage inside loadI18next.
+		void loadI18next(false, config.language);
 	}, [i18n, config.language]);
 
 	useEffect(() => {


### PR DESCRIPTION
## Summary

- Widget was mixing languages: i18n singleton booted with the browser-detected language before the site-owner `renderOptions.language` / `data-language` had been resolved, then each widget called `i18n.changeLanguage(config.language)` from a post-mount effect. Any child component that read `useTranslation()` in that window rendered against the browser language, then re-rendered against the site-owner language — the multi-language flash customers reported.
- Fix resolves the site-owner language in `WidgetFactory.createWidget()` **before** the lazy renderer load and threads it into `loadI18next(false, lng)`, so the singleton boots (or reconciles via `changeLanguage` + await) with the correct language before React mounts. Site-owner language wins; falls back to browser detection only when no `language` / `data-language` is set.
- Backend paths (`loadI18next(true)` in CLI, express middleware, tests) unaffected — new `lng` param is optional and unused on that path.

## What changed

- `packages/locale/src/i18nFrontend.ts` — `initializeI18n(callback, lng?)` passes `lng` into `i18n.init({ lng })` so the browser detector is skipped when the site owner has supplied a language.
- `packages/locale/src/loadI18next.ts` — `loadI18next(backend, lng?)` reconciles an already-initialised singleton (awaits `changeLanguage`) so the returned promise only resolves once the singleton is on the requested language. Prevents flash when a second widget on the same page requests a different language.
- `packages/procaptcha-bundle/src/util/language.ts` — extracted `resolveLanguage(renderOptions, element)` from `setLanguage` so the bundle can resolve the language before a config exists.
- `packages/procaptcha-bundle/src/util/widgetFactory.ts` — resolves language upfront, passes it into `getCaptchaRenderer(language)`.
- `procaptcha-react` / `procaptcha-pow` / `procaptcha-puzzle` / `procaptcha-frictionless` widgets — simplified the runtime safety-net `useEffect` and now pass `config.language` into `loadI18next` (helps direct-React consumers who don't go through `WidgetFactory`).

## Test plan

- [ ] `build:tsc` clean on `@prosopo/locale`, `procaptcha-react`, `procaptcha-pow`, `procaptcha-puzzle`, `procaptcha-frictionless`, `procaptcha-bundle` (verified locally)
- [ ] `biome check` clean on all 8 changed files (verified locally)
- [ ] Manual: render bundle widget with browser language = de, `data-language="fr"` → every visible string is French; no flash of German
- [ ] Manual: render bundle widget with no `data-language` → falls back to browser language (existing behaviour preserved)
- [ ] Manual: two widgets on same page with same `data-language` → both consistent
- [ ] Manual: direct-React consumer (`<Procaptcha config={{ language: "es" }} />`) → labels render in Spanish
- [ ] CI parallel matrix passes

## Follow-ups (not in this PR)

Hard-coded English fallbacks (`"Loading..."` in `CaptchaComponent`, `"No challenge set."` in `ProcaptchaWidget`) still render in English regardless of language. These are only briefly visible and don't contribute to the mixed-language complaint; a follow-up PR can add translation keys across the 32 locale files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)