### PR TITLE
test(file-server): unit tests + injectable units

### DIFF
--- a/.changeset/file-server-unit-tests.md
+++ b/.changeset/file-server-unit-tests.md
@@ -1,0 +1,6 @@
+---
+"@prosopo/file-server": patch
+---
+
+Extract the app, remote handler and env parsing into injectable units, add unit
+tests, and harden env parsing plus remote resize failures.

--- a/packages/file-server/package.json
+++ b/packages/file-server/package.json
@@ -23,7 +23,8 @@
 		"build:tsc": "tsc --build --verbose",
 		"build:cjs": "NODE_ENV=${NODE_ENV:-development}; vite build --config vite.cjs.config.ts --mode $NODE_ENV",
 		"typecheck": "tsc --project tsconfig.types.json",
-		"start": "node ./dist/index.js"
+		"start": "node ./dist/index.js",
+		"test": "NODE_ENV=${NODE_ENV:-test}; npx vitest run --config ./vite.test.config.ts"
 	},
 	"dependencies": {
 		"@prosopo/util": "3.3.4",

--- a/packages/file-server/src/fileServer.ts
+++ b/packages/file-server/src/fileServer.ts
@@ -181,6 +181,13 @@ export const createApp = (
 	const app = express();
 
 	for (const loc of env.paths) {
+		if ("" === loc.trim()) {
+			// express.static("") resolves to the process working directory, which
+			// would publish the whole deployment over HTTP. A blank entry is
+			// always a config mistake, so drop it rather than honour it.
+			deps.logger.warn("ignoring empty path entry");
+			continue;
+		}
 		// allow local filesystem lookup at each location
 		// http://localhost:3000/a.jpg
 		// serve path set to /

--- a/packages/file-server/src/fileServer.ts
+++ b/packages/file-server/src/fileServer.ts
@@ -102,10 +102,18 @@ export const toInt = (
 	return Number.isNaN(parsed) ? undefined : parsed;
 };
 
-/** Read configuration from the environment, loading the matching .env first. */
+/**
+ * Read configuration from the environment, loading the matching .env first.
+ *
+ * The .env load is skipped when a caller supplies its own `env`: dotenv writes
+ * into `process.env` and cannot populate an arbitrary object, so loading it
+ * would mutate global state without affecting a single value read below.
+ */
 export const getEnv = (env: NodeJS.ProcessEnv = process.env): FileServerEnv => {
-	const path = env.NODE_ENV ? `.env.${env.NODE_ENV}` : ".env";
-	dotenv.config({ path });
+	if (env === process.env) {
+		const path = env.NODE_ENV ? `.env.${env.NODE_ENV}` : ".env";
+		dotenv.config({ path });
+	}
 	return {
 		port: env.PROSOPO_FILE_SERVER_PORT || DEFAULT_PORT,
 		paths: parseArray(env.PROSOPO_FILE_SERVER_PATHS || "[]"),

--- a/packages/file-server/src/fileServer.ts
+++ b/packages/file-server/src/fileServer.ts
@@ -1,0 +1,210 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import type http from "node:http";
+import stream from "node:stream";
+import dotenv from "dotenv";
+import express, {
+	type Express,
+	type Request,
+	type RequestHandler,
+	type Response as ExpressResponse,
+} from "express";
+import sharp from "sharp";
+
+/** Port used when PROSOPO_FILE_SERVER_PORT is unset. */
+export const DEFAULT_PORT = 3000;
+
+/** Resolved configuration for a file server instance. */
+export interface FileServerEnv {
+	port: string | number;
+	paths: string[];
+	resize: number | undefined;
+	remotes: string[];
+	logLevel: string;
+}
+
+/** Console-shaped output sink, injected so tests can capture output. */
+export interface Logger {
+	info: (...args: unknown[]) => void;
+	warn: (...args: unknown[]) => void;
+	error: (...args: unknown[]) => void;
+}
+
+/**
+ * Fetches a remote URL. Injected so tests need no network.
+ *
+ * Note this is the global fetch Response, not express's same-named Response.
+ */
+export type FetchFn = (url: string) => Promise<globalThis.Response>;
+
+/** Resizes an image buffer to a square of `size` pixels. */
+export type ResizeFn = (image: Buffer, size: number) => Promise<Buffer>;
+
+/** Collaborators of the request handler. */
+export interface FileServerDeps {
+	logger: Logger;
+	fetch: FetchFn;
+	resize: ResizeFn;
+}
+
+/** Production resize, backed by sharp. */
+export const sharpResize: ResizeFn = (
+	image: Buffer,
+	size: number,
+): Promise<Buffer> =>
+	sharp(image).resize({ width: size, height: size, fit: "fill" }).toBuffer();
+
+/**
+ * Parse an env var that should hold a JSON array of strings.
+ *
+ * Anything that is not a JSON array of strings — including unparseable text —
+ * is treated as a single literal entry, so a bare path like `/srv/img` works
+ * as well as `["/srv/img"]`.
+ */
+export const parseArray = (value: string): string[] => {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(value);
+	} catch {
+		return [value];
+	}
+	if (
+		Array.isArray(parsed) &&
+		parsed.every((entry: unknown) => typeof entry === "string")
+	) {
+		return parsed;
+	}
+	return [value];
+};
+
+/** Parse an integer env var, yielding undefined for anything unparseable. */
+export const toInt = (
+	value: string | number | undefined,
+): number | undefined => {
+	if (typeof value === "number") {
+		return value;
+	}
+	if (value === undefined) {
+		return undefined;
+	}
+	const parsed = Number.parseInt(value);
+	return Number.isNaN(parsed) ? undefined : parsed;
+};
+
+/** Read configuration from the environment, loading the matching .env first. */
+export const getEnv = (env: NodeJS.ProcessEnv = process.env): FileServerEnv => {
+	const path = env.NODE_ENV ? `.env.${env.NODE_ENV}` : ".env";
+	dotenv.config({ path });
+	return {
+		port: env.PROSOPO_FILE_SERVER_PORT || DEFAULT_PORT,
+		paths: parseArray(env.PROSOPO_FILE_SERVER_PATHS || "[]"),
+		// the size to resize images to, undefined means no resize
+		resize: toInt(env.PROSOPO_FILE_SERVER_RESIZE) || undefined,
+		// the remote servers to proxy to
+		remotes: parseArray(env.PROSOPO_FILE_SERVER_REMOTES || "[]"),
+		logLevel: env.PROSOPO_LOG_LEVEL || "info",
+	};
+};
+
+/**
+ * Handler for anything not served from the local filesystem: try each remote in
+ * order, streaming back the first hit, and 404 if none of them have it.
+ *
+ * Each remote is attempted independently — a failing or slow remote is logged
+ * and skipped rather than failing the request.
+ */
+export const createRemoteHandler = (
+	env: FileServerEnv,
+	deps: FileServerDeps,
+): RequestHandler => {
+	return async (req: Request, res: ExpressResponse): Promise<void> => {
+		for (const remote of env.remotes) {
+			deps.logger.info("trying", remote, req.url);
+			let img: Buffer;
+			try {
+				const result = await deps.fetch(`${remote}${req.url}`);
+				if (result.status !== 200) {
+					deps.logger.warn("not found", remote, req.url, result.status);
+					continue;
+				}
+				deps.logger.info("found", remote, req.url);
+				const imgTmp = await result.arrayBuffer();
+				img = Buffer.from(imgTmp);
+			} catch (error) {
+				deps.logger.warn("error", remote, req.url, error);
+				continue;
+			}
+			if (env.resize) {
+				deps.logger.info("resizing", remote, req.url, env.resize);
+				try {
+					img = await deps.resize(img, env.resize);
+				} catch (error) {
+					// A non-image, or a corrupt one, must not take the request down:
+					// express 4 does not catch rejections from async handlers, so an
+					// unguarded throw here would leave the client hanging.
+					deps.logger.warn("resize failed", remote, req.url, error);
+					continue;
+				}
+			}
+			stream.Readable.from(img).pipe(res);
+			return;
+		}
+		// could not find file in any remote
+		res.status(404).send("Not found");
+	};
+};
+
+/** Build the express app: static paths first, then the remote fallback. */
+export const createApp = (
+	env: FileServerEnv,
+	deps: FileServerDeps,
+): Express => {
+	const app = express();
+
+	for (const loc of env.paths) {
+		// allow local filesystem lookup at each location
+		// http://localhost:3000/a.jpg
+		// serve path set to /
+		// url: pronode1.duckdns.org/img/a.jpg
+		// serve path set to /img
+		// url: pronode1.duckdns.org/a.jpg`
+		app.use("/", express.static(loc));
+		deps.logger.info(`Serving files from ${loc}`);
+	}
+
+	app.get("*", createRemoteHandler(env, deps));
+
+	return app;
+};
+
+/** Default collaborators: the real console, global fetch and sharp. */
+export const defaultDeps = (): FileServerDeps => ({
+	logger: console,
+	fetch: (url: string): Promise<globalThis.Response> => fetch(url),
+	resize: sharpResize,
+});
+
+/**
+ * Build the app from the environment and start listening. Returns the server so
+ * callers (and tests) can shut it down.
+ */
+export const main = async (
+	deps: FileServerDeps = defaultDeps(),
+): Promise<http.Server> => {
+	const env = getEnv();
+	const app = createApp(env, deps);
+	return app.listen(env.port, () => {
+		deps.logger.info(`File server running on port ${env.port}`);
+	});
+};

--- a/packages/file-server/src/index.ts
+++ b/packages/file-server/src/index.ts
@@ -1,4 +1,3 @@
-import stream from "node:stream";
 // Copyright 2021-2026 Prosopo (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,95 +12,9 @@ import stream from "node:stream";
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import { isMain } from "@prosopo/util";
-import dotenv from "dotenv";
-import express, { type Request, type Response } from "express";
-import sharp from "sharp";
+import { main } from "./fileServer.js";
 
-const parseArray = (value: string) => {
-	try {
-		return JSON.parse(value);
-	} catch (error) {
-		return [value];
-	}
-};
-
-const toInt = (value: string | number | undefined) => {
-	if (typeof value === "number") {
-		return value;
-	}
-	if (value === undefined) {
-		return undefined;
-	}
-	return Number.parseInt(value);
-};
-
-const getEnv = () => {
-	const path = process.env.NODE_ENV ? `.env.${process.env.NODE_ENV}` : ".env";
-	dotenv.config({ path });
-	return {
-		port: process.env.PROSOPO_FILE_SERVER_PORT || 3000,
-		paths: parseArray(process.env.PROSOPO_FILE_SERVER_PATHS || "[]"),
-		resize: toInt(process.env.PROSOPO_FILE_SERVER_RESIZE) || undefined, // the size to resize images to, undefined means no resize
-		remotes: parseArray(process.env.PROSOPO_FILE_SERVER_REMOTES || "[]"), // the remote servers to proxy to
-		logLevel: process.env.PROSOPO_LOG_LEVEL || "info",
-	};
-};
-
-const main = async () => {
-	const env = getEnv();
-
-	const app = express();
-
-	for (const loc of env.paths) {
-		// allow local filesystem lookup at each location
-		// http://localhost:3000/a.jpg
-		// serve path set to /
-		// url: pronode1.duckdns.org/img/a.jpg
-		// serve path set to /img
-		// url: pronode1.duckdns.org/a.jpg`
-		app.use("/", express.static(loc));
-		console.info(`Serving files from ${loc}`);
-	}
-
-	app.get("*", async (req: Request, res: Response) => {
-		for (const remote of env.remotes) {
-			console.info("trying", remote, req.url);
-			let img: Buffer;
-			try {
-				const result = await fetch(`${remote}${req.url}`);
-				if (result.status !== 200) {
-					console.warn("not found", remote, req.url, req.statusCode);
-					continue;
-				}
-				console.info("found", remote, req.url);
-				const imgTmp = await result.arrayBuffer();
-				img = Buffer.from(imgTmp);
-			} catch (error) {
-				console.warn("error", remote, req.url, error);
-				continue;
-			}
-			if (env.resize) {
-				console.info("resizing", remote, req.url, env.resize);
-				img = await sharp(img)
-					.resize({
-						width: env.resize,
-						height: env.resize,
-						fit: "fill",
-					})
-					.toBuffer();
-			}
-			stream.Readable.from(img).pipe(res);
-			return;
-		}
-		// could not find file in any remote
-		res.status(404).send("Not found");
-	});
-
-	// only run server if locations have been specified
-	app.listen(env.port, () => {
-		console.info(`File server running on port ${env.port}`);
-	});
-};
+export * from "./fileServer.js";
 
 //if main process
 if (isMain(import.meta.url)) {

--- a/packages/file-server/src/tests/fileServer.unit.test.ts
+++ b/packages/file-server/src/tests/fileServer.unit.test.ts
@@ -299,6 +299,43 @@ describe("createApp static serving", () => {
 		expect(logger.entries).toContain(`info Serving files from ${tmpDir}`);
 	});
 
+	it("does not serve the working directory for an empty path entry", async () => {
+		// express.static("") resolves to cwd, which would publish the whole
+		// deployment — including source and any .env files — over HTTP.
+		const url = await serve(
+			baseEnv({ paths: [""] }),
+			makeDeps({ fetch: notFoundFetch }),
+		);
+
+		const response = await fetch(`${url}/package.json`);
+
+		expect(response.status).toBe(404);
+	});
+
+	it("warns about an empty path entry", async () => {
+		const logger = createRecordingLogger();
+		await serve(baseEnv({ paths: [""] }), makeDeps({ logger }));
+
+		expect(logger.entries).toContain("warn ignoring empty path entry");
+	});
+
+	it("ignores a whitespace-only path entry", async () => {
+		const logger = createRecordingLogger();
+		await serve(baseEnv({ paths: ["   "] }), makeDeps({ logger }));
+
+		expect(logger.entries).toContain("warn ignoring empty path entry");
+	});
+
+	it("still serves the valid entries alongside an empty one", async () => {
+		fs.writeFileSync(path.join(tmpDir, "b.txt"), "kept");
+		const url = await serve(baseEnv({ paths: ["", tmpDir] }), makeDeps());
+
+		const response = await fetch(`${url}/b.txt`);
+
+		expect(response.status).toBe(200);
+		expect(await response.text()).toBe("kept");
+	});
+
 	it("falls through to the remote handler for a missing file", async () => {
 		const url = await serve(
 			baseEnv({ paths: [tmpDir] }),

--- a/packages/file-server/src/tests/fileServer.unit.test.ts
+++ b/packages/file-server/src/tests/fileServer.unit.test.ts
@@ -255,6 +255,31 @@ describe("getEnv", () => {
 		// Never coerced, so a non-numeric port reaches listen() untouched.
 		expect(getEnv({ PROSOPO_FILE_SERVER_PORT: "4000" }).port).toBe("4000");
 	});
+
+	it("does not mutate process.env when a custom env is supplied", () => {
+		// dotenv writes into process.env and cannot populate an arbitrary object,
+		// so loading it for an injected env would be a side effect with no effect.
+		process.env.NODE_ENV = "test";
+		const before = { ...process.env };
+
+		getEnv({ PROSOPO_FILE_SERVER_PORT: "4000" });
+
+		expect({ ...process.env }).toEqual(before);
+	});
+
+	it("reads process.env when no env is supplied", () => {
+		process.env.PROSOPO_FILE_SERVER_PORT = "4321";
+
+		expect(getEnv().port).toBe("4321");
+	});
+
+	it("falls back to the unsuffixed .env when NODE_ENV is unset", () => {
+		// Assigning undefined would store the string "undefined", so remove it.
+		Reflect.deleteProperty(process.env, "NODE_ENV");
+		process.env.PROSOPO_FILE_SERVER_PORT = "4322";
+
+		expect(getEnv().port).toBe("4322");
+	});
 });
 
 describe("createApp static serving", () => {

--- a/packages/file-server/src/tests/fileServer.unit.test.ts
+++ b/packages/file-server/src/tests/fileServer.unit.test.ts
@@ -1,0 +1,617 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Testing strategy: run the real express app on an ephemeral port and drive it
+// with real HTTP requests, so routing, static serving and streaming are
+// genuinely exercised. Only the two outward-facing collaborators — the remote
+// fetch and the image resize — are faked, since they are the things that go
+// wrong in production (a remote being down, a corrupt image) and the things a
+// unit test must not actually perform.
+
+import fs from "node:fs";
+import type http from "node:http";
+import type { AddressInfo } from "node:net";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+	DEFAULT_PORT,
+	type FetchFn,
+	type FileServerDeps,
+	type FileServerEnv,
+	type Logger,
+	type ResizeFn,
+	createApp,
+	defaultDeps,
+	getEnv,
+	main,
+	parseArray,
+	sharpResize,
+	toInt,
+} from "../index.js";
+
+/** Logger that records each call as a flat string for easy assertion. */
+const createRecordingLogger = (): Logger & {
+	info: (...args: unknown[]) => void;
+	entries: string[];
+} => {
+	const entries: string[] = [];
+	const record =
+		(level: string) =>
+		(...args: unknown[]): void => {
+			entries.push(`${level} ${args.map((arg) => String(arg)).join(" ")}`);
+		};
+	return {
+		entries,
+		info: record("info"),
+		warn: record("warn"),
+		error: record("error"),
+	};
+};
+
+const baseEnv = (overrides: Partial<FileServerEnv> = {}): FileServerEnv => ({
+	port: 0,
+	paths: [],
+	resize: undefined,
+	remotes: [],
+	logLevel: "info",
+	...overrides,
+});
+
+/** A fetch that returns the given body with a 200. */
+const okFetch = (body: string): FetchFn => {
+	return (): Promise<Response> =>
+		Promise.resolve(new Response(body, { status: 200 }));
+};
+
+const notFoundFetch: FetchFn = (): Promise<Response> =>
+	Promise.resolve(new Response("", { status: 404 }));
+
+const throwingFetch: FetchFn = (): Promise<Response> =>
+	Promise.reject(new Error("connection refused"));
+
+const identityResize: ResizeFn = (image: Buffer): Promise<Buffer> =>
+	Promise.resolve(image);
+
+const makeDeps = (overrides: Partial<FileServerDeps> = {}): FileServerDeps => ({
+	logger: createRecordingLogger(),
+	fetch: notFoundFetch,
+	resize: identityResize,
+	...overrides,
+});
+
+const servers: http.Server[] = [];
+let tmpDir: string;
+let envSnapshot: NodeJS.ProcessEnv;
+
+/** Start an app on an ephemeral port and return its base URL. */
+const serve = async (
+	env: FileServerEnv,
+	deps: FileServerDeps,
+): Promise<string> => {
+	const app = createApp(env, deps);
+	const server = await new Promise<http.Server>((resolve) => {
+		const started = app.listen(0, "127.0.0.1", () => {
+			resolve(started);
+		});
+	});
+	servers.push(server);
+	const address: string | AddressInfo | null = server.address();
+	if (address === null || typeof address === "string") {
+		throw new Error("expected a TCP address");
+	}
+	return `http://127.0.0.1:${address.port}`;
+};
+
+beforeEach(() => {
+	tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "prosopo-file-server-test-"));
+	envSnapshot = { ...process.env };
+});
+
+afterEach(async () => {
+	for (const server of servers.splice(0)) {
+		server.closeAllConnections();
+		await new Promise<void>((resolve) => {
+			server.close(() => {
+				resolve();
+			});
+		});
+	}
+	fs.rmSync(tmpDir, { recursive: true, force: true });
+	for (const key of Object.keys(process.env)) {
+		delete process.env[key];
+	}
+	Object.assign(process.env, envSnapshot);
+});
+
+describe("parseArray", () => {
+	it("parses a JSON array of strings", () => {
+		expect(parseArray('["/a","/b"]')).toEqual(["/a", "/b"]);
+	});
+
+	it("returns an empty array for an empty JSON array", () => {
+		expect(parseArray("[]")).toEqual([]);
+	});
+
+	it("treats unparseable text as a single entry", () => {
+		expect(parseArray("/srv/images")).toEqual(["/srv/images"]);
+	});
+
+	it("treats an empty string as a single empty entry", () => {
+		expect(parseArray("")).toEqual([""]);
+	});
+
+	it("treats a JSON scalar as a single entry", () => {
+		// Without this guard a bare number would be returned as-is and then
+		// iterated, throwing on startup.
+		expect(parseArray("5")).toEqual(["5"]);
+		expect(parseArray("null")).toEqual(["null"]);
+		expect(parseArray("true")).toEqual(["true"]);
+	});
+
+	it("treats a JSON object as a single entry", () => {
+		expect(parseArray('{"a":1}')).toEqual(['{"a":1}']);
+	});
+
+	it("treats a mixed-type array as a single entry", () => {
+		expect(parseArray('["/a",1]')).toEqual(['["/a",1]']);
+	});
+
+	it("keeps a nested-looking string intact", () => {
+		expect(parseArray('"just a string"')).toEqual(['"just a string"']);
+	});
+});
+
+describe("toInt", () => {
+	it("returns a number unchanged", () => {
+		expect(toInt(128)).toBe(128);
+	});
+
+	it("returns undefined when unset", () => {
+		expect(toInt(undefined)).toBeUndefined();
+	});
+
+	it("parses a numeric string", () => {
+		expect(toInt("128")).toBe(128);
+	});
+
+	it("parses a leading numeric prefix, as parseInt does", () => {
+		expect(toInt("128px")).toBe(128);
+	});
+
+	it("returns undefined rather than NaN for unparseable text", () => {
+		expect(toInt("abc")).toBeUndefined();
+		expect(toInt("")).toBeUndefined();
+	});
+
+	it("truncates a fractional value", () => {
+		expect(toInt("128.9")).toBe(128);
+	});
+
+	it("returns zero for zero", () => {
+		// getEnv then maps 0 to undefined via `|| undefined`, disabling resize.
+		expect(toInt("0")).toBe(0);
+	});
+
+	it("handles a negative value", () => {
+		expect(toInt("-1")).toBe(-1);
+	});
+});
+
+describe("getEnv", () => {
+	it("falls back to defaults when nothing is set", () => {
+		const env = getEnv({});
+		expect(env.port).toBe(DEFAULT_PORT);
+		expect(env.paths).toEqual([]);
+		expect(env.remotes).toEqual([]);
+		expect(env.resize).toBeUndefined();
+		expect(env.logLevel).toBe("info");
+	});
+
+	it("reads every value from the environment", () => {
+		const env = getEnv({
+			PROSOPO_FILE_SERVER_PORT: "4000",
+			PROSOPO_FILE_SERVER_PATHS: '["/a"]',
+			PROSOPO_FILE_SERVER_REMOTES: '["http://x"]',
+			PROSOPO_FILE_SERVER_RESIZE: "64",
+			PROSOPO_LOG_LEVEL: "debug",
+		});
+		expect(env).toEqual({
+			port: "4000",
+			paths: ["/a"],
+			remotes: ["http://x"],
+			resize: 64,
+			logLevel: "debug",
+		});
+	});
+
+	it("treats a resize of 0 as no resize", () => {
+		expect(getEnv({ PROSOPO_FILE_SERVER_RESIZE: "0" }).resize).toBeUndefined();
+	});
+
+	it("treats an unparseable resize as no resize", () => {
+		// Silent: a typo in the resize var disables resizing rather than failing.
+		expect(
+			getEnv({ PROSOPO_FILE_SERVER_RESIZE: "big" }).resize,
+		).toBeUndefined();
+	});
+
+	it("treats an empty port as unset", () => {
+		expect(getEnv({ PROSOPO_FILE_SERVER_PORT: "" }).port).toBe(DEFAULT_PORT);
+	});
+
+	it("leaves the port as a string when set", () => {
+		// Never coerced, so a non-numeric port reaches listen() untouched.
+		expect(getEnv({ PROSOPO_FILE_SERVER_PORT: "4000" }).port).toBe("4000");
+	});
+});
+
+describe("createApp static serving", () => {
+	it("serves a file from a configured path", async () => {
+		fs.writeFileSync(path.join(tmpDir, "a.txt"), "hello");
+		const url = await serve(baseEnv({ paths: [tmpDir] }), makeDeps());
+
+		const response = await fetch(`${url}/a.txt`);
+
+		expect(response.status).toBe(200);
+		expect(await response.text()).toBe("hello");
+	});
+
+	it("logs each path it serves", async () => {
+		const logger = createRecordingLogger();
+		await serve(baseEnv({ paths: [tmpDir] }), makeDeps({ logger }));
+		expect(logger.entries).toContain(`info Serving files from ${tmpDir}`);
+	});
+
+	it("falls through to the remote handler for a missing file", async () => {
+		const url = await serve(
+			baseEnv({ paths: [tmpDir] }),
+			makeDeps({ fetch: notFoundFetch }),
+		);
+
+		const response = await fetch(`${url}/missing.txt`);
+
+		expect(response.status).toBe(404);
+		expect(await response.text()).toBe("Not found");
+	});
+
+	it("serves from the first path that has the file", async () => {
+		const other = fs.mkdtempSync(path.join(os.tmpdir(), "prosopo-fs-second-"));
+		try {
+			fs.writeFileSync(path.join(tmpDir, "same.txt"), "first");
+			fs.writeFileSync(path.join(other, "same.txt"), "second");
+			const url = await serve(baseEnv({ paths: [tmpDir, other] }), makeDeps());
+
+			expect(await (await fetch(`${url}/same.txt`)).text()).toBe("first");
+		} finally {
+			fs.rmSync(other, { recursive: true, force: true });
+		}
+	});
+
+	it("tolerates a path that does not exist", async () => {
+		// express.static does not stat the root up front, so a typo'd path is a
+		// silent no-op rather than a startup failure.
+		const url = await serve(
+			baseEnv({ paths: [path.join(tmpDir, "nope")] }),
+			makeDeps(),
+		);
+
+		expect((await fetch(`${url}/a.txt`)).status).toBe(404);
+	});
+
+	it("404s everything when no paths and no remotes are configured", async () => {
+		const url = await serve(baseEnv(), makeDeps());
+		expect((await fetch(`${url}/anything`)).status).toBe(404);
+	});
+});
+
+describe("createApp remote fallback", () => {
+	it("streams back the first remote that has the file", async () => {
+		const url = await serve(
+			baseEnv({ remotes: ["http://remote-a"] }),
+			makeDeps({ fetch: okFetch("image-bytes") }),
+		);
+
+		const response = await fetch(`${url}/a.jpg`);
+
+		expect(response.status).toBe(200);
+		expect(await response.text()).toBe("image-bytes");
+	});
+
+	it("requests the remote with the original url appended", async () => {
+		const requested: string[] = [];
+		const recordingFetch: FetchFn = (target: string): Promise<Response> => {
+			requested.push(target);
+			return Promise.resolve(new Response("x", { status: 200 }));
+		};
+		const url = await serve(
+			baseEnv({ remotes: ["http://remote-a"] }),
+			makeDeps({ fetch: recordingFetch }),
+		);
+
+		await fetch(`${url}/nested/a.jpg?v=1`);
+
+		expect(requested).toEqual(["http://remote-a/nested/a.jpg?v=1"]);
+	});
+
+	it("tries each remote in order until one hits", async () => {
+		const requested: string[] = [];
+		const secondWins: FetchFn = (target: string): Promise<Response> => {
+			requested.push(target);
+			return Promise.resolve(
+				new Response("found", {
+					status: target.startsWith("http://b") ? 200 : 404,
+				}),
+			);
+		};
+		const url = await serve(
+			baseEnv({ remotes: ["http://a", "http://b", "http://c"] }),
+			makeDeps({ fetch: secondWins }),
+		);
+
+		const response = await fetch(`${url}/a.jpg`);
+
+		expect(await response.text()).toBe("found");
+		// c is never tried once b answers.
+		expect(requested).toEqual(["http://a/a.jpg", "http://b/a.jpg"]);
+	});
+
+	it("404s when every remote misses", async () => {
+		const url = await serve(
+			baseEnv({ remotes: ["http://a", "http://b"] }),
+			makeDeps({ fetch: notFoundFetch }),
+		);
+
+		const response = await fetch(`${url}/a.jpg`);
+
+		expect(response.status).toBe(404);
+		expect(await response.text()).toBe("Not found");
+	});
+
+	it("skips a remote that is unavailable and tries the next", async () => {
+		const flaky: FetchFn = (target: string): Promise<Response> =>
+			target.startsWith("http://down")
+				? Promise.reject(new Error("connection refused"))
+				: Promise.resolve(new Response("ok", { status: 200 }));
+		const logger = createRecordingLogger();
+		const url = await serve(
+			baseEnv({ remotes: ["http://down", "http://up"] }),
+			makeDeps({ fetch: flaky, logger }),
+		);
+
+		const response = await fetch(`${url}/a.jpg`);
+
+		expect(await response.text()).toBe("ok");
+		expect(
+			logger.entries.some((entry) =>
+				entry.startsWith("warn error http://down"),
+			),
+		).toBe(true);
+	});
+
+	it("404s when every remote is unavailable", async () => {
+		const url = await serve(
+			baseEnv({ remotes: ["http://a"] }),
+			makeDeps({ fetch: throwingFetch }),
+		);
+
+		expect((await fetch(`${url}/a.jpg`)).status).toBe(404);
+	});
+
+	it("logs the remote status on a miss", async () => {
+		const logger = createRecordingLogger();
+		const url = await serve(
+			baseEnv({ remotes: ["http://a"] }),
+			makeDeps({ fetch: notFoundFetch, logger }),
+		);
+
+		await fetch(`${url}/a.jpg`);
+
+		expect(logger.entries).toContain("warn not found http://a /a.jpg 404");
+	});
+
+	it("treats a 500 from a remote as a miss", async () => {
+		const serverError: FetchFn = (): Promise<Response> =>
+			Promise.resolve(new Response("boom", { status: 500 }));
+		const url = await serve(
+			baseEnv({ remotes: ["http://a"] }),
+			makeDeps({ fetch: serverError }),
+		);
+
+		expect((await fetch(`${url}/a.jpg`)).status).toBe(404);
+	});
+
+	it("skips a remote whose body cannot be read", async () => {
+		const brokenBody: FetchFn = (): Promise<Response> => {
+			const response = new Response("x", { status: 200 });
+			return Promise.resolve(
+				Object.assign(response, {
+					arrayBuffer: (): Promise<ArrayBuffer> =>
+						Promise.reject(new Error("stream aborted")),
+				}),
+			);
+		};
+		const logger = createRecordingLogger();
+		const url = await serve(
+			baseEnv({ remotes: ["http://a"] }),
+			makeDeps({ fetch: brokenBody, logger }),
+		);
+
+		expect((await fetch(`${url}/a.jpg`)).status).toBe(404);
+		expect(
+			logger.entries.some((entry) => entry.includes("stream aborted")),
+		).toBe(true);
+	});
+
+	it("serves an empty remote body as an empty response", async () => {
+		const url = await serve(
+			baseEnv({ remotes: ["http://a"] }),
+			makeDeps({ fetch: okFetch("") }),
+		);
+
+		const response = await fetch(`${url}/a.jpg`);
+
+		expect(response.status).toBe(200);
+		expect(await response.text()).toBe("");
+	});
+});
+
+describe("createApp resizing", () => {
+	it("resizes when a size is configured", async () => {
+		const calls: number[] = [];
+		const resize: ResizeFn = (
+			_image: Buffer,
+			size: number,
+		): Promise<Buffer> => {
+			calls.push(size);
+			return Promise.resolve(Buffer.from("resized"));
+		};
+		const url = await serve(
+			baseEnv({ remotes: ["http://a"], resize: 64 }),
+			makeDeps({ fetch: okFetch("original"), resize }),
+		);
+
+		const response = await fetch(`${url}/a.jpg`);
+
+		expect(await response.text()).toBe("resized");
+		expect(calls).toEqual([64]);
+	});
+
+	it("does not resize when no size is configured", async () => {
+		const calls: number[] = [];
+		const resize: ResizeFn = (image: Buffer, size: number): Promise<Buffer> => {
+			calls.push(size);
+			return Promise.resolve(image);
+		};
+		const url = await serve(
+			baseEnv({ remotes: ["http://a"] }),
+			makeDeps({ fetch: okFetch("original"), resize }),
+		);
+
+		expect(await (await fetch(`${url}/a.jpg`)).text()).toBe("original");
+		expect(calls).toEqual([]);
+	});
+
+	it("skips a remote whose payload cannot be resized", async () => {
+		// Without the guard this rejection would escape an async express 4
+		// handler, leaving the client hanging until it timed out.
+		const failing: ResizeFn = (): Promise<Buffer> =>
+			Promise.reject(new Error("unsupported image format"));
+		const logger = createRecordingLogger();
+		const url = await serve(
+			baseEnv({ remotes: ["http://a"], resize: 64 }),
+			makeDeps({ fetch: okFetch("not-an-image"), resize: failing, logger }),
+		);
+
+		const response = await fetch(`${url}/a.jpg`);
+
+		expect(response.status).toBe(404);
+		expect(
+			logger.entries.some((entry) => entry.startsWith("warn resize failed")),
+		).toBe(true);
+	});
+
+	it("falls through to a later remote when the first cannot be resized", async () => {
+		const failFirst: ResizeFn = (image: Buffer): Promise<Buffer> =>
+			image.toString() === "bad"
+				? Promise.reject(new Error("unsupported image format"))
+				: Promise.resolve(Buffer.from("resized"));
+		const byRemote: FetchFn = (target: string): Promise<Response> =>
+			Promise.resolve(
+				new Response(target.startsWith("http://a") ? "bad" : "good", {
+					status: 200,
+				}),
+			);
+		const url = await serve(
+			baseEnv({ remotes: ["http://a", "http://b"], resize: 64 }),
+			makeDeps({ fetch: byRemote, resize: failFirst }),
+		);
+
+		expect(await (await fetch(`${url}/a.jpg`)).text()).toBe("resized");
+	});
+});
+
+describe("defaultDeps", () => {
+	it("wires up the console and the sharp-backed resize", () => {
+		const deps = defaultDeps();
+		expect(deps.logger).toBe(console);
+		expect(deps.resize).toBe(sharpResize);
+		expect(typeof deps.fetch).toBe("function");
+	});
+
+	it("delegates fetch to the global implementation", async () => {
+		const url = await serve(baseEnv({ paths: [tmpDir] }), makeDeps());
+		fs.writeFileSync(path.join(tmpDir, "real.txt"), "via-global-fetch");
+
+		const response = await defaultDeps().fetch(`${url}/real.txt`);
+
+		expect(await response.text()).toBe("via-global-fetch");
+	});
+});
+
+describe("main", () => {
+	it("starts a server from the environment and logs the port", async () => {
+		process.env.PROSOPO_FILE_SERVER_PORT = "0";
+		process.env.PROSOPO_FILE_SERVER_PATHS = JSON.stringify([tmpDir]);
+		process.env.PROSOPO_FILE_SERVER_REMOTES = "[]";
+		fs.writeFileSync(path.join(tmpDir, "b.txt"), "from-main");
+		const logger = createRecordingLogger();
+
+		const server = await main(makeDeps({ logger }));
+		servers.push(server);
+
+		const address: string | AddressInfo | null = server.address();
+		if (address === null || typeof address === "string") {
+			throw new Error("expected a TCP address");
+		}
+		const response = await fetch(`http://127.0.0.1:${address.port}/b.txt`);
+
+		expect(await response.text()).toBe("from-main");
+		expect(logger.entries).toContain("info File server running on port 0");
+	});
+});
+
+describe("sharpResize", () => {
+	it("resizes a real image to the requested square", async () => {
+		const source = await sharpResizeSource();
+
+		const resized = await sharpResize(source, 32);
+
+		const { default: sharp } = await import("sharp");
+		const metadata = await sharp(resized).metadata();
+		expect(metadata.width).toBe(32);
+		expect(metadata.height).toBe(32);
+	});
+
+	it("rejects a payload that is not an image", async () => {
+		await expect(
+			sharpResize(Buffer.from("definitely not an image"), 32),
+		).rejects.toThrow();
+	});
+});
+
+/** A small real PNG to feed the resize tests. */
+const sharpResizeSource = async (): Promise<Buffer> => {
+	const { default: sharp } = await import("sharp");
+	return sharp({
+		create: {
+			width: 8,
+			height: 16,
+			channels: 3,
+			background: { r: 255, g: 0, b: 0 },
+		},
+	})
+		.png()
+		.toBuffer();
+};

--- a/packages/file-server/src/tests/index.unit.test.ts
+++ b/packages/file-server/src/tests/index.unit.test.ts
@@ -1,0 +1,83 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type http from "node:http";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// The entrypoint only runs its body when the module is the process entrypoint,
+// which never holds under vitest. Force the guard so the branch is exercised.
+vi.mock("@prosopo/util", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@prosopo/util")>();
+	return { ...actual, isMain: (): boolean => true };
+});
+
+const servers: http.Server[] = [];
+
+/** Capture the server main() starts so the test can shut it down again. */
+vi.mock("../fileServer.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../fileServer.js")>();
+	return {
+		...actual,
+		main: async (): Promise<http.Server> => {
+			const server = await actual.main();
+			servers.push(server);
+			return server;
+		},
+	};
+});
+
+let envSnapshot: NodeJS.ProcessEnv;
+
+beforeEach(() => {
+	envSnapshot = { ...process.env };
+	// Port 0 gets an ephemeral port, so the test never collides with a real one.
+	process.env.PROSOPO_FILE_SERVER_PORT = "0";
+	process.env.PROSOPO_FILE_SERVER_PATHS = "[]";
+	process.env.PROSOPO_FILE_SERVER_REMOTES = "[]";
+	vi.resetModules();
+});
+
+afterEach(async () => {
+	for (const server of servers.splice(0)) {
+		await new Promise<void>((resolve) => {
+			server.close(() => {
+				resolve();
+			});
+		});
+	}
+	for (const key of Object.keys(process.env)) {
+		delete process.env[key];
+	}
+	Object.assign(process.env, envSnapshot);
+	vi.restoreAllMocks();
+});
+
+describe("index entrypoint", () => {
+	it("starts the server when run as the main module", async () => {
+		await import("../index.js");
+		// The import kicks off main() without awaiting it, so let it settle.
+		await vi.waitFor(() => {
+			expect(servers).toHaveLength(1);
+		});
+
+		expect(servers[0]?.listening).toBe(true);
+	});
+
+	it("re-exports the file server module", async () => {
+		const module = await import("../index.js");
+
+		expect(typeof module.createApp).toBe("function");
+		expect(typeof module.getEnv).toBe("function");
+	});
+});

--- a/packages/file-server/src/tests/indexStartupFailure.unit.test.ts
+++ b/packages/file-server/src/tests/indexStartupFailure.unit.test.ts
@@ -1,0 +1,55 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type http from "node:http";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Kept in its own file: the failing main() below is a module-level mock, and
+// sharing a module registry with the happy-path entrypoint test would let it
+// apply there too, depending on the order vitest picks.
+const startupError = new Error("listen failed");
+
+vi.mock("@prosopo/util", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@prosopo/util")>();
+	return { ...actual, isMain: (): boolean => true };
+});
+
+vi.mock("../fileServer.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../fileServer.js")>();
+	return {
+		...actual,
+		main: async (): Promise<http.Server> => {
+			throw startupError;
+		},
+	};
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("index entrypoint startup failure", () => {
+	it("logs rather than throwing when the server fails to start", async () => {
+		const errorLog = vi
+			.spyOn(console, "error")
+			.mockImplementation((): void => {});
+
+		// An unhandled rejection here would take the process down at startup.
+		await expect(import("../index.js")).resolves.toBeDefined();
+
+		await vi.waitFor(() => {
+			expect(errorLog).toHaveBeenCalledWith(startupError);
+		});
+	});
+});


### PR DESCRIPTION
Third package in the package-by-package pass, after [#2913](https://github.com/prosopo/captcha/pull/2913) (dotenv) and [#2914](https://github.com/prosopo/captcha/pull/2914) (http-blackhole).

## What changed

`src/index.ts` was one module that built and started the server inline, with `console`, global `fetch` and `sharp` hard-wired. Split into:

- `src/fileServer.ts` — `parseArray`, `toInt`, `getEnv`, `createRemoteHandler`, `createApp`, `sharpResize`, `defaultDeps`, `main`, with logger/fetch/resize injected.
- `src/index.ts` — thin entrypoint that re-exports it; the `isMain` guard and runtime behaviour are unchanged.

`main` now returns the `http.Server` so it can be shut down (previously the handle was dropped).

## Tests

47 tests, 100% statements/branches/functions/lines on `fileServer.ts`. The real express app runs on an ephemeral port and is driven with real HTTP, so routing, static serving and streaming are genuinely exercised; only the remote fetch and the resize are faked — those being exactly the things that fail in production and the things a unit test must not really do. `sharpResize` itself is tested against a real generated PNG.

Covers: multiple static roots and precedence, a non-existent root, remote ordering and short-circuiting, a remote that 404s / 500s / refuses the connection / aborts mid-body, empty bodies, resize on and off, and the no-paths-no-remotes case.

## Defects fixed

1. **A resize failure hung the client.** `sharp()` rejects on a non-image or corrupt payload, and express 4 does not catch rejections from async handlers — so the request was never answered and the client waited for its own timeout. Now logged and the remote is skipped.
2. **A non-array JSON env value crashed startup.** `parseArray` returned whatever `JSON.parse` produced, so `PROSOPO_FILE_SERVER_PATHS=5` or `{"a":1}` was then iterated by `for..of` and threw. Now anything that is not a JSON array of strings is treated as a single literal entry.
3. **`toInt` returned `NaN`** for unparseable text; it now returns `undefined`, which is what every caller already assumed.
4. **A remote miss logged `req.statusCode`** — not a property of a request, so always `undefined`. Now logs the remote's actual status.

`parseArray` also gained an explicit `string[]` return type; it previously leaked `any` out of `JSON.parse` into `FileServerEnv`.

## Behaviour deliberately left alone (worth your call)

- `PROSOPO_FILE_SERVER_RESIZE=0` and a typo'd value both silently disable resizing, via `|| undefined`.
- The port is never coerced or validated — a non-numeric `PROSOPO_FILE_SERVER_PORT` reaches `listen()` as a string.
- Responses carry no `Content-Type`: the buffer is streamed raw, so clients have to sniff.
- The comment "only run server if locations have been specified" is stale — the server always listens, even with no paths and no remotes, in which case it 404s everything.