### PR TITLE
test(http-blackhole): unit tests + injectable units

### DIFF
--- a/.changeset/http-blackhole-fixes.md
+++ b/.changeset/http-blackhole-fixes.md
@@ -1,0 +1,7 @@
+---
+"@prosopo/http-blackhole": patch
+---
+
+Fix shutdown hanging on held-open connections, validate PORT strictly instead
+of silently defaulting, surface close() failures as a non-zero exit, ignore
+repeat shutdown signals, and log connections that never send a request.

--- a/.changeset/http-blackhole-unit-tests.md
+++ b/.changeset/http-blackhole-unit-tests.md
@@ -1,0 +1,6 @@
+---
+"@prosopo/http-blackhole": patch
+---
+
+Extract the server, request handler, port resolution and shutdown handler into
+injectable units and add unit tests covering them.

--- a/packages/http-blackhole/package.json
+++ b/packages/http-blackhole/package.json
@@ -11,7 +11,9 @@
 		"build": "npm run build:cross-env -- --mode ${NODE_ENV:-development}",
 		"build:cross-env": "vite build --config vite.esm.config.ts",
 		"build:cjs": "NODE_ENV=${NODE_ENV:-development}; vite build --config vite.cjs.config.ts --mode $NODE_ENV",
-		"start": "node dist/index.js"
+		"start": "node dist/index.js",
+		"typecheck": "tsc --noEmit",
+		"test": "NODE_ENV=${NODE_ENV:-test}; npx vitest run --config ./vite.test.config.ts"
 	},
 	"author": "",
 	"dependencies": {
@@ -22,8 +24,11 @@
 	"devDependencies": {
 		"@prosopo/config": "3.3.4",
 		"@types/node": "24.10.13",
+		"@vitest/coverage-v8": "4.1.10",
 		"tsx": "4.20.3",
-		"typescript": "5.9.3"
+		"typescript": "5.9.3",
+		"vite": "8.1.5",
+		"vitest": "4.1.10"
 	},
 	"repository": {
 		"type": "git",

--- a/packages/http-blackhole/src/blackhole.ts
+++ b/packages/http-blackhole/src/blackhole.ts
@@ -13,9 +13,13 @@
 // limitations under the License.
 
 import http from "node:http";
+import type net from "node:net";
 
-/** Port used when PORT is unset or does not parse to a non-zero number. */
+/** Port used when PORT is unset or blank. */
 export const DEFAULT_PORT = 8080;
+
+/** Highest port number the OS will accept. */
+export const MAX_PORT = 65535;
 
 /**
  * Console-shaped output sink. Injected so tests can capture output without
@@ -29,60 +33,126 @@ export interface Logger {
 /** Exit function, injected so tests do not terminate the test runner. */
 export type Exit = (code: number) => void;
 
+/** Raised when PORT is set to something that is not a usable port. */
+export class InvalidPortError extends Error {
+	constructor(value: string) {
+		super(
+			`Invalid PORT "${value}": expected a whole number between 0 and ${MAX_PORT}`,
+		);
+		this.name = "InvalidPortError";
+	}
+}
+
 /**
  * Resolve the listen port from a raw environment value.
  *
- * Note `Number(value) || DEFAULT_PORT` treats 0 as absent, so PORT=0 — which
- * would otherwise mean "pick any free port" — falls back to DEFAULT_PORT.
- * Values that parse to a number are passed straight through without a validity
- * check, so an out-of-range or fractional port surfaces later as a listen error.
+ * Unset or blank falls back to DEFAULT_PORT; anything else must be a plain
+ * decimal integer in range, or startup fails immediately rather than silently
+ * binding the wrong port. 0 is honoured, meaning "bind any free port".
  */
-export const resolvePort = (value: string | undefined): number =>
-	Number(value) || DEFAULT_PORT;
+export const resolvePort = (value: string | undefined): number => {
+	if (value === undefined) {
+		return DEFAULT_PORT;
+	}
+	const trimmed = value.trim();
+	if (trimmed === "") {
+		return DEFAULT_PORT;
+	}
+	// Deliberately stricter than Number(): hex, exponent and fractional forms
+	// in a PORT value are far more likely to be typos than intent.
+	if (!/^\d+$/.test(trimmed)) {
+		throw new InvalidPortError(value);
+	}
+	const port = Number(trimmed);
+	if (port > MAX_PORT) {
+		throw new InvalidPortError(value);
+	}
+	return port;
+};
+
+/** Human-readable request line, tolerating an unparsed method or url. */
+export const describeRequest = (req: http.IncomingMessage): string =>
+	`${req.method ?? "UNKNOWN"} ${req.url ?? "UNKNOWN"}`;
 
 /**
  * Handle one request by deliberately never responding: the socket is held open
  * so the client is forced to hit its own timeout. This is the entire purpose of
  * the package — it exists to test client-side timeout handling.
+ *
+ * The request line is recorded against the socket so the connection-level close
+ * listener can name it.
  */
 export const handleRequest = (
 	req: http.IncomingMessage,
 	logger: Logger,
+	lastRequest?: WeakMap<net.Socket, string>,
 ): void => {
-	logger.log(`Received request: ${req.method} ${req.url}`);
-	// Do nothing: simulate an unresponsive server, keeping the socket open.
+	const description = describeRequest(req);
+	logger.log(`Received request: ${description}`);
+	lastRequest?.set(req.socket, description);
+	// Do nothing else: simulate an unresponsive server, keeping the socket open.
 	req.socket.setTimeout(0); // Disable socket timeout
 	req.socket.setKeepAlive(true); // Keep the socket alive
-
-	req.socket.on("close", () => {
-		logger.log(`Connection closed by client: ${req.method} ${req.url}`);
-	});
 };
 
 /** Build the blackhole server. Does not listen — the caller decides that. */
-export const createBlackholeServer = (logger: Logger): http.Server =>
-	http.createServer((req: http.IncomingMessage) => {
-		handleRequest(req, logger);
+export const createBlackholeServer = (logger: Logger): http.Server => {
+	const server = http.createServer();
+	// Close is tracked per connection rather than per request, so a client that
+	// connects and then goes away without ever sending a request line is still
+	// accounted for.
+	const lastRequest = new WeakMap<net.Socket, string>();
+
+	server.on("connection", (socket: net.Socket) => {
+		logger.log("Connection opened");
+		socket.on("close", () => {
+			const description = lastRequest.get(socket);
+			logger.log(
+				description === undefined
+					? "Connection closed by client before any request"
+					: `Connection closed by client: ${description}`,
+			);
+		});
 	});
+
+	server.on("request", (req: http.IncomingMessage) => {
+		handleRequest(req, logger, lastRequest);
+	});
+
+	return server;
+};
 
 /**
  * Build the SIGINT/SIGTERM handler.
  *
- * Caveat: server.close() waits for in-flight connections to end, and this
- * server holds every connection open indefinitely by design. So whenever a
- * client is connected the callback never fires and the process never exits of
- * its own accord — the supervisor's grace period and SIGKILL end it instead.
+ * server.close() only stops new connections and waits for existing ones to end
+ * — and this server holds every connection open indefinitely by design, so it
+ * would wait forever. closeAllConnections() severs them so shutdown actually
+ * completes. Repeat signals are ignored, and a close failure exits non-zero
+ * rather than reporting a clean shutdown that did not happen.
  */
 export const createShutdown = (
 	server: http.Server,
 	logger: Logger,
 	exit: Exit,
 ): (() => void) => {
+	let shuttingDown = false;
 	return () => {
+		if (shuttingDown) {
+			logger.log("Shutdown already in progress; ignoring signal.");
+			return;
+		}
+		shuttingDown = true;
 		logger.log("\nShutting down http-blackhole server...");
-		server.close(() => {
+		server.close((error?: Error) => {
+			if (error) {
+				logger.log(`Server close failed: ${error.message}`);
+				exit(1);
+				return;
+			}
 			logger.log("Server closed. Exiting.");
 			exit(0);
 		});
+		server.closeAllConnections();
 	};
 };

--- a/packages/http-blackhole/src/blackhole.ts
+++ b/packages/http-blackhole/src/blackhole.ts
@@ -1,0 +1,88 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import http from "node:http";
+
+/** Port used when PORT is unset or does not parse to a non-zero number. */
+export const DEFAULT_PORT = 8080;
+
+/**
+ * Console-shaped output sink. Injected so tests can capture output without
+ * stubbing the global console, and so the entrypoint stays the only place that
+ * reaches for a real one.
+ */
+export interface Logger {
+	log: (message: string) => void;
+}
+
+/** Exit function, injected so tests do not terminate the test runner. */
+export type Exit = (code: number) => void;
+
+/**
+ * Resolve the listen port from a raw environment value.
+ *
+ * Note `Number(value) || DEFAULT_PORT` treats 0 as absent, so PORT=0 — which
+ * would otherwise mean "pick any free port" — falls back to DEFAULT_PORT.
+ * Values that parse to a number are passed straight through without a validity
+ * check, so an out-of-range or fractional port surfaces later as a listen error.
+ */
+export const resolvePort = (value: string | undefined): number =>
+	Number(value) || DEFAULT_PORT;
+
+/**
+ * Handle one request by deliberately never responding: the socket is held open
+ * so the client is forced to hit its own timeout. This is the entire purpose of
+ * the package — it exists to test client-side timeout handling.
+ */
+export const handleRequest = (
+	req: http.IncomingMessage,
+	logger: Logger,
+): void => {
+	logger.log(`Received request: ${req.method} ${req.url}`);
+	// Do nothing: simulate an unresponsive server, keeping the socket open.
+	req.socket.setTimeout(0); // Disable socket timeout
+	req.socket.setKeepAlive(true); // Keep the socket alive
+
+	req.socket.on("close", () => {
+		logger.log(`Connection closed by client: ${req.method} ${req.url}`);
+	});
+};
+
+/** Build the blackhole server. Does not listen — the caller decides that. */
+export const createBlackholeServer = (logger: Logger): http.Server =>
+	http.createServer((req: http.IncomingMessage) => {
+		handleRequest(req, logger);
+	});
+
+/**
+ * Build the SIGINT/SIGTERM handler.
+ *
+ * Caveat: server.close() waits for in-flight connections to end, and this
+ * server holds every connection open indefinitely by design. So whenever a
+ * client is connected the callback never fires and the process never exits of
+ * its own accord — the supervisor's grace period and SIGKILL end it instead.
+ */
+export const createShutdown = (
+	server: http.Server,
+	logger: Logger,
+	exit: Exit,
+): (() => void) => {
+	return () => {
+		logger.log("\nShutting down http-blackhole server...");
+		server.close(() => {
+			logger.log("Server closed. Exiting.");
+			exit(0);
+		});
+	};
+};

--- a/packages/http-blackhole/src/tests/blackhole.unit.test.ts
+++ b/packages/http-blackhole/src/tests/blackhole.unit.test.ts
@@ -14,7 +14,7 @@
 
 // Testing strategy: exercise the real node:http and node:net implementations
 // rather than mocking them, so the tests pin actual socket/server semantics
-// (in particular that close() blocks while a connection is held open). Fakes
+// (in particular that shutdown must sever held-open connections). Fakes
 // are used only for the two injected seams — the logger and the exit fn — so
 // tests can assert on output without touching the console or killing the
 // runner.
@@ -26,9 +26,12 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
 	DEFAULT_PORT,
 	type Exit,
+	InvalidPortError,
 	type Logger,
+	MAX_PORT,
 	createBlackholeServer,
 	createShutdown,
+	describeRequest,
 	handleRequest,
 	resolvePort,
 } from "../blackhole.js";
@@ -137,7 +140,6 @@ describe("resolvePort", () => {
 	});
 
 	it("returns the default for an empty string", () => {
-		// Number("") is 0, which is falsy, so the default applies.
 		expect(resolvePort("")).toBe(DEFAULT_PORT);
 	});
 
@@ -153,29 +155,44 @@ describe("resolvePort", () => {
 		expect(resolvePort(" 3000 ")).toBe(3000);
 	});
 
-	it("falls back to the default for a non-numeric value", () => {
-		// A typo in PORT is silently swallowed rather than failing fast.
-		expect(resolvePort("abc")).toBe(DEFAULT_PORT);
-		expect(resolvePort("8080abc")).toBe(DEFAULT_PORT);
+	it("throws on a non-numeric value rather than silently defaulting", () => {
+		expect(() => resolvePort("abc")).toThrow(InvalidPortError);
+		expect(() => resolvePort("8080abc")).toThrow(InvalidPortError);
 	});
 
-	it("falls back to the default for PORT=0", () => {
-		// 0 normally means "bind any free port", but it is falsy so it is
-		// overridden — the server can never be asked for an ephemeral port.
-		expect(resolvePort("0")).toBe(DEFAULT_PORT);
+	it("names the offending value in the error", () => {
+		expect(() => resolvePort("abc")).toThrow(
+			'Invalid PORT "abc": expected a whole number between 0 and 65535',
+		);
 	});
 
-	it("passes through values that are not valid ports", () => {
-		// No range or integer validation happens here; listen() rejects these
-		// later, at runtime.
-		expect(resolvePort("-1")).toBe(-1);
-		expect(resolvePort("99999")).toBe(99999);
-		expect(resolvePort("3000.5")).toBe(3000.5);
+	it("honours PORT=0 as a request for any free port", () => {
+		expect(resolvePort("0")).toBe(0);
 	});
 
-	it("accepts the numeric literal forms Number() understands", () => {
-		expect(resolvePort("0x1f")).toBe(31);
-		expect(resolvePort("1e3")).toBe(1000);
+	it("throws on an out-of-range port", () => {
+		expect(() => resolvePort("-1")).toThrow(InvalidPortError);
+		expect(() => resolvePort("99999")).toThrow(InvalidPortError);
+	});
+
+	it("accepts the range boundary", () => {
+		expect(resolvePort(String(MAX_PORT))).toBe(MAX_PORT);
+		expect(() => resolvePort(String(MAX_PORT + 1))).toThrow(InvalidPortError);
+	});
+
+	it("throws on a fractional port", () => {
+		expect(() => resolvePort("3000.5")).toThrow(InvalidPortError);
+	});
+
+	it("rejects numeric literal forms that are more likely typos", () => {
+		// Number() would happily read these as 31 and 1000.
+		expect(() => resolvePort("0x1f")).toThrow(InvalidPortError);
+		expect(() => resolvePort("1e3")).toThrow(InvalidPortError);
+		expect(() => resolvePort("+3000")).toThrow(InvalidPortError);
+	});
+
+	it("accepts a leading-zero port", () => {
+		expect(resolvePort("08080")).toBe(8080);
 	});
 });
 
@@ -204,25 +221,27 @@ describe("handleRequest", () => {
 		expect(writeSpy).not.toHaveBeenCalled();
 	});
 
-	it("logs when the client closes the connection", () => {
-		const logger = createRecordingLogger();
+	it("records the request line against the socket", () => {
 		const socket = createSocket();
-		handleRequest(createRequest(socket, "POST", "/bar"), logger);
-
-		socket.emit("close");
-
-		expect(logger.messages).toEqual([
-			"Received request: POST /bar",
-			"Connection closed by client: POST /bar",
-		]);
+		const lastRequest = new WeakMap<net.Socket, string>();
+		handleRequest(
+			createRequest(socket, "POST", "/bar"),
+			createRecordingLogger(),
+			lastRequest,
+		);
+		expect(lastRequest.get(socket)).toBe("POST /bar");
 	});
 
-	it("renders undefined method and url literally", () => {
-		// IncomingMessage leaves these undefined until parsed; the template
-		// stringifies them rather than guarding, so the log reads "undefined".
+	it("works without a request map", () => {
+		const logger = createRecordingLogger();
+		handleRequest(createRequest(createSocket(), "GET", "/x"), logger);
+		expect(logger.messages).toEqual(["Received request: GET /x"]);
+	});
+
+	it("labels an unparsed method and url rather than printing undefined", () => {
 		const logger = createRecordingLogger();
 		handleRequest(createRequest(createSocket(), undefined, undefined), logger);
-		expect(logger.messages).toEqual(["Received request: undefined undefined"]);
+		expect(logger.messages).toEqual(["Received request: UNKNOWN UNKNOWN"]);
 	});
 
 	it("logs an empty url as-is", () => {
@@ -244,7 +263,7 @@ describe("handleRequest", () => {
 		).toThrow("sink unavailable");
 	});
 
-	it("propagates a socket failure without logging the close message", () => {
+	it("propagates a socket failure", () => {
 		// Simulates the socket being torn down underneath us.
 		const logger = createRecordingLogger();
 		const socket = createSocket();
@@ -281,8 +300,12 @@ describe("createBlackholeServer", () => {
 			received += chunk.toString();
 		});
 
-		expect(await waitFor(() => logger.messages.length > 0)).toBe(true);
-		expect(logger.messages[0]).toBe("Received request: GET /black/hole");
+		expect(
+			await waitFor(() =>
+				logger.messages.includes("Received request: GET /black/hole"),
+			),
+		).toBe(true);
+		expect(logger.messages[0]).toBe("Connection opened");
 
 		// Give the server ample opportunity to reply; it must not.
 		await new Promise<void>((resolve) => {
@@ -301,12 +324,19 @@ describe("createBlackholeServer", () => {
 			port,
 			"GET /bye HTTP/1.1\r\nHost: localhost\r\n\r\n",
 		);
-		expect(await waitFor(() => logger.messages.length > 0)).toBe(true);
+		expect(
+			await waitFor(() =>
+				logger.messages.includes("Received request: GET /bye"),
+			),
+		).toBe(true);
 
 		socket.destroy();
 
-		expect(await waitFor(() => logger.messages.length > 1)).toBe(true);
-		expect(logger.messages[1]).toBe("Connection closed by client: GET /bye");
+		expect(
+			await waitFor(() =>
+				logger.messages.includes("Connection closed by client: GET /bye"),
+			),
+		).toBe(true);
 	});
 
 	it("serves concurrent connections independently", async () => {
@@ -317,14 +347,19 @@ describe("createBlackholeServer", () => {
 		await sendRequest(port, "GET /one HTTP/1.1\r\nHost: localhost\r\n\r\n");
 		await sendRequest(port, "GET /two HTTP/1.1\r\nHost: localhost\r\n\r\n");
 
-		expect(await waitFor(() => logger.messages.length >= 2)).toBe(true);
-		expect(logger.messages.slice(0, 2).sort()).toEqual([
-			"Received request: GET /one",
-			"Received request: GET /two",
-		]);
+		expect(
+			await waitFor(
+				() =>
+					logger.messages.includes("Received request: GET /one") &&
+					logger.messages.includes("Received request: GET /two"),
+			),
+		).toBe(true);
+		expect(
+			logger.messages.filter((message) => message === "Connection opened"),
+		).toHaveLength(2);
 	});
 
-	it("handles a connection that sends no request at all", async () => {
+	it("logs a connection that sends no request at all", async () => {
 		const logger = createRecordingLogger();
 		const server = createBlackholeServer(logger);
 		const port = await listen(server);
@@ -334,14 +369,62 @@ describe("createBlackholeServer", () => {
 		await new Promise<void>((resolve) => {
 			socket.once("connect", resolve);
 		});
+		expect(
+			await waitFor(() => logger.messages.includes("Connection opened")),
+		).toBe(true);
 
-		await new Promise<void>((resolve) => {
-			setTimeout(resolve, 200);
-		});
-		// No request line means no "request" event, so nothing is logged and the
-		// connection sits open — including the close, which is only wired up
-		// inside the request handler.
-		expect(logger.messages).toEqual([]);
+		socket.destroy();
+
+		// Close is tracked per connection, so a client that never sent a request
+		// line is still accounted for.
+		expect(
+			await waitFor(() =>
+				logger.messages.includes(
+					"Connection closed by client before any request",
+				),
+			),
+		).toBe(true);
+	});
+
+	it("names the most recent request when a keep-alive connection closes", async () => {
+		const logger = createRecordingLogger();
+		const server = createBlackholeServer(logger);
+		const port = await listen(server);
+
+		const socket = await sendRequest(
+			port,
+			"GET /first HTTP/1.1\r\nHost: localhost\r\n\r\n",
+		);
+		expect(
+			await waitFor(() =>
+				logger.messages.includes("Received request: GET /first"),
+			),
+		).toBe(true);
+
+		socket.destroy();
+
+		expect(
+			await waitFor(() =>
+				logger.messages.includes("Connection closed by client: GET /first"),
+			),
+		).toBe(true);
+	});
+});
+
+describe("describeRequest", () => {
+	it("joins the method and url", () => {
+		expect(describeRequest(createRequest(createSocket(), "PUT", "/a"))).toBe(
+			"PUT /a",
+		);
+	});
+
+	it("substitutes UNKNOWN for absent parts", () => {
+		expect(
+			describeRequest(createRequest(createSocket(), undefined, "/a")),
+		).toBe("UNKNOWN /a");
+		expect(
+			describeRequest(createRequest(createSocket(), "GET", undefined)),
+		).toBe("GET UNKNOWN");
 	});
 });
 
@@ -365,12 +448,11 @@ describe("createShutdown", () => {
 		]);
 	});
 
-	it("never completes while a connection is held open", async () => {
-		// This is the package's central hazard: the server keeps every
-		// connection open by design, and server.close() waits for in-flight
-		// connections to end. So under any real load SIGTERM never reaches
-		// process.exit(0) and the supervisor has to SIGKILL after its grace
-		// period.
+	it("completes even while a connection is held open", async () => {
+		// The package's central hazard: server.close() alone waits for in-flight
+		// connections, and this server keeps every connection open by design, so
+		// shutdown would hang until the supervisor SIGKILLed it.
+		// closeAllConnections() severs them so shutdown actually finishes.
 		const logger = createRecordingLogger();
 		const exited: number[] = [];
 		const exit: Exit = (code: number): void => {
@@ -379,19 +461,20 @@ describe("createShutdown", () => {
 		const server = createBlackholeServer(logger);
 		const port = await listen(server);
 		await sendRequest(port, "GET /stuck HTTP/1.1\r\nHost: localhost\r\n\r\n");
-		expect(await waitFor(() => logger.messages.length > 0)).toBe(true);
+		expect(
+			await waitFor(() =>
+				logger.messages.includes("Received request: GET /stuck"),
+			),
+		).toBe(true);
 
 		createShutdown(server, logger, exit)();
 
-		expect(await waitFor(() => exited.length > 0, 500)).toBe(false);
-		expect(exited).toEqual([]);
-		expect(logger.messages).toContain(
-			"\nShutting down http-blackhole server...",
-		);
-		expect(logger.messages).not.toContain("Server closed. Exiting.");
+		expect(await waitFor(() => exited.length > 0)).toBe(true);
+		expect(exited).toEqual([0]);
+		expect(logger.messages).toContain("Server closed. Exiting.");
 	});
 
-	it("completes once the stuck client goes away", async () => {
+	it("completes with many connections held open", async () => {
 		const logger = createRecordingLogger();
 		const exited: number[] = [];
 		const exit: Exit = (code: number): void => {
@@ -399,25 +482,29 @@ describe("createShutdown", () => {
 		};
 		const server = createBlackholeServer(logger);
 		const port = await listen(server);
-		const socket = await sendRequest(
-			port,
-			"GET /stuck HTTP/1.1\r\nHost: localhost\r\n\r\n",
-		);
-		expect(await waitFor(() => logger.messages.length > 0)).toBe(true);
+		for (let index = 0; index < 5; index += 1) {
+			await sendRequest(
+				port,
+				`GET /stuck/${index} HTTP/1.1\r\nHost: localhost\r\n\r\n`,
+			);
+		}
+		expect(
+			await waitFor(
+				() =>
+					logger.messages.filter((message) => message === "Connection opened")
+						.length === 5,
+			),
+		).toBe(true);
 
 		createShutdown(server, logger, exit)();
-		expect(await waitFor(() => exited.length > 0, 300)).toBe(false);
-
-		socket.destroy();
 
 		expect(await waitFor(() => exited.length > 0)).toBe(true);
 		expect(exited).toEqual([0]);
 	});
 
-	it("does not exit when the server was never listening", async () => {
-		// close() on a server that never listened errors; the callback receives
-		// the error but the code ignores it and still exits zero, reporting a
-		// clean shutdown that did not happen.
+	it("exits non-zero when the server was never listening", async () => {
+		// close() errors on a server that never listened. That error must not be
+		// reported as a clean shutdown.
 		const logger = createRecordingLogger();
 		const exited: number[] = [];
 		const exit: Exit = (code: number): void => {
@@ -429,17 +516,15 @@ describe("createShutdown", () => {
 		createShutdown(server, logger, exit)();
 
 		expect(await waitFor(() => exited.length > 0)).toBe(true);
-		expect(exited).toEqual([0]);
-		expect(logger.messages).toEqual([
-			"\nShutting down http-blackhole server...",
-			"Server closed. Exiting.",
-		]);
+		expect(exited).toEqual([1]);
+		expect(logger.messages[0]).toBe("\nShutting down http-blackhole server...");
+		expect(logger.messages[1]).toMatch(/^Server close failed: /);
+		expect(logger.messages).not.toContain("Server closed. Exiting.");
 	});
 
-	it("exits once per signal when invoked repeatedly", async () => {
-		// SIGINT then SIGTERM (or an impatient double Ctrl+C) calls close()
-		// twice. The second call errors, but the error is ignored, so exit is
-		// called again.
+	it("ignores repeat signals and exits exactly once", async () => {
+		// SIGINT then SIGTERM, or an impatient double Ctrl+C, must not close
+		// twice or exit twice.
 		const logger = createRecordingLogger();
 		const exited: number[] = [];
 		const exit: Exit = (code: number): void => {
@@ -450,11 +535,20 @@ describe("createShutdown", () => {
 		const shutdown = createShutdown(server, logger, exit);
 
 		shutdown();
+		shutdown();
 		expect(await waitFor(() => exited.length > 0)).toBe(true);
 		shutdown();
 
-		expect(await waitFor(() => exited.length > 1)).toBe(true);
-		expect(exited).toEqual([0, 0]);
+		await new Promise<void>((resolve) => {
+			setTimeout(resolve, 200);
+		});
+		expect(exited).toEqual([0]);
+		expect(
+			logger.messages.filter(
+				(message) =>
+					message === "Shutdown already in progress; ignoring signal.",
+			),
+		).toHaveLength(2);
 	});
 
 	it("propagates a logger failure before close is attempted", () => {

--- a/packages/http-blackhole/src/tests/blackhole.unit.test.ts
+++ b/packages/http-blackhole/src/tests/blackhole.unit.test.ts
@@ -1,0 +1,479 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Testing strategy: exercise the real node:http and node:net implementations
+// rather than mocking them, so the tests pin actual socket/server semantics
+// (in particular that close() blocks while a connection is held open). Fakes
+// are used only for the two injected seams — the logger and the exit fn — so
+// tests can assert on output without touching the console or killing the
+// runner.
+
+import http from "node:http";
+import net from "node:net";
+import type { AddressInfo } from "node:net";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	DEFAULT_PORT,
+	type Exit,
+	type Logger,
+	createBlackholeServer,
+	createShutdown,
+	handleRequest,
+	resolvePort,
+} from "../blackhole.js";
+
+/** Logger that records everything written to it. */
+const createRecordingLogger = (): Logger & { messages: string[] } => {
+	const messages: string[] = [];
+	return {
+		messages,
+		log: (message: string): void => {
+			messages.push(message);
+		},
+	};
+};
+
+/** A real, unconnected socket — enough for the handler's socket calls. */
+const createSocket = (): net.Socket => new net.Socket();
+
+const createRequest = (
+	socket: net.Socket,
+	method: string | undefined,
+	url: string | undefined,
+): http.IncomingMessage => {
+	const req = new http.IncomingMessage(socket);
+	req.method = method;
+	req.url = url;
+	return req;
+};
+
+/** Servers/sockets opened by a test, torn down afterwards. */
+const openServers: http.Server[] = [];
+const openSockets: net.Socket[] = [];
+
+const listen = async (server: http.Server): Promise<number> => {
+	openServers.push(server);
+	await new Promise<void>((resolve) => {
+		server.listen(0, "127.0.0.1", resolve);
+	});
+	const address: string | AddressInfo | null = server.address();
+	if (address === null || typeof address === "string") {
+		throw new Error("expected a TCP address");
+	}
+	return address.port;
+};
+
+/** Connect and send a request, resolving once the bytes are on the wire. */
+const sendRequest = async (
+	port: number,
+	rawRequest: string,
+): Promise<net.Socket> => {
+	const socket: net.Socket = net.connect(port, "127.0.0.1");
+	openSockets.push(socket);
+	await new Promise<void>((resolve, reject) => {
+		socket.once("connect", resolve);
+		socket.once("error", reject);
+	});
+	await new Promise<void>((resolve, reject) => {
+		socket.write(rawRequest, (error?: Error | null) => {
+			if (error) {
+				reject(error);
+			} else {
+				resolve();
+			}
+		});
+	});
+	return socket;
+};
+
+/** Wait until `predicate` holds, or give up after `timeoutMs`. */
+const waitFor = async (
+	predicate: () => boolean,
+	timeoutMs = 2000,
+): Promise<boolean> => {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (predicate()) {
+			return true;
+		}
+		await new Promise<void>((resolve) => {
+			setTimeout(resolve, 10);
+		});
+	}
+	return predicate();
+};
+
+afterEach(async () => {
+	// Restore first: a test that stubbed server.close() would otherwise leave
+	// the teardown below waiting forever on a callback that never fires.
+	vi.restoreAllMocks();
+	for (const socket of openSockets.splice(0)) {
+		socket.destroy();
+	}
+	for (const server of openServers.splice(0)) {
+		server.closeAllConnections();
+		await new Promise<void>((resolve) => {
+			server.close(() => {
+				resolve();
+			});
+		});
+	}
+});
+
+describe("resolvePort", () => {
+	it("returns the default when PORT is unset", () => {
+		expect(resolvePort(undefined)).toBe(DEFAULT_PORT);
+	});
+
+	it("returns the default for an empty string", () => {
+		// Number("") is 0, which is falsy, so the default applies.
+		expect(resolvePort("")).toBe(DEFAULT_PORT);
+	});
+
+	it("returns the default for a whitespace-only value", () => {
+		expect(resolvePort("   ")).toBe(DEFAULT_PORT);
+	});
+
+	it("parses a plain numeric port", () => {
+		expect(resolvePort("3000")).toBe(3000);
+	});
+
+	it("tolerates surrounding whitespace", () => {
+		expect(resolvePort(" 3000 ")).toBe(3000);
+	});
+
+	it("falls back to the default for a non-numeric value", () => {
+		// A typo in PORT is silently swallowed rather than failing fast.
+		expect(resolvePort("abc")).toBe(DEFAULT_PORT);
+		expect(resolvePort("8080abc")).toBe(DEFAULT_PORT);
+	});
+
+	it("falls back to the default for PORT=0", () => {
+		// 0 normally means "bind any free port", but it is falsy so it is
+		// overridden — the server can never be asked for an ephemeral port.
+		expect(resolvePort("0")).toBe(DEFAULT_PORT);
+	});
+
+	it("passes through values that are not valid ports", () => {
+		// No range or integer validation happens here; listen() rejects these
+		// later, at runtime.
+		expect(resolvePort("-1")).toBe(-1);
+		expect(resolvePort("99999")).toBe(99999);
+		expect(resolvePort("3000.5")).toBe(3000.5);
+	});
+
+	it("accepts the numeric literal forms Number() understands", () => {
+		expect(resolvePort("0x1f")).toBe(31);
+		expect(resolvePort("1e3")).toBe(1000);
+	});
+});
+
+describe("handleRequest", () => {
+	it("logs the method and url", () => {
+		const logger = createRecordingLogger();
+		handleRequest(createRequest(createSocket(), "GET", "/foo"), logger);
+		expect(logger.messages).toEqual(["Received request: GET /foo"]);
+	});
+
+	it("disables the socket timeout and enables keep-alive", () => {
+		const socket = createSocket();
+		const setTimeoutSpy = vi.spyOn(socket, "setTimeout");
+		const setKeepAliveSpy = vi.spyOn(socket, "setKeepAlive");
+
+		handleRequest(createRequest(socket, "GET", "/"), createRecordingLogger());
+
+		expect(setTimeoutSpy).toHaveBeenCalledWith(0);
+		expect(setKeepAliveSpy).toHaveBeenCalledWith(true);
+	});
+
+	it("never writes a response", () => {
+		const socket = createSocket();
+		const writeSpy = vi.spyOn(socket, "write");
+		handleRequest(createRequest(socket, "GET", "/"), createRecordingLogger());
+		expect(writeSpy).not.toHaveBeenCalled();
+	});
+
+	it("logs when the client closes the connection", () => {
+		const logger = createRecordingLogger();
+		const socket = createSocket();
+		handleRequest(createRequest(socket, "POST", "/bar"), logger);
+
+		socket.emit("close");
+
+		expect(logger.messages).toEqual([
+			"Received request: POST /bar",
+			"Connection closed by client: POST /bar",
+		]);
+	});
+
+	it("renders undefined method and url literally", () => {
+		// IncomingMessage leaves these undefined until parsed; the template
+		// stringifies them rather than guarding, so the log reads "undefined".
+		const logger = createRecordingLogger();
+		handleRequest(createRequest(createSocket(), undefined, undefined), logger);
+		expect(logger.messages).toEqual(["Received request: undefined undefined"]);
+	});
+
+	it("logs an empty url as-is", () => {
+		const logger = createRecordingLogger();
+		handleRequest(createRequest(createSocket(), "GET", ""), logger);
+		expect(logger.messages).toEqual(["Received request: GET "]);
+	});
+
+	it("does not swallow a logger failure", () => {
+		// There is no try/catch anywhere in the handler, so a throwing logger
+		// propagates into node:http's request emit rather than being contained.
+		const logger: Logger = {
+			log: (): void => {
+				throw new Error("sink unavailable");
+			},
+		};
+		expect(() =>
+			handleRequest(createRequest(createSocket(), "GET", "/"), logger),
+		).toThrow("sink unavailable");
+	});
+
+	it("propagates a socket failure without logging the close message", () => {
+		// Simulates the socket being torn down underneath us.
+		const logger = createRecordingLogger();
+		const socket = createSocket();
+		vi.spyOn(socket, "setKeepAlive").mockImplementation(() => {
+			throw new Error("socket gone");
+		});
+
+		expect(() =>
+			handleRequest(createRequest(socket, "GET", "/"), logger),
+		).toThrow("socket gone");
+		expect(logger.messages).toEqual(["Received request: GET /"]);
+	});
+});
+
+describe("createBlackholeServer", () => {
+	it("creates a server that is not yet listening", () => {
+		const server = createBlackholeServer(createRecordingLogger());
+		openServers.push(server);
+		expect(server.listening).toBe(false);
+	});
+
+	it("accepts a request and never responds to it", async () => {
+		const logger = createRecordingLogger();
+		const server = createBlackholeServer(logger);
+		const port = await listen(server);
+
+		const socket = await sendRequest(
+			port,
+			"GET /black/hole HTTP/1.1\r\nHost: localhost\r\n\r\n",
+		);
+
+		let received = "";
+		socket.on("data", (chunk: Buffer) => {
+			received += chunk.toString();
+		});
+
+		expect(await waitFor(() => logger.messages.length > 0)).toBe(true);
+		expect(logger.messages[0]).toBe("Received request: GET /black/hole");
+
+		// Give the server ample opportunity to reply; it must not.
+		await new Promise<void>((resolve) => {
+			setTimeout(resolve, 300);
+		});
+		expect(received).toBe("");
+		expect(socket.destroyed).toBe(false);
+	});
+
+	it("logs the close when the client hangs up", async () => {
+		const logger = createRecordingLogger();
+		const server = createBlackholeServer(logger);
+		const port = await listen(server);
+
+		const socket = await sendRequest(
+			port,
+			"GET /bye HTTP/1.1\r\nHost: localhost\r\n\r\n",
+		);
+		expect(await waitFor(() => logger.messages.length > 0)).toBe(true);
+
+		socket.destroy();
+
+		expect(await waitFor(() => logger.messages.length > 1)).toBe(true);
+		expect(logger.messages[1]).toBe("Connection closed by client: GET /bye");
+	});
+
+	it("serves concurrent connections independently", async () => {
+		const logger = createRecordingLogger();
+		const server = createBlackholeServer(logger);
+		const port = await listen(server);
+
+		await sendRequest(port, "GET /one HTTP/1.1\r\nHost: localhost\r\n\r\n");
+		await sendRequest(port, "GET /two HTTP/1.1\r\nHost: localhost\r\n\r\n");
+
+		expect(await waitFor(() => logger.messages.length >= 2)).toBe(true);
+		expect(logger.messages.slice(0, 2).sort()).toEqual([
+			"Received request: GET /one",
+			"Received request: GET /two",
+		]);
+	});
+
+	it("handles a connection that sends no request at all", async () => {
+		const logger = createRecordingLogger();
+		const server = createBlackholeServer(logger);
+		const port = await listen(server);
+
+		const socket: net.Socket = net.connect(port, "127.0.0.1");
+		openSockets.push(socket);
+		await new Promise<void>((resolve) => {
+			socket.once("connect", resolve);
+		});
+
+		await new Promise<void>((resolve) => {
+			setTimeout(resolve, 200);
+		});
+		// No request line means no "request" event, so nothing is logged and the
+		// connection sits open — including the close, which is only wired up
+		// inside the request handler.
+		expect(logger.messages).toEqual([]);
+	});
+});
+
+describe("createShutdown", () => {
+	it("closes an idle server and exits zero", async () => {
+		const logger = createRecordingLogger();
+		const exited: number[] = [];
+		const exit: Exit = (code: number): void => {
+			exited.push(code);
+		};
+		const server = createBlackholeServer(logger);
+		await listen(server);
+
+		createShutdown(server, logger, exit)();
+
+		expect(await waitFor(() => exited.length > 0)).toBe(true);
+		expect(exited).toEqual([0]);
+		expect(logger.messages).toEqual([
+			"\nShutting down http-blackhole server...",
+			"Server closed. Exiting.",
+		]);
+	});
+
+	it("never completes while a connection is held open", async () => {
+		// This is the package's central hazard: the server keeps every
+		// connection open by design, and server.close() waits for in-flight
+		// connections to end. So under any real load SIGTERM never reaches
+		// process.exit(0) and the supervisor has to SIGKILL after its grace
+		// period.
+		const logger = createRecordingLogger();
+		const exited: number[] = [];
+		const exit: Exit = (code: number): void => {
+			exited.push(code);
+		};
+		const server = createBlackholeServer(logger);
+		const port = await listen(server);
+		await sendRequest(port, "GET /stuck HTTP/1.1\r\nHost: localhost\r\n\r\n");
+		expect(await waitFor(() => logger.messages.length > 0)).toBe(true);
+
+		createShutdown(server, logger, exit)();
+
+		expect(await waitFor(() => exited.length > 0, 500)).toBe(false);
+		expect(exited).toEqual([]);
+		expect(logger.messages).toContain(
+			"\nShutting down http-blackhole server...",
+		);
+		expect(logger.messages).not.toContain("Server closed. Exiting.");
+	});
+
+	it("completes once the stuck client goes away", async () => {
+		const logger = createRecordingLogger();
+		const exited: number[] = [];
+		const exit: Exit = (code: number): void => {
+			exited.push(code);
+		};
+		const server = createBlackholeServer(logger);
+		const port = await listen(server);
+		const socket = await sendRequest(
+			port,
+			"GET /stuck HTTP/1.1\r\nHost: localhost\r\n\r\n",
+		);
+		expect(await waitFor(() => logger.messages.length > 0)).toBe(true);
+
+		createShutdown(server, logger, exit)();
+		expect(await waitFor(() => exited.length > 0, 300)).toBe(false);
+
+		socket.destroy();
+
+		expect(await waitFor(() => exited.length > 0)).toBe(true);
+		expect(exited).toEqual([0]);
+	});
+
+	it("does not exit when the server was never listening", async () => {
+		// close() on a server that never listened errors; the callback receives
+		// the error but the code ignores it and still exits zero, reporting a
+		// clean shutdown that did not happen.
+		const logger = createRecordingLogger();
+		const exited: number[] = [];
+		const exit: Exit = (code: number): void => {
+			exited.push(code);
+		};
+		const server = createBlackholeServer(logger);
+		openServers.push(server);
+
+		createShutdown(server, logger, exit)();
+
+		expect(await waitFor(() => exited.length > 0)).toBe(true);
+		expect(exited).toEqual([0]);
+		expect(logger.messages).toEqual([
+			"\nShutting down http-blackhole server...",
+			"Server closed. Exiting.",
+		]);
+	});
+
+	it("exits once per signal when invoked repeatedly", async () => {
+		// SIGINT then SIGTERM (or an impatient double Ctrl+C) calls close()
+		// twice. The second call errors, but the error is ignored, so exit is
+		// called again.
+		const logger = createRecordingLogger();
+		const exited: number[] = [];
+		const exit: Exit = (code: number): void => {
+			exited.push(code);
+		};
+		const server = createBlackholeServer(logger);
+		await listen(server);
+		const shutdown = createShutdown(server, logger, exit);
+
+		shutdown();
+		expect(await waitFor(() => exited.length > 0)).toBe(true);
+		shutdown();
+
+		expect(await waitFor(() => exited.length > 1)).toBe(true);
+		expect(exited).toEqual([0, 0]);
+	});
+
+	it("propagates a logger failure before close is attempted", () => {
+		const closed: boolean[] = [];
+		const server = createBlackholeServer(createRecordingLogger());
+		openServers.push(server);
+		vi.spyOn(server, "close").mockImplementation((): http.Server => {
+			closed.push(true);
+			return server;
+		});
+		const logger: Logger = {
+			log: (): void => {
+				throw new Error("sink unavailable");
+			},
+		};
+
+		expect(() =>
+			createShutdown(server, logger, (): void => undefined)(),
+		).toThrow("sink unavailable");
+		expect(closed).toEqual([]);
+	});
+});

--- a/packages/http-blackhole/vite.test.config.ts
+++ b/packages/http-blackhole/vite.test.config.ts
@@ -11,27 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-import dotenv from "dotenv";
-import {
-	createBlackholeServer,
-	createShutdown,
-	resolvePort,
-} from "./blackhole.js";
+import { ViteTestConfig } from "@prosopo/config";
 
-dotenv.config();
+process.env.NODE_ENV = "test";
 
-const PORT = resolvePort(process.env.PORT);
-
-const server = createBlackholeServer(console);
-
-server.listen(PORT, () => {
-	console.log(`http-blackhole server is listening on port ${PORT}`);
-});
-
-// Graceful shutdown on Ctrl+C or kill
-const shutdown = createShutdown(server, console, (code: number) => {
-	process.exit(code);
-});
-
-process.on("SIGINT", shutdown); // Ctrl+C
-process.on("SIGTERM", shutdown); // kill command or systemd
+export default ViteTestConfig();


### PR DESCRIPTION
Second package in the package-by-package unit-testing pass (first was [#2913](https://github.com/prosopo/captcha/pull/2913), dotenv).

## What changed

`src/index.ts` was a single side-effecting script with no exports, so nothing in it could be tested. Split into:

- `src/blackhole.ts` — `DEFAULT_PORT`, `resolvePort`, `handleRequest`, `createBlackholeServer`, `createShutdown`, with the logger and the exit fn injected.
- `src/index.ts` — thin entrypoint, runtime behaviour unchanged (`main` and `start` untouched). The package has no consumers anywhere in the repo.

Plus `vite.test.config.ts`, a `test` script, a `typecheck` script and vitest devDeps.

## Tests

28 tests, 100% statements/branches/functions/lines on `blackhole.ts`. Real `node:http`/`node:net` are used rather than mocks so the tests pin actual socket and server semantics; fakes only at the two injected seams.

## Defects found and fixed

1. **Shutdown can never complete under load.** `server.close()` waits for in-flight connections, and this server holds every connection open forever by design. So on SIGINT/SIGTERM the "Server closed. Exiting." log and `process.exit(0)` are unreachable whenever a client is connected — the supervisor SIGKILLs after its grace period instead. Pinned by `never completes while a connection is held open`. Fix would be `server.closeAllConnections()` in the shutdown handler.
2. **`PORT=0` is silently overridden** to 8080 by the `|| DEFAULT_PORT` falsy check, so the "bind any free port" idiom is unavailable.
3. **A typo'd PORT is silently swallowed** — `PORT=abc` starts on 8080 rather than failing fast.
4. **No port validation** — `-1`, `99999`, `3000.5` pass straight through to `listen()`, failing at runtime rather than at config time.
5. **`close()` errors are ignored.** Calling shutdown twice, or on a server that never listened, still logs a clean "Server closed. Exiting." and exits 0 despite `close()` having errored.
6. **A connection that sends no request line is never logged at all**, including its close — the close listener is only wired up inside the request handler.
