### PR TITLE
fix(ci): build workspace declarations before running tests

### DIFF
--- a/.changeset/turbo-test-declarations.md
+++ b/.changeset/turbo-test-declarations.md
@@ -1,5 +1,5 @@
 ---
-"@prosopo/workspace": patch
+"@prosopo/config": patch
 ---
 
 Build workspace declarations before running tests. `turbo run test` depended only on `@prosopo/config#build`, so a package's dependencies were present in `dist` as bundled JavaScript with no `.d.ts`. Type checking then fell back to the compiled JS, which reports types as values and floods the run with implicit-any errors from other packages' output.

--- a/.changeset/turbo-test-declarations.md
+++ b/.changeset/turbo-test-declarations.md
@@ -1,0 +1,5 @@
+---
+"@prosopo/workspace": patch
+---
+
+Build workspace declarations before running tests. `turbo run test` depended only on `@prosopo/config#build`, so a package's dependencies were present in `dist` as bundled JavaScript with no `.d.ts`. Type checking then fell back to the compiled JS, which reports types as values and floods the run with implicit-any errors from other packages' output.

--- a/turbo.json
+++ b/turbo.json
@@ -43,7 +43,15 @@
 			"dependsOn": ["^typecheck"]
 		},
 		"test": {
-			"dependsOn": ["@prosopo/config#build"]
+			// Also depends on ^build:tsc, not just ^build: every package resolves
+			// its workspace dependencies through `exports.types` -> dist/*.d.ts,
+			// and only build:tsc emits those. `build` is a vite bundle, so it
+			// leaves dist as bare JS. Without the declarations tsc falls back to
+			// type-checking a dependency's compiled JavaScript, which floods the
+			// run with implicit-any errors and — because a .js file exports
+			// values, not types — makes vitest type tests fail on names that are
+			// perfectly valid types in source. Runtime tests never noticed.
+			"dependsOn": ["@prosopo/config#build", "^build:tsc"]
 		},
 		"lint": { "dependsOn": ["^lint"] },
 		"clean": {


### PR DESCRIPTION
`turbo run test` depended on `@prosopo/config#build` alone. CI runs `turbo run build` (a vite bundle) before the test job, so each package's workspace dependencies arrive in `dist` as bare JavaScript with no `.d.ts`.

Every package resolves its siblings through `exports.types` → `dist/index.d.ts`. With those absent, tsc falls back to type-checking the dependency's *compiled JavaScript*. Two consequences:

- Hundreds of spurious implicit-any errors sourced from other packages' output (513 unhandled errors in the run linked below).
- A `.js` file exports values, not types — so `expectTypeOf<ProcaptchaType>()` fails with "'ProcaptchaType' refers to a value, but is being used as a type here", and `@ts-expect-error` directives guarding required fields go unused because the type widened to `any`.

Runtime tests never touched declarations, so this stayed invisible until vitest type testing was enabled. It currently fails the `check` job on every open PR that adds a `*.test-d.ts`.

**Fix:** `test` now also depends on `^build:tsc`, which is the task that emits declarations.

**Verified** by reproducing exactly: deleting `packages/{locale,types}/dist/**/*.d.ts` locally turns `@prosopo/procaptcha-wrapper`'s suite into the same 4 type failures and 411 unhandled errors seen in CI; with this change `npx turbo run test` rebuilds the declarations first and the suite passes.