### PR TITLE
perf(config): honour pure annotations so the widget ships less dead code

### DIFF
--- a/.changeset/treeshake-annotations.md
+++ b/.changeset/treeshake-annotations.md
@@ -1,0 +1,9 @@
+---
+"@prosopo/config": patch
+---
+
+Honour /*#__PURE__*/ annotations when tree-shaking. Rolldown has no
+`treeshake.preset`, so Rollup's "smallest" could not be carried across in the
+Vite 8 upgrade; ignoring pure annotations retained dead library code that every
+consumer shipped. Cuts ~17KB gzip off the procaptcha widget bundle with a
+byte-identical detector bundle.

--- a/dev/config/src/vite/vite.backend.config.ts
+++ b/dev/config/src/vite/vite.backend.config.ts
@@ -138,7 +138,13 @@ export default async function (
 			},
 			modulePreload: { polyfill: false },
 			rollupOptions: {
-				treeshake: { moduleSideEffects: true },
+				treeshake: {
+					// Rolldown has no `preset` support, so Rollup's "smallest" could
+					// not be carried over. Honouring pure annotations recovers part
+					// of that without the risk of moduleSideEffects: false.
+					annotations: true,
+					moduleSideEffects: true,
+				},
 				external: allExternal,
 				watch: false,
 				output: {

--- a/dev/config/src/vite/vite.frontend.config.ts
+++ b/dev/config/src/vite/vite.frontend.config.ts
@@ -189,9 +189,18 @@ export default async function (
 
 			rollupOptions: {
 				treeshake: {
-					annotations: false,
+					// Respect /*#__PURE__*/ annotations. Ignoring them retained
+					// dead library calls that every consumer then shipped;
+					// honouring them cuts ~17KB gzip off the widget bundle with
+					// a byte-identical detector.
+					annotations: true,
 					propertyReadSideEffects: false,
-					moduleSideEffects: "no-external", //true,
+					// Measured alternatives, both rejected:
+					//   moduleSideEffects: false        -> widget 8KB gzip LARGER
+					//   propertyWriteSideEffects: false -> detector dies on load
+					//                                     ("Maximum call stack
+					//                                     size exceeded")
+					moduleSideEffects: "no-external",
 					unknownGlobalSideEffects: false,
 				},
 				external: rollupExternal,


### PR DESCRIPTION
## What

Rolldown has no `treeshake.preset`, so Rollup's `"smallest"` could not be carried across in the Vite 8 upgrade and the backend config fell back to `{ moduleSideEffects: true }` — the least aggressive setting available.

`annotations: false` was also being passed, which tells the bundler to **ignore** `/*#__PURE__*/` markers. Those markers are the main mechanism by which unused library calls get dropped, so ignoring them retained dead code that every consumer then shipped.

## Measured impact

Production builds, full rebuild of libs + catcher + widget:

| artifact | before | after | delta |
|---|---:|---:|---:|
| widget raw | 2,190,560 | 2,138,613 | **−51,947 (−2.4%)** |
| widget gzip | 721,721 | 704,776 | **−16,945 (−2.3%)** |
| detector raw | 843,714 | 843,714 | byte-identical |
| detector gzip | 230,329 | 230,329 | byte-identical |

## Rejected alternatives (measured, not assumed)

| setting | outcome |
|---|---|
| `moduleSideEffects: false` | widget ~8KB gzip **larger**, not smaller |
| `propertyWriteSideEffects: false` | detector **dies on load**: `Maximum call stack size exceeded` |
| tree-shaking on esm/cjs library builds | same fatal stack overflow in the detector |

Tree-shaking therefore stays off for the library builds, and a comment now records why so it isn't "fixed" again later.

## Verification

- Detector bundle loads in headless chromium (regression harness)
- Provider suite unchanged: 1009 passed / 31 pre-existing local failures both with and without the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GagGdoZ8Lyj876K5EsDwRb