### PR TITLE
feat(database): stream puzzle captcha records to central captchastorage DB

### DIFF
--- a/.changeset/puzzle-central-streaming.md
+++ b/.changeset/puzzle-central-streaming.md
@@ -1,0 +1,12 @@
+---
+"@prosopo/database": patch
+"@prosopo/types-database": patch
+---
+
+feat(database): stream puzzle captcha records to the central captchastorage DB in real-time
+
+Puzzle records were being written to each provider node's local mongo but never reached the central `captchastorage` DB on mongo1 — `CentralDbStreamer` only exposed `streamPow*` and `streamImage*` methods, and `provider.ts`'s `storePuzzleCaptchaRecord` / `updatePuzzleCaptchaRecordResult` / `updatePuzzleCaptchaRecord` had no streamer calls at all. As a result 35 puzzle records were successfully written to per-pronode mongos over 7d but zero landed in the central store, so portal aggregations and the audit search return no puzzle data regardless of live activity.
+
+Adds `streamPuzzleRecord` / `streamPuzzleUpdate` on `CentralDbStreamer` mirroring the PoW pattern (fire-and-forget, `challenge` upsert key, `pendingStage` guard callback so concurrent updates aren't dropped). Wires those calls into every puzzle write/update site in `provider.ts`. Adds `puzzlecaptcha` to `CaptchaDatabase`'s tables and extends `saveCaptchas`/`getCaptchas` with a puzzle branch for parity with the existing pow/image bulk-write paths. Adds `StoredPuzzleCaptchaRecordSchema` in `@prosopo/types-database` and threads `PuzzleCaptchaRecord` through the `ICaptchaDatabase` interface.
+
+Existing puzzle records on pronode local mongos are not backfilled — this change is forward-only.

--- a/packages/database/src/databases/captcha.ts
+++ b/packages/database/src/databases/captcha.ts
@@ -18,7 +18,9 @@ import {
 	type CaptchaProperties,
 	type ICaptchaDatabase,
 	type PoWCaptchaRecord,
+	type PuzzleCaptchaRecord,
 	StoredPoWCaptchaRecordSchema,
+	StoredPuzzleCaptchaRecordSchema,
 	type StoredSession,
 	StoredSessionRecordSchema,
 	StoredUserCommitmentRecordSchema,
@@ -47,6 +49,7 @@ enum TableNames {
 	session = "session",
 	commitment = "commitment",
 	powcaptcha = "powcaptcha",
+	puzzlecaptcha = "puzzlecaptcha",
 }
 
 const CAPTCHA_TABLES = [
@@ -64,6 +67,11 @@ const CAPTCHA_TABLES = [
 		collectionName: TableNames.commitment,
 		modelName: "UserCommitment",
 		schema: StoredUserCommitmentRecordSchema,
+	},
+	{
+		collectionName: TableNames.puzzlecaptcha,
+		modelName: "PuzzleCaptcha",
+		schema: StoredPuzzleCaptchaRecordSchema,
 	},
 ];
 
@@ -191,6 +199,7 @@ export class CaptchaDatabase extends MongoDatabase implements ICaptchaDatabase {
 		sessionEvents: StoredSession[],
 		imageCaptchaEvents: UserCommitmentRecord[],
 		powCaptchaEvents: PoWCaptchaRecord[],
+		puzzleCaptchaEvents: PuzzleCaptchaRecord[] = [],
 	) {
 		await this.connect();
 		if (sessionEvents.length) {
@@ -264,6 +273,31 @@ export class CaptchaDatabase extends MongoDatabase implements ICaptchaDatabase {
 			}));
 		}
 
+		if (puzzleCaptchaEvents.length) {
+			const result = await this.tables.puzzlecaptcha.bulkWrite(
+				puzzleCaptchaEvents.map((doc) => {
+					const { _id, ...safeDoc } = doc;
+					const normalised = CaptchaDatabase.normaliseDocCompositeIps(safeDoc);
+					return {
+						updateOne: {
+							filter: { challenge: normalised.challenge },
+							update: { $set: normalised },
+							upsert: true,
+						},
+					};
+				}),
+			);
+			logger.info(() => ({
+				data: {
+					upsertedCount: result.upsertedCount,
+					matchedCount: result.matchedCount,
+					modifiedCount: result.modifiedCount,
+					totalProcessed: puzzleCaptchaEvents.length,
+				},
+				msg: "Mongo Saved Puzzle Events",
+			}));
+		}
+
 		await this.close();
 	}
 
@@ -273,6 +307,7 @@ export class CaptchaDatabase extends MongoDatabase implements ICaptchaDatabase {
 	): Promise<{
 		userCommitmentRecords: UserCommitmentRecord[];
 		powCaptchaRecords: PoWCaptchaRecord[];
+		puzzleCaptchaRecords: PuzzleCaptchaRecord[];
 	}> {
 		await this.connect();
 
@@ -287,9 +322,15 @@ export class CaptchaDatabase extends MongoDatabase implements ICaptchaDatabase {
 				.limit(limit)
 				.lean<PoWCaptchaRecord[]>();
 
+			const puzzleCaptchaResults = await this.tables.puzzlecaptcha
+				.find(filter)
+				.limit(limit)
+				.lean<PuzzleCaptchaRecord[]>();
+
 			return {
 				userCommitmentRecords: commitmentResults,
 				powCaptchaRecords: powCaptchaResults,
+				puzzleCaptchaRecords: puzzleCaptchaResults,
 			};
 		} catch (error) {
 			throw new ProsopoDBError("DATABASE.QUERY_ERROR", {

--- a/packages/database/src/databases/centralDbStreamer.ts
+++ b/packages/database/src/databases/centralDbStreamer.ts
@@ -15,6 +15,7 @@
 import { type Logger, getLogger } from "@prosopo/logger";
 import type {
 	PoWCaptchaRecord,
+	PuzzleCaptchaRecord,
 	StoredSession,
 	UserCommitmentRecord,
 } from "@prosopo/types-database";
@@ -193,6 +194,54 @@ export class CentralDbStreamer {
 				this.logger.error(() => ({
 					err,
 					msg: "Failed to fetch image record for central DB streaming",
+				}));
+			});
+	}
+
+	/**
+	 * Stream a puzzle captcha record (create or update) to the central DB.
+	 * Fire-and-forget: errors are logged, never thrown.
+	 */
+	streamPuzzleRecord(
+		record: PuzzleCaptchaRecord,
+		markStored?: MarkStoredCallback,
+	): void {
+		const timestamp = this.getRecordTimestamp(record);
+		this.ensureConnected()
+			.then(() => {
+				const { _id, ...safeDoc } = record;
+				return this.db.tables.puzzlecaptcha.updateOne(
+					{ challenge: safeDoc.challenge },
+					{ $set: safeDoc },
+					{ upsert: true },
+				);
+			})
+			.then(() => markStored?.(timestamp))
+			.catch((err: unknown) => {
+				this.logger.error(() => ({
+					err,
+					msg: "Failed to stream puzzle record to central DB",
+				}));
+			});
+	}
+
+	/**
+	 * Stream a partial puzzle update by fetching the full record first, then upserting.
+	 */
+	streamPuzzleUpdate(
+		getFullRecord: () => Promise<PuzzleCaptchaRecord | null>,
+		markStored?: MarkStoredCallback,
+	): void {
+		getFullRecord()
+			.then((record) => {
+				if (record) {
+					this.streamPuzzleRecord(record, markStored);
+				}
+			})
+			.catch((err: unknown) => {
+				this.logger.error(() => ({
+					err,
+					msg: "Failed to fetch puzzle record for central DB streaming",
 				}));
 			});
 	}

--- a/packages/database/src/databases/provider.ts
+++ b/packages/database/src/databases/provider.ts
@@ -1118,6 +1118,19 @@ export class ProviderDatabase
 				},
 				msg: "PuzzleCaptcha record added successfully",
 			}));
+			this.centralStreamer?.streamPuzzleRecord(
+				puzzleCaptchaRecord as PuzzleCaptchaRecord,
+				(ts) =>
+					this.tables.puzzlecaptcha
+						.updateOne(
+							{ challenge, lastUpdatedTimestamp: { $lte: ts } },
+							{
+								$set: { storedAtTimestamp: ts },
+								$unset: { pendingStage: 1 },
+							},
+						)
+						.then(() => {}),
+			);
 		} catch (error) {
 			const err = new ProsopoDBError("DATABASE.CAPTCHA_UPDATE_FAILED", {
 				context: {
@@ -1276,6 +1289,19 @@ export class ProviderDatabase
 				},
 				msg: "PuzzleCaptcha record updated successfully",
 			}));
+			this.centralStreamer?.streamPuzzleUpdate(
+				() => this.getPuzzleCaptchaRecordByChallenge(challenge),
+				(ts) =>
+					this.tables.puzzlecaptcha
+						.updateOne(
+							{ challenge, lastUpdatedTimestamp: { $lte: ts } },
+							{
+								$set: { storedAtTimestamp: ts },
+								$unset: { pendingStage: 1 },
+							},
+						)
+						.then(() => {}),
+			);
 		} catch (error) {
 			const err = new ProsopoDBError("DATABASE.CAPTCHA_UPDATE_FAILED", {
 				context: {
@@ -1330,11 +1356,37 @@ export class ProviderDatabase
 		// required.
 		if (Object.keys(pipelineExprs).length === 0) {
 			await tables.puzzlecaptcha.updateOne({ challenge }, { $set: baseSet });
+			this.centralStreamer?.streamPuzzleUpdate(
+				() => this.getPuzzleCaptchaRecordByChallenge(challenge),
+				(ts) =>
+					this.tables.puzzlecaptcha
+						.updateOne(
+							{ challenge, lastUpdatedTimestamp: { $lte: ts } },
+							{
+								$set: { storedAtTimestamp: ts },
+								$unset: { pendingStage: 1 },
+							},
+						)
+						.then(() => {}),
+			);
 			return;
 		}
 		await tables.puzzlecaptcha.updateOne({ challenge }, [
 			{ $set: { ...baseSet, ...pipelineExprs } },
 		]);
+		this.centralStreamer?.streamPuzzleUpdate(
+			() => this.getPuzzleCaptchaRecordByChallenge(challenge),
+			(ts) =>
+				this.tables.puzzlecaptcha
+					.updateOne(
+						{ challenge, lastUpdatedTimestamp: { $lte: ts } },
+						{
+							$set: { storedAtTimestamp: ts },
+							$unset: { pendingStage: 1 },
+						},
+					)
+					.then(() => {}),
+		);
 	}
 
 	/** @description Get serverChecked Dapp User image captcha commitments from the commitments table

--- a/packages/database/src/tests/integration/puzzleCentralStreaming.integration.test.ts
+++ b/packages/database/src/tests/integration/puzzleCentralStreaming.integration.test.ts
@@ -1,0 +1,269 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { LogLevel, getLogger } from "@prosopo/logger";
+import {
+	CaptchaStatus,
+	type CompositeIpAddress,
+	type IPInfoResponse,
+	IpAddressType,
+} from "@prosopo/types";
+import type { PuzzleCaptchaRecord } from "@prosopo/types-database";
+import { MongoMemoryServer } from "mongodb-memory-server";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { CentralDbStreamer } from "../../databases/centralDbStreamer.js";
+
+// End-to-end guard for the puzzle central-streaming path. Spins up an
+// in-memory mongod, calls streamPuzzleRecord/streamPuzzleUpdate through the
+// real streamer, and confirms the doc lands in the `puzzlecaptcha` collection
+// on the central DB with the fields we set — the round-trip proof that the
+// wiring added alongside pow/image works for puzzles too.
+
+const logger = getLogger(LogLevel.enum.error, "puzzleCentralStreaming.test");
+
+const ipv4Composite = (lower: bigint): CompositeIpAddress => ({
+	lower,
+	type: IpAddressType.v4,
+});
+
+const validIpInfo: IPInfoResponse = {
+	ip: "203.0.113.7",
+	isValid: true,
+	isVPN: false,
+	isTor: false,
+	isProxy: false,
+	isDatacenter: false,
+	isAbuser: false,
+	isMobile: false,
+	isSatellite: false,
+	isCrawler: false,
+	countryCode: "GB",
+	asnNumber: 64500,
+	abuserScore: 0.01,
+	companyAbuserScore: 0.01,
+};
+
+const buildPuzzleRecord = (
+	challenge: string,
+	overrides?: Partial<PuzzleCaptchaRecord>,
+): PuzzleCaptchaRecord =>
+	({
+		challenge,
+		userAccount: "userTest",
+		dappAccount: "dappTest",
+		requestedAtTimestamp: new Date("2026-06-10T07:30:00Z"),
+		lastUpdatedTimestamp: new Date("2026-06-10T07:30:05Z"),
+		ipAddress: ipv4Composite(3405803783n),
+		headers: { host: "pronode-test.local" },
+		ja4: "t13d1516h2_test_abcdef",
+		result: { status: CaptchaStatus.pending },
+		userSubmitted: false,
+		serverChecked: false,
+		targetX: 100,
+		targetY: 200,
+		originX: 50,
+		originY: 150,
+		tolerance: 10,
+		providerSignature: "0xproviderSig",
+		sessionId: "pronode-test-session-puzzle-1",
+		ipInfo: validIpInfo,
+		...overrides,
+	}) as unknown as PuzzleCaptchaRecord;
+
+const waitForDoc = async <T>(
+	fetch: () => Promise<T | null>,
+	maxAttempts = 50,
+): Promise<T | null> => {
+	let stored: T | null = null;
+	for (let i = 0; i < maxAttempts && stored === null; i++) {
+		await new Promise<void>((r) => setTimeout(r, 20));
+		stored = await fetch();
+	}
+	return stored;
+};
+
+describe("CentralDbStreamer end-to-end: puzzle records", () => {
+	let mongod: MongoMemoryServer;
+	let streamer: CentralDbStreamer;
+
+	beforeAll(async () => {
+		mongod = await MongoMemoryServer.create();
+		streamer = new CentralDbStreamer(mongod.getUri(), logger);
+	});
+
+	afterAll(async () => {
+		const db = (streamer as unknown as { db: { close: () => Promise<void> } })
+			.db;
+		await db.close();
+		await mongod.stop();
+	});
+
+	it("streamPuzzleRecord upserts the record to central puzzlecaptcha collection", async () => {
+		const challenge = "puzzle-e2e-1";
+		const record = buildPuzzleRecord(challenge);
+
+		streamer.streamPuzzleRecord(record);
+
+		const tables = (
+			streamer as unknown as {
+				db: {
+					tables: {
+						puzzlecaptcha: import("mongoose").Model<PuzzleCaptchaRecord>;
+					};
+				};
+			}
+		).db.tables;
+
+		const stored = await waitForDoc(() =>
+			tables.puzzlecaptcha
+				.findOne({ challenge })
+				.lean<PuzzleCaptchaRecord>(),
+		);
+
+		expect(stored).not.toBeNull();
+		if (!stored) return;
+
+		expect(stored.challenge).toBe(challenge);
+		expect(stored.userAccount).toBe("userTest");
+		expect(stored.dappAccount).toBe("dappTest");
+		expect(stored.targetX).toBe(100);
+		expect(stored.tolerance).toBe(10);
+		expect(stored.sessionId).toBe("pronode-test-session-puzzle-1");
+		expect(stored.result?.status).toBe(CaptchaStatus.pending);
+		expect(stored.ipInfo).toMatchObject(validIpInfo);
+	});
+
+	it("streamPuzzleRecord calls markStored with the record's lastUpdatedTimestamp", async () => {
+		const challenge = "puzzle-e2e-2";
+		const record = buildPuzzleRecord(challenge);
+
+		let capturedTimestamp: Date | undefined;
+		const markStored = async (ts: Date): Promise<void> => {
+			capturedTimestamp = ts;
+		};
+
+		streamer.streamPuzzleRecord(record, markStored);
+
+		// Wait until markStored fires (streamer is fire-and-forget).
+		for (let i = 0; i < 50 && capturedTimestamp === undefined; i++) {
+			await new Promise<void>((r) => setTimeout(r, 20));
+		}
+
+		expect(capturedTimestamp).toBeDefined();
+		expect(capturedTimestamp?.toISOString()).toBe(
+			record.lastUpdatedTimestamp?.toISOString(),
+		);
+	});
+
+	it("streamPuzzleRecord upsert replaces fields on subsequent calls with the same challenge", async () => {
+		// Mirrors the real production sequence: create → local write completes →
+		// stream (pending) → update → local write completes → stream (approved).
+		// The fetch step between streams gives the first write time to land, so
+		// the second write really is the last one to hit the central DB.
+		const challenge = "puzzle-e2e-upsert";
+		const first = buildPuzzleRecord(challenge, {
+			result: { status: CaptchaStatus.pending },
+			userSubmitted: false,
+			lastUpdatedTimestamp: new Date("2026-06-10T07:30:05Z"),
+		});
+		const second = buildPuzzleRecord(challenge, {
+			result: { status: CaptchaStatus.approved },
+			userSubmitted: true,
+			serverChecked: true,
+			lastUpdatedTimestamp: new Date("2026-06-10T07:30:10Z"),
+		});
+
+		const tables = (
+			streamer as unknown as {
+				db: {
+					tables: {
+						puzzlecaptcha: import("mongoose").Model<PuzzleCaptchaRecord>;
+					};
+				};
+			}
+		).db.tables;
+
+		streamer.streamPuzzleRecord(first);
+
+		// Wait until the first (pending) write lands before firing the second.
+		const afterFirst = await waitForDoc(() =>
+			tables.puzzlecaptcha
+				.findOne({ challenge })
+				.lean<PuzzleCaptchaRecord>(),
+		);
+		expect(afterFirst?.result?.status).toBe(CaptchaStatus.pending);
+
+		streamer.streamPuzzleRecord(second);
+
+		// Poll until the approved state lands.
+		let stored: PuzzleCaptchaRecord | null = null;
+		for (let i = 0; i < 50; i++) {
+			await new Promise<void>((r) => setTimeout(r, 20));
+			stored = await tables.puzzlecaptcha
+				.findOne({ challenge })
+				.lean<PuzzleCaptchaRecord>();
+			if (stored?.result?.status === CaptchaStatus.approved) break;
+		}
+
+		expect(stored).not.toBeNull();
+		if (!stored) return;
+		expect(stored.result?.status).toBe(CaptchaStatus.approved);
+		expect(stored.userSubmitted).toBe(true);
+		expect(stored.serverChecked).toBe(true);
+	});
+
+	it("streamPuzzleUpdate fetches the full record and streams it", async () => {
+		const challenge = "puzzle-e2e-update";
+		const record = buildPuzzleRecord(challenge, {
+			result: { status: CaptchaStatus.approved },
+			userSubmitted: true,
+		});
+
+		let fetchCalled = false;
+		streamer.streamPuzzleUpdate(async () => {
+			fetchCalled = true;
+			return record;
+		});
+
+		const tables = (
+			streamer as unknown as {
+				db: {
+					tables: {
+						puzzlecaptcha: import("mongoose").Model<PuzzleCaptchaRecord>;
+					};
+				};
+			}
+		).db.tables;
+
+		const stored = await waitForDoc(() =>
+			tables.puzzlecaptcha
+				.findOne({ challenge })
+				.lean<PuzzleCaptchaRecord>(),
+		);
+
+		expect(fetchCalled).toBe(true);
+		expect(stored).not.toBeNull();
+		if (!stored) return;
+		expect(stored.userSubmitted).toBe(true);
+		expect(stored.result?.status).toBe(CaptchaStatus.approved);
+	});
+
+	// The null-fetch case (streamPuzzleUpdate skips the write when fetch
+	// returns null) is covered by the unit test in centralDbStreamer.unit.test.ts.
+	// It's fiddly here because the update path never triggers a streamer
+	// connection when it short-circuits on null, so the shared MongoMemoryServer
+	// tables map isn't guaranteed to be populated by the time we try to read
+	// from it — that's a test-harness artefact, not a code path worth
+	// duplicating.
+});

--- a/packages/database/src/tests/integration/puzzleCentralStreaming.integration.test.ts
+++ b/packages/database/src/tests/integration/puzzleCentralStreaming.integration.test.ts
@@ -126,9 +126,7 @@ describe("CentralDbStreamer end-to-end: puzzle records", () => {
 		).db.tables;
 
 		const stored = await waitForDoc(() =>
-			tables.puzzlecaptcha
-				.findOne({ challenge })
-				.lean<PuzzleCaptchaRecord>(),
+			tables.puzzlecaptcha.findOne({ challenge }).lean<PuzzleCaptchaRecord>(),
 		);
 
 		expect(stored).not.toBeNull();
@@ -198,9 +196,7 @@ describe("CentralDbStreamer end-to-end: puzzle records", () => {
 
 		// Wait until the first (pending) write lands before firing the second.
 		const afterFirst = await waitForDoc(() =>
-			tables.puzzlecaptcha
-				.findOne({ challenge })
-				.lean<PuzzleCaptchaRecord>(),
+			tables.puzzlecaptcha.findOne({ challenge }).lean<PuzzleCaptchaRecord>(),
 		);
 		expect(afterFirst?.result?.status).toBe(CaptchaStatus.pending);
 
@@ -247,9 +243,7 @@ describe("CentralDbStreamer end-to-end: puzzle records", () => {
 		).db.tables;
 
 		const stored = await waitForDoc(() =>
-			tables.puzzlecaptcha
-				.findOne({ challenge })
-				.lean<PuzzleCaptchaRecord>(),
+			tables.puzzlecaptcha.findOne({ challenge }).lean<PuzzleCaptchaRecord>(),
 		);
 
 		expect(fetchCalled).toBe(true);

--- a/packages/database/src/tests/unit/databases/centralDbStreamer.unit.test.ts
+++ b/packages/database/src/tests/unit/databases/centralDbStreamer.unit.test.ts
@@ -15,6 +15,7 @@
 import type { Logger } from "@prosopo/logger";
 import type {
 	PoWCaptchaRecord,
+	PuzzleCaptchaRecord,
 	StoredSession,
 	UserCommitmentRecord,
 } from "@prosopo/types-database";
@@ -50,6 +51,7 @@ describe("CentralDbStreamer", () => {
 	let mockPowUpdateOne: MockInstance;
 	let mockCommitmentUpdateOne: MockInstance;
 	let mockSessionUpdateOne: MockInstance;
+	let mockPuzzleUpdateOne: MockInstance;
 
 	beforeEach(() => {
 		vi.clearAllMocks();
@@ -59,6 +61,7 @@ describe("CentralDbStreamer", () => {
 		mockPowUpdateOne = vi.fn().mockResolvedValue({ upsertedCount: 1 });
 		mockCommitmentUpdateOne = vi.fn().mockResolvedValue({ upsertedCount: 1 });
 		mockSessionUpdateOne = vi.fn().mockResolvedValue({ upsertedCount: 1 });
+		mockPuzzleUpdateOne = vi.fn().mockResolvedValue({ upsertedCount: 1 });
 
 		streamer = new CentralDbStreamer(
 			"mongodb://localhost:27017/test",
@@ -76,6 +79,7 @@ describe("CentralDbStreamer", () => {
 			powcaptcha: { updateOne: mockPowUpdateOne },
 			commitment: { updateOne: mockCommitmentUpdateOne },
 			session: { updateOne: mockSessionUpdateOne },
+			puzzlecaptcha: { updateOne: mockPuzzleUpdateOne },
 		};
 	});
 
@@ -253,6 +257,129 @@ describe("CentralDbStreamer", () => {
 				{ upsert: true },
 			);
 			expect(markStored).toHaveBeenCalledWith(record.lastUpdatedTimestamp);
+		});
+	});
+
+	describe("streamPuzzleRecord", () => {
+		const makePuzzleRecord = (
+			overrides?: Partial<PuzzleCaptchaRecord>,
+		): PuzzleCaptchaRecord =>
+			({
+				challenge: "puzzle-challenge-1",
+				userAccount: "user1",
+				dappAccount: "dapp1",
+				targetX: 100,
+				targetY: 200,
+				originX: 50,
+				originY: 150,
+				tolerance: 10,
+				requestedAtTimestamp: new Date("2026-01-01T00:00:00Z"),
+				lastUpdatedTimestamp: new Date("2026-01-01T01:00:00Z"),
+				result: { status: "pending" },
+				...overrides,
+			}) as unknown as PuzzleCaptchaRecord;
+
+		it("upserts the record to central DB keyed by challenge and calls markStored with the record timestamp", async () => {
+			const record = makePuzzleRecord();
+			const markStored = vi
+				.fn<MarkStoredCallback>()
+				.mockResolvedValue(undefined);
+
+			streamer.streamPuzzleRecord(record, markStored);
+			await flush();
+
+			expect(mockPuzzleUpdateOne).toHaveBeenCalledWith(
+				{ challenge: record.challenge },
+				{
+					$set: expect.objectContaining({ challenge: record.challenge }),
+				},
+				{ upsert: true },
+			);
+			expect(markStored).toHaveBeenCalledWith(record.lastUpdatedTimestamp);
+		});
+
+		it("strips _id from the record before upserting", async () => {
+			const record = makePuzzleRecord();
+			(record as unknown as Record<string, unknown>)._id = "should-be-removed";
+
+			streamer.streamPuzzleRecord(record);
+			await flush();
+
+			const call = mockPuzzleUpdateOne.mock.calls[0] as unknown[];
+			const setArg = (call[1] as { $set: Record<string, unknown> }).$set;
+			expect(setArg._id).toBeUndefined();
+		});
+
+		it("does not throw when the central write fails", async () => {
+			mockPuzzleUpdateOne.mockRejectedValueOnce(new Error("write failed"));
+			const markStored = vi.fn<MarkStoredCallback>();
+
+			streamer.streamPuzzleRecord(makePuzzleRecord(), markStored);
+			await flush();
+
+			expect(markStored).not.toHaveBeenCalled();
+			expect(errorSpy).toHaveBeenCalled();
+		});
+
+		it("falls back to requestedAtTimestamp when lastUpdatedTimestamp is missing", async () => {
+			const ts = new Date("2026-02-01T00:00:00Z");
+			const record = makePuzzleRecord({
+				lastUpdatedTimestamp: undefined,
+				requestedAtTimestamp: ts,
+			});
+			const markStored = vi
+				.fn<MarkStoredCallback>()
+				.mockResolvedValue(undefined);
+
+			streamer.streamPuzzleRecord(record, markStored);
+			await flush();
+
+			expect(markStored).toHaveBeenCalledWith(ts);
+		});
+	});
+
+	describe("streamPuzzleUpdate", () => {
+		it("fetches the full record then streams it", async () => {
+			const record = {
+				challenge: "puzzle-challenge-2",
+				lastUpdatedTimestamp: new Date("2026-03-01T00:00:00Z"),
+			} as unknown as PuzzleCaptchaRecord;
+			const getFullRecord = vi.fn().mockResolvedValue(record);
+			const markStored = vi
+				.fn<MarkStoredCallback>()
+				.mockResolvedValue(undefined);
+
+			streamer.streamPuzzleUpdate(getFullRecord, markStored);
+			await flush();
+
+			expect(getFullRecord).toHaveBeenCalled();
+			expect(mockPuzzleUpdateOne).toHaveBeenCalledWith(
+				{ challenge: "puzzle-challenge-2" },
+				expect.objectContaining({}),
+				{ upsert: true },
+			);
+			expect(markStored).toHaveBeenCalledWith(record.lastUpdatedTimestamp);
+		});
+
+		it("does not stream when the record is not found", async () => {
+			const getFullRecord = vi.fn().mockResolvedValue(null);
+
+			streamer.streamPuzzleUpdate(getFullRecord);
+			await flush();
+
+			expect(mockPuzzleUpdateOne).not.toHaveBeenCalled();
+		});
+
+		it("logs error when fetch fails", async () => {
+			const getFullRecord = vi
+				.fn()
+				.mockRejectedValue(new Error("fetch failed"));
+
+			streamer.streamPuzzleUpdate(getFullRecord);
+			await flush();
+
+			expect(errorSpy).toHaveBeenCalled();
+			expect(mockPuzzleUpdateOne).not.toHaveBeenCalled();
 		});
 	});
 

--- a/packages/types-database/src/types/captcha.ts
+++ b/packages/types-database/src/types/captcha.ts
@@ -18,6 +18,8 @@ import type { IDatabase } from "./mongo.js";
 import {
 	type PoWCaptchaRecord,
 	PoWCaptchaRecordSchema,
+	type PuzzleCaptchaRecord,
+	PuzzleCaptchaRecordSchema,
 	type SessionRecord,
 	SessionRecordSchema,
 	type UserCommitmentRecord,
@@ -39,11 +41,17 @@ export const StoredPoWCaptchaRecordSchema: Schema = new Schema({
 });
 StoredPoWCaptchaRecordSchema.index({ sessionId: 1 });
 
+export const StoredPuzzleCaptchaRecordSchema: Schema = new Schema({
+	...PuzzleCaptchaRecordSchema.obj,
+});
+StoredPuzzleCaptchaRecordSchema.index({ sessionId: 1 });
+
 export interface ICaptchaDatabase extends IDatabase {
 	saveCaptchas(
 		sessionEvents: StoredSession[],
 		imageCaptchaEvents: UserCommitmentRecord[],
 		powCaptchaEvents: PoWCaptchaRecord[],
+		puzzleCaptchaEvents?: PuzzleCaptchaRecord[],
 	): Promise<void>;
 	getCaptchas(
 		filter: RootFilterQuery<CaptchaProperties>,
@@ -51,6 +59,7 @@ export interface ICaptchaDatabase extends IDatabase {
 	): Promise<{
 		userCommitmentRecords: UserCommitmentRecord[];
 		powCaptchaRecords: PoWCaptchaRecord[];
+		puzzleCaptchaRecords: PuzzleCaptchaRecord[];
 	}>;
 }
 


### PR DESCRIPTION
## Summary

Puzzle records were being written to each provider node's local mongo but never reached the central `captchastorage` DB on mongo1. `CentralDbStreamer` only exposed `streamPow*` / `streamImage*` methods, and every puzzle write/update site in `provider.ts` had **no streamer call at all**.

Result: over 7d, 35 successful puzzle record writes on pronodes, **zero** landed centrally, so `TCaptchaCountData.puzzle` fields were dead-code and audit search returned no puzzle rows regardless of live activity.

## Change

- `CentralDbStreamer` — added `streamPuzzleRecord` / `streamPuzzleUpdate` mirroring the PoW pattern (fire-and-forget, `challenge` upsert key, `pendingStage` guard callback so concurrent local updates aren't dropped).
- `provider.ts` — wired those calls into `storePuzzleCaptchaRecord`, `updatePuzzleCaptchaRecordResult`, and both branches of `updatePuzzleCaptchaRecord`.
- `CaptchaDatabase` (`captcha.ts`) — added `puzzlecaptcha` table entry; extended `saveCaptchas` / `getCaptchas` with a puzzle branch for parity with pow/image bulk-write paths.
- `types-database` — added `StoredPuzzleCaptchaRecordSchema`; threaded `PuzzleCaptchaRecord` through the `ICaptchaDatabase.saveCaptchas` / `getCaptchas` signatures (added as optional param + return field so existing callers stay compatible).

Forward-only — existing puzzle records on pronode local mongos are **not** backfilled.

## Coordinated PR

Paired with the central-store + aggregator wiring in `captcha-private` PR (link to follow once opened). This PR must land first, then the outer PR bumps the submodule ref.

## Test plan

- [ ] `npm run -w @prosopo/database build:tsc` passes
- [ ] `npm run -w @prosopo/types-database build:tsc` passes
- [ ] Unit tests for `CentralDbStreamer.streamPuzzleRecord/Update` (follow-up)
- [ ] After deploy: `mongo1.prosopo.io captchastorage.puzzlecaptcha` collection starts populating; `TCaptchaCountData.puzzle` fields become non-zero in the hourly aggregation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)