### PR TITLE
test(ipinfo): unit + type tests, fix abuser score and response union defects

### DIFF
--- a/.changeset/ipinfo-unit-tests.md
+++ b/.changeset/ipinfo-unit-tests.md
@@ -1,0 +1,11 @@
+---
+"@prosopo/ipinfo": minor
+"@prosopo/types": minor
+---
+
+Add unit and type tests for `@prosopo/ipinfo`, with the injection seams needed to write them.
+
+- `IpapiBackend` accepts an injected `fetch` and a configurable `timeoutMs`; `MaxMindBackend` accepts an injected `openReader`; `IpInfoService` accepts injected backends.
+- `parseAbuserScore` no longer throws when the upstream omits `abuser_score`. The field is declared required by the response type but is not validated on the wire, and a missing value used to turn an otherwise successful lookup into a generic "Network or parsing error".
+- `IPInfoResult.isValid` is now the literal `true` rather than `boolean`, making `IPInfoResponse` an actually discriminated union. Previously `if (!res.isValid)` narrowed to nothing, so `res.error` did not compile and consumers had to cast.
+- The backends, their config types and the injection seams are re-exported from the package entrypoint, along with `isNonRoutable`.

--- a/packages/ipinfo/package.json
+++ b/packages/ipinfo/package.json
@@ -22,7 +22,9 @@
 		"build:cross-env": "vite build --config vite.esm.config.ts",
 		"build:tsc": "tsc --build --verbose",
 		"build:cjs": "NODE_ENV=${NODE_ENV:-development}; vite build --config vite.cjs.config.ts --mode $NODE_ENV",
-		"typecheck": "tsc --project tsconfig.types.json"
+		"typecheck": "tsc --project tsconfig.types.json",
+		"test": "NODE_ENV=${NODE_ENV:-test}; npx vitest run --config ./vite.test.config.ts",
+		"test:watch": "NODE_ENV=${NODE_ENV:-test}; npx vitest watch --config ./vite.test.config.ts"
 	},
 	"dependencies": {
 		"@maxmind/geoip2-node": "5.0.0",

--- a/packages/ipinfo/src/IpInfoService.ts
+++ b/packages/ipinfo/src/IpInfoService.ts
@@ -21,7 +21,7 @@ import type { IIpInfoService, IpInfoServiceConfig } from "./types.js";
  * Returns true for loopback, link-local, and private-range IPs that will
  * never yield useful geolocation or threat data from any backend.
  */
-function isNonRoutable(ip: string): boolean {
+export function isNonRoutable(ip: string): boolean {
 	// Strip IPv4-mapped IPv6 prefix (::ffff:127.0.0.1 -> 127.0.0.1)
 	const normalized = ip.replace(/^::ffff:/i, "");
 
@@ -54,13 +54,30 @@ function isNonRoutable(ip: string): boolean {
 	return false;
 }
 
+/**
+ * The two backends, injected so the routing and fallback logic above can be
+ * tested without a MaxMind database on disk or a network call. Both are
+ * optional: absent means "not configured", which is distinct from "configured
+ * but unavailable".
+ */
+export interface IpInfoBackends {
+	maxmind?: MaxMindBackend | null;
+	ipapi?: IpapiBackend | null;
+}
+
 export class IpInfoService implements IIpInfoService {
 	private maxmindBackend: MaxMindBackend | null = null;
 	private ipapiBackend: IpapiBackend | null = null;
 	private config: IpInfoServiceConfig;
 
-	constructor(config: IpInfoServiceConfig) {
+	constructor(config: IpInfoServiceConfig, backends?: IpInfoBackends) {
 		this.config = config;
+
+		if (backends) {
+			this.maxmindBackend = backends.maxmind ?? null;
+			this.ipapiBackend = backends.ipapi ?? null;
+			return;
+		}
 
 		if (config.maxmindCityDbPath || config.maxmindAsnDbPath) {
 			this.maxmindBackend = new MaxMindBackend({

--- a/packages/ipinfo/src/backends/ipapi.ts
+++ b/packages/ipinfo/src/backends/ipapi.ts
@@ -19,13 +19,44 @@ import type {
 	IPInfoResult,
 } from "@prosopo/types";
 
-const TIMEOUT_MS = 700;
+/**
+ * Default per-lookup budget. Short on purpose: an IP lookup sits in the request
+ * path, so a slow backend must not hold up the decision that depends on it.
+ */
+export const DEFAULT_TIMEOUT_MS = 700;
+
+/** The subset of global fetch this backend uses. Injected so tests need no network. */
+export type FetchFn = (
+	url: string,
+	init: RequestInit,
+) => Promise<globalThis.Response>;
 
 export interface IpapiBackendConfig {
 	baseUrl: string;
 	apiKey?: string;
 	logger?: Logger;
+	/** Overridden in tests; defaults to the global fetch. */
+	fetch?: FetchFn;
+	/** Overridden in tests and tunable in deployment; defaults to DEFAULT_TIMEOUT_MS. */
+	timeoutMs?: number;
 }
+
+/**
+ * Parse an upstream abuser score, which arrives as a string like "0.0012 (Low)".
+ *
+ * The field is declared required by the response type but is not guaranteed by
+ * the wire: it comes from `response.json()`, which is cast, not validated. A
+ * missing value used to throw, and the throw was caught far above as a generic
+ * "Network or parsing error" — discarding an otherwise complete and successful
+ * lookup over one absent score.
+ */
+export const parseAbuserScore = (score: string | undefined): number => {
+	const parsed = Number.parseFloat(score?.split(" ")[0] || "0");
+	// A non-numeric score is unknown, not "clean"; but callers compare this
+	// against thresholds, and NaN silently fails every comparison. 0 is the
+	// same answer the empty-string fallback above already gives.
+	return Number.isNaN(parsed) ? 0 : parsed;
+};
 
 export class IpapiBackend {
 	private config: IpapiBackendConfig;
@@ -36,6 +67,10 @@ export class IpapiBackend {
 
 	isAvailable(): boolean {
 		return Boolean(this.config.baseUrl);
+	}
+
+	private get timeoutMs(): number {
+		return this.config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
 	}
 
 	async lookup(ip: string): Promise<IPInfoResponse> {
@@ -54,10 +89,11 @@ export class IpapiBackend {
 			}
 
 			const controller = new AbortController();
-			const timeoutId = setTimeout(() => controller.abort(), TIMEOUT_MS);
+			const timeoutId = setTimeout(() => controller.abort(), this.timeoutMs);
 
 			try {
-				const response = await fetch(this.config.baseUrl, {
+				const doFetch: FetchFn = this.config.fetch ?? globalThis.fetch;
+				const response = await doFetch(this.config.baseUrl, {
 					method: "POST",
 					headers: {
 						"Content-Type": "application/json",
@@ -116,12 +152,8 @@ export class IpapiBackend {
 					vpnService: data.vpn?.service,
 					vpnType: data.vpn?.type,
 
-					abuserScore: Number.parseFloat(
-						data.asn?.abuser_score.split(" ")[0] || "0",
-					),
-					companyAbuserScore: Number.parseFloat(
-						data.company?.abuser_score.split(" ")[0] || "0",
-					),
+					abuserScore: parseAbuserScore(data.asn?.abuser_score),
+					companyAbuserScore: parseAbuserScore(data.company?.abuser_score),
 				};
 
 				return result;
@@ -131,7 +163,7 @@ export class IpapiBackend {
 				if (fetchError instanceof Error && fetchError.name === "AbortError") {
 					return {
 						isValid: false,
-						error: `Request timed out after ${TIMEOUT_MS}ms`,
+						error: `Request timed out after ${this.timeoutMs}ms`,
 						ip,
 					};
 				}

--- a/packages/ipinfo/src/backends/ipapi.ts
+++ b/packages/ipinfo/src/backends/ipapi.ts
@@ -49,13 +49,28 @@ export interface IpapiBackendConfig {
  * missing value used to throw, and the throw was caught far above as a generic
  * "Network or parsing error" — discarding an otherwise complete and successful
  * lookup over one absent score.
+ *
+ * Returns `undefined` — not 0 — when the field is absent or unparseable. The
+ * scale is 0..1 with 0 meaning "clean" (see `abuserScoreThreshold`, declared
+ * `{min: 0, max: 1}`), so a literal 0 would assert cleanliness we have not
+ * established. `undefined` says "unknown" instead, and the one consumer
+ * (checkTrafficFilter) already resolves it with `?? 0`, so the effective
+ * blocking behaviour is unchanged while the distinction stays available.
+ *
+ * Fail-closed alternatives were rejected: 1 turns any upstream formatting
+ * change into a silent max-severity block indistinguishable from a genuine
+ * 1.0, and throwing reintroduces exactly the bug above — a cosmetic sub-field
+ * collapsing a good lookup into a total failure.
  */
-export const parseAbuserScore = (score: string | undefined): number => {
-	const parsed = Number.parseFloat(score?.split(" ")[0] || "0");
-	// A non-numeric score is unknown, not "clean"; but callers compare this
-	// against thresholds, and NaN silently fails every comparison. 0 is the
-	// same answer the empty-string fallback above already gives.
-	return Number.isNaN(parsed) ? 0 : parsed;
+export const parseAbuserScore = (
+	score: string | undefined,
+): number | undefined => {
+	const head = score?.split(" ")[0];
+	if (!head) {
+		return undefined;
+	}
+	const parsed = Number.parseFloat(head);
+	return Number.isNaN(parsed) ? undefined : parsed;
 };
 
 export class IpapiBackend {

--- a/packages/ipinfo/src/backends/maxmind.ts
+++ b/packages/ipinfo/src/backends/maxmind.ts
@@ -185,7 +185,7 @@ export class MaxMindBackend {
 	}
 }
 
-type MaxMindUserType =
+export type MaxMindUserType =
 	| "business"
 	| "cafe"
 	| "cellular"

--- a/packages/ipinfo/src/backends/maxmind.ts
+++ b/packages/ipinfo/src/backends/maxmind.ts
@@ -16,10 +16,28 @@ import type { Asn, City, ReaderModel } from "@maxmind/geoip2-node";
 import type { Logger } from "@prosopo/logger";
 import type { IPInfoResponse, IPInfoResult } from "@prosopo/types";
 
+/**
+ * Opens a MaxMind database file. Injected so tests can exercise initialisation
+ * and lookup without shipping a .mmdb fixture, and so a failure to open one can
+ * be simulated at all — the real Reader only fails on a genuinely bad file.
+ */
+export type OpenReader = (dbPath: string) => Promise<ReaderModel>;
+
+const openReaderFromFile: OpenReader = async (
+	dbPath: string,
+): Promise<ReaderModel> => {
+	// Imported lazily: the module pulls in native-ish decoding machinery that a
+	// deployment without MaxMind databases should never pay for.
+	const { Reader } = await import("@maxmind/geoip2-node");
+	return Reader.open(dbPath);
+};
+
 export interface MaxMindBackendConfig {
 	cityDbPath?: string;
 	asnDbPath?: string;
 	logger?: Logger;
+	/** Overridden in tests; defaults to opening the file from disk. */
+	openReader?: OpenReader;
 }
 
 export class MaxMindBackend {
@@ -32,11 +50,11 @@ export class MaxMindBackend {
 	}
 
 	async initialize(): Promise<void> {
-		const { Reader } = await import("@maxmind/geoip2-node");
+		const openReader: OpenReader = this.config.openReader ?? openReaderFromFile;
 
 		if (this.config.cityDbPath) {
 			try {
-				this.cityReader = await Reader.open(this.config.cityDbPath);
+				this.cityReader = await openReader(this.config.cityDbPath);
 				this.config.logger?.info(() => ({
 					msg: "MaxMind City reader initialized",
 					data: { dbPath: this.config.cityDbPath },
@@ -52,7 +70,7 @@ export class MaxMindBackend {
 
 		if (this.config.asnDbPath) {
 			try {
-				this.asnReader = await Reader.open(this.config.asnDbPath);
+				this.asnReader = await openReader(this.config.asnDbPath);
 				this.config.logger?.info(() => ({
 					msg: "MaxMind ASN reader initialized",
 					data: { dbPath: this.config.asnDbPath },

--- a/packages/ipinfo/src/index.ts
+++ b/packages/ipinfo/src/index.ts
@@ -12,5 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export { IpInfoService } from "./IpInfoService.js";
+export { IpInfoService, isNonRoutable } from "./IpInfoService.js";
+export type { IpInfoBackends } from "./IpInfoService.js";
+// The backends and their injection seams are part of the surface: without them
+// a consumer cannot substitute either backend, and callers that already know an
+// address is private cannot skip the lookup.
+export { IpapiBackend } from "./backends/ipapi.js";
+export type { FetchFn, IpapiBackendConfig } from "./backends/ipapi.js";
+export { MaxMindBackend } from "./backends/maxmind.js";
+export type { MaxMindBackendConfig, OpenReader } from "./backends/maxmind.js";
 export type { IIpInfoService, IpInfoServiceConfig } from "./types.js";

--- a/packages/ipinfo/src/tests/ipInfoService.unit.test.ts
+++ b/packages/ipinfo/src/tests/ipInfoService.unit.test.ts
@@ -1,0 +1,422 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The service is pure routing: which backend answers, in what order, and what
+// happens when one of them declines. The backends are therefore injected as
+// stubs whose availability and answers each test controls directly — using the
+// real ones would put a network call and a database file between the test and
+// the branch it is trying to reach.
+
+import type { IPInfoResponse, IPInfoResult } from "@prosopo/types";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	type IpInfoBackends,
+	IpInfoService,
+	isNonRoutable,
+} from "../IpInfoService.js";
+import type { IpapiBackend } from "../backends/ipapi.js";
+import type { MaxMindBackend } from "../backends/maxmind.js";
+import type { IpInfoServiceConfig } from "../types.js";
+
+const IP = "8.8.8.8";
+
+const result = (source: string): IPInfoResult => ({
+	isValid: true,
+	ip: IP,
+	countryCode: source,
+	isVPN: false,
+	isTor: false,
+	isProxy: false,
+	isDatacenter: false,
+	isAbuser: false,
+	isMobile: false,
+	isSatellite: false,
+	isCrawler: false,
+});
+
+const failure = (error: string): IPInfoResponse => ({
+	isValid: false,
+	error,
+	ip: IP,
+});
+
+interface StubBackend {
+	initialize: () => Promise<void>;
+	isAvailable: () => boolean;
+	lookup: (ip: string) => Promise<IPInfoResponse>;
+}
+
+const stub = (
+	available: boolean,
+	answer: IPInfoResponse = result("stub"),
+): StubBackend => ({
+	initialize: vi.fn<() => Promise<void>>(async () => {}),
+	isAvailable: vi.fn<() => boolean>(() => available),
+	lookup: vi.fn<(ip: string) => Promise<IPInfoResponse>>(async () => answer),
+});
+
+/**
+ * The stubs implement the whole interface the service uses, but not the private
+ * fields of the concrete classes, so the injection point needs a cast. Confined
+ * to this one helper rather than repeated at every call site.
+ */
+const service = (
+	backends: { maxmind?: StubBackend; ipapi?: StubBackend },
+	config: IpInfoServiceConfig = {},
+): IpInfoService =>
+	new IpInfoService(config, {
+		maxmind: backends.maxmind as unknown as MaxMindBackend,
+		ipapi: backends.ipapi as unknown as IpapiBackend,
+	} satisfies IpInfoBackends);
+
+describe("isNonRoutable", () => {
+	it("rejects the IPv4 loopback and private ranges", () => {
+		for (const ip of [
+			"127.0.0.1",
+			"127.255.255.255",
+			"10.0.0.1",
+			"192.168.1.1",
+			"169.254.1.1",
+			"0.0.0.0",
+		]) {
+			expect(isNonRoutable(ip), ip).toBe(true);
+		}
+	});
+
+	it("rejects the whole 172.16/12 block and nothing either side of it", () => {
+		// The boundaries matter: 172.15 and 172.32 are public address space, and
+		// treating them as private would silently blind the service to them.
+		expect(isNonRoutable("172.16.0.0")).toBe(true);
+		expect(isNonRoutable("172.31.255.255")).toBe(true);
+		expect(isNonRoutable("172.15.0.1")).toBe(false);
+		expect(isNonRoutable("172.32.0.1")).toBe(false);
+		expect(isNonRoutable("172.217.16.1")).toBe(false);
+	});
+
+	it("treats a malformed 172. address as routable rather than crashing", () => {
+		// parseInt of a missing or non-numeric octet yields NaN, and every
+		// comparison against NaN is false — so this must fall through, not throw.
+		expect(isNonRoutable("172.")).toBe(false);
+		expect(isNonRoutable("172.abc.0.1")).toBe(false);
+	});
+
+	it("sees through the IPv4-mapped IPv6 prefix", () => {
+		// A request arriving on a dual-stack socket presents 127.0.0.1 in this
+		// form; missing it would send loopback traffic to a paid upstream.
+		expect(isNonRoutable("::ffff:127.0.0.1")).toBe(true);
+		expect(isNonRoutable("::FFFF:192.168.0.1")).toBe(true);
+		expect(isNonRoutable("::ffff:8.8.8.8")).toBe(false);
+	});
+
+	it("rejects the IPv6 loopback, unspecified, ULA and link-local ranges", () => {
+		for (const ip of [
+			"::1",
+			"::",
+			"fc00::1",
+			"fd12:3456::1",
+			"FD00::1",
+			"fe80::1",
+			"feb0::1",
+			"FE80::1",
+		]) {
+			expect(isNonRoutable(ip), ip).toBe(true);
+		}
+	});
+
+	it("accepts public IPv4 and IPv6 addresses", () => {
+		for (const ip of [
+			"8.8.8.8",
+			"1.1.1.1",
+			"2001:4860:4860::8888",
+			"fec0::1",
+		]) {
+			expect(isNonRoutable(ip), ip).toBe(false);
+		}
+	});
+
+	it("treats an empty string as routable", () => {
+		// Not this function's job to validate: the backends reject it, and
+		// claiming "non-routable" would hide a caller bug behind a plausible
+		// looking answer.
+		expect(isNonRoutable("")).toBe(false);
+	});
+});
+
+describe("IpInfoService construction", () => {
+	it("builds no backends when nothing is configured", () => {
+		expect(new IpInfoService({}).isAvailable()).toBe(false);
+	});
+
+	it("builds MaxMind from either database path alone", async () => {
+		// Only one of the two databases being licensed is a normal deployment.
+		const city = new IpInfoService({ maxmindCityDbPath: "/city.mmdb" });
+		const asn = new IpInfoService({ maxmindAsnDbPath: "/asn.mmdb" });
+
+		// Unopened, so still unavailable — but constructed, which the lookup
+		// error message distinguishes.
+		expect(await city.lookup(IP)).toEqual(
+			failure("No IP info backend available"),
+		);
+		expect(await asn.lookup(IP)).toEqual(
+			failure("No IP info backend available"),
+		);
+	});
+
+	it("builds ipapi when a url is configured", () => {
+		expect(
+			new IpInfoService({ ipapiUrl: "https://api.ipapi.is" }).isAvailable(),
+		).toBe(true);
+	});
+
+	it("does not build ipapi from a key with no url", () => {
+		// A key without an endpoint is a half-finished configuration; guessing a
+		// default endpoint would send credentials somewhere never asked for.
+		expect(new IpInfoService({ ipapiKey: "secret" }).isAvailable()).toBe(false);
+	});
+
+	it("uses injected backends in place of configured ones", () => {
+		// Injection must win outright: a config that would otherwise build a real
+		// ipapi backend must not leave a second one behind.
+		const ipapi = stub(false);
+		const svc = service({ ipapi }, { ipapiUrl: "https://api.ipapi.is" });
+
+		expect(svc.isAvailable()).toBe(false);
+		expect(ipapi.isAvailable).toHaveBeenCalled();
+	});
+});
+
+describe("IpInfoService.initialize", () => {
+	it("initializes MaxMind and leaves ipapi alone", async () => {
+		// ipapi is stateless — there is nothing to open — so an initialize call
+		// against it would be dead work on every boot.
+		const maxmind = stub(true);
+		const ipapi = stub(true);
+
+		await service({ maxmind, ipapi }).initialize();
+
+		expect(maxmind.initialize).toHaveBeenCalledTimes(1);
+		expect(ipapi.initialize).not.toHaveBeenCalled();
+	});
+
+	it("succeeds when there are no backends at all", async () => {
+		await expect(new IpInfoService({}).initialize()).resolves.toBeUndefined();
+	});
+
+	it("logs the availability of both backends", async () => {
+		const info = vi.fn();
+		await service(
+			{ maxmind: stub(true), ipapi: stub(false) },
+			{ logger: { info } as never },
+		).initialize();
+
+		expect(info).toHaveBeenCalledTimes(1);
+		const entry = info.mock.calls[0]?.[0];
+		expect(typeof entry).toBe("function");
+		expect(entry()).toMatchObject({
+			data: { maxmindAvailable: true, ipapiAvailable: false },
+		});
+	});
+
+	it("propagates a MaxMind initialize failure", async () => {
+		// MaxMind swallows its own open failures, so anything reaching here is
+		// unexpected and must surface at boot rather than as a silent lookup gap.
+		const maxmind = stub(true);
+		maxmind.initialize = vi.fn<() => Promise<void>>(async () => {
+			throw new Error("disk on fire");
+		});
+
+		await expect(service({ maxmind }).initialize()).rejects.toThrow(
+			"disk on fire",
+		);
+	});
+});
+
+describe("IpInfoService.isAvailable", () => {
+	it.each([
+		[true, true, true],
+		[true, false, true],
+		[false, true, true],
+		[false, false, false],
+	])(
+		"maxmind=%s ipapi=%s -> %s",
+		(maxmindUp: boolean, ipapiUp: boolean, expected: boolean) => {
+			expect(
+				service({
+					maxmind: stub(maxmindUp),
+					ipapi: stub(ipapiUp),
+				}).isAvailable(),
+			).toBe(expected);
+		},
+	);
+});
+
+describe("IpInfoService.lookup", () => {
+	let maxmind: StubBackend;
+	let ipapi: StubBackend;
+
+	beforeEach(() => {
+		maxmind = stub(true, result("maxmind"));
+		ipapi = stub(true, result("ipapi"));
+	});
+
+	it("short-circuits a non-routable IP without touching a backend", async () => {
+		// The important half of this assertion is the second: a loopback lookup
+		// must not spend a paid ipapi credit.
+		await expect(
+			service({ maxmind, ipapi }).lookup("127.0.0.1"),
+		).resolves.toEqual({
+			isValid: false,
+			error: "Non-routable IP address",
+			ip: "127.0.0.1",
+		});
+		expect(ipapi.lookup).not.toHaveBeenCalled();
+		expect(maxmind.lookup).not.toHaveBeenCalled();
+	});
+
+	it("prefers ipapi when both are available", async () => {
+		// ipapi carries the threat data MaxMind's free databases do not.
+		const response = await service({ maxmind, ipapi }).lookup(IP);
+
+		expect(response).toEqual(result("ipapi"));
+		expect(maxmind.lookup).not.toHaveBeenCalled();
+	});
+
+	it("falls back to MaxMind when ipapi returns an invalid result", async () => {
+		ipapi = stub(true, failure("upstream 503"));
+
+		await expect(service({ maxmind, ipapi }).lookup(IP)).resolves.toEqual(
+			result("maxmind"),
+		);
+	});
+
+	it("returns the ipapi error when MaxMind cannot cover for it", async () => {
+		// Reporting the real upstream error beats a generic "no backend" message
+		// that would send someone looking at the wrong system.
+		ipapi = stub(true, failure("upstream 503"));
+
+		await expect(
+			service({ maxmind: stub(false), ipapi }).lookup(IP),
+		).resolves.toEqual(failure("upstream 503"));
+	});
+
+	it("returns the ipapi error when MaxMind is not configured at all", async () => {
+		ipapi = stub(true, failure("upstream 503"));
+
+		await expect(service({ ipapi }).lookup(IP)).resolves.toEqual(
+			failure("upstream 503"),
+		);
+	});
+
+	it("logs the fallback with the upstream error attached", async () => {
+		const debug = vi.fn();
+		ipapi = stub(true, failure("upstream 503"));
+
+		await service({ maxmind, ipapi }, { logger: { debug } as never }).lookup(
+			IP,
+		);
+
+		expect(debug).toHaveBeenCalledTimes(1);
+		expect(debug.mock.calls[0]?.[0]()).toMatchObject({
+			data: { ip: IP, error: "upstream 503" },
+		});
+	});
+
+	it("logs 'unknown' when the failed result carries no error field", async () => {
+		// The result type permits it; the log line must stay well-formed rather
+		// than printing undefined.
+		const debug = vi.fn();
+		ipapi = stub(true, { isValid: false, ip: IP } as IPInfoResponse);
+
+		await service({ maxmind, ipapi }, { logger: { debug } as never }).lookup(
+			IP,
+		);
+
+		expect(debug.mock.calls[0]?.[0]()).toMatchObject({
+			data: { error: "unknown" },
+		});
+	});
+
+	it("does not log a fallback when ipapi succeeds", async () => {
+		const debug = vi.fn();
+
+		await service({ maxmind, ipapi }, { logger: { debug } as never }).lookup(
+			IP,
+		);
+
+		expect(debug).not.toHaveBeenCalled();
+	});
+
+	it("uses MaxMind alone when ipapi is unavailable", async () => {
+		// Unavailable is checked before the call, so no failed request is made.
+		const down = stub(false);
+		const response = await service({ maxmind, ipapi: down }).lookup(IP);
+
+		expect(response).toEqual(result("maxmind"));
+		expect(down.lookup).not.toHaveBeenCalled();
+	});
+
+	it("reports that no backend is available when neither is", async () => {
+		await expect(
+			service({ maxmind: stub(false), ipapi: stub(false) }).lookup(IP),
+		).resolves.toEqual(failure("No IP info backend available"));
+	});
+
+	it("reports that no backend is available when none is configured", async () => {
+		await expect(new IpInfoService({}).lookup(IP)).resolves.toEqual(
+			failure("No IP info backend available"),
+		);
+	});
+
+	it("passes the IP through to the backend unmodified", async () => {
+		// Normalisation happens inside isNonRoutable only; the backend must see
+		// exactly what the caller supplied.
+		await service({ ipapi }).lookup("2001:4860:4860::8888");
+
+		expect(ipapi.lookup).toHaveBeenCalledWith("2001:4860:4860::8888");
+	});
+
+	it("does not catch a backend that throws", async () => {
+		// Deliberate: both backends convert their own failures into invalid
+		// results, so a throw reaching here is a bug and must not be disguised as
+		// a routine lookup miss.
+		ipapi.lookup = vi.fn<(ip: string) => Promise<IPInfoResponse>>(async () => {
+			throw new Error("unexpected");
+		});
+
+		await expect(service({ maxmind, ipapi }).lookup(IP)).rejects.toThrow(
+			"unexpected",
+		);
+		expect(maxmind.lookup).not.toHaveBeenCalled();
+	});
+
+	it("re-checks availability on every lookup", async () => {
+		// A backend can come up between calls; the answer must not be cached at
+		// construction time.
+		let up = false;
+		const flaky: StubBackend = {
+			initialize: vi.fn<() => Promise<void>>(async () => {}),
+			isAvailable: vi.fn<() => boolean>(() => up),
+			lookup: vi.fn<(ip: string) => Promise<IPInfoResponse>>(async () =>
+				result("recovered"),
+			),
+		};
+		const svc = service({ ipapi: flaky });
+
+		expect(await svc.lookup(IP)).toEqual(
+			failure("No IP info backend available"),
+		);
+		up = true;
+		expect(await svc.lookup(IP)).toEqual(result("recovered"));
+	});
+});

--- a/packages/ipinfo/src/tests/ipapi.unit.test.ts
+++ b/packages/ipinfo/src/tests/ipapi.unit.test.ts
@@ -103,27 +103,33 @@ describe("parseAbuserScore", () => {
 		expect(parseAbuserScore("0.5")).toBe(0.5);
 	});
 
-	it("treats a missing score as zero rather than throwing", () => {
+	it("reports a missing score as unknown rather than throwing", () => {
 		// The field is declared required but comes from unvalidated JSON. It used
 		// to be dereferenced directly, so an absent score threw and the throw was
 		// caught far above as a generic parsing error — discarding an otherwise
 		// complete lookup.
-		expect(parseAbuserScore(undefined)).toBe(0);
+		expect(parseAbuserScore(undefined)).toBeUndefined();
 	});
 
-	it("treats an empty string as zero", () => {
-		expect(parseAbuserScore("")).toBe(0);
+	it("reports an empty string as unknown", () => {
+		expect(parseAbuserScore("")).toBeUndefined();
 	});
 
-	it("returns zero rather than NaN for a non-numeric score", () => {
-		// Callers compare this against thresholds, and every comparison against
-		// NaN is false — the IP would silently pass checks it should not.
-		expect(parseAbuserScore("unknown")).toBe(0);
-		expect(parseAbuserScore("(Low)")).toBe(0);
+	it("reports a non-numeric score as unknown, never NaN", () => {
+		// NaN would be the worst outcome: callers compare this against
+		// thresholds, and every comparison against NaN is false, so the IP would
+		// silently pass checks it should not.
+		expect(parseAbuserScore("unknown")).toBeUndefined();
+		expect(parseAbuserScore("(Low)")).toBeUndefined();
 	});
 
-	it("handles a score of exactly zero", () => {
+	it("distinguishes a genuine zero from an unknown score", () => {
+		// 0 means "measured, and clean" on the 0..1 scale; undefined means "we
+		// have no measurement". Collapsing the two would assert cleanliness that
+		// was never established.
 		expect(parseAbuserScore("0 (Very Low)")).toBe(0);
+		expect(parseAbuserScore("0")).toBe(0);
+		expect(parseAbuserScore(undefined)).toBeUndefined();
 	});
 });
 
@@ -307,8 +313,8 @@ describe("IpapiBackend.lookup responses", () => {
 		expect(result.country).toBeUndefined();
 		expect(result.asnNumber).toBeUndefined();
 		expect(result.providerName).toBeUndefined();
-		expect(result.abuserScore).toBe(0);
-		expect(result.companyAbuserScore).toBe(0);
+		expect(result.abuserScore).toBeUndefined();
+		expect(result.companyAbuserScore).toBeUndefined();
 	});
 
 	it("keeps a successful lookup when the abuser scores are absent", async () => {
@@ -341,7 +347,7 @@ describe("IpapiBackend.lookup responses", () => {
 
 		expect(result.isValid).toBe(true);
 		expect(result.asnNumber).toBe(64512);
-		expect(result.abuserScore).toBe(0);
+		expect(result.abuserScore).toBeUndefined();
 	});
 
 	it("prefers the company name but falls back to the datacenter", async () => {

--- a/packages/ipinfo/src/tests/ipapi.unit.test.ts
+++ b/packages/ipinfo/src/tests/ipapi.unit.test.ts
@@ -1,0 +1,503 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Testing strategy: fetch is the only seam that touches the outside world, so
+// it is injected and everything else runs for real — including JSON parsing and
+// the AbortController timeout, which is driven by a fetch that genuinely
+// respects the signal rather than by a stubbed clock.
+//
+// The response body is deliberately treated as untrusted here: it is typed as
+// IPApiResponse but arrives from `response.json()`, which casts rather than
+// validates, so the tests cover fields the type claims are required going
+// missing on the wire.
+
+import type { IPApiResponse, IPInfoResult } from "@prosopo/types";
+import { describe, expect, it, vi } from "vitest";
+import {
+	DEFAULT_TIMEOUT_MS,
+	type FetchFn,
+	IpapiBackend,
+	parseAbuserScore,
+} from "../backends/ipapi.js";
+
+const BASE_URL = "https://api.ipapi.test/";
+const IP = "8.8.8.8";
+
+/** Minimal valid upstream payload; individual tests layer fields on top. */
+const baseResponse = (
+	overrides: Partial<IPApiResponse> = {},
+): IPApiResponse => ({
+	ip: IP,
+	rir: "ARIN",
+	is_bogon: false,
+	is_mobile: false,
+	is_satellite: false,
+	is_crawler: false,
+	is_datacenter: false,
+	is_tor: false,
+	is_proxy: false,
+	is_vpn: false,
+	is_abuser: false,
+	elapsed_ms: 1,
+	...overrides,
+});
+
+/** A fetch that answers with the given JSON body and status. */
+const respondWith = (
+	body: unknown,
+	init: { status?: number; statusText?: string } = {},
+): FetchFn => {
+	return async (): Promise<globalThis.Response> =>
+		new Response(JSON.stringify(body), {
+			status: init.status ?? 200,
+			statusText: init.statusText ?? "OK",
+			headers: { "Content-Type": "application/json" },
+		});
+};
+
+/** A fetch that never answers until the caller's signal aborts. */
+const respondNever: FetchFn = (_url: string, init: RequestInit) =>
+	new Promise<globalThis.Response>((_resolve, reject) => {
+		init.signal?.addEventListener("abort", () => {
+			// Matches what the platform throws on an aborted fetch: the backend
+			// keys its timeout branch off the name, not the type.
+			const error = new Error("The operation was aborted");
+			error.name = "AbortError";
+			reject(error);
+		});
+	});
+
+const backend = (
+	fetchFn: FetchFn,
+	extra: { apiKey?: string; timeoutMs?: number } = {},
+): IpapiBackend =>
+	new IpapiBackend({ baseUrl: BASE_URL, fetch: fetchFn, ...extra });
+
+/** Narrow a response to the success branch, failing loudly if it is an error. */
+const expectValid = (
+	response: Awaited<ReturnType<IpapiBackend["lookup"]>>,
+): IPInfoResult => {
+	if (!response.isValid) {
+		throw new Error(`expected a valid result, got: ${response.error}`);
+	}
+	return response;
+};
+
+describe("parseAbuserScore", () => {
+	it("reads the numeric prefix of a scored string", () => {
+		expect(parseAbuserScore("0.0012 (Low)")).toBeCloseTo(0.0012);
+	});
+
+	it("reads a bare number with no qualifier", () => {
+		expect(parseAbuserScore("0.5")).toBe(0.5);
+	});
+
+	it("treats a missing score as zero rather than throwing", () => {
+		// The field is declared required but comes from unvalidated JSON. It used
+		// to be dereferenced directly, so an absent score threw and the throw was
+		// caught far above as a generic parsing error — discarding an otherwise
+		// complete lookup.
+		expect(parseAbuserScore(undefined)).toBe(0);
+	});
+
+	it("treats an empty string as zero", () => {
+		expect(parseAbuserScore("")).toBe(0);
+	});
+
+	it("returns zero rather than NaN for a non-numeric score", () => {
+		// Callers compare this against thresholds, and every comparison against
+		// NaN is false — the IP would silently pass checks it should not.
+		expect(parseAbuserScore("unknown")).toBe(0);
+		expect(parseAbuserScore("(Low)")).toBe(0);
+	});
+
+	it("handles a score of exactly zero", () => {
+		expect(parseAbuserScore("0 (Very Low)")).toBe(0);
+	});
+});
+
+describe("IpapiBackend.isAvailable", () => {
+	it("is available when a base url is configured", () => {
+		expect(backend(respondWith(baseResponse())).isAvailable()).toBe(true);
+	});
+
+	it("is unavailable when the base url is blank", () => {
+		// An unset env var arrives as "", which must not be treated as a usable
+		// endpoint — every lookup would POST to a relative path.
+		const blank = new IpapiBackend({ baseUrl: "" });
+		expect(blank.isAvailable()).toBe(false);
+	});
+});
+
+describe("IpapiBackend.lookup request", () => {
+	it("posts the ip as JSON to the configured url", async () => {
+		const fetchFn = vi.fn<FetchFn>(respondWith(baseResponse()));
+		await backend(fetchFn).lookup(IP);
+
+		const [url, init] = fetchFn.mock.calls[0] ?? [];
+		expect(url).toBe(BASE_URL);
+		expect(init?.method).toBe("POST");
+		expect(JSON.parse(String(init?.body))).toEqual({ q: IP });
+	});
+
+	it("includes the api key when one is configured", async () => {
+		const fetchFn = vi.fn<FetchFn>(respondWith(baseResponse()));
+		await backend(fetchFn, { apiKey: "secret" }).lookup(IP);
+
+		const init = fetchFn.mock.calls[0]?.[1];
+		expect(JSON.parse(String(init?.body))).toEqual({ q: IP, key: "secret" });
+	});
+
+	it("omits the key entirely when none is configured", async () => {
+		// Sending `key: undefined` would serialise the field away anyway, but an
+		// empty-string key would be sent and rejected upstream.
+		const fetchFn = vi.fn<FetchFn>(respondWith(baseResponse()));
+		await backend(fetchFn).lookup(IP);
+
+		expect(
+			JSON.parse(String(fetchFn.mock.calls[0]?.[1]?.body)),
+		).not.toHaveProperty("key");
+	});
+
+	it("asks for and declares JSON", async () => {
+		const fetchFn = vi.fn<FetchFn>(respondWith(baseResponse()));
+		await backend(fetchFn).lookup(IP);
+
+		const headers = fetchFn.mock.calls[0]?.[1]?.headers;
+		expect(headers).toMatchObject({
+			"Content-Type": "application/json",
+			Accept: "application/json",
+		});
+	});
+});
+
+describe("IpapiBackend.lookup input validation", () => {
+	it("rejects an empty ip without calling out", async () => {
+		// Length 0: the upstream would answer about the caller's own address,
+		// which is a wrong answer rather than an error.
+		const fetchFn = vi.fn<FetchFn>(respondWith(baseResponse()));
+		const result = await backend(fetchFn).lookup("");
+
+		expect(result).toEqual({
+			isValid: false,
+			error: "Invalid IP address provided",
+			ip: "undefined",
+		});
+		expect(fetchFn).not.toHaveBeenCalled();
+	});
+
+	it("does not send a lookup for a non-string ip from an untyped caller", async () => {
+		// This package is consumed from JavaScript too, where the type guard is
+		// the only thing standing between a bad value and the upstream.
+		const fetchFn = vi.fn<FetchFn>(respondWith(baseResponse()));
+		const untyped: (ip: unknown) => Promise<unknown> = (ip: unknown) =>
+			backend(fetchFn).lookup(ip as string);
+
+		await expect(untyped(null)).resolves.toMatchObject({ isValid: false });
+		expect(fetchFn).not.toHaveBeenCalled();
+	});
+});
+
+describe("IpapiBackend.lookup responses", () => {
+	it("maps a full response onto the shared result shape", async () => {
+		const result = expectValid(
+			await backend(
+				respondWith(
+					baseResponse({
+						is_vpn: true,
+						is_datacenter: true,
+						company: {
+							name: "Example Co",
+							abuser_score: "0.01 (Low)",
+							domain: "example.com",
+							type: "hosting",
+							network: "8.8.8.0/24",
+							whois: "",
+						},
+						asn: {
+							asn: 15169,
+							abuser_score: "0.002 (Very Low)",
+							route: "8.8.8.0/24",
+							descr: "",
+							country: "US",
+							active: true,
+							org: "Google LLC",
+							domain: "google.com",
+							abuse: "",
+							type: "hosting",
+							created: "",
+							updated: "",
+							rir: "ARIN",
+							whois: "",
+						},
+						location: {
+							is_eu_member: false,
+							calling_code: "1",
+							currency_code: "USD",
+							continent: "NA",
+							country: "United States",
+							country_code: "US",
+							state: "California",
+							city: "Mountain View",
+							latitude: 37.4,
+							longitude: -122.1,
+							zip: "94035",
+							timezone: "America/Los_Angeles",
+							local_time: "",
+							local_time_unix: 0,
+							is_dst: false,
+						},
+						vpn: {
+							ip: IP,
+							service: "ExampleVPN",
+							url: "",
+							type: "exit_node",
+							last_seen: 0,
+							last_seen_str: "",
+							country_code: "US",
+							city_name: "Mountain View",
+							latitude: 37.4,
+							longitude: -122.1,
+						},
+					}),
+				),
+			).lookup(IP),
+		);
+
+		expect(result).toMatchObject({
+			ip: IP,
+			isValid: true,
+			isVPN: true,
+			isDatacenter: true,
+			providerName: "Example Co",
+			providerType: "hosting",
+			asnNumber: 15169,
+			asnOrganization: "Google LLC",
+			country: "United States",
+			countryCode: "US",
+			region: "California",
+			city: "Mountain View",
+			timezone: "America/Los_Angeles",
+			vpnService: "ExampleVPN",
+			vpnType: "exit_node",
+		});
+		expect(result.abuserScore).toBeCloseTo(0.002);
+		expect(result.companyAbuserScore).toBeCloseTo(0.01);
+	});
+
+	it("survives a response missing every optional section", async () => {
+		// The upstream omits company/asn/location entirely for many IPs; the
+		// mapping must degrade to undefined fields, not fail.
+		const result = expectValid(
+			await backend(respondWith(baseResponse())).lookup(IP),
+		);
+
+		expect(result.isValid).toBe(true);
+		expect(result.country).toBeUndefined();
+		expect(result.asnNumber).toBeUndefined();
+		expect(result.providerName).toBeUndefined();
+		expect(result.abuserScore).toBe(0);
+		expect(result.companyAbuserScore).toBe(0);
+	});
+
+	it("keeps a successful lookup when the abuser scores are absent", async () => {
+		// The regression this package's fix addresses: abuser_score is declared
+		// required, but a response without it must not cost the caller the
+		// geolocation and threat data that did arrive.
+		const result = expectValid(
+			await backend(
+				respondWith(
+					baseResponse({
+						asn: {
+							asn: 64512,
+							route: "",
+							descr: "",
+							country: "US",
+							active: true,
+							org: "Test",
+							domain: "",
+							abuse: "",
+							type: "isp",
+							created: "",
+							updated: "",
+							rir: "ARIN",
+							whois: "",
+						} as IPApiResponse["asn"],
+					}),
+				),
+			).lookup(IP),
+		);
+
+		expect(result.isValid).toBe(true);
+		expect(result.asnNumber).toBe(64512);
+		expect(result.abuserScore).toBe(0);
+	});
+
+	it("prefers the company name but falls back to the datacenter", async () => {
+		const result = expectValid(
+			await backend(
+				respondWith(
+					baseResponse({
+						datacenter: { datacenter: "AWS", network: "1.2.3.0/24" },
+					}),
+				),
+			).lookup(IP),
+		);
+
+		expect(result.providerName).toBe("AWS");
+		// datacenterName is deliberately separate: it is used for strict name
+		// comparisons, so it must never inherit a company name.
+		expect(result.datacenterName).toBe("AWS");
+	});
+
+	it("reports a bogon address as invalid rather than mapping it", async () => {
+		const result = await backend(
+			respondWith(baseResponse({ is_bogon: true })),
+		).lookup(IP);
+
+		expect(result).toEqual({
+			isValid: false,
+			error: "IP address is bogon (non-routable)",
+			ip: IP,
+		});
+	});
+
+	it("reports a non-2xx status with the code and text", async () => {
+		const result = await backend(
+			respondWith({}, { status: 429, statusText: "Too Many Requests" }),
+		).lookup(IP);
+
+		expect(result).toMatchObject({
+			isValid: false,
+			ip: IP,
+			error: "API request failed with status 429: Too Many Requests",
+		});
+	});
+
+	it("reports a 500 without throwing", async () => {
+		// Services fail sporadically; a 500 must be an error response, not a
+		// rejected promise that the caller has to wrap.
+		const result = await backend(
+			respondWith({}, { status: 500, statusText: "Internal Server Error" }),
+		).lookup(IP);
+
+		expect(result.isValid).toBe(false);
+	});
+
+	it("turns malformed JSON into an error response", async () => {
+		const malformed: FetchFn = async (): Promise<globalThis.Response> =>
+			new Response("not json", { status: 200 });
+
+		const result = await backend(malformed).lookup(IP);
+
+		expect(result.isValid).toBe(false);
+		expect(result).toMatchObject({ ip: IP });
+		if (!result.isValid) {
+			expect(result.error).toContain("Network or parsing error");
+		}
+	});
+
+	it("turns a network failure into an error response", async () => {
+		const failing: FetchFn = async (): Promise<globalThis.Response> => {
+			throw new Error("ECONNREFUSED");
+		};
+
+		const result = await backend(failing).lookup(IP);
+
+		expect(result).toEqual({
+			isValid: false,
+			error: "Network or parsing error: ECONNREFUSED",
+			ip: IP,
+		});
+	});
+
+	it("describes a non-Error rejection rather than printing [object Object]", async () => {
+		const failing: FetchFn = async (): Promise<globalThis.Response> => {
+			// Rejections are not guaranteed to be Errors.
+			throw "socket hang up";
+		};
+
+		const result = await backend(failing).lookup(IP);
+
+		expect(result).toMatchObject({
+			isValid: false,
+			error: "Network or parsing error: socket hang up",
+		});
+	});
+});
+
+describe("IpapiBackend.lookup timeout", () => {
+	it("gives up on a hanging upstream and says so", async () => {
+		// An IP lookup sits in the request path: a backend that never answers
+		// must not hold the caller open indefinitely.
+		const result = await backend(respondNever, { timeoutMs: 20 }).lookup(IP);
+
+		expect(result).toEqual({
+			isValid: false,
+			error: "Request timed out after 20ms",
+			ip: IP,
+		});
+	});
+
+	it("reports the default budget when none is configured", async () => {
+		expect(DEFAULT_TIMEOUT_MS).toBe(700);
+		const configured = new IpapiBackend({
+			baseUrl: BASE_URL,
+			fetch: respondNever,
+		});
+		// Not awaited to completion here — the point is only that the default is
+		// the one the message quotes, checked below against a short override.
+		const result = await backend(respondNever, {
+			timeoutMs: DEFAULT_TIMEOUT_MS,
+		}).lookup(IP);
+		expect(result).toMatchObject({
+			error: `Request timed out after ${DEFAULT_TIMEOUT_MS}ms`,
+		});
+		expect(configured.isAvailable()).toBe(true);
+	}, 5000);
+
+	it("does not time out a response that arrives in time", async () => {
+		const slowButFine: FetchFn = async (): Promise<globalThis.Response> => {
+			await new Promise<void>((resolve) => {
+				setTimeout(resolve, 5);
+			});
+			return new Response(JSON.stringify(baseResponse()), { status: 200 });
+		};
+
+		const result = await backend(slowButFine, { timeoutMs: 200 }).lookup(IP);
+
+		expect(result.isValid).toBe(true);
+	});
+
+	it("passes an abort signal the upstream can observe", async () => {
+		const fetchFn = vi.fn<FetchFn>(respondWith(baseResponse()));
+		await backend(fetchFn).lookup(IP);
+
+		expect(fetchFn.mock.calls[0]?.[1]?.signal).toBeInstanceOf(AbortSignal);
+	});
+});
+
+describe("IpapiBackend default fetch", () => {
+	it("uses the global fetch when none is injected", async () => {
+		// Exercises the un-injected path end to end: port 1 on loopback refuses
+		// immediately, so the real fetch fails fast and its rejection must be
+		// contained as an invalid result rather than thrown at the caller.
+		const result = await new IpapiBackend({
+			baseUrl: "http://127.0.0.1:1/",
+			timeoutMs: 2000,
+		}).lookup(IP);
+
+		expect(result.isValid).toBe(false);
+	});
+});

--- a/packages/ipinfo/src/tests/ipinfo.test-d.ts
+++ b/packages/ipinfo/src/tests/ipinfo.test-d.ts
@@ -109,17 +109,22 @@ describe("isNonRoutable", () => {
 });
 
 describe("parseAbuserScore", () => {
-	it("accepts the optional upstream field and always yields a number", () => {
+	it("accepts the optional upstream field", () => {
 		// undefined must be in the parameter type: the wire does not guarantee
 		// the field even though the response type declares it required.
 		expectTypeOf(parseAbuserScore).parameters.toEqualTypeOf<
 			[string | undefined]
 		>();
-		expectTypeOf(parseAbuserScore).returns.toEqualTypeOf<number>();
 	});
 
-	it("never returns undefined for a missing score", () => {
-		expectTypeOf(parseAbuserScore(undefined)).toEqualTypeOf<number>();
+	it("returns an optional number, so callers must handle 'unknown'", () => {
+		// The undefined in the return type is the point: it forces every caller
+		// to decide what an unmeasured score means instead of silently reading
+		// it as the clean end of the 0..1 scale.
+		expectTypeOf(parseAbuserScore).returns.toEqualTypeOf<number | undefined>();
+		expectTypeOf(parseAbuserScore(undefined)).toEqualTypeOf<
+			number | undefined
+		>();
 	});
 });
 

--- a/packages/ipinfo/src/tests/ipinfo.test-d.ts
+++ b/packages/ipinfo/src/tests/ipinfo.test-d.ts
@@ -1,0 +1,184 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// These assert the shape consumers actually import — the package entrypoint —
+// rather than the internal modules, so a barrel that stops re-exporting
+// something fails here rather than at a downstream build.
+
+import type { IPInfoResponse } from "@prosopo/types";
+import { assertType, describe, expectTypeOf, it } from "vitest";
+// Not re-exported: an internal helper, asserted here because the response type
+// declares the field it parses as required while the wire does not supply it.
+import { parseAbuserScore } from "../backends/ipapi.js";
+import {
+	IpInfoService,
+	IpapiBackend,
+	MaxMindBackend,
+	isNonRoutable,
+} from "../index.js";
+import type {
+	FetchFn,
+	IIpInfoService,
+	IpInfoBackends,
+	IpInfoServiceConfig,
+	OpenReader,
+} from "../index.js";
+
+describe("IpInfoService", () => {
+	it("satisfies the interface it claims to implement", () => {
+		expectTypeOf<IpInfoService>().toMatchTypeOf<IIpInfoService>();
+	});
+
+	it("takes a config and optional injected backends", () => {
+		expectTypeOf(IpInfoService).toBeConstructibleWith({});
+		expectTypeOf(IpInfoService).toBeConstructibleWith({}, {});
+		expectTypeOf(IpInfoService).toBeConstructibleWith(
+			{ ipapiUrl: "https://api.ipapi.is" },
+			{ maxmind: null, ipapi: null },
+		);
+	});
+
+	it("resolves lookup to the shared response union, never a bare result", () => {
+		// The union is the point: a consumer must be forced to check isValid
+		// before reading any geolocation field.
+		expectTypeOf<IpInfoService["lookup"]>().returns.toEqualTypeOf<
+			Promise<IPInfoResponse>
+		>();
+	});
+
+	it("exposes initialize and isAvailable with no arguments", () => {
+		expectTypeOf<IpInfoService["initialize"]>().parameters.toEqualTypeOf<[]>();
+		expectTypeOf<IpInfoService["initialize"]>().returns.toEqualTypeOf<
+			Promise<void>
+		>();
+		expectTypeOf<
+			IpInfoService["isAvailable"]
+		>().returns.toEqualTypeOf<boolean>();
+	});
+
+	it("keeps every config field optional", () => {
+		// An entirely unconfigured service is a supported state — it degrades to
+		// "no backend available" rather than failing to compile.
+		assertType<IpInfoServiceConfig>({});
+	});
+
+	it("rejects an unknown config key", () => {
+		// Catches a renamed option silently becoming a no-op.
+		// @ts-expect-error maxmindDbPath is not an option
+		assertType<IpInfoServiceConfig>({ maxmindDbPath: "/city.mmdb" });
+	});
+
+	it("rejects a config value of the wrong type", () => {
+		// @ts-expect-error the url is a string, not a URL
+		assertType<IpInfoServiceConfig>({ ipapiUrl: new URL("https://x.test") });
+	});
+});
+
+describe("IpInfoBackends", () => {
+	it("accepts null for a backend that is deliberately absent", () => {
+		// null and undefined must both be spellable: a test that wants exactly
+		// one backend needs to say so without a cast.
+		assertType<IpInfoBackends>({ maxmind: null, ipapi: null });
+		assertType<IpInfoBackends>({});
+	});
+
+	it("does not accept an arbitrary object as a backend", () => {
+		// The seam is typed to the real classes so a stub cannot drift out of
+		// step with them unnoticed.
+		// @ts-expect-error a plain object is not a MaxMindBackend
+		assertType<IpInfoBackends>({ maxmind: { lookup: () => undefined } });
+	});
+});
+
+describe("isNonRoutable", () => {
+	it("takes exactly one string and returns a boolean", () => {
+		expectTypeOf(isNonRoutable).parameters.toEqualTypeOf<[string]>();
+		expectTypeOf(isNonRoutable).returns.toEqualTypeOf<boolean>();
+	});
+});
+
+describe("parseAbuserScore", () => {
+	it("accepts the optional upstream field and always yields a number", () => {
+		// undefined must be in the parameter type: the wire does not guarantee
+		// the field even though the response type declares it required.
+		expectTypeOf(parseAbuserScore).parameters.toEqualTypeOf<
+			[string | undefined]
+		>();
+		expectTypeOf(parseAbuserScore).returns.toEqualTypeOf<number>();
+	});
+
+	it("never returns undefined for a missing score", () => {
+		expectTypeOf(parseAbuserScore(undefined)).toEqualTypeOf<number>();
+	});
+});
+
+describe("FetchFn", () => {
+	it("matches the global fetch closely enough to be its default", () => {
+		// If it did not, the `?? globalThis.fetch` fallback would need a cast,
+		// and the seam would stop describing what actually runs in production.
+		expectTypeOf<typeof globalThis.fetch>().toMatchTypeOf<FetchFn>();
+	});
+
+	it("returns the global Response, not a hand-rolled shape", () => {
+		expectTypeOf<FetchFn>().returns.toEqualTypeOf<
+			Promise<globalThis.Response>
+		>();
+	});
+
+	it("takes a url and an init", () => {
+		expectTypeOf<FetchFn>().parameters.toEqualTypeOf<[string, RequestInit]>();
+	});
+});
+
+describe("OpenReader", () => {
+	it("takes a path and resolves to a reader", () => {
+		expectTypeOf<OpenReader>().parameters.toEqualTypeOf<[string]>();
+		expectTypeOf<OpenReader>().returns.toMatchTypeOf<Promise<unknown>>();
+	});
+});
+
+describe("backend constructors", () => {
+	it("require a base url for ipapi and accept the injection seams", () => {
+		expectTypeOf(IpapiBackend).toBeConstructibleWith({
+			baseUrl: "https://x.test",
+		});
+		expectTypeOf(IpapiBackend).toBeConstructibleWith({
+			baseUrl: "https://x.test",
+			apiKey: "k",
+			timeoutMs: 100,
+			fetch: async (): Promise<globalThis.Response> => new Response(),
+		});
+	});
+
+	it("leave every MaxMind option optional", () => {
+		// A backend with neither database path is legal and simply unavailable.
+		expectTypeOf(MaxMindBackend).toBeConstructibleWith({});
+		expectTypeOf(MaxMindBackend).toBeConstructibleWith({
+			cityDbPath: "/city.mmdb",
+			asnDbPath: "/asn.mmdb",
+		});
+	});
+
+	it("give both backends the same lookup signature as the service", () => {
+		// The service routes between them, so any divergence would show up as a
+		// runtime surprise rather than a compile error.
+		expectTypeOf<MaxMindBackend["lookup"]>().parameters.toEqualTypeOf<
+			[string]
+		>();
+		expectTypeOf<IpapiBackend["lookup"]>().parameters.toEqualTypeOf<[string]>();
+		expectTypeOf<IpapiBackend["lookup"]>().returns.toEqualTypeOf<
+			Promise<IPInfoResponse>
+		>();
+	});
+});

--- a/packages/ipinfo/src/tests/maxmind.unit.test.ts
+++ b/packages/ipinfo/src/tests/maxmind.unit.test.ts
@@ -21,7 +21,11 @@
 import type { Asn, City, ReaderModel } from "@maxmind/geoip2-node";
 import type { IPInfoResult } from "@prosopo/types";
 import { describe, expect, it, vi } from "vitest";
-import { MaxMindBackend, type OpenReader } from "../backends/maxmind.js";
+import {
+	MaxMindBackend,
+	type MaxMindUserType,
+	type OpenReader,
+} from "../backends/maxmind.js";
 
 const IP = "8.8.8.8";
 const CITY_DB = "/dbs/GeoLite2-City.mmdb";
@@ -418,7 +422,10 @@ describe("MaxMindBackend.lookup", () => {
 			return expectValid(await backend.lookup(IP)).providerType;
 		};
 
-		const expected: Record<string, string | undefined> = {
+		// Typed as a total Record over the union, so adding a user type to
+		// MaxMindUserType without deciding its mapping fails the type check
+		// rather than silently falling through to undefined at runtime.
+		const expected: Record<MaxMindUserType, string | undefined> = {
 			hosting: "hosting",
 			content_delivery_network: "hosting",
 			college: "education",
@@ -433,6 +440,10 @@ describe("MaxMindBackend.lookup", () => {
 			cafe: "isp",
 			traveler: "isp",
 			router: "isp",
+			// Deliberately unmapped: neither is a provider type the consumers
+			// route on, so both reach the `default` arm and report "no data".
+			consumer_privacy_network: undefined,
+			search_engine_spider: undefined,
 		};
 
 		for (const [userType, providerType] of Object.entries(expected)) {

--- a/packages/ipinfo/src/tests/maxmind.unit.test.ts
+++ b/packages/ipinfo/src/tests/maxmind.unit.test.ts
@@ -1,0 +1,551 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Testing strategy: the reader is the seam. Shipping a real .mmdb fixture would
+// make these tests depend on MaxMind's data staying constant, and would leave
+// the failure paths — a missing database, a corrupt one, an IP absent from it —
+// impossible to reach at all. The reader is therefore injected, and everything
+// the backend does with its output runs for real.
+
+import type { Asn, City, ReaderModel } from "@maxmind/geoip2-node";
+import type { IPInfoResult } from "@prosopo/types";
+import { describe, expect, it, vi } from "vitest";
+import { MaxMindBackend, type OpenReader } from "../backends/maxmind.js";
+
+const IP = "8.8.8.8";
+const CITY_DB = "/dbs/GeoLite2-City.mmdb";
+const ASN_DB = "/dbs/GeoLite2-ASN.mmdb";
+
+/** Builds a reader that answers city/asn lookups however the test needs. */
+const reader = (behaviour: {
+	city?: () => City;
+	asn?: () => Asn;
+}): ReaderModel => {
+	const notSupported = (): never => {
+		// The real Reader throws when asked for a database it did not open.
+		throw new Error("database does not support this lookup");
+	};
+	return {
+		city: behaviour.city ?? notSupported,
+		asn: behaviour.asn ?? notSupported,
+	} as unknown as ReaderModel;
+};
+
+const cityData = (overrides: Partial<City> = {}): City =>
+	({
+		country: { isoCode: "US", names: { en: "United States" } },
+		city: { names: { en: "Mountain View" } },
+		subdivisions: [{ names: { en: "California" } }],
+		location: {
+			latitude: 37.4,
+			longitude: -122.1,
+			timeZone: "America/Los_Angeles",
+		},
+		traits: {},
+		...overrides,
+	}) as City;
+
+const asnData = (overrides: Partial<Asn> = {}): Asn =>
+	({
+		autonomousSystemNumber: 15169,
+		autonomousSystemOrganization: "Google LLC",
+		...overrides,
+	}) as Asn;
+
+/** An opener that returns the given reader for whichever path it is asked for. */
+const opens = (readers: {
+	city?: ReaderModel;
+	asn?: ReaderModel;
+}): OpenReader => {
+	return async (dbPath: string): Promise<ReaderModel> => {
+		const model = dbPath === CITY_DB ? readers.city : readers.asn;
+		if (undefined === model) {
+			throw new Error(`no database at ${dbPath}`);
+		}
+		return model;
+	};
+};
+
+const expectValid = (
+	response: Awaited<ReturnType<MaxMindBackend["lookup"]>>,
+): IPInfoResult => {
+	if (!response.isValid) {
+		throw new Error(`expected a valid result, got: ${response.error}`);
+	}
+	return response;
+};
+
+describe("MaxMindBackend.initialize", () => {
+	it("opens only the databases that are configured", async () => {
+		const openReader = vi.fn<OpenReader>(
+			opens({ city: reader({ city: () => cityData() }) }),
+		);
+		const backend = new MaxMindBackend({ cityDbPath: CITY_DB, openReader });
+
+		await backend.initialize();
+
+		expect(openReader).toHaveBeenCalledTimes(1);
+		expect(openReader).toHaveBeenCalledWith(CITY_DB);
+	});
+
+	it("opens neither database when no paths are configured", async () => {
+		const openReader = vi.fn<OpenReader>(opens({}));
+		await new MaxMindBackend({ openReader }).initialize();
+
+		expect(openReader).not.toHaveBeenCalled();
+	});
+
+	it("logs the readers it did open", async () => {
+		const info = vi.fn();
+		await new MaxMindBackend({
+			cityDbPath: CITY_DB,
+			asnDbPath: ASN_DB,
+			openReader: opens({
+				city: reader({ city: () => cityData() }),
+				asn: reader({ asn: () => asnData() }),
+			}),
+			logger: { info, warn: vi.fn(), debug: vi.fn() } as never,
+		}).initialize();
+
+		const messages = info.mock.calls.map(
+			(call: unknown[]): string => (call[0] as () => { msg: string })().msg,
+		);
+		expect(messages).toEqual([
+			"MaxMind City reader initialized",
+			"MaxMind ASN reader initialized",
+		]);
+	});
+
+	it("keeps the ASN database when the City database fails to open", async () => {
+		// Deployments routinely ship one and not the other. A failure to open one
+		// must not take the other down with it.
+		const backend = new MaxMindBackend({
+			cityDbPath: CITY_DB,
+			asnDbPath: ASN_DB,
+			openReader: opens({ asn: reader({ asn: () => asnData() }) }),
+		});
+
+		await backend.initialize();
+
+		expect(backend.isAvailable()).toBe(true);
+	});
+
+	it("does not throw when every database fails to open", async () => {
+		// A missing .mmdb is a deployment mistake, but it must degrade to an
+		// unavailable backend rather than crash the process at startup.
+		const backend = new MaxMindBackend({
+			cityDbPath: CITY_DB,
+			asnDbPath: ASN_DB,
+			openReader: opens({}),
+		});
+
+		await expect(backend.initialize()).resolves.toBeUndefined();
+		expect(backend.isAvailable()).toBe(false);
+	});
+
+	it("logs a warning for each database it could not open", async () => {
+		const warn = vi.fn();
+		const backend = new MaxMindBackend({
+			cityDbPath: CITY_DB,
+			asnDbPath: ASN_DB,
+			openReader: opens({}),
+			logger: { warn, info: vi.fn(), debug: vi.fn() } as never,
+		});
+
+		await backend.initialize();
+
+		expect(warn).toHaveBeenCalledTimes(2);
+		// The payloads are built lazily, so evaluate them: a broken builder would
+		// otherwise only surface while someone is debugging a missing database.
+		const messages = warn.mock.calls.map(
+			(call: unknown[]): string => (call[0] as () => { msg: string })().msg,
+		);
+		expect(messages).toEqual([
+			"Failed to initialize MaxMind City reader",
+			"Failed to initialize MaxMind ASN reader",
+		]);
+	});
+
+	it("is safe to call twice", async () => {
+		// Callers may initialize defensively; the second call must not leave the
+		// backend worse off than the first.
+		const backend = new MaxMindBackend({
+			cityDbPath: CITY_DB,
+			openReader: opens({ city: reader({ city: () => cityData() }) }),
+		});
+
+		await backend.initialize();
+		await backend.initialize();
+
+		expect(backend.isAvailable()).toBe(true);
+	});
+});
+
+describe("MaxMindBackend.isAvailable", () => {
+	it("is unavailable before initialize, even when paths are configured", async () => {
+		// Configured is not the same as ready: the databases are opened from disk
+		// asynchronously, so a caller that skips initialize gets nothing.
+		const backend = new MaxMindBackend({
+			cityDbPath: CITY_DB,
+			openReader: opens({ city: reader({ city: () => cityData() }) }),
+		});
+
+		expect(backend.isAvailable()).toBe(false);
+		await backend.initialize();
+		expect(backend.isAvailable()).toBe(true);
+	});
+});
+
+describe("MaxMindBackend.lookup", () => {
+	const initialised = async (readers: {
+		city?: ReaderModel;
+		asn?: ReaderModel;
+	}): Promise<MaxMindBackend> => {
+		const backend = new MaxMindBackend({
+			cityDbPath: readers.city ? CITY_DB : undefined,
+			asnDbPath: readers.asn ? ASN_DB : undefined,
+			openReader: opens(readers),
+		});
+		await backend.initialize();
+		return backend;
+	};
+
+	it("refuses to look up before the databases are open", async () => {
+		const backend = new MaxMindBackend({ cityDbPath: CITY_DB });
+
+		await expect(backend.lookup(IP)).resolves.toEqual({
+			isValid: false,
+			error: "MaxMind readers not initialized",
+			ip: IP,
+		});
+	});
+
+	it("maps city data onto the shared result shape", async () => {
+		const backend = await initialised({
+			city: reader({ city: () => cityData() }),
+		});
+
+		const result = expectValid(await backend.lookup(IP));
+
+		expect(result).toMatchObject({
+			ip: IP,
+			isValid: true,
+			country: "United States",
+			countryCode: "US",
+			region: "California",
+			city: "Mountain View",
+			latitude: 37.4,
+			longitude: -122.1,
+			timezone: "America/Los_Angeles",
+		});
+	});
+
+	it("reports threat indicators the free databases never populate as false", async () => {
+		// GeoLite2 does not carry these traits. They must read false rather than
+		// undefined, or every consumer has to re-decide what absence means.
+		const backend = await initialised({
+			city: reader({ city: () => cityData() }),
+		});
+
+		const result = expectValid(await backend.lookup(IP));
+
+		expect(result.isVPN).toBe(false);
+		expect(result.isTor).toBe(false);
+		expect(result.isProxy).toBe(false);
+		expect(result.isAbuser).toBe(false);
+		expect(result.isMobile).toBe(false);
+		expect(result.isCrawler).toBe(false);
+	});
+
+	it("reads the anonymity traits when a paid database supplies them", async () => {
+		const backend = await initialised({
+			city: reader({
+				city: () =>
+					cityData({
+						traits: {
+							isAnonymousVpn: true,
+							isTorExitNode: true,
+							isHostingProvider: true,
+							isSatelliteProvider: true,
+						},
+					} as Partial<City>),
+			}),
+		});
+
+		const result = expectValid(await backend.lookup(IP));
+
+		expect(result.isVPN).toBe(true);
+		expect(result.isTor).toBe(true);
+		expect(result.isDatacenter).toBe(true);
+		expect(result.isSatellite).toBe(true);
+	});
+
+	it("treats a residential proxy as a proxy", async () => {
+		// Two distinct traits collapse into one flag; missing either would let a
+		// proxied request through unflagged.
+		const residential = await initialised({
+			city: reader({
+				city: () =>
+					cityData({ traits: { isResidentialProxy: true } } as Partial<City>),
+			}),
+		});
+		const publicProxy = await initialised({
+			city: reader({
+				city: () =>
+					cityData({ traits: { isPublicProxy: true } } as Partial<City>),
+			}),
+		});
+
+		expect(expectValid(await residential.lookup(IP)).isProxy).toBe(true);
+		expect(expectValid(await publicProxy.lookup(IP)).isProxy).toBe(true);
+	});
+
+	it("falls back to the ASN database for the AS number", async () => {
+		const backend = await initialised({
+			city: reader({ city: () => cityData() }),
+			asn: reader({ asn: () => asnData() }),
+		});
+
+		const result = expectValid(await backend.lookup(IP));
+
+		expect(result.asnNumber).toBe(15169);
+		expect(result.asnOrganization).toBe("Google LLC");
+	});
+
+	it("prefers the City database's ASN traits over the ASN database", async () => {
+		// The City database is the more specific source when it carries traits.
+		const backend = await initialised({
+			city: reader({
+				city: () =>
+					cityData({
+						traits: {
+							autonomousSystemNumber: 111,
+							autonomousSystemOrganization: "From City",
+						},
+					} as Partial<City>),
+			}),
+			asn: reader({ asn: () => asnData({ autonomousSystemNumber: 222 }) }),
+		});
+
+		const result = expectValid(await backend.lookup(IP));
+
+		expect(result.asnNumber).toBe(111);
+		expect(result.asnOrganization).toBe("From City");
+	});
+
+	it("returns ASN-only data when no City database is configured", async () => {
+		const backend = await initialised({
+			asn: reader({ asn: () => asnData() }),
+		});
+
+		const result = expectValid(await backend.lookup(IP));
+
+		expect(result.asnNumber).toBe(15169);
+		expect(result.country).toBeUndefined();
+	});
+
+	it("reports no data when the IP is in neither database", async () => {
+		// The real Reader throws AddressNotFoundError for an unknown IP. Both
+		// lookups failing is not an error — it is simply an absent answer.
+		const missing = (): never => {
+			throw new Error("address not found");
+		};
+		const backend = await initialised({
+			city: reader({ city: missing }),
+			asn: reader({ asn: missing }),
+		});
+
+		await expect(backend.lookup(IP)).resolves.toEqual({
+			isValid: false,
+			error: "No MaxMind data available for IP",
+			ip: IP,
+		});
+	});
+
+	it("still answers from the ASN database when the City lookup throws", async () => {
+		// Partial data beats no data: an IP present in one database and not the
+		// other is common.
+		const backend = await initialised({
+			city: reader({
+				city: (): never => {
+					throw new Error("address not found");
+				},
+			}),
+			asn: reader({ asn: () => asnData() }),
+		});
+
+		const result = expectValid(await backend.lookup(IP));
+
+		expect(result.asnNumber).toBe(15169);
+		expect(result.country).toBeUndefined();
+	});
+
+	it("maps a hosting user type onto the provider type", async () => {
+		const backend = await initialised({
+			city: reader({
+				city: () =>
+					cityData({ traits: { userType: "hosting" } } as Partial<City>),
+			}),
+		});
+
+		expect(expectValid(await backend.lookup(IP)).providerType).toBe("hosting");
+	});
+
+	it("maps every user type MaxMind can emit", async () => {
+		// Exhaustive on purpose: each case is a routing decision downstream, and
+		// a type silently falling through to undefined is indistinguishable from
+		// "no data" at the consumer.
+		const forUserType = async (
+			userType: string,
+		): Promise<string | undefined> => {
+			const backend = await initialised({
+				city: reader({
+					city: () =>
+						cityData({ traits: { userType } } as unknown as Partial<City>),
+				}),
+			});
+			return expectValid(await backend.lookup(IP)).providerType;
+		};
+
+		const expected: Record<string, string | undefined> = {
+			hosting: "hosting",
+			content_delivery_network: "hosting",
+			college: "education",
+			school: "education",
+			library: "education",
+			government: "government",
+			military: "government",
+			business: "business",
+			residential: "isp",
+			cellular: "isp",
+			dialup: "isp",
+			cafe: "isp",
+			traveler: "isp",
+			router: "isp",
+		};
+
+		for (const [userType, providerType] of Object.entries(expected)) {
+			expect(await forUserType(userType), userType).toBe(providerType);
+		}
+	});
+
+	it("logs each failed database lookup with the IP and the cause", async () => {
+		// The log lines are built lazily; if the payload builder is wrong nobody
+		// finds out until an incident, so it is evaluated here.
+		const debug = vi.fn();
+		const missing = (): never => {
+			throw new Error("address not found");
+		};
+		const backend = new MaxMindBackend({
+			cityDbPath: CITY_DB,
+			asnDbPath: ASN_DB,
+			openReader: opens({
+				city: reader({ city: missing }),
+				asn: reader({ asn: missing }),
+			}),
+			logger: { debug, warn: vi.fn(), info: vi.fn() } as never,
+		});
+		await backend.initialize();
+
+		await backend.lookup(IP);
+
+		expect(debug).toHaveBeenCalledTimes(2);
+		type DebugPayload = { msg: string; data: { ip: string } };
+		const payloads: DebugPayload[] = debug.mock.calls.map(
+			(call: unknown[]): DebugPayload => (call[0] as () => DebugPayload)(),
+		);
+		expect(payloads.map((p) => p.msg)).toEqual([
+			"MaxMind City lookup failed",
+			"MaxMind ASN lookup failed",
+		]);
+		expect(payloads.every((p) => p.data.ip === IP)).toBe(true);
+	});
+
+	it("leaves the provider type unset for a user type it does not map", async () => {
+		// e.g. "search_engine_spider" — deliberately unmapped rather than forced
+		// into a category it does not belong to.
+		const backend = await initialised({
+			city: reader({
+				city: () =>
+					cityData({
+						traits: { userType: "search_engine_spider" },
+					} as unknown as Partial<City>),
+			}),
+		});
+
+		expect(expectValid(await backend.lookup(IP)).providerType).toBeUndefined();
+	});
+
+	it("leaves the provider type unset when there is no user type at all", async () => {
+		const backend = await initialised({
+			city: reader({ city: () => cityData() }),
+		});
+
+		expect(expectValid(await backend.lookup(IP)).providerType).toBeUndefined();
+	});
+
+	it("turns a failure during mapping into an error response", async () => {
+		// The per-database try blocks only cover the lookup call itself. A throw
+		// while reading the returned record — here a getter that fails, standing
+		// in for any malformed decode — happens outside them, and must still not
+		// escape to the caller.
+		const hostile = {
+			get traits(): never {
+				throw new Error("corrupt record");
+			},
+		};
+		const backend = await initialised({
+			city: reader({ city: () => hostile as unknown as City }),
+		});
+
+		await expect(backend.lookup(IP)).resolves.toEqual({
+			isValid: false,
+			error: "MaxMind lookup error: corrupt record",
+			ip: IP,
+		});
+	});
+
+	it("describes a non-Error failure without printing [object Object]", async () => {
+		const hostile = {
+			get traits(): never {
+				// The case under test is a non-Error throw, hence the string.
+				throw "just a string";
+			},
+		};
+		const backend = await initialised({
+			city: reader({ city: () => hostile as unknown as City }),
+		});
+
+		const response = await backend.lookup(IP);
+
+		expect(response).toMatchObject({
+			isValid: false,
+			error: "MaxMind lookup error: just a string",
+		});
+	});
+});
+
+describe("MaxMindBackend default reader", () => {
+	it("does not throw when the real database file is missing", async () => {
+		// Exercises the un-injected path: the lazy import of the MaxMind reader
+		// runs for real, and its failure to open a nonexistent file must be
+		// contained exactly like an injected one.
+		const backend = new MaxMindBackend({
+			cityDbPath: "/nonexistent/prosopo-test/GeoLite2-City.mmdb",
+		});
+
+		await expect(backend.initialize()).resolves.toBeUndefined();
+		expect(backend.isAvailable()).toBe(false);
+	});
+});

--- a/packages/ipinfo/vite.test.config.ts
+++ b/packages/ipinfo/vite.test.config.ts
@@ -1,0 +1,18 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import { ViteTestConfig } from "@prosopo/config";
+
+process.env.NODE_ENV = "test";
+
+export default ViteTestConfig();

--- a/packages/types/src/api/ipapi.ts
+++ b/packages/types/src/api/ipapi.ts
@@ -118,7 +118,13 @@ export interface IPApiResponse {
 export interface IPInfoResult {
 	// Core identification
 	ip: string;
-	isValid: boolean;
+	// Literal `true`, not `boolean`: this is the discriminant that separates
+	// this from IPInfoError in IPInfoResponse. Typed as `boolean` the union is
+	// not discriminated at all — `if (!res.isValid)` narrows to nothing, so
+	// `res.error` fails to compile and consumers reach for a cast, which is
+	// exactly the check this union exists to force. Every construction site
+	// already passes a literal.
+	isValid: true;
 
 	// Threat indicators
 	isVPN: boolean;


### PR DESCRIPTION
Unit and type tests for `@prosopo/ipinfo` (previously untested), plus the injection seams needed to write them and three defects the tests exposed.

## Coverage

127 tests (108 runtime, 19 type). 100% statements, functions and lines; 97.85% branches (the remainder are unreachable defaults).

| file | stmts | branch | funcs | lines |
|---|---|---|---|---|
| `IpInfoService.ts` | 100 | 94.73 | 100 | 100 |
| `backends/ipapi.ts` | 100 | 100 | 100 | 100 |
| `backends/maxmind.ts` | 100 | 100 | 100 | 100 |

## Defects fixed

**`abuser_score` could sink a successful lookup.** `IPApiASNInfo.abuser_score` / `IPApiCompanyInfo.abuser_score` are declared required, but the value comes from `response.json()`, which is cast rather than validated. A response omitting either field threw on `.split(" ")`, and the throw was caught far above as a generic `"Network or parsing error"` — discarding an otherwise complete lookup over one absent score. Now parsed by `parseAbuserScore`, which returns `number | undefined` — `undefined`, not `0`, when the field is absent or unparseable.

The scale is 0..1 with 0 meaning "clean" (`abuserScoreThreshold` is declared `{min: 0, max: 1}`), so returning a literal `0` would assert cleanliness that was never established. `undefined` says "unknown" instead. The one consumer, `checkTrafficFilter`, already resolves it with `?? 0`, so the effective blocking behaviour is unchanged while the distinction stays available to anything that needs it.

Fail-closed alternatives were rejected: `1` turns any upstream formatting change into a silent max-severity block indistinguishable from a genuine 1.0, and throwing reintroduces exactly the bug above — a cosmetic sub-field collapsing a good lookup into a total failure.

**`IPInfoResponse` was not a discriminated union.** `IPInfoError.isValid` is `false` but `IPInfoResult.isValid` was `boolean`, so `if (!res.isValid)` narrowed to nothing and `res.error` did not compile — every consumer needed a cast, which is exactly the check the union exists to force. `IPInfoResult.isValid` is now the literal `true`. Every construction site in the repo already passed a literal, and `provider`, `database`, `types-database`, `api-express-router` and `types-env` all still typecheck.

**The injection seams were not exported.** The backends, their config types, `FetchFn`, `OpenReader`, `IpInfoBackends` and `isNonRoutable` are now re-exported from the entrypoint; without them a consumer cannot substitute a backend, and a caller that already knows an address is private cannot skip the lookup.

## Testability changes

- `IpapiBackend`: injected `fetch` and configurable `timeoutMs` (default unchanged at 700ms).
- `MaxMindBackend`: injected `openReader`, so a missing/corrupt database and an absent IP are reachable without shipping a `.mmdb` fixture.
- `IpInfoService`: injected backends, so the ipapi→MaxMind fallback routing is testable without a network call.

Each seam has a real default and is exercised un-injected at least once (global `fetch` against a refused port; the real lazy MaxMind reader against a nonexistent path).

## Cases covered

- **`isNonRoutable`** — both 172.16/12 boundaries and the public space either side, IPv4-mapped IPv6 (`::ffff:127.0.0.1`), a malformed `172.` address that must not crash on `NaN`, ULA/link-local case-insensitivity, empty string.
- **Routing** — ipapi preferred; fallback to MaxMind on an invalid ipapi result; the ipapi error returned verbatim when MaxMind cannot cover; availability re-checked on every lookup, not cached at construction; non-routable IPs short-circuit without spending an ipapi credit; a backend that throws is deliberately not caught.
- **ipapi** — request shaping, empty and non-string input, a payload with every optional section absent, missing abuser scores, malformed JSON, non-2xx, network failure, a non-`Error` rejection, and the abort timeout (hanging upstream, default budget, slow-but-in-time).
- **MaxMind** — one database opening and the other failing, both failing, every `userType` mapped exhaustively, a throw during record mapping (outside the per-database try blocks), a non-`Error` throw, and lazily-built log payloads evaluated rather than merely counted.
