### PR TITLE
test(http-blackhole): add vitest type tests for the server API

### DIFF
--- a/.changeset/http-blackhole-request-log.md
+++ b/.changeset/http-blackhole-request-log.md
@@ -1,0 +1,23 @@
+---
+"@prosopo/http-blackhole": patch
+---
+
+fix(http-blackhole): make the per-socket request log unsubstitutable
+
+`handleRequest` took the request log as a `WeakMap` parameter, which does not
+actually constrain anything: `Map` is structurally assignable to `WeakMap`
+(both satisfy get/set/has/delete, and neither narrows `Symbol.toStringTag` to a
+literal), so a caller passing a strongly-keyed `Map` compiled cleanly and would
+have retained every socket the process ever served — on a server that holds
+every connection open by design.
+
+The seam is now a `RecordRequest` callback, which admits no such substitution,
+and the map itself is built by `createRequestLog` — a single construction site
+the tests assert against directly, by registering a socket, dropping the only
+strong reference and forcing collection with `--expose-gc`. Weakness is a
+property of the class rather than of the type, so observing it is the only way
+to prove it.
+
+Also covers `src/index.ts`, which was previously untested: it starts listening,
+registers both SIGINT and SIGTERM, exits zero on a clean shutdown, and ignores
+a repeat signal.

--- a/.changeset/http-blackhole-request-log.md
+++ b/.changeset/http-blackhole-request-log.md
@@ -1,5 +1,5 @@
 ---
-"@prosopo/http-blackhole": patch
+"@prosopo/http-blackhole": minor
 ---
 
 fix(http-blackhole): make the per-socket request log unsubstitutable
@@ -17,6 +17,9 @@ the tests assert against directly, by registering a socket, dropping the only
 strong reference and forcing collection with `--expose-gc`. Weakness is a
 property of the class rather than of the type, so observing it is the only way
 to prove it.
+
+`handleRequest`'s third parameter changes type, which is breaking for anyone
+calling it directly — hence a minor rather than a patch on this 0.x/1.x package.
 
 Also covers `src/index.ts`, which was previously untested: it starts listening,
 registers both SIGINT and SIGTERM, exits zero on a clean shutdown, and ignores

--- a/.changeset/http-blackhole-type-tests.md
+++ b/.changeset/http-blackhole-type-tests.md
@@ -1,0 +1,13 @@
+---
+"@prosopo/http-blackhole": patch
+---
+
+test(http-blackhole): add vitest type tests for the server API
+
+Pins the injection seams that make this package testable: `Exit` returning
+`void` rather than `never` (the `never` of `process.exit` would make every line
+after an exit call unreachable to the compiler, which is wrong for the
+recording double the tests inject), `Logger.log` taking a single pre-formatted
+string, `resolvePort` accepting `string | undefined` so callers need not narrow
+`process.env.PORT` first, and `createShutdown` returning a zero-argument
+handler that `process.on` accepts directly.

--- a/packages/http-blackhole/package.json
+++ b/packages/http-blackhole/package.json
@@ -13,7 +13,7 @@
 		"build:cjs": "NODE_ENV=${NODE_ENV:-development}; vite build --config vite.cjs.config.ts --mode $NODE_ENV",
 		"start": "node dist/index.js",
 		"typecheck": "tsc --noEmit",
-		"test": "NODE_ENV=${NODE_ENV:-test}; npx vitest run --config ./vite.test.config.ts"
+		"test": "NODE_ENV=${NODE_ENV:-test}; NODE_OPTIONS=\"${NODE_OPTIONS:-} --expose-gc\" npx vitest run --config ./vite.test.config.ts"
 	},
 	"author": "",
 	"dependencies": {

--- a/packages/http-blackhole/src/blackhole.ts
+++ b/packages/http-blackhole/src/blackhole.ts
@@ -75,21 +75,44 @@ export const describeRequest = (req: http.IncomingMessage): string =>
 	`${req.method ?? "UNKNOWN"} ${req.url ?? "UNKNOWN"}`;
 
 /**
+ * Records the last request line seen on a socket, so the connection-level close
+ * listener can name it.
+ *
+ * A callback rather than the map itself: `Map` is structurally assignable to
+ * `WeakMap` (both satisfy get/set/has/delete, and neither narrows
+ * `Symbol.toStringTag` to a literal), so a parameter typed `WeakMap` would
+ * happily accept a strongly-keyed `Map` and silently retain every socket the
+ * process has ever served. Narrowing the seam to a function removes the
+ * substitution entirely and leaves exactly one place that decides how requests
+ * are stored — see `createRequestLog`.
+ */
+export type RecordRequest = (socket: net.Socket, description: string) => void;
+
+/**
+ * The per-socket request log.
+ *
+ * Weak on purpose: this server holds every connection open indefinitely and is
+ * pointed at by clients under test, so a strongly-keyed map would grow for the
+ * lifetime of the process and pin each socket's buffers with it. Weakness is a
+ * property of the class, not of the type — hence a single construction site
+ * that tests can assert on directly.
+ */
+export const createRequestLog = (): WeakMap<net.Socket, string> =>
+	new WeakMap<net.Socket, string>();
+
+/**
  * Handle one request by deliberately never responding: the socket is held open
  * so the client is forced to hit its own timeout. This is the entire purpose of
  * the package — it exists to test client-side timeout handling.
- *
- * The request line is recorded against the socket so the connection-level close
- * listener can name it.
  */
 export const handleRequest = (
 	req: http.IncomingMessage,
 	logger: Logger,
-	lastRequest?: WeakMap<net.Socket, string>,
+	record?: RecordRequest,
 ): void => {
 	const description = describeRequest(req);
 	logger.log(`Received request: ${description}`);
-	lastRequest?.set(req.socket, description);
+	record?.(req.socket, description);
 	// Do nothing else: simulate an unresponsive server, keeping the socket open.
 	req.socket.setTimeout(0); // Disable socket timeout
 	req.socket.setKeepAlive(true); // Keep the socket alive
@@ -101,7 +124,7 @@ export const createBlackholeServer = (logger: Logger): http.Server => {
 	// Close is tracked per connection rather than per request, so a client that
 	// connects and then goes away without ever sending a request line is still
 	// accounted for.
-	const lastRequest = new WeakMap<net.Socket, string>();
+	const lastRequest = createRequestLog();
 
 	server.on("connection", (socket: net.Socket) => {
 		logger.log("Connection opened");
@@ -116,7 +139,9 @@ export const createBlackholeServer = (logger: Logger): http.Server => {
 	});
 
 	server.on("request", (req: http.IncomingMessage) => {
-		handleRequest(req, logger, lastRequest);
+		handleRequest(req, logger, (socket: net.Socket, description: string) => {
+			lastRequest.set(socket, description);
+		});
 	});
 
 	return server;

--- a/packages/http-blackhole/src/tests/blackhole.test-d.ts
+++ b/packages/http-blackhole/src/tests/blackhole.test-d.ts
@@ -1,0 +1,170 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type http from "node:http";
+import type net from "node:net";
+import { assertType, describe, expectTypeOf, it } from "vitest";
+import {
+	DEFAULT_PORT,
+	type Exit,
+	InvalidPortError,
+	type Logger,
+	MAX_PORT,
+	createBlackholeServer,
+	createShutdown,
+	describeRequest,
+	handleRequest,
+	resolvePort,
+} from "../blackhole.js";
+
+describe("port constants", () => {
+	it("are plain numbers, usable directly by listen()", () => {
+		expectTypeOf(DEFAULT_PORT).toEqualTypeOf<number>();
+		expectTypeOf(MAX_PORT).toEqualTypeOf<number>();
+	});
+});
+
+describe("Logger", () => {
+	it("takes a single string, so callers must format before logging", () => {
+		// Deliberately narrower than console.log: a variadic sink would let a
+		// caller pass objects that the capture in tests could not compare.
+		expectTypeOf<Logger["log"]>().parameters.toEqualTypeOf<[string]>();
+		expectTypeOf<Logger["log"]>().returns.toEqualTypeOf<void>();
+	});
+
+	it("is satisfied by the real console", () => {
+		// The entrypoint passes console straight in.
+		expectTypeOf(console).toMatchTypeOf<Logger>();
+	});
+
+	it("rejects a sink that only takes objects", () => {
+		// @ts-expect-error log must accept a string
+		const bad: Logger = { log: (_message: { text: string }): void => {} };
+		assertType<Logger>(bad);
+	});
+});
+
+describe("Exit", () => {
+	it("takes an exit code and returns void, not never", () => {
+		// process.exit is typed `never`; using that here would make every line
+		// after an exit() call unreachable in the eyes of the compiler, which is
+		// wrong for the injected test double that simply records the code.
+		expectTypeOf<Exit>().parameters.toEqualTypeOf<[number]>();
+		expectTypeOf<Exit>().returns.toEqualTypeOf<void>();
+	});
+
+	it("accepts a recording double", () => {
+		const codes: number[] = [];
+		const exit: Exit = (code: number): void => {
+			codes.push(code);
+		};
+		expectTypeOf(exit).toEqualTypeOf<Exit>();
+	});
+
+	it("requires the code, so no caller can exit ambiguously", () => {
+		const exit: Exit = (): void => {};
+		// @ts-expect-error the exit code is mandatory
+		exit();
+	});
+});
+
+describe("InvalidPortError", () => {
+	it("is an Error subclass so existing catch blocks keep working", () => {
+		expectTypeOf<InvalidPortError>().toMatchTypeOf<Error>();
+	});
+
+	it("is constructed from the offending raw value", () => {
+		expectTypeOf(InvalidPortError).toBeConstructibleWith("not-a-port");
+		// @ts-expect-error the offending value is required
+		new InvalidPortError();
+	});
+});
+
+describe("resolvePort", () => {
+	it("accepts an unset env var without the caller narrowing first", () => {
+		// process.env.PORT is `string | undefined`; requiring a narrow here would
+		// push the fallback decision back out to every call site.
+		expectTypeOf(resolvePort).parameters.toEqualTypeOf<[string | undefined]>();
+		expectTypeOf(resolvePort).toBeCallableWith(undefined);
+	});
+
+	it("always returns a number, never a string passthrough", () => {
+		expectTypeOf(resolvePort).returns.toEqualTypeOf<number>();
+	});
+
+	it("rejects a number, which would bypass validation entirely", () => {
+		// @ts-expect-error only raw env strings are accepted
+		resolvePort(8080);
+	});
+});
+
+describe("describeRequest", () => {
+	it("maps a request to a string, tolerating unparsed fields", () => {
+		expectTypeOf(describeRequest).parameters.toEqualTypeOf<
+			[http.IncomingMessage]
+		>();
+		expectTypeOf(describeRequest).returns.toEqualTypeOf<string>();
+	});
+});
+
+describe("handleRequest", () => {
+	it("returns void: never responding is the point of the package", () => {
+		expectTypeOf(handleRequest).returns.toEqualTypeOf<void>();
+	});
+
+	it("takes the socket-keyed request map as optional", () => {
+		// createBlackholeServer supplies it; direct callers should not have to.
+		expectTypeOf(handleRequest).parameters.toEqualTypeOf<
+			[http.IncomingMessage, Logger, (WeakMap<net.Socket, string> | undefined)?]
+		>();
+	});
+
+	it("declares the request map weakly, so sockets are not retained", () => {
+		// Note the type system cannot enforce this: Map is structurally
+		// assignable to WeakMap, so a caller passing a Map would compile. The
+		// declared type is the only signal, hence pinning it here.
+		expectTypeOf<Parameters<typeof handleRequest>[2]>().toEqualTypeOf<
+			WeakMap<net.Socket, string> | undefined
+		>();
+	});
+});
+
+describe("createBlackholeServer", () => {
+	it("returns a real http.Server so the caller controls listening", () => {
+		expectTypeOf(createBlackholeServer).returns.toEqualTypeOf<http.Server>();
+		expectTypeOf(createBlackholeServer).parameters.toEqualTypeOf<[Logger]>();
+	});
+});
+
+describe("createShutdown", () => {
+	it("returns a zero-argument handler, matching the signal listener shape", () => {
+		expectTypeOf(createShutdown).returns.toEqualTypeOf<() => void>();
+		expectTypeOf(createShutdown).returns.parameters.toEqualTypeOf<[]>();
+	});
+
+	it("requires the server, logger and exit together", () => {
+		expectTypeOf(createShutdown).parameters.toEqualTypeOf<
+			[http.Server, Logger, Exit]
+		>();
+	});
+
+	it("produces something process.on can be handed directly", () => {
+		const handler: () => void = createShutdown(
+			createBlackholeServer({ log: (): void => {} }),
+			{ log: (): void => {} },
+			(): void => {},
+		);
+		expectTypeOf(handler).toMatchTypeOf<NodeJS.SignalsListener>();
+	});
+});

--- a/packages/http-blackhole/src/tests/blackhole.test-d.ts
+++ b/packages/http-blackhole/src/tests/blackhole.test-d.ts
@@ -21,7 +21,9 @@ import {
 	InvalidPortError,
 	type Logger,
 	MAX_PORT,
+	type RecordRequest,
 	createBlackholeServer,
+	createRequestLog,
 	createShutdown,
 	describeRequest,
 	handleRequest,
@@ -123,20 +125,40 @@ describe("handleRequest", () => {
 		expectTypeOf(handleRequest).returns.toEqualTypeOf<void>();
 	});
 
-	it("takes the socket-keyed request map as optional", () => {
+	it("takes the recorder as optional", () => {
 		// createBlackholeServer supplies it; direct callers should not have to.
 		expectTypeOf(handleRequest).parameters.toEqualTypeOf<
-			[http.IncomingMessage, Logger, (WeakMap<net.Socket, string> | undefined)?]
+			[http.IncomingMessage, Logger, (RecordRequest | undefined)?]
 		>();
 	});
 
-	it("declares the request map weakly, so sockets are not retained", () => {
-		// Note the type system cannot enforce this: Map is structurally
-		// assignable to WeakMap, so a caller passing a Map would compile. The
-		// declared type is the only signal, hence pinning it here.
-		expectTypeOf<Parameters<typeof handleRequest>[2]>().toEqualTypeOf<
-			WeakMap<net.Socket, string> | undefined
+	it("takes a recorder callback, not a map that a Map could impersonate", () => {
+		// A parameter typed WeakMap would accept a strongly-keyed Map, since Map
+		// is structurally assignable to it — the retention bug would compile
+		// cleanly. A function signature admits no such substitution.
+		const req = {} as http.IncomingMessage;
+		// @ts-expect-error a map is no longer accepted here
+		handleRequest(req, { log: (): void => {} }, new Map<net.Socket, string>());
+	});
+});
+
+describe("RecordRequest", () => {
+	it("takes the socket and the formatted description", () => {
+		expectTypeOf<RecordRequest>().parameters.toEqualTypeOf<
+			[net.Socket, string]
 		>();
+		expectTypeOf<RecordRequest>().returns.toEqualTypeOf<void>();
+	});
+});
+
+describe("createRequestLog", () => {
+	it("returns a WeakMap, the only thing that actually guarantees weakness", () => {
+		// Weakness is a property of the class, not of the type, so this is the
+		// single construction site the runtime test asserts against.
+		expectTypeOf(createRequestLog).returns.toEqualTypeOf<
+			WeakMap<net.Socket, string>
+		>();
+		expectTypeOf(createRequestLog).parameters.toEqualTypeOf<[]>();
 	});
 });
 

--- a/packages/http-blackhole/src/tests/blackhole.unit.test.ts
+++ b/packages/http-blackhole/src/tests/blackhole.unit.test.ts
@@ -29,7 +29,9 @@ import {
 	InvalidPortError,
 	type Logger,
 	MAX_PORT,
+	type RecordRequest,
 	createBlackholeServer,
+	createRequestLog,
 	createShutdown,
 	describeRequest,
 	handleRequest,
@@ -49,6 +51,21 @@ const createRecordingLogger = (): Logger & { messages: string[] } => {
 
 /** A real, unconnected socket — enough for the handler's socket calls. */
 const createSocket = (): net.Socket => new net.Socket();
+
+/**
+ * Run a garbage collection. Exposed via `--expose-gc` in this package's vitest
+ * config; without it the weakness of the request log cannot be observed, so
+ * fail loudly rather than quietly skipping the assertion it underpins.
+ */
+const forceGc = (): void => {
+	const gc: (() => void) | undefined = globalThis.gc;
+	if (undefined === gc) {
+		throw new Error(
+			"gc is not exposed; run vitest with --expose-gc (see vite.test.config.ts)",
+		);
+	}
+	gc();
+};
 
 const createRequest = (
 	socket: net.Socket,
@@ -196,6 +213,60 @@ describe("resolvePort", () => {
 	});
 });
 
+describe("createRequestLog", () => {
+	it("is weakly keyed, so a served socket can still be collected", async () => {
+		// The point of the whole seam. Proven by observation rather than by the
+		// type system, which cannot distinguish a WeakMap from a Map here.
+		const collected = await new Promise<boolean>((resolve) => {
+			const log = createRequestLog();
+			const registry = new FinalizationRegistry<string>(() => {
+				resolve(true);
+			});
+
+			// Scoped so the only strong reference dies at the end of the block;
+			// the log's own reference is the one under test.
+			((): void => {
+				const socket = createSocket();
+				registry.register(socket, "socket");
+				log.set(socket, "GET /");
+				socket.destroy();
+			})();
+
+			// A single gc() call is not guaranteed to reach an object that has
+			// just become unreachable, so drive several with the microtask and
+			// macrotask queues drained in between, then give up rather than hang.
+			let attempts = 0;
+			const collect = (): void => {
+				if (attempts >= 20) {
+					resolve(false);
+					return;
+				}
+				attempts += 1;
+				forceGc();
+				setTimeout(collect, 10);
+			};
+			collect();
+		});
+
+		expect(collected).toBe(true);
+	});
+
+	it("does not expose enumeration, which would defeat the weakness", () => {
+		// forEach/keys/size would each need a strong reference to every key.
+		const log: WeakMap<net.Socket, string> = createRequestLog();
+		expect(log).toBeInstanceOf(WeakMap);
+		expect("size" in log).toBe(false);
+		expect("forEach" in log).toBe(false);
+	});
+
+	it("returns a fresh log each call, so servers do not share state", () => {
+		const socket = createSocket();
+		const first = createRequestLog();
+		first.set(socket, "GET /");
+		expect(createRequestLog().get(socket)).toBeUndefined();
+	});
+});
+
 describe("handleRequest", () => {
 	it("logs the method and url", () => {
 		const logger = createRecordingLogger();
@@ -223,16 +294,39 @@ describe("handleRequest", () => {
 
 	it("records the request line against the socket", () => {
 		const socket = createSocket();
-		const lastRequest = new WeakMap<net.Socket, string>();
+		const log = createRequestLog();
 		handleRequest(
 			createRequest(socket, "POST", "/bar"),
 			createRecordingLogger(),
-			lastRequest,
+			(recorded: net.Socket, description: string) => {
+				log.set(recorded, description);
+			},
 		);
-		expect(lastRequest.get(socket)).toBe("POST /bar");
+		expect(log.get(socket)).toBe("POST /bar");
 	});
 
-	it("works without a request map", () => {
+	it("passes the request's own socket to the recorder", () => {
+		const socket = createSocket();
+		const record = vi.fn<RecordRequest>();
+		handleRequest(
+			createRequest(socket, "POST", "/bar"),
+			createRecordingLogger(),
+			record,
+		);
+		expect(record).toHaveBeenCalledWith(socket, "POST /bar");
+	});
+
+	it("records the same placeholders it logs for an unparsed request", () => {
+		const record = vi.fn<RecordRequest>();
+		handleRequest(
+			createRequest(createSocket(), undefined, undefined),
+			createRecordingLogger(),
+			record,
+		);
+		expect(record).toHaveBeenCalledWith(expect.anything(), "UNKNOWN UNKNOWN");
+	});
+
+	it("works without a recorder", () => {
 		const logger = createRecordingLogger();
 		handleRequest(createRequest(createSocket(), "GET", "/x"), logger);
 		expect(logger.messages).toEqual(["Received request: GET /x"]);

--- a/packages/http-blackhole/src/tests/blackhole.unit.test.ts
+++ b/packages/http-blackhole/src/tests/blackhole.unit.test.ts
@@ -53,15 +53,18 @@ const createRecordingLogger = (): Logger & { messages: string[] } => {
 const createSocket = (): net.Socket => new net.Socket();
 
 /**
- * Run a garbage collection. Exposed via `--expose-gc` in this package's vitest
- * config; without it the weakness of the request log cannot be observed, so
- * fail loudly rather than quietly skipping the assertion it underpins.
+ * Run a garbage collection. `--expose-gc` is added to NODE_OPTIONS by this
+ * package's `test` script in package.json, not by vite.test.config.ts — vitest
+ * does not forward execArgv to its pool workers. Running this file directly
+ * with a bare `vitest` will therefore fail here; without gc the weakness of the
+ * request log cannot be observed, so fail loudly rather than quietly skipping
+ * the assertion it underpins.
  */
 const forceGc = (): void => {
 	const gc: (() => void) | undefined = globalThis.gc;
 	if (undefined === gc) {
 		throw new Error(
-			"gc is not exposed; run vitest with --expose-gc (see vite.test.config.ts)",
+			"gc is not exposed; run this suite via `npm run test` in packages/http-blackhole, which sets NODE_OPTIONS=--expose-gc",
 		);
 	}
 	gc();
@@ -233,17 +236,22 @@ describe("createRequestLog", () => {
 			})();
 
 			// A single gc() call is not guaranteed to reach an object that has
-			// just become unreachable, so drive several with the microtask and
-			// macrotask queues drained in between, then give up rather than hang.
+			// just become unreachable, and FinalizationRegistry callbacks are
+			// explicitly not scheduled on any deadline — so drive gc repeatedly
+			// with the microtask and macrotask queues drained in between. The
+			// budget below (100 x 20ms = 2s) is generous rather than tight: a
+			// slow or loaded CI runner must not be able to turn "not collected
+			// yet" into a failed assertion. The test times out long before this
+			// gives up if collection genuinely never happens.
 			let attempts = 0;
 			const collect = (): void => {
-				if (attempts >= 20) {
+				if (attempts >= 100) {
 					resolve(false);
 					return;
 				}
 				attempts += 1;
 				forceGc();
-				setTimeout(collect, 10);
+				setTimeout(collect, 20);
 			};
 			collect();
 		});

--- a/packages/http-blackhole/src/tests/indexEntrypoint.unit.test.ts
+++ b/packages/http-blackhole/src/tests/indexEntrypoint.unit.test.ts
@@ -1,0 +1,182 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The entrypoint runs on import: it binds a port, registers signal handlers and
+// wires process.exit in as the shutdown callback. It therefore gets a file of
+// its own — importing it from a shared file would leak a listening server and a
+// pair of signal handlers into every other test, and vitest shuffles order.
+//
+// PORT=0 keeps the bind from colliding with anything, and process.exit is
+// stubbed before the import so exercising shutdown does not kill the runner.
+
+import type { MockInstance } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/** Matches process.exit, which accepts a string or null code as well. */
+type ExitStub = (code?: string | number | null) => never;
+
+const originalPort: string | undefined = process.env.PORT;
+const signals: NodeJS.Signals[] = ["SIGINT", "SIGTERM"];
+
+/** Signal handlers present before the import, so only new ones are removed. */
+let preexisting: Map<NodeJS.Signals, NodeJS.SignalsListener[]>;
+
+const listenersAddedByImport = (
+	signal: NodeJS.Signals,
+): NodeJS.SignalsListener[] => {
+	const before: NodeJS.SignalsListener[] = preexisting.get(signal) ?? [];
+	return process
+		.listeners(signal)
+		.filter((listener: NodeJS.SignalsListener) => !before.includes(listener));
+};
+
+const waitForLog = async (
+	log: MockInstance<Console["log"]>,
+	fragment: string,
+	timeoutMs = 5000,
+): Promise<boolean> => {
+	const deadline = Date.now() + timeoutMs;
+	const seen = (): boolean =>
+		log.mock.calls.some((call: unknown[]) =>
+			call.some(
+				(arg: unknown) => typeof arg === "string" && arg.includes(fragment),
+			),
+		);
+	while (Date.now() < deadline) {
+		if (seen()) {
+			return true;
+		}
+		await new Promise<void>((resolve) => {
+			setTimeout(resolve, 10);
+		});
+	}
+	return seen();
+};
+
+beforeEach(() => {
+	preexisting = new Map(
+		signals.map((signal: NodeJS.Signals) => [
+			signal,
+			[...process.listeners(signal)],
+		]),
+	);
+	// Bind an ephemeral port: the real default would clash with anything already
+	// running locally, and a clash is an unhandled 'error' that kills the run.
+	process.env.PORT = "0";
+	// The entrypoint does its work as an import side effect, so the module cache
+	// must be cleared or only the first test in this file would actually run it.
+	vi.resetModules();
+});
+
+afterEach(async () => {
+	// Drive shutdown before restoring the process.exit stub: the test's server is
+	// still listening, and its own handler is the only reference to it. Repeat
+	// invocations are ignored by design, so this is safe after a test that has
+	// already shut down.
+	for (const listener of listenersAddedByImport("SIGINT")) {
+		listener("SIGINT");
+	}
+	await new Promise<void>((resolve) => {
+		setTimeout(resolve, 50);
+	});
+	for (const signal of signals) {
+		for (const listener of listenersAddedByImport(signal)) {
+			process.removeListener(signal, listener);
+		}
+	}
+	if (undefined === originalPort) {
+		Reflect.deleteProperty(process.env, "PORT");
+	} else {
+		process.env.PORT = originalPort;
+	}
+	vi.restoreAllMocks();
+});
+
+describe("index entrypoint", () => {
+	it("starts listening and registers both shutdown signals", async () => {
+		const log = vi.spyOn(console, "log").mockImplementation((): void => {});
+		vi.spyOn(process, "exit").mockImplementation(((): void => {}) as ExitStub);
+
+		await import("../index.js");
+
+		expect(await waitForLog(log, "is listening on port")).toBe(true);
+		// Both signals must be wired, not just SIGINT: a container stop sends
+		// SIGTERM, and an unhandled SIGTERM would skip shutdown entirely.
+		expect(listenersAddedByImport("SIGINT")).toHaveLength(1);
+		expect(listenersAddedByImport("SIGTERM")).toHaveLength(1);
+	});
+
+	it("shuts down cleanly and exits zero when signalled", async () => {
+		const log = vi.spyOn(console, "log").mockImplementation((): void => {});
+		const exit = vi
+			.spyOn(process, "exit")
+			.mockImplementation(((): void => {}) as ExitStub);
+
+		await import("../index.js");
+		await waitForLog(log, "is listening on port");
+
+		const handler: NodeJS.SignalsListener | undefined =
+			listenersAddedByImport("SIGINT")[0];
+		if (undefined === handler) {
+			throw new Error("the entrypoint registered no SIGINT handler");
+		}
+		handler("SIGINT");
+
+		// This is the whole reason shutdown severs connections: without that, a
+		// server holding sockets open by design never finishes closing, and this
+		// log line would never arrive.
+		expect(await waitForLog(log, "Server closed. Exiting.")).toBe(true);
+		expect(exit).toHaveBeenCalledWith(0);
+	});
+
+	it("wires the shutdown so a repeat signal is ignored", async () => {
+		const log = vi.spyOn(console, "log").mockImplementation((): void => {});
+		vi.spyOn(process, "exit").mockImplementation(((): void => {}) as ExitStub);
+
+		await import("../index.js");
+		await waitForLog(log, "is listening on port");
+
+		const handler: NodeJS.SignalsListener | undefined =
+			listenersAddedByImport("SIGINT")[0];
+		if (undefined === handler) {
+			throw new Error("the entrypoint registered no SIGINT handler");
+		}
+		// A user holding Ctrl+C sends several in a row; the second must not start
+		// a second close, which would call back with an ERR_SERVER_NOT_RUNNING.
+		handler("SIGINT");
+		handler("SIGINT");
+
+		expect(await waitForLog(log, "Shutdown already in progress")).toBe(true);
+		expect(await waitForLog(log, "Server closed. Exiting.")).toBe(true);
+	});
+
+	it("binds the port taken from the environment", async () => {
+		const log = vi.spyOn(console, "log").mockImplementation((): void => {});
+		vi.spyOn(process, "exit").mockImplementation(((): void => {}) as ExitStub);
+
+		await import("../index.js");
+		await waitForLog(log, "is listening on port");
+
+		// PORT=0 asks the OS for any free port, so the reported port is whatever
+		// was actually bound — proving the value came from the environment and
+		// was not the hardcoded default.
+		const message: string | undefined = log.mock.calls
+			.flat()
+			.find(
+				(arg: unknown): arg is string =>
+					typeof arg === "string" && arg.includes("is listening on port"),
+			);
+		expect(message).toBe("http-blackhole server is listening on port 0");
+	});
+});

--- a/packages/http-blackhole/src/tests/indexEntrypoint.unit.test.ts
+++ b/packages/http-blackhole/src/tests/indexEntrypoint.unit.test.ts
@@ -168,9 +168,10 @@ describe("index entrypoint", () => {
 		await import("../index.js");
 		await waitForLog(log, "is listening on port");
 
-		// PORT=0 asks the OS for any free port, so the reported port is whatever
-		// was actually bound — proving the value came from the environment and
-		// was not the hardcoded default.
+		// The entrypoint logs the configured PORT, not the port the OS actually
+		// bound — with PORT=0 it says 0 while listening on an ephemeral port.
+		// That is what is asserted here: the value came from the environment
+		// rather than from the hardcoded default.
 		const message: string | undefined = log.mock.calls
 			.flat()
 			.find(


### PR DESCRIPTION
Adds `src/tests/blackhole.test-d.ts` (20 type tests). No config change needed — vitest type checking is already on in the shared config.

Pins the injection seams that make this package testable at all:

- `Exit` returns `void`, not `never`. `process.exit` is typed `never`, and using that here would make every line after an exit call unreachable to the compiler — wrong for the recording double the tests inject.
- `Logger.log` takes a single pre-formatted string rather than being variadic, so captured output in tests is directly comparable.
- `resolvePort` accepts `string | undefined`, so callers do not have to narrow `process.env.PORT` before calling; and it rejects a `number`, which would bypass validation entirely.
- `createShutdown` returns a zero-argument handler that `process.on` accepts directly.
- `handleRequest` returns `void` — never responding is the whole point of the package — and takes the socket-keyed map as optional. One test notes explicitly that the weak-keying cannot be enforced by the type system (`Map` is structurally assignable to `WeakMap`), so the declared type is the only signal.

`npm run -w @prosopo/http-blackhole test` → 56 passed (36 runtime + 20 type), no type errors.