### PR TITLE
test(dotenv): add vitest type tests for the env API

### DIFF
--- a/.changeset/dotenv-type-tests.md
+++ b/.changeset/dotenv-type-tests.md
@@ -1,0 +1,12 @@
+---
+"@prosopo/dotenv": patch
+---
+
+test(dotenv): add vitest type tests for the env API
+
+Runtime tests cannot catch a published signature that silently widens. These
+pin the parts consumers depend on: `getEnv` and `getEnvFile` returning a plain
+`string` rather than `string | undefined` (both already default the absent
+case away, so a nullable return would push work back onto every caller),
+`loadEnv` returning the resolved path rather than void, and the optional
+positional arguments of `loadEnv`/`getEnvFile` in order.

--- a/packages/dotenv/src/tests/env.test-d.ts
+++ b/packages/dotenv/src/tests/env.test-d.ts
@@ -1,0 +1,110 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, expectTypeOf, it } from "vitest";
+import { getEnv, getEnvFile, loadEnv } from "../env.js";
+
+describe("getEnv", () => {
+	it("always yields a string, since it falls back to development", () => {
+		// A `string | undefined` return would force every caller to handle an
+		// absent NODE_ENV that this function has already defaulted away.
+		expectTypeOf(getEnv).returns.toEqualTypeOf<string>();
+	});
+
+	it("takes no arguments: it reads process.env directly", () => {
+		expectTypeOf(getEnv).parameters.toEqualTypeOf<[]>();
+	});
+});
+
+describe("loadEnv", () => {
+	it("returns the resolved env path rather than void", () => {
+		// Callers log and assert on which file was actually loaded.
+		expectTypeOf(loadEnv).returns.toEqualTypeOf<string>();
+	});
+
+	it("is callable with no arguments at all", () => {
+		expectTypeOf(loadEnv).toBeCallableWith();
+	});
+
+	it("takes every argument as optional, in order", () => {
+		expectTypeOf(loadEnv).parameters.toEqualTypeOf<
+			[
+				(string | undefined)?,
+				(string | undefined)?,
+				(string | undefined)?,
+				(string | undefined)?,
+				(boolean | undefined)?,
+			]
+		>();
+	});
+
+	it("accepts a partially specified call", () => {
+		expectTypeOf(loadEnv).toBeCallableWith("/root");
+		expectTypeOf(loadEnv).toBeCallableWith("/root", ".env");
+		expectTypeOf(loadEnv).toBeCallableWith(
+			"/root",
+			".env",
+			"/root/.env",
+			"test",
+			true,
+		);
+	});
+
+	it("keeps override a boolean, not a truthy anything", () => {
+		// @ts-expect-error override is a boolean flag
+		loadEnv("/root", ".env", "/root/.env", "test", "yes");
+	});
+
+	it("rejects a numeric root directory", () => {
+		// @ts-expect-error rootDir is a path string
+		loadEnv(1);
+	});
+});
+
+describe("getEnvFile", () => {
+	it("always resolves to a path string", () => {
+		// It returns a best-effort path even when nothing was found on disk, so
+		// the caller never has to handle undefined.
+		expectTypeOf(getEnvFile).returns.toEqualTypeOf<string>();
+	});
+
+	it("is callable with no arguments, defaulting filename and search root", () => {
+		expectTypeOf(getEnvFile).toBeCallableWith();
+	});
+
+	it("takes four optional positional arguments", () => {
+		expectTypeOf(getEnvFile).parameters.toEqualTypeOf<
+			[
+				(string | undefined)?,
+				(string | undefined)?,
+				(string | undefined)?,
+				(string | undefined)?,
+			]
+		>();
+	});
+
+	it("accepts an explicit nodeEnv override in last position", () => {
+		expectTypeOf(getEnvFile).toBeCallableWith(
+			"/root",
+			".env",
+			"/fallback",
+			"production",
+		);
+	});
+
+	it("rejects an extra argument", () => {
+		// @ts-expect-error there is no fifth parameter
+		getEnvFile("/root", ".env", "/fallback", "production", true);
+	});
+});

--- a/packages/dotenv/src/tests/env.test-d.ts
+++ b/packages/dotenv/src/tests/env.test-d.ts
@@ -13,7 +13,10 @@
 // limitations under the License.
 
 import { describe, expectTypeOf, it } from "vitest";
-import { getEnv, getEnvFile, loadEnv } from "../env.js";
+// Imported from the package entrypoint, not ../env.js: these assertions exist
+// to pin what consumers actually receive, so a barrel that stops re-exporting
+// something — or narrows it — must fail here.
+import { getEnv, getEnvFile, loadEnv } from "../index.js";
 
 describe("getEnv", () => {
 	it("always yields a string, since it falls back to development", () => {


### PR DESCRIPTION
Adds `src/tests/env.test-d.ts` (13 type tests). Vitest type checking was already enabled in the shared config (`typecheck.enabled`), and its default `typecheck.include` picks up `*.test-d.ts` — no config change was needed, only the test files.

Runtime tests cannot catch a published signature that silently widens, so these pin the parts consumers depend on:

- `getEnv` and `getEnvFile` return a plain `string`, not `string | undefined` — both already default the absent case away, so a nullable return would push that work back onto every caller.
- `loadEnv` returns the resolved env path rather than void; callers log and assert on which file was actually loaded.
- The optional positional arguments of `loadEnv` and `getEnvFile`, in order, including negative cases (`override` must be a boolean, no fifth argument on `getEnvFile`).

`npm run -w @prosopo/dotenv test` → 64 passed (51 runtime + 13 type), no type errors, 100% coverage retained.