### PR TITLE
fix(traffic-filter): default skipExtrasOnValidDnsPath to true

### DIFF
--- a/.changeset/skip-extras-on-valid-dns-path-default.md
+++ b/.changeset/skip-extras-on-valid-dns-path-default.md
@@ -1,0 +1,6 @@
+---
+"@prosopo/types": patch
+"@prosopo/types-database": patch
+---
+
+fix(traffic-filter): default skipExtrasOnValidDnsPath to true

--- a/packages/types-database/src/types/client.ts
+++ b/packages/types-database/src/types/client.ts
@@ -197,7 +197,7 @@ export const UserSettingsSchema = new Schema({
 		abuserScoreThreshold: { type: Number, min: 0, max: 1, default: 0 },
 		blockDatacenter: { type: Boolean, default: false },
 		datacenterNameAllowlist: { type: [String], required: false },
-		skipExtrasOnValidDnsPath: { type: Boolean, default: false },
+		skipExtrasOnValidDnsPath: { type: Boolean, default: true },
 		blockMobile: { type: Boolean, default: false },
 		blockSatellite: { type: Boolean, default: false },
 		blockCrawler: { type: Boolean, default: false },

--- a/packages/types/src/client/settings.ts
+++ b/packages/types/src/client/settings.ts
@@ -208,11 +208,13 @@ export const TrafficFilterSchema = object({
 	)
 		.max(MAX_DATACENTER_ALLOWLIST_ENTRIES)
 		.optional(),
-	// Opt-in: when the catcher confirmed `dnsEvent.pathValid === true`, skip
-	// the datacenter / VPN / proxy / Tor evaluation on the DNS peer +
-	// resolver IPs. Otherwise users on public DoH resolvers (whose resolver
-	// IPs are necessarily datacenter) trip the rule.
-	skipExtrasOnValidDnsPath: boolean().optional().default(false),
+	// When the catcher confirmed `dnsEvent.pathValid === true`, skip the
+	// datacenter / VPN / proxy / Tor evaluation on the DNS peer + resolver
+	// IPs. Default on: without this, users on public DoH resolvers or ISP
+	// shared anycast resolvers (whose resolver IPs are necessarily
+	// datacenter or high-abuser) trip the rule despite the visitor being
+	// a real user on a real network.
+	skipExtrasOnValidDnsPath: boolean().optional().default(true),
 	blockMobile: boolean().optional().default(false),
 	blockSatellite: boolean().optional().default(false),
 	blockCrawler: boolean().optional().default(false),


### PR DESCRIPTION
## Summary

- Flip `TrafficFilterSchema.skipExtrasOnValidDnsPath` default from `false` to `true`
- Same flip on the Mongo `UserSettingsSchema`
- Updated the comment

## Why

Off-by-default was blocking real users on ISP shared-anycast / public DoH resolvers whose resolver IPs are unavoidably classified as datacenter or high-abuser, despite the DNS path check confirming the visitor is on a real network end-to-end.

## Test plan

- [ ] `checkTrafficFilter` unit tests still pass
- [ ] Existing customer traffic-filter documents are honoured (schema default only applies to new records / unset fields)

🤖 Generated with [Claude Code](https://claude.com/claude-code)