### PR TITLE
fix(vector): pin base image to 0.55 instead of latest-debian

### DIFF
--- a/docker/images/vector/src/Dockerfile
+++ b/docker/images/vector/src/Dockerfile
@@ -2,7 +2,18 @@
 
 # docker run -it --rm --env-file vector.env -v /home/geopro/bench/captcha5/vector.toml:/etc/vector/vector.toml prosopo/vector:latest
 
-FROM timberio/vector:latest-debian
+# Pinned, NOT `latest-debian`. Vector 0.57 made env-var interpolation opt-in
+# (behind --dangerously-allow-env-var-interpolation), so under 0.57 every
+# ${VAR} in vector.toml below is sent verbatim: the sink URI becomes the
+# literal `${NODE_ENV:?err}_provider_node` stream and basic auth puts
+# `${OO_USERNAME:?err}` in the Authorization header, so every write 401s.
+# Vector still starts and reports healthchecks passing, so the only symptom is
+# that nothing reaches OpenObserve. The floating tag meant a rebuild alone was
+# enough to trigger it. 0.55 interpolates by default and fails loudly on an
+# unset var. Do not add the 0.57 flag while pinned here: 0.55 does not
+# recognise it (it has the inverse, --disable-env-var-interpolation) and will
+# refuse to start.
+FROM timberio/vector:0.55.0-debian
 
 # Add Docker's official GPG key:
 RUN apt-get update \


### PR DESCRIPTION
Vector 0.57 made config env-var interpolation opt-in behind `--dangerously-allow-env-var-interpolation`. This image is `FROM timberio/vector:latest-debian`, so a rebuild alone would have pulled 0.57 and silently broken log shipping for every provider/pronode: sink URIs become the literal `${NODE_ENV:?err}_provider_node` stream and basic auth sends `${OO_USERNAME:?err}` in the Authorization header, so every write 401s — while vector still starts and reports healthchecks passing.

Verified by running the same config under both images:

| image | `vector validate` |
|---|---|
| `0.55.0-debian` | fails loudly — `Non-empty environment variable required in config` |
| `0.57.0-debian` | passes, then ships the literal `${NODE_ENV:?err}` |

The published `prosopo/vector:3.1.1` currently in the fleet happens to have baked 0.55, so providers/pronodes are unaffected today (confirmed against the OpenObserve access log — they post `production_provider_node`/`production_provider_mongo` and get 200). This just pins the tag so that stays true. No republish needed. Handling 0.57 properly is deferred.