### PR TITLE
test(database): prime CentralDbStreamer connection in beforeAll to fix flaky streaming tests

### DIFF
--- a/.changeset/central-streaming-test-race-fix.md
+++ b/.changeset/central-streaming-test-race-fix.md
@@ -1,0 +1,11 @@
+---
+"@prosopo/database": patch
+---
+
+test(database): prime CentralDbStreamer connection in beforeAll to remove startup race
+
+`CentralDbStreamer` calls `ensureConnected` lazily on the first fire-and-forget stream, so `db.tables.<collection>` is populated by an async mongoose model registration that the tests don't await. On a fast CI runner the test's synchronous `tables.<collection>.findOne(...)` can execute before that registration lands, throwing `TypeError: Cannot read properties of undefined (reading 'findOne')` — observed intermittently on `puzzleCentralStreaming.integration.test.ts > streamPuzzleUpdate fetches the full record and streams it` (the failing case has an extra promise hop through `getFullRecord()`, which widens the race).
+
+`beforeAll` in the two affected integration tests now awaits `db.connect()` directly (via the same cast style already used by `afterAll` for `db.close()`), guaranteeing `db.tables.*` is populated before any test reads from it. `MongoDatabase.connect()` is idempotent (base/mongo.ts:85) and mongoose's `connection.model(name, schema)` returns the existing model when re-registered with the same schema instance, so the streamer's later lazy `ensureConnected` call is safe.
+
+Purely a test-race fix — no production code changes.

--- a/packages/database/src/tests/integration/centralStreamingEnrichment.integration.test.ts
+++ b/packages/database/src/tests/integration/centralStreamingEnrichment.integration.test.ts
@@ -129,6 +129,14 @@ describe("CentralDbStreamer end-to-end: UserCommitmentSchema.parse → streamIma
 	beforeAll(async () => {
 		mongod = await MongoMemoryServer.create();
 		streamer = new CentralDbStreamer(mongod.getUri(), logger);
+		// Prime the streamer's mongoose connection so `db.tables.<name>` is
+		// populated before the test reads from it. Streamer writes are
+		// fire-and-forget and `ensureConnected` is called lazily, so a
+		// synchronous `tables.<name>.findOne(...)` can throw on undefined.
+		// `MongoDatabase.connect()` is idempotent (mongo.ts:85).
+		await (
+			streamer as unknown as { db: { connect: () => Promise<void> } }
+		).db.connect();
 	});
 
 	afterAll(async () => {

--- a/packages/database/src/tests/integration/puzzleCentralStreaming.integration.test.ts
+++ b/packages/database/src/tests/integration/puzzleCentralStreaming.integration.test.ts
@@ -100,6 +100,16 @@ describe("CentralDbStreamer end-to-end: puzzle records", () => {
 	beforeAll(async () => {
 		mongod = await MongoMemoryServer.create();
 		streamer = new CentralDbStreamer(mongod.getUri(), logger);
+		// Prime the streamer's mongoose connection so `db.tables.<name>` is
+		// populated before tests race to read from it. The streamer's own
+		// `ensureConnected` is called lazily on the first stream, which
+		// leaves a window where a synchronous `tables.<name>.findOne(...)`
+		// throws on `undefined`. `MongoDatabase.connect()` is idempotent
+		// (mongo.ts:85) so the streamer's later ensureConnected reuse is
+		// safe.
+		await (
+			streamer as unknown as { db: { connect: () => Promise<void> } }
+		).db.connect();
 	});
 
 	afterAll(async () => {


### PR DESCRIPTION
## Summary
- The `puzzleCentralStreaming.integration.test.ts > streamPuzzleUpdate fetches the full record and streams it` case has been flaking on unrelated PRs with `TypeError: Cannot read properties of undefined (reading 'findOne')` on `tables.puzzlecaptcha.findOne(...)`. Observed on #2851's CI, reproducible on fast runners.
- Root cause: `CentralDbStreamer` calls `ensureConnected` lazily on the first fire-and-forget stream, so `db.tables.<collection>` is populated by an async mongoose `connection.model(...)` registration that the tests don't await. The failing `streamPuzzleUpdate` case has an extra promise hop through `getFullRecord()`, which widens the race enough that the synchronous `tables.<collection>.findOne(...)` in the test executes before registration lands. `centralStreamingEnrichment.integration.test.ts` has the same shape and was likely to flake next.
- Fix: `beforeAll` in both files now awaits `db.connect()` directly via the same cast style already used by `afterAll` for `db.close()`. `MongoDatabase.connect()` is idempotent (`base/mongo.ts:85`, `if (this.connected) return;`) and mongoose returns the existing model when re-registered with the same schema instance, so the streamer's later lazy `ensureConnected` reuse is safe.
- Purely a test-race fix — no production code changes.

## Test plan
- [x] `npx vitest run packages/database/src/tests/integration/puzzleCentralStreaming.integration.test.ts` — 4/4 pass locally, 5 consecutive runs green
- [x] `npx vitest run packages/database/src/tests/integration/centralStreamingEnrichment.integration.test.ts` — 2/2 pass
- [x] `npm run -w @prosopo/database build:tsc` — clean
- [ ] Merge and monitor CI on subsequent unrelated PRs (#2851 was the canary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)