### PR TITLE
fix(provider): stop treating apex-TLS failure as spam-email evidence

### DIFF
--- a/.changeset/spam-email-tls-error-fp.md
+++ b/.changeset/spam-email-tls-error-fp.md
@@ -1,0 +1,9 @@
+---
+"@prosopo/provider": patch
+---
+
+fix(provider): stop treating apex-TLS-handshake failure as spam-email evidence
+
+`checkSpamEmail` was auto-rejecting any email domain whose apex website failed a modern TLS handshake (`https://<domain>` → `EPROTO` / `unsupported protocol`). This is a property of the web server, not the email domain — small-business domains routinely host mail on modern providers (Zoho / Google / Fastmail) while the apex site runs legacy Apache with only TLSv1.0 and an expired self-signed cert, and modern Node/OpenSSL 3 refuses those handshakes.
+
+The `tlsError → return true` short-circuit is removed. The TLS observation is still logged (as `info`, for signal), and the check now falls through to the remaining DNS signals (redirect-target spam lookup, CNAME spam lookup, MX-target spam lookup) — those are the signals that actually reflect email reputation. Existing coverage on those paths is unchanged; two unit tests cover the new behaviour (apex TLS error alone is not spam; spam via MX is still caught when apex has a TLS error).

--- a/packages/provider/src/tasks/spam/checkSpamEmail.ts
+++ b/packages/provider/src/tasks/spam/checkSpamEmail.ts
@@ -90,13 +90,17 @@ export async function checkSpamEmail(
 		}));
 		return false; // Allow if DNS check fails
 	}
-	// If TLS error detected, reject
+	// TLS error on the apex website is NOT evidence that the email domain
+	// is spam. Small-business domains legitimately host email on modern
+	// providers (Zoho / Google / Fastmail) while their apex site sits on a
+	// legacy Apache/nginx that no longer negotiates a modern TLS version.
+	// Log the observation but keep evaluating the remaining signals (redirect
+	// target, CNAME, MX) — those are the ones tied to actual email reputation.
 	if (dnsCheckResult.redirectResult.tlsError) {
-		logger.warn(() => ({
-			msg: "Email domain has TLS error",
+		logger.info(() => ({
+			msg: "Email domain apex has TLS error — observed, not treated as spam",
 			domain: normalizedDomain,
 		}));
-		return true;
 	}
 	// If redirect domain found, check it in spam list
 	if (dnsCheckResult.redirectResult.redirectUrl) {

--- a/packages/provider/src/tests/unit/tasks/spam/checkSpamEmail.unit.test.ts
+++ b/packages/provider/src/tests/unit/tasks/spam/checkSpamEmail.unit.test.ts
@@ -322,7 +322,11 @@ describe("checkSpamEmail", () => {
 	});
 
 	describe("DNS checks", () => {
-		it("should detect spam when domain has TLS error", async () => {
+		it("should NOT flag as spam when apex has TLS error but other DNS signals are clean", async () => {
+			// A TLS handshake failure on the apex website is a property of the
+			// web-server, not of the email domain — legitimate small-business
+			// domains routinely have modern MX (Zoho/Google/Fastmail) alongside
+			// a legacy apex site. The check must fall through to CNAME / MX.
 			(db.getSpamEmailDomain as ReturnType<typeof vi.fn>).mockResolvedValue(
 				null,
 			);
@@ -338,7 +342,30 @@ describe("checkSpamEmail", () => {
 				config,
 				logger,
 			);
+			expect(result).toBe(false);
+		});
+
+		it("should still catch spam via MX when apex has TLS error", async () => {
+			// TLS error must not short-circuit — the MX-target spam check has
+			// to keep running so genuinely-spammy domains are still caught.
+			(db.getSpamEmailDomain as ReturnType<typeof vi.fn>)
+				.mockResolvedValueOnce(null) // apex domain not listed
+				.mockResolvedValueOnce({ domain: "spam-mx.com" }); // MX target listed
+
+			mockRunDnsChecks.mockResolvedValue({
+				cnameResult: null,
+				mxRecordResult: [{ priority: 10, exchange: "mx.spam-mx.com." }],
+				redirectResult: { tlsError: true },
+			});
+
+			const result = await checkSpamEmail(
+				"user@suspicious.com",
+				db,
+				config,
+				logger,
+			);
 			expect(result).toBe(true);
+			expect(db.getSpamEmailDomain).toHaveBeenCalledWith("mx.spam-mx.com");
 		});
 
 		it("should check redirect domain when redirect is found", async () => {


### PR DESCRIPTION
## Summary
- `checkSpamEmail`'s `tlsError → return true` short-circuit was rejecting any email whose apex website couldn't complete a modern TLS handshake — a property of the web server, not the email domain.
- Live FP: `user@example.com` blocked at signup. Root cause: `https://example.com` runs Apache/2.2.15 (2011) speaking only TLSv1.0 with an expired self-signed cert, while the domain's actual MX is Zoho (`mx.zoho.eu`) — a legitimate business inbox.
- Fix: drop the short-circuit; the check now falls through to the redirect-target / CNAME / MX-target spam lookups that were already there and actually reflect email reputation. TLS observation is still logged (info-level) for signal.

## Test plan
- [x] `checkSpamEmail.unit.test.ts` — apex TLS error alone does **not** flag as spam when other DNS signals are clean
- [x] `checkSpamEmail.unit.test.ts` — spam via MX is still caught when apex has a TLS error (regression guard)
- [x] All 38 tests pass, typecheck clean, biome clean
- [ ] Verify no regressions on the wider spam-email test suite in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)