### PR TITLE
feat(decision-machine): thread puzzle fields and forward checkbox coords on escalation

### DIFF
--- a/.changeset/feat-puzzle-dm-threading.md
+++ b/.changeset/feat-puzzle-dm-threading.md
@@ -1,0 +1,12 @@
+---
+"@prosopo/types": patch
+"@prosopo/provider": patch
+"@prosopo/procaptcha-pow": patch
+"@prosopo/procaptcha-frictionless": patch
+---
+
+feat(decision-machine): thread puzzle fields and forward checkbox coords on escalation
+
+- Add optional `coords` and `puzzleEvents` to `DecisionMachineInput` so decision machines can gate on entry-point telemetry and puzzle drag trails.
+- Populate `coords` on the pow, puzzle and image `decide()` inputs. Puzzle also passes `puzzleEvents`. Image gains `behavioralDataPacked` / `deviceCapability` — previously always undefined, which silently disabled the global synthetic-mouse-timing check on the one captcha type it targets.
+- Extend `ProcaptchaEscalationHandler` with an optional `coords` argument so the PoW widget can forward its trusted checkbox click through the PoW→image/puzzle escalation. The frictionless wrapper prefers escalation coords over pending retry coords. Puzzle and image widgets already accept `startCoords`, so the escalated widget now seeds the salt with the real (x, y) instead of (0, 0).

--- a/packages/procaptcha-frictionless/src/ProcaptchaFrictionless.tsx
+++ b/packages/procaptcha-frictionless/src/ProcaptchaFrictionless.tsx
@@ -175,10 +175,12 @@ export const ProcaptchaFrictionless = ({
 		captchaType: string,
 		frictionlessState: FrictionlessState,
 		autoStart = false,
+		escalationCoords?: RetryCoords,
 	) => {
 		const onEscalate = (
 			next: CaptchaType.image | CaptchaType.puzzle,
 			newSessionId: string,
+			coords?: RetryCoords,
 		) => {
 			void renderForCaptchaType(
 				next,
@@ -187,6 +189,7 @@ export const ProcaptchaFrictionless = ({
 					sessionId: newSessionId,
 				},
 				true,
+				coords,
 			);
 		};
 
@@ -214,10 +217,13 @@ export const ProcaptchaFrictionless = ({
 		// Consume any pending retry coords now — the resumed widget owns them
 		// for exactly one auto-fired `manager.start(x, y)`. Cleared so a
 		// subsequent escalation/re-render doesn't accidentally re-inject.
-		const { autoStart: resumedAutoStart, startCoords } = consumeRetryMountProps(
-			pendingRetryCoordsRef,
-			autoStart,
-		);
+		// Escalation coords (from a PoW→image/puzzle handoff) take precedence
+		// over pending retry coords when both are present, because escalation
+		// is the current transition and the pending retry belongs to a prior
+		// widget instance that never got to consume them.
+		const { autoStart: resumedAutoStart, startCoords: retryStartCoords } =
+			consumeRetryMountProps(pendingRetryCoordsRef, autoStart);
+		const startCoords = escalationCoords ?? retryStartCoords;
 
 		if (captchaType === CaptchaType.image) {
 			const Procaptcha = await ProcaptchaLoader();

--- a/packages/procaptcha-pow/src/services/Manager.ts
+++ b/packages/procaptcha-pow/src/services/Manager.ts
@@ -163,7 +163,17 @@ export const Manager = (
 		updateState({ successfullChallengeTimeout });
 	};
 
+	// Checkbox click coords captured on the entry-point tick (or forwarded
+	// from a session-invalidated retry). Persisted in the closure so an
+	// eventual escalation can hand them to the escalated image/puzzle widget
+	// via `onEscalate` — otherwise the escalated widget seeds (0, 0) into
+	// its own salt and the entry-point telemetry is lost across the hop.
+	let checkboxClickX = 0;
+	let checkboxClickY = 0;
+
 	const start = async (x = 0, y = 0) => {
+		checkboxClickX = x;
+		checkboxClickY = y;
 		await providerRetry(
 			async () => {
 				if (state.loading) {
@@ -378,10 +388,24 @@ export const Manager = (
 						// follow-up image/puzzle challenge. Hand off to the wrapper —
 						// don't fire onHuman or onFailed; the wrapper mounts the next
 						// widget and the standard success/failure path resumes there.
+						//
+						// Forward the trusted checkbox coords captured on this widget's
+						// tick so the escalated widget seeds its salt with the real
+						// (x, y) rather than defaulting to (0, 0). Mirrors the
+						// session-invalidated retry path in ProcaptchaFrictionless.
 						updateState({ loading: false });
+						// (0, 0) is the untrusted-event / autoStart default —
+						// treat it as "no coords" so the escalated widget doesn't
+						// re-encode a fake click into its salt. Matches the
+						// filter applied in handleSessionInvalidated.
+						const isRealClick =
+							checkboxClickX !== 0 || checkboxClickY !== 0;
 						onEscalate?.(
 							escalation[ApiParams.captchaType],
 							escalation[ApiParams.sessionId],
+							isRealClick
+								? { x: checkboxClickX, y: checkboxClickY }
+								: undefined,
 						);
 					} else if (verifiedSolution[ApiParams.verified]) {
 						updateState({

--- a/packages/procaptcha-pow/src/services/Manager.ts
+++ b/packages/procaptcha-pow/src/services/Manager.ts
@@ -398,8 +398,7 @@ export const Manager = (
 						// treat it as "no coords" so the escalated widget doesn't
 						// re-encode a fake click into its salt. Matches the
 						// filter applied in handleSessionInvalidated.
-						const isRealClick =
-							checkboxClickX !== 0 || checkboxClickY !== 0;
+						const isRealClick = checkboxClickX !== 0 || checkboxClickY !== 0;
 						onEscalate?.(
 							escalation[ApiParams.captchaType],
 							escalation[ApiParams.sessionId],

--- a/packages/provider/src/tasks/imgCaptcha/imgCaptchaTasks.ts
+++ b/packages/provider/src/tasks/imgCaptcha/imgCaptchaTasks.ts
@@ -982,6 +982,8 @@ export class ImgCaptchaManager extends CaptchaManager {
 				captchaResult: "passed",
 				headers: solution.headers,
 				captchaType: CaptchaType.image,
+				behavioralDataPacked: solution.behavioralDataPacked,
+				deviceCapability: solution.deviceCapability,
 				countryCode: solution.ipInfo?.isValid
 					? solution.ipInfo.countryCode
 					: undefined,
@@ -997,6 +999,7 @@ export class ImgCaptchaManager extends CaptchaManager {
 				ruleType: sessionRecord?.ruleType,
 				webView: sessionRecord?.webView,
 				iFrame: sessionRecord?.iFrame,
+				coords: solution.coords,
 			};
 
 			try {

--- a/packages/provider/src/tasks/powCaptcha/powTasks.ts
+++ b/packages/provider/src/tasks/powCaptcha/powTasks.ts
@@ -895,6 +895,7 @@ export class PowCaptchaManager extends CaptchaManager {
 					ruleType: sessionRecord?.ruleType,
 					webView: sessionRecord?.webView,
 					iFrame: sessionRecord?.iFrame,
+					coords: challengeRecord.coords,
 				};
 
 				const decision = await this.decisionMachineRunner.decide(

--- a/packages/provider/src/tasks/puzzleCaptcha/puzzleTasks.ts
+++ b/packages/provider/src/tasks/puzzleCaptcha/puzzleTasks.ts
@@ -734,6 +734,8 @@ export class PuzzleCaptchaManager extends CaptchaManager {
 				ruleType: sessionRecord?.ruleType,
 				webView: sessionRecord?.webView,
 				iFrame: sessionRecord?.iFrame,
+				coords: challengeRecord.coords,
+				puzzleEvents: challengeRecord.puzzleEvents,
 			};
 
 			const decision = await this.decisionMachineRunner.decide(

--- a/packages/types/src/decisionMachine/index.ts
+++ b/packages/types/src/decisionMachine/index.ts
@@ -18,7 +18,7 @@ import {
 	CaptchaType,
 	DecisionMachineCaptchaTypeSchema,
 } from "../client/captchaType/captchaType.js";
-import type { RequestHeaders } from "../provider/api.js";
+import type { PuzzleEvent, RequestHeaders } from "../provider/api.js";
 import type { ScoreComponents } from "../provider/database.js";
 import type { SimdReadings } from "../provider/detection.js";
 import type { FrictionlessReason } from "../provider/reasons.js";
@@ -103,6 +103,17 @@ export type DecisionMachineInput = {
 	ruleType?: string[];
 	webView?: boolean;
 	iFrame?: boolean;
+	// Checkbox click + shape clicks embedded in the solution salt. For pow
+	// and puzzle this is `[[[checkboxX, checkboxY]]]` (single click); for
+	// image the outer array has one entry per tile with the first tile's
+	// inner array prefixed by the checkbox click. Missing when the client
+	// omitted the salt, produced an invalid one, or the record pre-dates
+	// coord capture.
+	coords?: [number, number][][];
+	// Puzzle-only: per-event trail of the drag from origin to target,
+	// captured client-side and persisted on the puzzle captcha record.
+	// Always undefined on pow / image inputs.
+	puzzleEvents?: PuzzleEvent[];
 };
 
 export type DecisionMachineOutput = {

--- a/packages/types/src/procaptcha/props.ts
+++ b/packages/types/src/procaptcha/props.ts
@@ -30,10 +30,17 @@ import type { Account, Callbacks } from "./manager.js";
  * the frictionless wrapper, which then mounts the chosen image/puzzle widget
  * in place. Internal to the procaptcha-frictionless → procaptcha-pow flow —
  * dapps do not see this.
+ *
+ * `coords` are the trusted checkbox click position captured by the PoW widget
+ * on its own checkbox tick. Forwarded so the escalated image/puzzle widget
+ * can seed the same (x, y) into its salt — otherwise the escalation path
+ * would silently record `coords[0] = [[0, 0]]` and drop the entry-point
+ * telemetry the direct image/puzzle path preserves.
  */
 export type ProcaptchaEscalationHandler = (
 	captchaType: CaptchaType.image | CaptchaType.puzzle,
 	sessionId: string,
+	coords?: { x: number; y: number },
 ) => void;
 
 // Generic behavioral data collectors for analytics


### PR DESCRIPTION
## Summary
- Add optional `coords` and `puzzleEvents` to `DecisionMachineInput` so decision machines can gate on entry-point telemetry and puzzle drag trails.
- Populate `coords` on the pow, puzzle and image `decide()` inputs. Puzzle also passes `puzzleEvents`. Image gains `behavioralDataPacked` and `deviceCapability` — previously always `undefined`, which silently disabled the global synthetic-mouse-timing check on the one captcha type it targets.
- Extend `ProcaptchaEscalationHandler` with an optional `coords` argument so the PoW widget can forward its trusted checkbox click through the PoW→image/puzzle escalation. The frictionless wrapper prefers escalation coords over pending retry coords. Puzzle and image widgets already accept `startCoords`, so the escalated widget now seeds the salt with the real `(x, y)` instead of `(0, 0)`.

## Test plan
- [ ] `npm run -w @prosopo/types build:tsc`
- [ ] `npm run -w @prosopo/provider build:tsc`
- [ ] `npm run -w @prosopo/procaptcha-pow build:tsc`
- [ ] `npm run -w @prosopo/procaptcha-puzzle build:tsc`
- [ ] `npm run -w @prosopo/procaptcha-react build:tsc`
- [ ] `npm run -w @prosopo/procaptcha-frictionless build:tsc`
- [ ] Existing unit tests in `packages/provider/src/tests/unit/tasks/puzzleCaptcha` pass (new fields are optional so nothing to update)
- [ ] Manual: click the checkbox, escalate PoW → puzzle, submit; confirm `usercommitments`/`powcaptchas` and `puzzlecaptchas` records carry `coords[0][0]` = the real click and not `[0, 0]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)