### PR TITLE
fix(provider): skip city and distance rules for same trusted provider

### DIFF
--- a/.changeset/ip-validation-same-provider-skip.md
+++ b/.changeset/ip-validation-same-provider-skip.md
@@ -1,0 +1,9 @@
+---
+"@prosopo/provider": patch
+---
+
+fix(provider): skip city and distance IP validation rules for same trusted provider
+
+Dual-stack and CGNAT subscribers routinely egress via different POPs of the same operator (e.g. AT&T's BellSouth v4 pool + AT&T Internet v6 pool — distinct ASNs but identical `company.name` from ipapi). The city-change and distance-exceed rules previously fired on such traffic, producing PoW captcha rejections with `City changed from Laredo to Los Angeles; IP addresses are 1930km apart` even though the ISP-change rule correctly recognised the provider match.
+
+`evaluateIpValidationRules` now gates the city-change and distance-exceed rule blocks on a `sameTrustedProvider` precondition: both providers match (non-`"Unknown"`), same `countryCode`, and neither endpoint is a datacenter (guards against AWS/Cloudflare same-`company.name` false negatives where "same corporate owner" absolutely does not mean "same subscriber"). Country-change, ISP-change, VPN/proxy, and abuse-score rules are unchanged.

--- a/packages/provider/src/tests/unit/util.evaluateIpValidationRules.unit.test.ts
+++ b/packages/provider/src/tests/unit/util.evaluateIpValidationRules.unit.test.ts
@@ -135,14 +135,14 @@ describe("evaluateIpValidationRules", () => {
 					country: "A",
 					countryCode: "A",
 					provider: "X",
-					connectionType: "residential",
+					connectionType: "datacenter",
 					isVpnOrProxy: false,
 				},
 				ip2Details: {
 					country: "A",
 					countryCode: "A",
 					provider: "X",
-					connectionType: "residential",
+					connectionType: "datacenter",
 					isVpnOrProxy: false,
 				},
 				distanceKm: 2000,
@@ -199,7 +199,7 @@ describe("evaluateIpValidationRules", () => {
 					countryCode: "A",
 					city: "CityA",
 					provider: "X",
-					connectionType: "residential",
+					connectionType: "datacenter",
 					isVpnOrProxy: false,
 				},
 				ip2Details: {
@@ -207,7 +207,7 @@ describe("evaluateIpValidationRules", () => {
 					countryCode: "A",
 					city: "CityB",
 					provider: "X",
-					connectionType: "residential",
+					connectionType: "datacenter",
 					isVpnOrProxy: false,
 				},
 				differentProviders: false,
@@ -238,7 +238,7 @@ describe("evaluateIpValidationRules", () => {
 					countryCode: "A",
 					city: "CityA",
 					provider: "X",
-					connectionType: "residential",
+					connectionType: "datacenter",
 					isVpnOrProxy: false,
 				},
 				ip2Details: {
@@ -246,7 +246,7 @@ describe("evaluateIpValidationRules", () => {
 					countryCode: "A",
 					city: "CityB",
 					provider: "X",
-					connectionType: "residential",
+					connectionType: "datacenter",
 					isVpnOrProxy: false,
 				},
 				differentProviders: false,
@@ -515,6 +515,203 @@ describe("evaluateIpValidationRules", () => {
 			mockLogger,
 		);
 		expect(result.action).toBe(IPValidationAction.Flag);
+	});
+
+	describe("same trusted provider skip", () => {
+		const sameProviderRules: IIPValidationRules = {
+			...baseRules,
+			actions: {
+				...baseRules.actions,
+				cityChangeAction: IPValidationAction.Reject,
+				distanceExceedAction: IPValidationAction.Reject,
+			},
+			distanceThresholdKm: 500,
+		};
+
+		it("skips city and distance rules when both IPs share the same non-datacenter provider in the same country (eyematch shape)", () => {
+			const comparison: IPComparisonResult = {
+				ipsMatch: false,
+				ip1: "68.153.66.63",
+				ip2: "2600:387:15:6437::7",
+				comparison: {
+					ip1Details: {
+						country: "United States",
+						countryCode: "US",
+						city: "Laredo",
+						provider: "AT&T Enterprises, LLC",
+						connectionType: "residential",
+						isVpnOrProxy: false,
+					},
+					ip2Details: {
+						country: "United States",
+						countryCode: "US",
+						city: "San Antonio",
+						provider: "AT&T Enterprises, LLC",
+						connectionType: "residential",
+						isVpnOrProxy: false,
+					},
+					distanceKm: 1930,
+					differentProviders: false,
+					differentConnectionTypes: false,
+					anyVpnOrProxy: false,
+				},
+			};
+			const result = evaluateIpValidationRules(
+				comparison,
+				sameProviderRules,
+				mockLogger,
+			);
+			expect(result.action).toBe(IPValidationAction.Allow);
+			expect(result.errorMessage).toBeUndefined();
+		});
+
+		it("does not skip when either endpoint is a datacenter (guards AWS/Cloudflare same-company case)", () => {
+			const comparison: IPComparisonResult = {
+				ipsMatch: false,
+				ip1: "ip1",
+				ip2: "ip2",
+				comparison: {
+					ip1Details: {
+						country: "United States",
+						countryCode: "US",
+						city: "Ashburn",
+						provider: "Amazon.com, Inc.",
+						connectionType: "datacenter",
+						isVpnOrProxy: false,
+					},
+					ip2Details: {
+						country: "United States",
+						countryCode: "US",
+						city: "Ashburn",
+						provider: "Amazon.com, Inc.",
+						connectionType: "datacenter",
+						isVpnOrProxy: false,
+					},
+					distanceKm: 3800,
+					differentProviders: false,
+					differentConnectionTypes: false,
+					anyVpnOrProxy: false,
+				},
+			};
+			const result = evaluateIpValidationRules(
+				comparison,
+				sameProviderRules,
+				mockLogger,
+			);
+			expect(result.action).toBe(IPValidationAction.Reject);
+			expect(result.errorMessage).toMatch(/IP addresses are 3800\.00km apart/);
+		});
+
+		it("does not skip when provider is Unknown on both sides", () => {
+			const comparison: IPComparisonResult = {
+				ipsMatch: false,
+				ip1: "ip1",
+				ip2: "ip2",
+				comparison: {
+					ip1Details: {
+						country: "United States",
+						countryCode: "US",
+						city: "A",
+						provider: "Unknown",
+						connectionType: "residential",
+						isVpnOrProxy: false,
+					},
+					ip2Details: {
+						country: "United States",
+						countryCode: "US",
+						city: "B",
+						provider: "Unknown",
+						connectionType: "residential",
+						isVpnOrProxy: false,
+					},
+					distanceKm: 2000,
+					differentProviders: false,
+					differentConnectionTypes: false,
+					anyVpnOrProxy: false,
+				},
+			};
+			const result = evaluateIpValidationRules(
+				comparison,
+				sameProviderRules,
+				mockLogger,
+			);
+			expect(result.action).toBe(IPValidationAction.Reject);
+		});
+
+		it("does not skip when country codes differ", () => {
+			const comparison: IPComparisonResult = {
+				ipsMatch: false,
+				ip1: "ip1",
+				ip2: "ip2",
+				comparison: {
+					ip1Details: {
+						country: "United States",
+						countryCode: "US",
+						city: "New York",
+						provider: "Vodafone Group",
+						connectionType: "residential",
+						isVpnOrProxy: false,
+					},
+					ip2Details: {
+						country: "United Kingdom",
+						countryCode: "GB",
+						city: "London",
+						provider: "Vodafone Group",
+						connectionType: "residential",
+						isVpnOrProxy: false,
+					},
+					distanceKm: 5500,
+					differentProviders: false,
+					differentConnectionTypes: false,
+					anyVpnOrProxy: false,
+				},
+			};
+			const result = evaluateIpValidationRules(
+				comparison,
+				sameProviderRules,
+				mockLogger,
+			);
+			expect(result.action).toBe(IPValidationAction.Reject);
+		});
+
+		it("still applies abuse-score rule even when same-provider skip fires", () => {
+			const comparison: IPComparisonResult = {
+				ipsMatch: false,
+				ip1: "ip1",
+				ip2: "ip2",
+				comparison: {
+					ip1Details: {
+						country: "United States",
+						countryCode: "US",
+						city: "Laredo",
+						provider: "AT&T Enterprises, LLC",
+						connectionType: "residential",
+						isVpnOrProxy: false,
+						abuserScore: 0.001,
+					},
+					ip2Details: {
+						country: "United States",
+						countryCode: "US",
+						city: "San Antonio",
+						provider: "AT&T Enterprises, LLC",
+						connectionType: "residential",
+						isVpnOrProxy: false,
+						abuserScore: 0.02,
+					},
+					distanceKm: 1930,
+					differentProviders: false,
+					differentConnectionTypes: false,
+					anyVpnOrProxy: false,
+				},
+			};
+			const result = evaluateIpValidationRules(
+				comparison,
+				sameProviderRules,
+				mockLogger,
+			);
+			expect(result.action).toBe(IPValidationAction.Reject);
+			expect(result.errorMessage).toContain("Abuse score");
+		});
 	});
 
 	it("returns Flag if abuse score triggers Flag action", () => {

--- a/packages/provider/src/util.ts
+++ b/packages/provider/src/util.ts
@@ -227,10 +227,39 @@ export const evaluateIpValidationRules = (
 		});
 	}
 
+	// Same-subscriber precondition for the geo-drift rules.
+	// Why: ipapi normalises `company.name` to the corporate parent, so a
+	// dual-stack or CGNAT customer whose v4 and v6 legs egress through
+	// different POPs of the same operator (e.g. AT&T BellSouth v4 pool +
+	// AT&T Internet v6 pool) resolves to the same provider string even
+	// when the underlying ASNs differ. In that case, city drift and
+	// large geographic distance between the two addresses are expected.
+	const ip1Provider = comparison.comparison.ip1Details?.provider;
+	const ip2Provider = comparison.comparison.ip2Details?.provider;
+	const ip1ConnectionType = comparison.comparison.ip1Details?.connectionType;
+	const ip2ConnectionType = comparison.comparison.ip2Details?.connectionType;
+	const sameTrustedProvider =
+		!comparison.comparison.differentProviders &&
+		!!ip1Provider &&
+		ip1Provider !== "Unknown" &&
+		ip1CountryCode === ip2CountryCode &&
+		ip1ConnectionType !== "datacenter" &&
+		ip2ConnectionType !== "datacenter";
+
+	if (sameTrustedProvider) {
+		logger.info(() => ({
+			msg: "Skipping city and distance IP validation rules for same trusted provider",
+			data: {
+				provider: ip1Provider,
+				countryCode: ip1CountryCode,
+			},
+		}));
+	}
+
 	// Check for city change
 	const ip1City = comparison.comparison.ip1Details?.city;
 	const ip2City = comparison.comparison.ip2Details?.city;
-	if (ip1City !== ip2City) {
+	if (!sameTrustedProvider && ip1City !== ip2City) {
 		conditions.push({
 			met: true,
 			action: effectiveRules.actions.cityChangeAction,
@@ -240,8 +269,6 @@ export const evaluateIpValidationRules = (
 
 	// Check for ISP change
 	if (comparison.comparison.differentProviders) {
-		const ip1Provider = comparison.comparison.ip1Details?.provider;
-		const ip2Provider = comparison.comparison.ip2Details?.provider;
 		conditions.push({
 			met: true,
 			action: effectiveRules.actions.ispChangeAction,
@@ -252,6 +279,7 @@ export const evaluateIpValidationRules = (
 	// Check for distance exceed condition
 	const distanceKm = comparison.comparison.distanceKm;
 	if (
+		!sameTrustedProvider &&
 		distanceKm !== undefined &&
 		distanceKm > effectiveRules.distanceThresholdKm
 	) {


### PR DESCRIPTION
## Summary
- Dual-stack / CGNAT subscribers (e.g. AT&T BellSouth v4 pool + AT&T Internet v6 pool — distinct ASNs but identical `company.name` from ipapi) were being rejected by the PoW captcha IP validation with `City changed from … to …; IP addresses are …km apart`. Real prod incident on eyematch.ai on 2026-07-22: the two IPs geolocated 1930 km apart while the ISP-change rule correctly recognised the provider match.
- The ISP-change rule already consults `differentProviders`. The city-change and distance-exceed rules didn't — so they fired anyway.
- This PR adds a `sameTrustedProvider` precondition on the city-change and distance-exceed rule blocks in `evaluateIpValidationRules`: both providers match, provider is not the `"Unknown"` fallback, same `countryCode`, and neither endpoint is a `datacenter` (guards against AWS/Cloudflare same-`company.name` false negatives, where "same company" absolutely does not mean "same subscriber").
- Country-change, ISP-change, VPN/proxy, and abuse-score rules are untouched.

## Test plan
- [x] `npx vitest run packages/provider/src/tests/unit/util.evaluateIpValidationRules.unit.test.ts` — 19 pass (5 new cases: eyematch shape allow, datacenter no-skip, Unknown-provider no-skip, country mismatch no-skip, abuse-score still fires)
- [x] `npx vitest run packages/provider/src/tests/unit/services/ipComparison.unit.test.ts packages/provider/src/tests/unit/util.ipDistance.unit.test.ts` — 15 pass, no regressions
- [x] `npm run -w @prosopo/provider build:tsc` — clean
- [ ] Watch OO2 `production_provider_node` for `"Skipping city and distance IP validation rules for same trusted provider"` once deployed, to confirm the skip fires on real dual-stack traffic and stays within trusted providers

🤖 Generated with [Claude Code](https://claude.com/claude-code)