### PR TITLE
fix(load-balancer): retry healthz with backoff, stop LB-hostname fallback

### DIFF
--- a/.changeset/healthz-retry-with-backoff.md
+++ b/.changeset/healthz-retry-with-backoff.md
@@ -1,0 +1,13 @@
+---
+"@prosopo/load-balancer": patch
+---
+
+fix(load-balancer): retry healthz with exponential backoff and stop falling back to the load-balanced hostname
+
+`resolvePinnedUrl` previously swallowed any healthz failure (network error, non-2xx, malformed body) and returned the load-balanced hostname (`pronode.prosopo.io`). That hostname isn't a registered on-chain provider, so the verify path rejected every token minted through this fallback with `Provider not found`. The tab-scoped promise cache made it worse: one healthz blip at page load poisoned every subsequent captcha attempt in that tab.
+
+Now:
+
+- Healthz is retried with full-jitter exponential backoff (3 attempts total, 250ms/500ms base, 2s cap) before surfacing the error.
+- On terminal failure the pin cache entry is evicted and the error is thrown, so `providerRetry` in `@prosopo/procaptcha-common` can fall through to `getRandomProviderFromList` (which picks a specific on-chain provider and bypasses healthz entirely).
+- Extracted a small `retryWithBackoff` helper in the same package for the backoff maths.

--- a/packages/load-balancer/src/providers.ts
+++ b/packages/load-balancer/src/providers.ts
@@ -18,6 +18,7 @@ import {
 	type IpMode,
 	loadBalancer,
 } from "./balancer.js";
+import { retryWithBackoff } from "./retry.js";
 
 // Base DNS endpoint per env — the `pronode.prosopo.io` family is latency-routed
 // (A/AAAA records across the pronode fleet). Clients hit this URL's `/healthz`
@@ -56,6 +57,19 @@ const cacheKey = (env: EnvironmentTypes, ipMode?: IpMode): CacheKey =>
 	`${env}|${ipMode ?? "dual"}`;
 const pinPromiseCache: Map<CacheKey, Promise<string>> = new Map();
 
+// Healthz retry policy. Healthz is a prerequisite for pinning a session to a
+// specific pronode — without a pinned host the token embeds the load-balanced
+// hostname, which isn't a registered on-chain provider and gets rejected at
+// verify time. A transient blip therefore mustn't fail immediately: retry
+// with exponential-backoff + full jitter before surfacing the error.
+const HEALTHZ_MAX_ATTEMPTS = 3;
+const HEALTHZ_RETRY_BASE_DELAY_MS = 250;
+const HEALTHZ_RETRY_MAX_DELAY_MS = 2_000;
+
+let healthzMaxAttempts = HEALTHZ_MAX_ATTEMPTS;
+let healthzRetryBaseDelayMs = HEALTHZ_RETRY_BASE_DELAY_MS;
+let healthzRetryMaxDelayMs = HEALTHZ_RETRY_MAX_DELAY_MS;
+
 const fetchPinnedHost = async (baseUrl: string): Promise<string> => {
 	const res = await fetch(`${baseUrl}/healthz`, {
 		method: "GET",
@@ -71,6 +85,13 @@ const fetchPinnedHost = async (baseUrl: string): Promise<string> => {
 	}
 	return body.host;
 };
+
+const fetchPinnedHostWithRetry = (baseUrl: string): Promise<string> =>
+	retryWithBackoff(() => fetchPinnedHost(baseUrl), {
+		maxAttempts: healthzMaxAttempts,
+		baseDelayMs: healthzRetryBaseDelayMs,
+		maxDelayMs: healthzRetryMaxDelayMs,
+	});
 
 const resolveBaseUrl = (env: EnvironmentTypes): string =>
 	DNS_ENDPOINT[env] ?? DNS_ENDPOINT.development;
@@ -93,18 +114,22 @@ const resolvePinnedUrl = async (
 
 	const promise = (async () => {
 		try {
-			const host = await fetchPinnedHost(base);
+			const host = await fetchPinnedHostWithRetry(base);
 			const parsed = new URL(base);
 			// /healthz returns the bare pronodeN.prosopo.io (env.config.host).
 			// Re-apply the ipMode label so the per-pronode URL stays on the same
 			// single-stack sub-zone (`ipv4.pronode4.prosopo.io`).
 			parsed.hostname = withIpModeLabel(host, ipMode);
 			return parsed.toString().replace(/\/$/, "");
-		} catch {
-			// Healthz unreachable / malformed — fall back to the load-balanced
-			// hostname (with the ipMode label still applied). Clients still
-			// work, they just lose per-pronode stickiness.
-			return base;
+		} catch (err) {
+			// Healthz is a prerequisite for the rest of the captcha flow — the
+			// token must embed a specific pronodeN URL for verify to accept it.
+			// Evict the cached rejection so a subsequent captcha attempt gets a
+			// fresh chance, and surface the error so the caller's own retry
+			// (`providerRetry` in @prosopo/procaptcha-common) can fall through
+			// to `getRandomProviderFromList`, which bypasses healthz entirely.
+			pinPromiseCache.delete(key);
+			throw err;
 		}
 	})();
 
@@ -228,4 +253,27 @@ export const _resetPinCache = () => {
 // Not exported from the package index — internal use only.
 export const _resetProviderListCache = () => {
 	providerListPromiseCache.clear();
+};
+
+// Test-only override for the healthz retry policy — tests use it to disable
+// backoff delays (baseDelayMs: 0) and to shorten/lengthen the attempt count.
+// Not exported from the package index — internal use only.
+export const _setHealthzRetryPolicy = (opts: {
+	maxAttempts?: number;
+	baseDelayMs?: number;
+	maxDelayMs?: number;
+}) => {
+	if (opts.maxAttempts !== undefined) healthzMaxAttempts = opts.maxAttempts;
+	if (opts.baseDelayMs !== undefined)
+		healthzRetryBaseDelayMs = opts.baseDelayMs;
+	if (opts.maxDelayMs !== undefined) healthzRetryMaxDelayMs = opts.maxDelayMs;
+};
+
+// Test-only reset for the healthz retry policy — restores the defaults so an
+// override in one test doesn't leak into the next. Not exported from the
+// package index — internal use only.
+export const _resetHealthzRetryPolicy = () => {
+	healthzMaxAttempts = HEALTHZ_MAX_ATTEMPTS;
+	healthzRetryBaseDelayMs = HEALTHZ_RETRY_BASE_DELAY_MS;
+	healthzRetryMaxDelayMs = HEALTHZ_RETRY_MAX_DELAY_MS;
 };

--- a/packages/load-balancer/src/retry.ts
+++ b/packages/load-balancer/src/retry.ts
@@ -1,0 +1,77 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export type RetryOptions = {
+	// Total attempts including the first. `1` disables retries.
+	maxAttempts: number;
+	// Base delay for the first retry — attempt N waits in [0, base * 2^N].
+	baseDelayMs: number;
+	// Upper bound on the jitter window so backoff can't grow unboundedly.
+	maxDelayMs: number;
+	// Injectable for deterministic tests. Defaults to Math.random.
+	random?: () => number;
+	// Injectable for deterministic tests. Defaults to setTimeout-based sleep.
+	sleep?: (ms: number) => Promise<void>;
+};
+
+const defaultSleep = (ms: number): Promise<void> =>
+	ms > 0
+		? new Promise((resolve) => setTimeout(resolve, ms))
+		: Promise.resolve();
+
+// Full-jitter exponential backoff — attempt N picks a uniform delay in the
+// range [0, min(maxDelayMs, baseDelayMs * 2^N)]. Full jitter (rather than
+// equal jitter) desynchronises clients that all failed at the same moment,
+// so their retries don't reconverge into a thundering herd against whatever
+// they're calling. Matches the algorithm in @prosopo/procaptcha-common's
+// getRetryDelayMs so both retry paths behave the same way.
+export const getBackoffDelayMs = (
+	attempt: number,
+	baseDelayMs: number,
+	maxDelayMs: number,
+	random: () => number = Math.random,
+): number => {
+	const safeAttempt = Math.max(0, Math.floor(attempt));
+	const cap = Math.min(maxDelayMs, baseDelayMs * 2 ** safeAttempt);
+	return Math.round(random() * cap);
+};
+
+/**
+ * Run `fn` up to `maxAttempts` times, sleeping with full-jitter exponential
+ * backoff between attempts. Returns the first successful value. If every
+ * attempt throws, throws the last error (Error-normalised).
+ */
+export const retryWithBackoff = async <T>(
+	fn: () => Promise<T>,
+	opts: RetryOptions,
+): Promise<T> => {
+	const {
+		maxAttempts,
+		baseDelayMs,
+		maxDelayMs,
+		random = Math.random,
+		sleep = defaultSleep,
+	} = opts;
+	let lastErr: unknown;
+	for (let attempt = 0; attempt < maxAttempts; attempt++) {
+		try {
+			return await fn();
+		} catch (err) {
+			lastErr = err;
+			if (attempt >= maxAttempts - 1) break;
+			await sleep(getBackoffDelayMs(attempt, baseDelayMs, maxDelayMs, random));
+		}
+	}
+	throw lastErr instanceof Error ? lastErr : new Error(String(lastErr));
+};

--- a/packages/load-balancer/src/tests/providers.unit.test.ts
+++ b/packages/load-balancer/src/tests/providers.unit.test.ts
@@ -15,8 +15,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { HardcodedProvider } from "../balancer.js";
 import {
+	_resetHealthzRetryPolicy,
 	_resetPinCache,
 	_resetProviderListCache,
+	_setHealthzRetryPolicy,
 	getProviders,
 	getRandomActiveProvider,
 	getRandomProviderFromList,
@@ -45,10 +47,14 @@ const mockHealthzFetch = (host: string, ok = true, status = 200) => {
 
 beforeEach(() => {
 	_resetPinCache();
+	// Keep the retry policy but drop backoff to zero so failure-path tests
+	// don't sit waiting on real timers.
+	_setHealthzRetryPolicy({ baseDelayMs: 0, maxDelayMs: 0 });
 });
 
 afterEach(() => {
 	globalThis.fetch = originalFetch;
+	_resetHealthzRetryPolicy();
 });
 
 describe("getRandomActiveProvider (dual stack)", () => {
@@ -79,13 +85,16 @@ describe("getRandomActiveProvider (dual stack)", () => {
 		expect(mocked).toHaveBeenCalledTimes(1);
 	});
 
-	it("falls back to the dual-stack base URL when /healthz responds non-OK", async () => {
-		mockHealthzFetch("ignored", false, 503);
-		const result = await getRandomActiveProvider("production");
-		expect(result.provider.url).toBe("https://pronode.prosopo.io");
+	it("throws after all healthz retries are exhausted (does not fall back to LB hostname)", async () => {
+		const mocked = mockHealthzFetch("ignored", false, 503);
+		await expect(getRandomActiveProvider("production")).rejects.toThrow(
+			/healthz responded with 503/,
+		);
+		// 3 attempts total = initial + 2 retries.
+		expect(mocked).toHaveBeenCalledTimes(3);
 	});
 
-	it("falls back to the dual-stack base URL when /healthz body is malformed", async () => {
+	it("throws when the healthz body is malformed after retries", async () => {
 		const mocked = vi.fn(async () => ({
 			ok: true,
 			status: 200,
@@ -93,8 +102,53 @@ describe("getRandomActiveProvider (dual stack)", () => {
 		}));
 		// biome-ignore lint/suspicious/noExplicitAny: minimal Response stub for the unit test
 		globalThis.fetch = mocked as any;
+		await expect(getRandomActiveProvider("production")).rejects.toThrow(
+			/missing host field/,
+		);
+		expect(mocked).toHaveBeenCalledTimes(3);
+	});
+
+	it("retries a transient healthz failure and pins on the eventual success", async () => {
+		let call = 0;
+		const mocked = vi.fn(async () => {
+			call++;
+			if (call === 1) {
+				return { ok: false, status: 503, json: async () => ({}) };
+			}
+			return {
+				ok: true,
+				status: 200,
+				json: async () => ({ ok: true, host: "pronode8.prosopo.io" }),
+			};
+		});
+		// biome-ignore lint/suspicious/noExplicitAny: minimal Response stub for the unit test
+		globalThis.fetch = mocked as any;
 		const result = await getRandomActiveProvider("production");
-		expect(result.provider.url).toBe("https://pronode.prosopo.io");
+		expect(result.provider.url).toBe("https://pronode8.prosopo.io");
+		expect(mocked).toHaveBeenCalledTimes(2);
+	});
+
+	it("evicts a failed pin so the next captcha attempt retries healthz fresh", async () => {
+		let call = 0;
+		const mocked = vi.fn(async () => {
+			call++;
+			if (call <= 3) {
+				return { ok: false, status: 502, json: async () => ({}) };
+			}
+			return {
+				ok: true,
+				status: 200,
+				json: async () => ({ ok: true, host: "pronode9.prosopo.io" }),
+			};
+		});
+		// biome-ignore lint/suspicious/noExplicitAny: minimal Response stub for the unit test
+		globalThis.fetch = mocked as any;
+		await expect(getRandomActiveProvider("production")).rejects.toThrow();
+		// First call failed 3 times; a fresh call must be able to retry — not
+		// return the poisoned cached rejection.
+		const result = await getRandomActiveProvider("production");
+		expect(result.provider.url).toBe("https://pronode9.prosopo.io");
+		expect(mocked).toHaveBeenCalledTimes(4);
 	});
 });
 
@@ -121,10 +175,11 @@ describe("getRandomActiveProvider (single stack ipMode)", () => {
 		);
 	});
 
-	it("falls back to the ipv4-labelled global URL when ipv4 /healthz fails", async () => {
+	it("throws for ipv4 mode when /healthz fails (no fallback to ipv4.pronode.prosopo.io)", async () => {
 		mockHealthzFetch("ignored", false, 500);
-		const result = await getRandomActiveProvider("production", "ipv4");
-		expect(result.provider.url).toBe("https://ipv4.pronode.prosopo.io");
+		await expect(
+			getRandomActiveProvider("production", "ipv4"),
+		).rejects.toThrow(/healthz responded with 500/);
 	});
 
 	it("keeps the dual-stack cache and the ipv4 cache separate", async () => {

--- a/packages/load-balancer/src/tests/providers.unit.test.ts
+++ b/packages/load-balancer/src/tests/providers.unit.test.ts
@@ -177,9 +177,9 @@ describe("getRandomActiveProvider (single stack ipMode)", () => {
 
 	it("throws for ipv4 mode when /healthz fails (no fallback to ipv4.pronode.prosopo.io)", async () => {
 		mockHealthzFetch("ignored", false, 500);
-		await expect(
-			getRandomActiveProvider("production", "ipv4"),
-		).rejects.toThrow(/healthz responded with 500/);
+		await expect(getRandomActiveProvider("production", "ipv4")).rejects.toThrow(
+			/healthz responded with 500/,
+		);
 	});
 
 	it("keeps the dual-stack cache and the ipv4 cache separate", async () => {

--- a/packages/load-balancer/src/tests/retry.unit.test.ts
+++ b/packages/load-balancer/src/tests/retry.unit.test.ts
@@ -1,0 +1,151 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, expect, it, vi } from "vitest";
+import { getBackoffDelayMs, retryWithBackoff } from "../retry.js";
+
+const noopSleep = (_ms: number): Promise<void> => Promise.resolve();
+
+describe("getBackoffDelayMs", () => {
+	it("scales the delay cap exponentially with the attempt index", () => {
+		// random=1 → returns the full cap so the exponent is observable.
+		expect(getBackoffDelayMs(0, 100, 10_000, () => 1)).toBe(100);
+		expect(getBackoffDelayMs(1, 100, 10_000, () => 1)).toBe(200);
+		expect(getBackoffDelayMs(2, 100, 10_000, () => 1)).toBe(400);
+		expect(getBackoffDelayMs(3, 100, 10_000, () => 1)).toBe(800);
+	});
+
+	it("caps the delay at maxDelayMs even for large attempt indices", () => {
+		expect(getBackoffDelayMs(10, 100, 1_000, () => 1)).toBe(1_000);
+		expect(getBackoffDelayMs(20, 100, 1_000, () => 1)).toBe(1_000);
+	});
+
+	it("clamps negative or fractional attempt indices to zero", () => {
+		expect(getBackoffDelayMs(-5, 100, 10_000, () => 1)).toBe(100);
+		expect(getBackoffDelayMs(0.9, 100, 10_000, () => 1)).toBe(100);
+	});
+
+	it("uses full jitter — random=0 yields 0, random=1 yields the cap", () => {
+		expect(getBackoffDelayMs(2, 100, 10_000, () => 0)).toBe(0);
+		expect(getBackoffDelayMs(2, 100, 10_000, () => 0.5)).toBe(200);
+		expect(getBackoffDelayMs(2, 100, 10_000, () => 1)).toBe(400);
+	});
+});
+
+describe("retryWithBackoff", () => {
+	it("returns the value on the first successful attempt without sleeping", async () => {
+		const sleep = vi.fn(noopSleep);
+		const fn = vi.fn(async () => "ok");
+		const result = await retryWithBackoff(fn, {
+			maxAttempts: 3,
+			baseDelayMs: 100,
+			maxDelayMs: 1_000,
+			sleep,
+		});
+		expect(result).toBe("ok");
+		expect(fn).toHaveBeenCalledTimes(1);
+		expect(sleep).not.toHaveBeenCalled();
+	});
+
+	it("retries on failure and returns on the eventual success", async () => {
+		const sleep = vi.fn(noopSleep);
+		let call = 0;
+		const fn = vi.fn(async () => {
+			call++;
+			if (call < 3) throw new Error(`transient ${call}`);
+			return "ok";
+		});
+		const result = await retryWithBackoff(fn, {
+			maxAttempts: 5,
+			baseDelayMs: 100,
+			maxDelayMs: 1_000,
+			random: () => 0.5,
+			sleep,
+		});
+		expect(result).toBe("ok");
+		expect(fn).toHaveBeenCalledTimes(3);
+		// Sleeps only between attempts, so N-1 sleeps for N-attempts-until-success.
+		expect(sleep).toHaveBeenCalledTimes(2);
+	});
+
+	it("throws the final error after maxAttempts exhausted", async () => {
+		const sleep = vi.fn(noopSleep);
+		let call = 0;
+		const fn = vi.fn(async () => {
+			call++;
+			throw new Error(`fail ${call}`);
+		});
+		await expect(
+			retryWithBackoff(fn, {
+				maxAttempts: 3,
+				baseDelayMs: 100,
+				maxDelayMs: 1_000,
+				sleep,
+			}),
+		).rejects.toThrow("fail 3");
+		expect(fn).toHaveBeenCalledTimes(3);
+		// Sleeps after attempts 1 and 2, but not after the final attempt.
+		expect(sleep).toHaveBeenCalledTimes(2);
+	});
+
+	it("normalises non-Error throws into an Error before rethrowing", async () => {
+		const fn = vi.fn(async () => {
+			throw "string thrown";
+		});
+		await expect(
+			retryWithBackoff(fn, {
+				maxAttempts: 2,
+				baseDelayMs: 0,
+				maxDelayMs: 0,
+				sleep: noopSleep,
+			}),
+		).rejects.toThrow("string thrown");
+	});
+
+	it("passes exponentially-growing delays to sleep", async () => {
+		const sleep = vi.fn(noopSleep);
+		const fn = vi.fn(async () => {
+			throw new Error("boom");
+		});
+		await expect(
+			retryWithBackoff(fn, {
+				maxAttempts: 4,
+				baseDelayMs: 100,
+				maxDelayMs: 10_000,
+				random: () => 1,
+				sleep,
+			}),
+		).rejects.toThrow("boom");
+		// random=1 → delays equal the cap: 100, 200, 400.
+		const delays = sleep.mock.calls.map(([ms]) => ms);
+		expect(delays).toEqual([100, 200, 400]);
+	});
+
+	it("does not retry when maxAttempts is 1 (retry disabled)", async () => {
+		const sleep = vi.fn(noopSleep);
+		const fn = vi.fn(async () => {
+			throw new Error("nope");
+		});
+		await expect(
+			retryWithBackoff(fn, {
+				maxAttempts: 1,
+				baseDelayMs: 100,
+				maxDelayMs: 1_000,
+				sleep,
+			}),
+		).rejects.toThrow("nope");
+		expect(fn).toHaveBeenCalledTimes(1);
+		expect(sleep).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## Summary

- `resolvePinnedUrl` (in `@prosopo/load-balancer/providers.ts`) previously swallowed any healthz failure and returned `https://pronode.prosopo.io` (the DNS-LB hostname). That URL is never a registered on-chain provider, so the `verify` handler at `captcha/packages/server/src/server.ts:227` rejected every token minted through this fallback with `Provider not found` and `verified:false`.
- The tab-scoped `pinPromiseCache` cached the fallback, so a single healthz blip at page load poisoned every subsequent captcha attempt in that tab until reload.
- This PR: (1) retries healthz with full-jitter exponential backoff — 3 attempts total, delays 250ms/500ms base capped at 2s, (2) on terminal failure, evicts the cache entry and throws so `providerRetry` in `@prosopo/procaptcha-common` falls through to `getRandomProviderFromList` (specific on-chain provider, bypasses healthz), (3) extracts the backoff maths into a small `retryWithBackoff` helper.

## Evidence (from oo2 `production_lambdas`)

- Prior to the DNS-LB rollout on Jun 23 2026, `Provider not found` was 0–31/day.
- After rollout: sustained 500–1000/day baseline, with spikes on Jul 7 (34,776), Jul 22 (12,069) and Jul 23 (22,716). Every sampled error has `providerUrl: "https://pronode.prosopo.io"`.
- Current rate (last 24h): 133 (0.06% of verify calls).

## Test plan

- [x] `npm run -w @prosopo/load-balancer build:tsc` passes
- [x] `npm run -w @prosopo/load-balancer test` — 42 tests pass across 3 files; coverage 97% providers.ts, 97% retry.ts
- [x] New tests: retry succeeds after transient failure, throws after all retries, cache eviction on failure so next call retries fresh, ipv4 mode also throws (no ipv4.pronode.prosopo.io fallback)
- [x] New tests: retry.ts helper — backoff maths, full jitter, cap, sleep injection, error normalisation, `maxAttempts: 1` disables retries

## Version impact

`npx changeset status` — patch bumps propagate through: load-balancer → procaptcha-common/procaptcha-pow/procaptcha-puzzle/procaptcha/procaptcha-react/procaptcha-frictionless/procaptcha-bundle/provider/provider-mock/server/scripts → **@prosopo/cli 3.6.70** and @prosopo/client-example-server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)