### PR TITLE
feat(procaptcha): block on SIMD readings at solution submit

### DIFF
--- a/.changeset/blocking-simd-readings-on-submit.md
+++ b/.changeset/blocking-simd-readings-on-submit.md
@@ -1,0 +1,24 @@
+---
+"@prosopo/procaptcha-common": patch
+"@prosopo/procaptcha-pow": patch
+"@prosopo/procaptcha-puzzle": patch
+"@prosopo/procaptcha": patch
+---
+
+feat(procaptcha): block on SIMD readings at solution submit
+
+Solution submit is the last hop the client controls, so it's the last chance to
+attach the catcher's WASM SIMD readings for a session. The image, PoW and puzzle
+managers now wait for the benchmark there via a shared
+`getSimdReadingsForSubmit` helper, capped at 5s, instead of attaching only
+whatever the prefetch happened to have resolved.
+
+The helper passes the budget down to the detector *and* races it locally — the
+detector ships prebuilt, so a bundle that ignores `timeoutMs` (or a benchmark
+wedged on a busy main thread) can't hang the submission. It never rejects: a
+missing accessor, a rejection, a synchronous throw and a timeout all resolve to
+`undefined` and the solution is submitted without readings, so a user is never
+failed over telemetry.
+
+The earlier frictionless POST and challenge GET hops are unchanged and remain
+non-blocking.

--- a/packages/procaptcha-common/src/index.ts
+++ b/packages/procaptcha-common/src/index.ts
@@ -17,6 +17,7 @@ export * from "./state/builder.js";
 export * from "./callbacks/defaultCallbacks.js";
 export * from "./callbacks/defaultEvents.js";
 export * from "./extensionLoader.js";
+export * from "./simdReadings.js";
 export * from "./elements/window.js";
 export * from "./reactComponents/Reload.js";
 export * from "./reactComponents/Checkbox.js";

--- a/packages/procaptcha-common/src/simdReadings.ts
+++ b/packages/procaptcha-common/src/simdReadings.ts
@@ -1,0 +1,74 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * How long the client blocks on the catcher's WASM SIMD benchmark at solution
+ * submit time before giving up.
+ *
+ * Submit is the last hop the client controls, so it's the last chance to attach
+ * readings for this session — earlier hops (the frictionless POST and the
+ * challenge GET) are deliberately non-blocking and only attach what the
+ * catcher's prefetch has already resolved. Here we wait, capped at 5s so a
+ * stalled or unsupported benchmark can't hold a solved captcha hostage.
+ */
+export const SIMD_READINGS_SUBMIT_TIMEOUT_MS = 5000;
+
+/**
+ * Anything carrying the catcher's SIMD accessor — in practice the frictionless
+ * state threaded through each widget's manager. Structural so the pow, puzzle
+ * and image managers can all pass their own state type.
+ */
+export interface SimdReadingsSource {
+	getSimdReadings?: (timeoutMs?: number) => Promise<string | undefined>;
+}
+
+/**
+ * Block on the catcher's SIMD readings for up to `timeoutMs`, then resolve with
+ * whatever we have.
+ *
+ * The detector ships as a prebuilt bundle, so its handling of `timeoutMs` is
+ * opaque to us — we pass the budget down *and* race it ourselves, otherwise a
+ * bundle that ignores the argument (or a benchmark wedged on a busy main
+ * thread) would hang the submission indefinitely.
+ *
+ * Never rejects: a missing accessor, a rejected promise, a synchronous throw,
+ * and a timeout all resolve to `undefined`. Readings are telemetry — failing a
+ * user's captcha over them would be a far worse outcome than losing the signal
+ * for one session.
+ */
+export const getSimdReadingsForSubmit = async (
+	source: SimdReadingsSource | undefined,
+	timeoutMs: number = SIMD_READINGS_SUBMIT_TIMEOUT_MS,
+): Promise<string | undefined> => {
+	if (!source?.getSimdReadings) return undefined;
+	const { getSimdReadings } = source;
+
+	let readings: Promise<string | undefined>;
+	try {
+		readings = Promise.resolve(getSimdReadings.call(source, timeoutMs));
+	} catch {
+		return undefined;
+	}
+
+	let timeoutId: ReturnType<typeof setTimeout> | undefined;
+	const timeout = new Promise<undefined>((resolve) => {
+		timeoutId = setTimeout(() => resolve(undefined), timeoutMs);
+	});
+
+	try {
+		return await Promise.race([readings.catch(() => undefined), timeout]);
+	} finally {
+		if (timeoutId !== undefined) clearTimeout(timeoutId);
+	}
+};

--- a/packages/procaptcha-common/src/simdReadings.ts
+++ b/packages/procaptcha-common/src/simdReadings.ts
@@ -12,41 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/**
- * How long the client blocks on the catcher's WASM SIMD benchmark at solution
- * submit time before giving up.
- *
- * Submit is the last hop the client controls, so it's the last chance to attach
- * readings for this session — earlier hops (the frictionless POST and the
- * challenge GET) are deliberately non-blocking and only attach what the
- * catcher's prefetch has already resolved. Here we wait, capped at 5s so a
- * stalled or unsupported benchmark can't hold a solved captcha hostage.
- */
 export const SIMD_READINGS_SUBMIT_TIMEOUT_MS = 5000;
 
-/**
- * Anything carrying the catcher's SIMD accessor — in practice the frictionless
- * state threaded through each widget's manager. Structural so the pow, puzzle
- * and image managers can all pass their own state type.
- */
 export interface SimdReadingsSource {
 	getSimdReadings?: (timeoutMs?: number) => Promise<string | undefined>;
 }
 
-/**
- * Block on the catcher's SIMD readings for up to `timeoutMs`, then resolve with
- * whatever we have.
- *
- * The detector ships as a prebuilt bundle, so its handling of `timeoutMs` is
- * opaque to us — we pass the budget down *and* race it ourselves, otherwise a
- * bundle that ignores the argument (or a benchmark wedged on a busy main
- * thread) would hang the submission indefinitely.
- *
- * Never rejects: a missing accessor, a rejected promise, a synchronous throw,
- * and a timeout all resolve to `undefined`. Readings are telemetry — failing a
- * user's captcha over them would be a far worse outcome than losing the signal
- * for one session.
- */
 export const getSimdReadingsForSubmit = async (
 	source: SimdReadingsSource | undefined,
 	timeoutMs: number = SIMD_READINGS_SUBMIT_TIMEOUT_MS,

--- a/packages/procaptcha-common/src/tests/simdReadings.test.ts
+++ b/packages/procaptcha-common/src/tests/simdReadings.test.ts
@@ -1,0 +1,149 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	SIMD_READINGS_SUBMIT_TIMEOUT_MS,
+	type SimdReadingsSource,
+	getSimdReadingsForSubmit,
+} from "../simdReadings.js";
+
+afterEach(() => {
+	vi.useRealTimers();
+	vi.restoreAllMocks();
+});
+
+describe("getSimdReadingsForSubmit", () => {
+	it("blocks on the readings and returns them", async () => {
+		const getSimdReadings = vi.fn<
+			(timeoutMs?: number) => Promise<string | undefined>
+		>(async () => "ENCODED_SIMD");
+		const source: SimdReadingsSource = { getSimdReadings };
+
+		await expect(getSimdReadingsForSubmit(source)).resolves.toBe(
+			"ENCODED_SIMD",
+		);
+	});
+
+	it("passes the submit timeout budget down to the detector", async () => {
+		const getSimdReadings = vi.fn<
+			(timeoutMs?: number) => Promise<string | undefined>
+		>(async () => "ENCODED_SIMD");
+
+		await getSimdReadingsForSubmit({ getSimdReadings });
+
+		expect(getSimdReadings).toHaveBeenCalledWith(
+			SIMD_READINGS_SUBMIT_TIMEOUT_MS,
+		);
+		expect(SIMD_READINGS_SUBMIT_TIMEOUT_MS).toBe(5000);
+	});
+
+	it("waits for slow readings that still land inside the budget", async () => {
+		vi.useFakeTimers();
+		const getSimdReadings = vi.fn<
+			(timeoutMs?: number) => Promise<string | undefined>
+		>(
+			() =>
+				new Promise<string>((resolve) => {
+					setTimeout(() => resolve("LATE_SIMD"), 4000);
+				}),
+		);
+
+		const pending = getSimdReadingsForSubmit({ getSimdReadings });
+		await vi.advanceTimersByTimeAsync(4000);
+
+		await expect(pending).resolves.toBe("LATE_SIMD");
+	});
+
+	it("gives up at the timeout when the detector never resolves", async () => {
+		vi.useFakeTimers();
+		const getSimdReadings = vi.fn<
+			(timeoutMs?: number) => Promise<string | undefined>
+		>(() => new Promise<string>(() => undefined));
+
+		const pending = getSimdReadingsForSubmit({ getSimdReadings });
+		await vi.advanceTimersByTimeAsync(SIMD_READINGS_SUBMIT_TIMEOUT_MS);
+
+		await expect(pending).resolves.toBeUndefined();
+	});
+
+	it("honours an explicit timeout override", async () => {
+		vi.useFakeTimers();
+		const getSimdReadings = vi.fn<
+			(timeoutMs?: number) => Promise<string | undefined>
+		>(() => new Promise<string>(() => undefined));
+
+		const pending = getSimdReadingsForSubmit({ getSimdReadings }, 100);
+		await vi.advanceTimersByTimeAsync(100);
+
+		await expect(pending).resolves.toBeUndefined();
+		expect(getSimdReadings).toHaveBeenCalledWith(100);
+	});
+
+	it("resolves undefined when the readings promise rejects", async () => {
+		const getSimdReadings = vi.fn<
+			(timeoutMs?: number) => Promise<string | undefined>
+		>(async () => {
+			throw new Error("benchmark failed");
+		});
+
+		await expect(
+			getSimdReadingsForSubmit({ getSimdReadings }),
+		).resolves.toBeUndefined();
+	});
+
+	it("resolves undefined when the accessor throws synchronously", async () => {
+		const getSimdReadings = vi.fn<
+			(timeoutMs?: number) => Promise<string | undefined>
+		>(() => {
+			throw new Error("detector exploded");
+		});
+
+		await expect(
+			getSimdReadingsForSubmit({ getSimdReadings }),
+		).resolves.toBeUndefined();
+	});
+
+	it("resolves undefined without a source or accessor", async () => {
+		await expect(getSimdReadingsForSubmit(undefined)).resolves.toBeUndefined();
+		await expect(getSimdReadingsForSubmit({})).resolves.toBeUndefined();
+	});
+
+	it("calls the accessor with the source as `this`", async () => {
+		// The detector ships prebuilt; its accessor may be a method relying on
+		// its own receiver, so it must not be invoked detached.
+		const source = {
+			marker: "SIMD_FROM_THIS",
+			getSimdReadings(this: { marker: string }): Promise<string | undefined> {
+				return Promise.resolve(this.marker);
+			},
+		};
+
+		await expect(getSimdReadingsForSubmit(source)).resolves.toBe(
+			"SIMD_FROM_THIS",
+		);
+	});
+
+	it("clears the timeout timer once readings arrive", async () => {
+		vi.useFakeTimers();
+		const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout");
+		const getSimdReadings = vi.fn<
+			(timeoutMs?: number) => Promise<string | undefined>
+		>(async () => "ENCODED_SIMD");
+
+		await getSimdReadingsForSubmit({ getSimdReadings });
+
+		expect(clearTimeoutSpy).toHaveBeenCalled();
+	});
+});

--- a/packages/procaptcha-pow/src/services/Manager.ts
+++ b/packages/procaptcha-pow/src/services/Manager.ts
@@ -338,9 +338,7 @@ export const Manager = (
 						}
 					}
 
-					// Last hop we control — block on the benchmark (capped at 5s)
-					// rather than attaching only what already happens to be
-					// resolved. See getSimdReadingsForSubmit.
+					// Wait 5 secs for ongoing SIMD, else submit without
 					const simdReadings =
 						await getSimdReadingsForSubmit(frictionlessState);
 					const hpValue = getHoneypotValue?.();

--- a/packages/procaptcha-pow/src/services/Manager.ts
+++ b/packages/procaptcha-pow/src/services/Manager.ts
@@ -23,11 +23,12 @@ import {
 import {
 	ExtensionLoader,
 	buildUpdateState,
+	getDefaultEvents,
 	getProcaptchaRandomActiveProvider,
+	getSimdReadingsForSubmit,
 	pickIpMode,
 	providerRetry,
 } from "@prosopo/procaptcha-common";
-import { getDefaultEvents } from "@prosopo/procaptcha-common";
 import {
 	type Account,
 	ApiParams,
@@ -337,9 +338,11 @@ export const Manager = (
 						}
 					}
 
-					const simdReadings = frictionlessState?.getSimdReadings
-						? await frictionlessState.getSimdReadings()
-						: undefined;
+					// Last hop we control — block on the benchmark (capped at 5s)
+					// rather than attaching only what already happens to be
+					// resolved. See getSimdReadingsForSubmit.
+					const simdReadings =
+						await getSimdReadingsForSubmit(frictionlessState);
 					const hpValue = getHoneypotValue?.();
 					const clientMetaData = hpValue ? { hp: hpValue } : undefined;
 					// Best-effort proof of fingerprint; submission proceeds without it

--- a/packages/procaptcha-puzzle/src/services/Manager.ts
+++ b/packages/procaptcha-puzzle/src/services/Manager.ts
@@ -405,9 +405,7 @@ export const Manager = (
 				salt = embedData(randomSalt, coords);
 			}
 
-			// Last hop we control — block on the benchmark (capped at 5s) rather
-			// than attaching only what already happens to be resolved.
-			// See getSimdReadingsForSubmit.
+			// Wait 5 secs for ongoing SIMD, else submit without
 			const simdReadings = await getSimdReadingsForSubmit(frictionlessState);
 			const hpValue = getHoneypotValue?.();
 			const clientMetaData = hpValue ? { hp: hpValue } : undefined;

--- a/packages/procaptcha-puzzle/src/services/Manager.ts
+++ b/packages/procaptcha-puzzle/src/services/Manager.ts
@@ -18,11 +18,12 @@ import { ProsopoEnvError } from "@prosopo/common";
 import {
 	ExtensionLoader,
 	buildUpdateState,
+	getDefaultEvents,
 	getProcaptchaRandomActiveProvider,
+	getSimdReadingsForSubmit,
 	pickIpMode,
 	providerRetry,
 } from "@prosopo/procaptcha-common";
-import { getDefaultEvents } from "@prosopo/procaptcha-common";
 import {
 	type Account,
 	ApiParams,
@@ -404,9 +405,10 @@ export const Manager = (
 				salt = embedData(randomSalt, coords);
 			}
 
-			const simdReadings = frictionlessState?.getSimdReadings
-				? await frictionlessState.getSimdReadings()
-				: undefined;
+			// Last hop we control — block on the benchmark (capped at 5s) rather
+			// than attaching only what already happens to be resolved.
+			// See getSimdReadingsForSubmit.
+			const simdReadings = await getSimdReadingsForSubmit(frictionlessState);
 			const hpValue = getHoneypotValue?.();
 			const clientMetaData = hpValue ? { hp: hpValue } : undefined;
 			const verifiedSolution = await providerApi.submitPuzzleCaptchaSolution(

--- a/packages/procaptcha/src/modules/Manager.ts
+++ b/packages/procaptcha/src/modules/Manager.ts
@@ -343,9 +343,7 @@ export function Manager(
 					}
 				}
 
-				// Last hop we control — block on the benchmark (capped at 5s)
-				// rather than attaching only what already happens to be
-				// resolved. See getSimdReadingsForSubmit.
+				// Wait 5 secs for ongoing SIMD, else submit without
 				const simdReadings = await getSimdReadingsForSubmit(frictionlessState);
 				const hpValue = getHoneypotValue?.();
 				const clientMetaData = hpValue ? { hp: hpValue } : undefined;

--- a/packages/procaptcha/src/modules/Manager.ts
+++ b/packages/procaptcha/src/modules/Manager.ts
@@ -22,11 +22,12 @@ import {
 import {
 	ExtensionLoader,
 	buildUpdateState,
+	getDefaultEvents,
 	getProcaptchaRandomActiveProvider,
+	getSimdReadingsForSubmit,
 	pickIpMode,
 	providerRetry,
 } from "@prosopo/procaptcha-common";
-import { getDefaultEvents } from "@prosopo/procaptcha-common";
 import {
 	type Account,
 	ApiParams,
@@ -342,9 +343,10 @@ export function Manager(
 					}
 				}
 
-				const simdReadings = frictionlessState?.getSimdReadings
-					? await frictionlessState.getSimdReadings()
-					: undefined;
+				// Last hop we control — block on the benchmark (capped at 5s)
+				// rather than attaching only what already happens to be
+				// resolved. See getSimdReadingsForSubmit.
+				const simdReadings = await getSimdReadingsForSubmit(frictionlessState);
 				const hpValue = getHoneypotValue?.();
 				const clientMetaData = hpValue ? { hp: hpValue } : undefined;
 				// send the commitment to the provider


### PR DESCRIPTION
## What

Solution submit is the last hop the client controls, so it's the last chance to attach the catcher's WASM SIMD readings for a session. The image, PoW and puzzle managers now **block** on the benchmark there — capped at **5s** — instead of attaching only whatever the prefetch happened to have already resolved.

## Why

SIMD readings flow through three attach points today, first-hop-wins server-side (`SimdReadingsStage`):

| Hop | Before | After |
|---|---|---|
| Frictionless `POST` (`customDetectBot`) | deliberately omitted; fires a 60s fire-and-forget prefetch so the benchmark runs during the network round-trip | unchanged |
| Challenge `GET` (`getSimdReadings(0)`) | non-blocking — attaches only if the prefetch already resolved | unchanged |
| Solution submit | `await getSimdReadings()` with the detector's opaque default budget | **blocks up to 5s via `getSimdReadingsForSubmit`** |

Submit was already awaited, but on the detector's own default timeout, which is opaque to us — `packages/detector` ships as a prebuilt bundle. That meant no upper bound on how long a solved captcha could sit waiting, and no guarantee we'd actually waited at all.

## How

New shared helper `getSimdReadingsForSubmit` in `@prosopo/procaptcha-common`, used by all three managers:

- Passes the 5s budget down to the detector **and** races it locally, so a bundle that ignores `timeoutMs` — or a benchmark wedged on a busy main thread — can't hang the submission.
- Invokes the accessor with the source as `this`, since the prebuilt detector's accessor may rely on its own receiver.
- **Never rejects.** A missing accessor, a rejected promise, a synchronous throw and a timeout all resolve to `undefined`, and the solution submits without readings. Readings are telemetry — failing a real user's captcha over them would be a far worse outcome than losing the signal for one session. Non-frictionless flows have no catcher at all, so `undefined` has to stay a valid outcome.

Provider-side schemas are unchanged: `simdReadings` stays optional on all submit endpoints.

## Testing

- 10 new unit tests covering the happy path, timeout-budget propagation, slow-but-in-budget readings, never-resolving detector, explicit timeout override, rejection, synchronous throw, missing source/accessor, `this` binding, and timer cleanup. `simdReadings.ts` at 100% statement/branch/function/line coverage.
- `@prosopo/procaptcha-common` suite: 75 passed.
- `@prosopo/procaptcha-frictionless` suite: 18 passed — the existing `customDetectBotSimd` tests still assert the frictionless hop stays non-blocking.
- `npm run lint` and `typecheck` clean across all four touched packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GniKidD2mqR151pLf1JrzN