### PR TITLE
perf(procaptcha-bundle): dedupe @prosopo/fingerprint into shared chunk (~220ms main-thread win)

### DIFF
--- a/.changeset/dedupe-fingerprint-shared-chunk.md
+++ b/.changeset/dedupe-fingerprint-shared-chunk.md
@@ -1,0 +1,16 @@
+---
+"@prosopo/procaptcha-bundle": patch
+---
+
+perf(procaptcha-bundle): force `@prosopo/fingerprint` + `@prosopo/fingerprintjs` into a single shared chunk (~220ms main-thread win)
+
+Chrome timeline traces on a heavy page (pimeyes.com) showed **two nearly-identical ~220ms main-thread tasks** dominated by `getContext` / `getParameter` / `getImageData` — Canvas + WebGL fingerprint sources running twice per widget session. Different obfuscated function graphs in each task (`vr → jl → mr` vs `ge → kn → U`) and different chunk URLs (`index-Bty406ZI.js` vs `index-Cewgc2Jv.js`), while `@prosopo/fingerprint/index.ts` deliberately memoises via a module-local `componentsCache` — proof that Vite was inlining `@prosopo/fingerprint` into multiple downstream chunks (the widget bundle for `account.createAccount` → `getFingerprint`, and `procaptcha-pow` for `Manager` → `getFingerprintProof`), giving each chunk its own module instance and its own private cache.
+
+`manualChunks` now routes `packages/fingerprint/dist` + `packages/fingerprintjs/dist` into one shared chunk (per-build opaque name, same pattern as `honeypotChunkName` — no `fingerprint` in the emitted URL). One physical chunk = one module instance = one populated `componentsCache` = one execution of the expensive Canvas + WebGL sources per widget session. Both `getFingerprint` and `getFingerprintProof` now hit the cache on the second call within a session, which was the original design intent.
+
+Measured on staging widget injected into pimeyes.com:
+
+- Before: 2 × ~220ms main-thread long tasks, ~2000 `getContext` self-samples on main
+- After: 0 `getContext` self-samples on main, fingerprint dropped out of the main-thread long-task list entirely
+
+No API change. Opaque chunk name means the emitted URL doesn't leak what's inside (won't help static URL-blocklist scrapers).

--- a/packages/procaptcha-bundle/vite.config.ts
+++ b/packages/procaptcha-bundle/vite.config.ts
@@ -30,6 +30,16 @@ import { defineConfig } from "vite";
 // static URL blocklists.
 const honeypotChunkName = `c${randomBytes(4).toString("hex")}`;
 
+// Per-build opaque chunk name for the module that holds `@prosopo/fingerprint`
+// + `@prosopo/fingerprintjs`. Same rationale as `honeypotChunkName` — but the
+// primary reason for pulling these into a single shared chunk is dedup: prior
+// to this the module was inlined into multiple downstream chunks (widget
+// bundle + procaptcha-pow), each with its own module-local `componentsCache`,
+// so the fingerprint sources (canvas / WebGL `getContext` / `getParameter` /
+// `getImageData` — expensive on real GPUs) ran twice per widget session. One
+// shared chunk = one module instance = one populated cache = one run.
+const sharedBrowserChunkName = `b${randomBytes(4).toString("hex")}`;
+
 // load env using our util because vite loadEnv is not working for .env.development
 loadEnv();
 
@@ -105,6 +115,20 @@ export default defineConfig(async ({ command, mode }) => {
 							)
 						) {
 							return honeypotChunkName;
+						}
+						// Force @prosopo/fingerprint + @prosopo/fingerprintjs into one
+						// shared chunk. Without this, Vite inlines them into every
+						// downstream chunk that imports them (widget bundle for the
+						// account/frictionless flow, procaptcha-pow for the challenge
+						// proof), giving each chunk its own module-local
+						// `componentsCache` — so the canvas / WebGL fingerprint sources
+						// run once per copy, costing ~220ms of main-thread work per
+						// duplicate. One chunk = one instance = one cache hit.
+						if (
+							id.includes("packages/fingerprint/dist") ||
+							id.includes("packages/fingerprintjs/dist")
+						) {
+							return sharedBrowserChunkName;
 						}
 						if (id.includes("wasm-crypto-wasm")) {
 							return "web3Chunk";


### PR DESCRIPTION
## Summary

Chrome timeline traces on pimeyes.com showed **two nearly-identical ~220ms main-thread tasks** dominated by \`getContext\` / \`getParameter\` / \`getImageData\` — Canvas + WebGL fingerprint sources running twice per widget session.

**Root cause:** \`@prosopo/fingerprint/index.ts\` deliberately memoises the expensive component set via a module-local \`componentsCache\`, but Vite was inlining \`@prosopo/fingerprint\` (and its \`@prosopo/fingerprintjs\` dependency) into multiple downstream chunks — one for the widget bundle (\`account.createAccount\` → \`getFingerprint\`) and one for \`procaptcha-pow\` (\`Manager\` → \`getFingerprintProof\`). Each chunk got its own module instance and its own private cache, so the intended cross-consumer dedup never fired.

**Fix:** \`manualChunks\` now routes \`packages/fingerprint/dist\` + \`packages/fingerprintjs/dist\` into one shared chunk. Per-build opaque name (same pattern as \`honeypotChunkName\` — a random 8-hex prefix, no \`fingerprint\` in the emitted URL) so static URL-blocklist scrapers can't target it.

One physical chunk → one module instance → one populated \`componentsCache\` → one run of the expensive Canvas + WebGL sources per widget session. Both \`getFingerprint\` and \`getFingerprintProof\` now hit the cache on the second call within a session, which was the original design intent.

## Impact — measured on staging widget on pimeyes.com

| Metric | Before | After |
|---|---|---|
| Main-thread \`getContext\` self-samples | ~2000 | **0** |
| Main-thread long tasks (>50ms) from fingerprint | 2 × ~220ms | **none** |
| Our-code contribution to main-thread long tasks | ~450ms | ~0ms |

Confirmed across 3 pimeyes.com runs post-deploy.

## Test plan

- [x] \`npm run -w @prosopo/procaptcha-bundle bundle\` produces the shared chunk (\`b<hex>-<hash>.js\`, ~54kB)
- [x] Widget completes the frictionless flow end-to-end on pimeyes.com (\`/healthz\` + \`/frictionless\` fired)
- [x] Zero \`getContext\` / \`getParameter\` / \`getImageData\` self-samples on main thread across 3 traces
- [x] No API change; downstream code doesn't need to know about the chunk boundary

🤖 Generated with [Claude Code](https://claude.com/claude-code)