### PR TITLE
test(workspace): unit + type tests, fix root path encoding and coverage detection

### DIFF
--- a/.changeset/workspace-tests.md
+++ b/.changeset/workspace-tests.md
@@ -1,0 +1,20 @@
+---
+"@prosopo/workspace": minor
+"@prosopo/config": patch
+---
+
+test(workspace): unit + type tests, fix root-path encoding, stale getters and coverage for non-`packages/` workspaces
+
+- `getRootDir` used `new URL(...).pathname`, which is percent-encoded — a
+  checkout under a path containing a space or a `#` produced `%20`/`%23` and
+  every derived path failed to resolve. Now uses `fileURLToPath`.
+- `getClientExampleDir` and `getDappExampleDir` returned paths for
+  `demos/client-example` and `demos/dapp-example`, neither of which exists any
+  more. Both were unused; removed.
+- `findWorkspaceRoot` takes an optional injected dependency set so the search
+  can be tested against a synthetic tree, and no longer parses package.json
+  into an implicitly-`any` value.
+- `ViteTestConfig` decided whether it was running inside a package by looking
+  for `/packages/` in the cwd, so workspaces under `dev/`, `demos/` and
+  `integration/` fell through to the repo-root globs and reported 0/0 coverage
+  regardless of what their tests covered.

--- a/dev/config/src/vite/vite.test.config.ts
+++ b/dev/config/src/vite/vite.test.config.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import fs from "node:fs";
 import path from "node:path";
 import tsconfigPaths from "vite-tsconfig-paths";
 import { defineConfig } from "vitest/config";
@@ -30,10 +31,18 @@ export default function (tsConfigPath?: string) {
 			: "@(|)";
 	console.log(`Filtering tests by type: ${testTypeGlob}`);
 
-	// Determine coverage include paths based on current working directory
+	// Determine coverage include paths based on current working directory.
+	//
+	// Detected by looking for a package alongside the cwd rather than by
+	// matching "/packages/" in the path: workspaces also live in dev/, demos/
+	// and integration/, and those were falling through to the repo-root globs
+	// below, which match `packages/*/src/**` only — so they reported 0/0
+	// coverage no matter what their tests exercised. Neither repo root has a
+	// `src` directory, so this cannot misfire in the other direction.
 	const cwd = process.cwd();
 	const isRunningFromPackage =
-		cwd.includes("/packages/") && cwd.includes("/src") === false;
+		fs.existsSync(path.join(cwd, "package.json")) &&
+		fs.existsSync(path.join(cwd, "src"));
 
 	// If running from a package directory, include local src files
 	// If running from repo root, include all package src files

--- a/dev/workspace/package.json
+++ b/dev/workspace/package.json
@@ -18,7 +18,8 @@
 		"build:cross-env": "vite build --config vite.esm.config.ts",
 		"build:tsc": "tsc --build --verbose",
 		"build:cjs": "NODE_ENV=${NODE_ENV:-development}; vite build --config vite.cjs.config.ts --mode $NODE_ENV",
-		"typecheck": "tsc --project tsconfig.types.json"
+		"typecheck": "tsc --project tsconfig.types.json",
+		"test": "NODE_ENV=${NODE_ENV:-test}; npx vitest run --config ./vite.test.config.ts"
 	},
 	"engines": {
 		"node": "^24",
@@ -29,7 +30,12 @@
 	"devDependencies": {
 		"@prosopo/config": "3.3.4",
 		"@types/node": "22.10.2",
-		"del-cli": "6.0.0"
+		"@vitest/coverage-v8": "4.1.10",
+		"del-cli": "6.0.0",
+		"dotenv": "16.4.5",
+		"typescript": "5.6.2",
+		"vite": "8.1.5",
+		"vitest": "4.1.10"
 	},
 	"repository": {
 		"type": "git",

--- a/dev/workspace/src/projectInfo.ts
+++ b/dev/workspace/src/projectInfo.ts
@@ -14,11 +14,25 @@
 
 import fs from "node:fs";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 // Top Level
 
-export const getRootDir = () =>
-	new URL("../../..", import.meta.url).pathname.slice(0, -1);
+/**
+ * The repository root — three levels up from this module, which sits at
+ * `dev/workspace/{src,dist}/`. Both the source and the built layout are the
+ * same depth, so this holds whether it is imported from `src` under vitest or
+ * from `dist` by a consumer.
+ *
+ * `fileURLToPath` rather than `new URL(...).pathname`: `pathname` is
+ * percent-encoded, so a checkout under a path containing a space or a `#`
+ * yields `%20`/`%23` and every derived path fails to resolve.
+ *
+ * `path.resolve` drops the trailing separator that URL resolution leaves on a
+ * directory, which is what the previous `.slice(0, -1)` was doing by hand.
+ */
+export const getRootDir = (): string =>
+	path.resolve(fileURLToPath(new URL("../../..", import.meta.url)));
 
 export const getCacheDir = () => `${getRootDir()}/.cache`;
 
@@ -40,15 +54,16 @@ export const getScriptsPkgDir = () => `${getDevDir()}/scripts`;
 
 // Demos
 
-export const getClientExampleDir = () => `${getDemosDir()}/client-example`;
+// `getClientExampleDir` and `getDappExampleDir` used to live here. Both
+// `demos/client-example` and `demos/dapp-example` were removed from the
+// repository, so the getters returned paths that no longer exist; neither had
+// any remaining caller.
 
 export const getClientExampleServerDir = () =>
 	`${getDemosDir()}/client-example-server`;
 
 export const getClientBundleExampleDir = () =>
 	`${getDemosDir()}/client-bundle-example`;
-
-export const getDappExampleDir = () => `${getDemosDir()}/dapp-example`;
 
 // Packages
 
@@ -107,39 +122,75 @@ export const getWidgetSkeletonPkgDir = () =>
 
 export const getLocalePkgDir = () => `${getPackagesDir()}/locale`;
 
+/** The maximum number of directories, starting at cwd, that are inspected. */
+export const WORKSPACE_ROOT_MAX_DEPTH = 5;
+
+/**
+ * The ambient state `findWorkspaceRoot` reads.
+ *
+ * Injected rather than reached for directly so the search can be exercised
+ * against a synthetic tree. Replacing `node:fs` wholesale instead would either
+ * touch the developer's real filesystem or swap out a module the rest of the
+ * run depends on.
+ */
+export interface WorkspaceRootDeps {
+	cwd: () => string;
+	existsSync: (target: string) => boolean;
+	readFileSync: (target: string) => string;
+	warn: (message: string) => void;
+}
+
+const defaultDeps: WorkspaceRootDeps = {
+	cwd: (): string => process.cwd(),
+	existsSync: (target: string): boolean => fs.existsSync(target),
+	readFileSync: (target: string): string => fs.readFileSync(target, "utf8"),
+	warn: (message: string): void => console.warn(message),
+};
+
+/** The one field of a package.json this module cares about. */
+interface NamedPackageJson {
+	name?: unknown;
+}
+
 /**
  * Finds the workspace root directory (captcha-private)
  */
-export const findWorkspaceRoot = (name?: string): string => {
-	const currentDir = process.cwd();
+export const findWorkspaceRoot = (
+	name?: string,
+	deps: WorkspaceRootDeps = defaultDeps,
+): string => {
+	const currentDir = deps.cwd();
 	const lintDirPattern = /(.+)\/captcha\/dev\/lint$/;
 	const match = currentDir.match(lintDirPattern);
-	name = name || "@prosopo/captcha-private";
+	const targetName = name || "@prosopo/captcha-private";
 
 	if (match?.[1]) {
 		return match[1];
 	}
 
 	const websitePath = path.join(currentDir, "packages", "prosopo-website");
-	if (fs.existsSync(websitePath)) {
+	if (deps.existsSync(websitePath)) {
 		return currentDir;
 	}
 
 	let dir = currentDir;
-	const maxDepth = 5;
 
-	for (let i = 0; i < maxDepth; i++) {
+	for (let i = 0; i < WORKSPACE_ROOT_MAX_DEPTH; i++) {
 		const packageJsonPath = path.join(dir, "package.json");
 
-		if (fs.existsSync(packageJsonPath)) {
+		if (deps.existsSync(packageJsonPath)) {
 			try {
-				const packageJson = JSON.parse(
-					fs.readFileSync(packageJsonPath, "utf8"),
+				// Deliberately shallow typing: this is an arbitrary file on disk,
+				// so the only safe assumption is that `name`, if present, may be
+				// anything. A malformed or unreadable package.json must not abort
+				// the ascent — a directory higher up may still be the root.
+				const packageJson: NamedPackageJson = JSON.parse(
+					deps.readFileSync(packageJsonPath),
 				);
-				if (packageJson.name === name) {
+				if (packageJson.name === targetName) {
 					return dir;
 				}
-			} catch (e) {
+			} catch {
 				// Continue if there's an error
 			}
 		}
@@ -154,8 +205,6 @@ export const findWorkspaceRoot = (name?: string): string => {
 	}
 
 	// If all approaches fail, warn but return current directory
-	console.warn(
-		"Warning: Could not find workspace root. Using current directory.",
-	);
+	deps.warn("Warning: Could not find workspace root. Using current directory.");
 	return currentDir;
 };

--- a/dev/workspace/src/tests/findWorkspaceRoot.unit.test.ts
+++ b/dev/workspace/src/tests/findWorkspaceRoot.unit.test.ts
@@ -1,0 +1,366 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import path from "node:path";
+import { describe, expect, test, vi } from "vitest";
+import {
+	WORKSPACE_ROOT_MAX_DEPTH,
+	type WorkspaceRootDeps,
+	findWorkspaceRoot,
+} from "../projectInfo.js";
+
+const DEFAULT_NAME = "@prosopo/captcha-private";
+
+interface Tree {
+	/** Absolute path -> file contents. Directories are implied by their files. */
+	files: Record<string, string>;
+	cwd: string;
+}
+
+interface Harness {
+	deps: WorkspaceRootDeps;
+	warnings: string[];
+	reads: string[];
+}
+
+const harness = (tree: Tree, overrides: Partial<WorkspaceRootDeps> = {}) => {
+	const warnings: string[] = [];
+	const reads: string[] = [];
+	const deps: WorkspaceRootDeps = {
+		cwd: (): string => tree.cwd,
+		existsSync: (target: string): boolean => target in tree.files,
+		readFileSync: (target: string): string => {
+			reads.push(target);
+			const contents = tree.files[target];
+			if (contents === undefined) {
+				throw new Error(`ENOENT: ${target}`);
+			}
+			return contents;
+		},
+		warn: (message: string): void => {
+			warnings.push(message);
+		},
+		...overrides,
+	};
+	const result: Harness = { deps, warnings, reads };
+	return result;
+};
+
+const manifest = (name: string): string => JSON.stringify({ name });
+
+describe("findWorkspaceRoot, lint directory shortcut", () => {
+	// dev/lint runs with its own cwd and the workspace root is two levels above
+	// the captcha submodule, which the ordinary ascent would not reach within
+	// the depth limit.
+	test("returns the directory above captcha/ when run from captcha/dev/lint", () => {
+		const { deps } = harness({
+			files: {},
+			cwd: "/home/x/repo/captcha/dev/lint",
+		});
+		expect(findWorkspaceRoot(undefined, deps)).toBe("/home/x/repo");
+	});
+
+	test("takes precedence over the package.json ascent", () => {
+		// Even with a matching manifest right there, the lint path wins.
+		const { deps, reads } = harness({
+			files: {
+				"/home/x/repo/captcha/dev/lint/package.json": manifest(DEFAULT_NAME),
+			},
+			cwd: "/home/x/repo/captcha/dev/lint",
+		});
+		expect(findWorkspaceRoot(undefined, deps)).toBe("/home/x/repo");
+		expect(reads).toEqual([]);
+	});
+
+	test("does not fire for a sibling of dev/lint", () => {
+		const { deps } = harness({
+			files: {},
+			cwd: "/home/x/repo/captcha/dev/scripts",
+		});
+		expect(findWorkspaceRoot(undefined, deps)).toBe(
+			"/home/x/repo/captcha/dev/scripts",
+		);
+	});
+
+	test("does not fire for a directory below dev/lint", () => {
+		// The pattern is anchored at the end, so only the lint dir itself counts.
+		const { deps } = harness({
+			files: {},
+			cwd: "/home/x/repo/captcha/dev/lint/src",
+		});
+		expect(findWorkspaceRoot(undefined, deps)).toBe(
+			"/home/x/repo/captcha/dev/lint/src",
+		);
+	});
+
+	test("requires a non-empty prefix before captcha/dev/lint", () => {
+		// `/captcha/dev/lint` at the filesystem root has nothing to return, so
+		// the pattern must not match and produce an empty string.
+		const { deps } = harness({ files: {}, cwd: "/captcha/dev/lint" });
+		expect(findWorkspaceRoot(undefined, deps)).not.toBe("");
+	});
+});
+
+describe("findWorkspaceRoot, website shortcut", () => {
+	test("returns cwd when packages/prosopo-website is present", () => {
+		const { deps } = harness({
+			files: { "/home/x/repo/packages/prosopo-website": "" },
+			cwd: "/home/x/repo",
+		});
+		expect(findWorkspaceRoot(undefined, deps)).toBe("/home/x/repo");
+	});
+
+	test("takes precedence over an ancestor whose manifest matches", () => {
+		const { deps } = harness({
+			files: {
+				"/home/x/repo/sub/packages/prosopo-website": "",
+				"/home/x/package.json": manifest(DEFAULT_NAME),
+			},
+			cwd: "/home/x/repo/sub",
+		});
+		expect(findWorkspaceRoot(undefined, deps)).toBe("/home/x/repo/sub");
+	});
+});
+
+describe("findWorkspaceRoot, package.json ascent", () => {
+	test("matches in the current directory", () => {
+		const { deps } = harness({
+			files: { "/home/x/repo/package.json": manifest(DEFAULT_NAME) },
+			cwd: "/home/x/repo",
+		});
+		expect(findWorkspaceRoot(undefined, deps)).toBe("/home/x/repo");
+	});
+
+	test("ascends past directories whose manifest does not match", () => {
+		const { deps } = harness({
+			files: {
+				"/home/x/repo/captcha/packages/cli/package.json":
+					manifest("@prosopo/cli"),
+				"/home/x/repo/captcha/package.json": manifest("@prosopo/captcha"),
+				"/home/x/repo/package.json": manifest(DEFAULT_NAME),
+			},
+			cwd: "/home/x/repo/captcha/packages/cli",
+		});
+		expect(findWorkspaceRoot(undefined, deps)).toBe("/home/x/repo");
+	});
+
+	test("ascends past directories with no package.json at all", () => {
+		const { deps } = harness({
+			files: { "/home/x/package.json": manifest(DEFAULT_NAME) },
+			cwd: "/home/x/a/b/c",
+		});
+		expect(findWorkspaceRoot(undefined, deps)).toBe("/home/x");
+	});
+
+	test("honours a caller-supplied name", () => {
+		const { deps } = harness({
+			files: { "/home/x/repo/package.json": manifest("@acme/other") },
+			cwd: "/home/x/repo",
+		});
+		expect(findWorkspaceRoot("@acme/other", deps)).toBe("/home/x/repo");
+	});
+
+	test("an empty name falls back to the default rather than matching nothing", () => {
+		// `name || default` treats "" as absent. A manifest with an empty name
+		// must therefore not be treated as a match.
+		const { deps } = harness({
+			files: {
+				"/home/x/repo/package.json": manifest(""),
+				"/home/x/package.json": manifest(DEFAULT_NAME),
+			},
+			cwd: "/home/x/repo",
+		});
+		expect(findWorkspaceRoot("", deps)).toBe("/home/x");
+	});
+
+	test("returns the nearest match when two ancestors both match", () => {
+		const { deps } = harness({
+			files: {
+				"/home/x/repo/package.json": manifest(DEFAULT_NAME),
+				"/home/x/package.json": manifest(DEFAULT_NAME),
+			},
+			cwd: "/home/x/repo",
+		});
+		expect(findWorkspaceRoot(undefined, deps)).toBe("/home/x/repo");
+	});
+
+	test("a name match is exact, not a prefix", () => {
+		const { deps } = harness({
+			files: {
+				"/home/x/repo/package.json": manifest("@prosopo/captcha-private-2"),
+			},
+			cwd: "/home/x/repo",
+		});
+		expect(findWorkspaceRoot(undefined, deps)).toBe("/home/x/repo");
+		// Falls through to the warning path rather than matching the near-miss.
+	});
+});
+
+describe("findWorkspaceRoot, malformed input", () => {
+	// A package.json anywhere on the ascent may be unreadable or invalid. That
+	// must not abort the search: a directory higher up may still be the root.
+	test("skips a manifest that is not valid JSON", () => {
+		const { deps } = harness({
+			files: {
+				"/home/x/repo/package.json": "{not json",
+				"/home/x/package.json": manifest(DEFAULT_NAME),
+			},
+			cwd: "/home/x/repo",
+		});
+		expect(findWorkspaceRoot(undefined, deps)).toBe("/home/x");
+	});
+
+	test("skips a manifest that fails to read", () => {
+		const { deps } = harness(
+			{
+				files: {
+					"/home/x/repo/package.json": manifest(DEFAULT_NAME),
+					"/home/x/package.json": manifest(DEFAULT_NAME),
+				},
+				cwd: "/home/x/repo",
+			},
+			{
+				readFileSync: (target: string): string => {
+					if (target === "/home/x/repo/package.json") {
+						throw new Error("EACCES: permission denied");
+					}
+					return manifest(DEFAULT_NAME);
+				},
+			},
+		);
+		expect(findWorkspaceRoot(undefined, deps)).toBe("/home/x");
+	});
+
+	test("skips a manifest with no name field", () => {
+		const { deps } = harness({
+			files: {
+				"/home/x/repo/package.json": JSON.stringify({ version: "1.0.0" }),
+				"/home/x/package.json": manifest(DEFAULT_NAME),
+			},
+			cwd: "/home/x/repo",
+		});
+		expect(findWorkspaceRoot(undefined, deps)).toBe("/home/x");
+	});
+
+	test("skips a manifest whose name is not a string", () => {
+		const { deps } = harness({
+			files: {
+				"/home/x/repo/package.json": JSON.stringify({ name: { nested: true } }),
+				"/home/x/package.json": manifest(DEFAULT_NAME),
+			},
+			cwd: "/home/x/repo",
+		});
+		expect(findWorkspaceRoot(undefined, deps)).toBe("/home/x");
+	});
+
+	test("skips a manifest that is valid JSON but not an object", () => {
+		// JSON.parse("null") succeeds, and `null.name` would throw — inside the
+		// try, so it is caught, but the ascent must still continue.
+		const { deps } = harness({
+			files: {
+				"/home/x/repo/package.json": "null",
+				"/home/x/package.json": manifest(DEFAULT_NAME),
+			},
+			cwd: "/home/x/repo",
+		});
+		expect(findWorkspaceRoot(undefined, deps)).toBe("/home/x");
+	});
+
+	test("skips an empty manifest file", () => {
+		const { deps } = harness({
+			files: {
+				"/home/x/repo/package.json": "",
+				"/home/x/package.json": manifest(DEFAULT_NAME),
+			},
+			cwd: "/home/x/repo",
+		});
+		expect(findWorkspaceRoot(undefined, deps)).toBe("/home/x");
+	});
+});
+
+describe("findWorkspaceRoot, giving up", () => {
+	test("warns and returns cwd when nothing matches", () => {
+		const { deps, warnings } = harness({ files: {}, cwd: "/home/x/repo" });
+		expect(findWorkspaceRoot(undefined, deps)).toBe("/home/x/repo");
+		expect(warnings).toHaveLength(1);
+		expect(warnings[0]).toContain("Could not find workspace root");
+	});
+
+	test("does not warn when a root is found", () => {
+		const { deps, warnings } = harness({
+			files: { "/home/x/repo/package.json": manifest(DEFAULT_NAME) },
+			cwd: "/home/x/repo",
+		});
+		findWorkspaceRoot(undefined, deps);
+		expect(warnings).toEqual([]);
+	});
+
+	test("stops after the depth limit even when a match sits just beyond it", () => {
+		// Deliberate: the limit bounds an unbounded walk toward /. A match
+		// further up is missed, and the caller gets cwd plus a warning rather
+		// than a wrong-but-plausible directory.
+		const deepCwd = `/home/${"a/".repeat(WORKSPACE_ROOT_MAX_DEPTH + 2)}leaf`;
+		const { deps, warnings } = harness({
+			files: { "/home/package.json": manifest(DEFAULT_NAME) },
+			cwd: deepCwd,
+		});
+		expect(findWorkspaceRoot(undefined, deps)).toBe(deepCwd);
+		expect(warnings).toHaveLength(1);
+	});
+
+	test("finds a match exactly at the depth limit", () => {
+		// WORKSPACE_ROOT_MAX_DEPTH iterations means cwd plus its first four
+		// ancestors are inspected.
+		const { deps } = harness({
+			files: { "/a/package.json": manifest(DEFAULT_NAME) },
+			cwd: "/a/b/c/d/e",
+		});
+		expect(findWorkspaceRoot(undefined, deps)).toBe("/a");
+	});
+
+	test("terminates at the filesystem root instead of looping on itself", () => {
+		// path.dirname("/") === "/", so without the break the loop would inspect
+		// the same directory for every remaining iteration.
+		const existsSync = vi.fn((target: string): boolean => target === "/x");
+		const { deps, warnings } = harness({ files: {}, cwd: "/" }, { existsSync });
+		expect(findWorkspaceRoot(undefined, deps)).toBe("/");
+		expect(warnings).toHaveLength(1);
+		// cwd inspection only: the website probe plus one package.json probe.
+		expect(existsSync).toHaveBeenCalledTimes(2);
+	});
+});
+
+describe("findWorkspaceRoot, real filesystem", () => {
+	// Two end-to-end passes through the default dependencies, so the real
+	// wiring is covered and not only the injected variant.
+	test("finds the captcha repo root from inside the workspace package", () => {
+		// The test runs with cwd at dev/workspace, two levels below the repo
+		// root, which the default depth comfortably reaches.
+		expect(findWorkspaceRoot("@prosopo/captcha")).toBe(
+			path.resolve(process.cwd(), "../.."),
+		);
+	});
+
+	test("warns through console.warn and returns cwd for a name that is not there", () => {
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+		try {
+			expect(findWorkspaceRoot("@prosopo/no-such-workspace-root")).toBe(
+				process.cwd(),
+			);
+			expect(warn).toHaveBeenCalledTimes(1);
+		} finally {
+			warn.mockRestore();
+		}
+	});
+});

--- a/dev/workspace/src/tests/projectInfo.unit.test.ts
+++ b/dev/workspace/src/tests/projectInfo.unit.test.ts
@@ -1,0 +1,270 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, test } from "vitest";
+import * as projectInfo from "../projectInfo.js";
+import {
+	getAccountPkgDir,
+	getApiPkgDir,
+	getCacheDir,
+	getCliPkgDir,
+	getClientBundleExampleDir,
+	getClientExampleServerDir,
+	getCommonPkgDir,
+	getConfigPkgDir,
+	getDatabasePkgDir,
+	getDatasetsFsPkgDir,
+	getDatasetsPkgDir,
+	getDemosDir,
+	getDevDir,
+	getDotEnvPkgDir,
+	getEnvPkgDir,
+	getFileServerPkgDir,
+	getLocalePkgDir,
+	getNodeModulesDir,
+	getPackagesDir,
+	getProcaptchaBundlePkgDir,
+	getProcaptchaCommonPkgDir,
+	getProcaptchaFrictionlessPkgDir,
+	getProcaptchaPkgDir,
+	getProcaptchaPoWPkgDir,
+	getProcaptchaReactPkgDir,
+	getProviderPkgDir,
+	getRootDir,
+	getScriptsPkgDir,
+	getServerPkgDir,
+	getTestResultsDir,
+	getTypesDatabasePkgDir,
+	getTypesEnvPkgDir,
+	getTypesPkgDir,
+	getUtilPkgDir,
+	getWidgetSkeletonPkgDir,
+} from "../projectInfo.js";
+
+describe("getRootDir", () => {
+	test("resolves to the repository root, identified by its package.json name", () => {
+		// The whole module is a tree of string concatenations hanging off this
+		// one value, so if it is wrong every other getter is wrong too.
+		const manifest: unknown = JSON.parse(
+			fs.readFileSync(path.join(getRootDir(), "package.json"), "utf8"),
+		);
+		expect(manifest).toMatchObject({ name: "@prosopo/captcha" });
+	});
+
+	test("returns an absolute path", () => {
+		expect(path.isAbsolute(getRootDir())).toBe(true);
+	});
+
+	test("has no trailing separator, so `${dir}/x` yields a single slash", () => {
+		// Callers interpolate rather than path.join, so a trailing separator
+		// would produce `//` in every derived path.
+		expect(getRootDir().endsWith(path.sep)).toBe(false);
+		expect(getPackagesDir()).not.toContain("//");
+	});
+
+	test("contains no percent-encoding", () => {
+		// `new URL(...).pathname` is percent-encoded, so a checkout under a path
+		// containing a space or a `#` used to yield `%20`/`%23` and every derived
+		// path failed to resolve.
+		expect(getRootDir()).not.toMatch(/%[0-9A-Fa-f]{2}/);
+	});
+
+	test("is stable across calls", () => {
+		expect(getRootDir()).toBe(getRootDir());
+	});
+
+	test("locates the root the same way whether imported from src or dist", () => {
+		// Both layouts sit at the same depth (dev/workspace/{src,dist}), which is
+		// what makes the fixed `../../..` correct. If either moves, this breaks.
+		expect(path.basename(path.dirname(getDevDir()))).toBe(
+			path.basename(getRootDir()),
+		);
+	});
+});
+
+describe("top-level directories", () => {
+	const cases: [string, () => string, string][] = [
+		["cache", getCacheDir, ".cache"],
+		["dev", getDevDir, "dev"],
+		["demos", getDemosDir, "demos"],
+		["packages", getPackagesDir, "packages"],
+		["node_modules", getNodeModulesDir, "node_modules"],
+	];
+
+	test.each(cases)("%s hangs directly off the root", (_name, getter, leaf) => {
+		expect(getter()).toBe(`${getRootDir()}/${leaf}`);
+	});
+
+	test("test results live under the cache dir, not the root", () => {
+		// The cache dir is gitignored wholesale; putting results anywhere else
+		// would commit them.
+		expect(getTestResultsDir()).toBe(`${getCacheDir()}/test-results`);
+		expect(getTestResultsDir().startsWith(`${getCacheDir()}/`)).toBe(true);
+	});
+});
+
+// Every getter is a hand-written string. A package that is renamed or removed
+// leaves the getter silently pointing at nothing, and the caller only finds out
+// at runtime — which is how `getClientExampleDir` and `getDappExampleDir` came
+// to return paths for directories that no longer exist. Asserting the target
+// exists is the only thing that catches that.
+describe("every exported directory getter points at a directory that exists", () => {
+	const getters: [string, () => string][] = [
+		["getRootDir", getRootDir],
+		["getDevDir", getDevDir],
+		["getDemosDir", getDemosDir],
+		["getPackagesDir", getPackagesDir],
+		["getNodeModulesDir", getNodeModulesDir],
+		["getConfigPkgDir", getConfigPkgDir],
+		["getScriptsPkgDir", getScriptsPkgDir],
+		["getClientExampleServerDir", getClientExampleServerDir],
+		["getClientBundleExampleDir", getClientBundleExampleDir],
+		["getAccountPkgDir", getAccountPkgDir],
+		["getApiPkgDir", getApiPkgDir],
+		["getCliPkgDir", getCliPkgDir],
+		["getCommonPkgDir", getCommonPkgDir],
+		["getDatabasePkgDir", getDatabasePkgDir],
+		["getDatasetsPkgDir", getDatasetsPkgDir],
+		["getDatasetsFsPkgDir", getDatasetsFsPkgDir],
+		["getDotEnvPkgDir", getDotEnvPkgDir],
+		["getEnvPkgDir", getEnvPkgDir],
+		["getFileServerPkgDir", getFileServerPkgDir],
+		["getProcaptchaPkgDir", getProcaptchaPkgDir],
+		["getProcaptchaBundlePkgDir", getProcaptchaBundlePkgDir],
+		["getProcaptchaCommonPkgDir", getProcaptchaCommonPkgDir],
+		["getProcaptchaFrictionlessPkgDir", getProcaptchaFrictionlessPkgDir],
+		["getProcaptchaPoWPkgDir", getProcaptchaPoWPkgDir],
+		["getProcaptchaReactPkgDir", getProcaptchaReactPkgDir],
+		["getProviderPkgDir", getProviderPkgDir],
+		["getServerPkgDir", getServerPkgDir],
+		["getTypesPkgDir", getTypesPkgDir],
+		["getTypesDatabasePkgDir", getTypesDatabasePkgDir],
+		["getTypesEnvPkgDir", getTypesEnvPkgDir],
+		["getUtilPkgDir", getUtilPkgDir],
+		["getWidgetSkeletonPkgDir", getWidgetSkeletonPkgDir],
+		["getLocalePkgDir", getLocalePkgDir],
+	];
+
+	test.each(getters)("%s", (_name, getter) => {
+		const target = getter();
+		expect(fs.existsSync(target), target).toBe(true);
+		expect(fs.statSync(target).isDirectory(), target).toBe(true);
+	});
+
+	// getCacheDir and getTestResultsDir are excluded above: both are created on
+	// demand by a test run, so a clean checkout legitimately lacks them.
+	test("the cache dir is the only getter allowed not to exist yet", () => {
+		expect(getCacheDir()).toBe(`${getRootDir()}/.cache`);
+	});
+
+	test("the list above covers every exported getter", () => {
+		// Guards against a new getter being added without an existence check.
+		const exported = Object.keys(projectInfo).filter(
+			(key) => key.startsWith("get") && key.endsWith("Dir"),
+		);
+		const checked = new Set([
+			...getters.map(([name]) => name),
+			"getCacheDir",
+			"getTestResultsDir",
+		]);
+		expect(exported.filter((name) => !checked.has(name))).toEqual([]);
+	});
+});
+
+describe("package getters resolve under their declared parent", () => {
+	test("every *PkgDir sits directly under packages/ or dev/", () => {
+		const pkgGetters = Object.entries(projectInfo).filter(
+			(entry): entry is [string, () => string] =>
+				entry[0].endsWith("PkgDir") && typeof entry[1] === "function",
+		);
+		expect(pkgGetters.length).toBeGreaterThan(0);
+		for (const [name, getter] of pkgGetters) {
+			const parent = path.dirname(getter());
+			expect([getPackagesDir(), getDevDir()], name).toContain(parent);
+		}
+	});
+
+	test("the demo getters sit under demos/", () => {
+		expect(path.dirname(getClientExampleServerDir())).toBe(getDemosDir());
+		expect(path.dirname(getClientBundleExampleDir())).toBe(getDemosDir());
+	});
+
+	test("no two getters resolve to the same directory", () => {
+		// A copy-paste slip between two similarly named packages (procaptcha vs
+		// procaptcha-common) would otherwise go unnoticed.
+		const paths = Object.entries(projectInfo)
+			.filter(
+				(entry): entry is [string, () => string] =>
+					entry[0].startsWith("get") &&
+					entry[0].endsWith("Dir") &&
+					typeof entry[1] === "function",
+			)
+			.map(([, getter]) => getter());
+		expect(new Set(paths).size).toBe(paths.length);
+	});
+
+	test("each package directory name matches its getter name", () => {
+		// getProcaptchaPoWPkgDir -> procaptcha-pow. Catches a getter renamed
+		// without its path being updated, and vice versa.
+		const expected: Record<string, string> = {
+			getAccountPkgDir: "account",
+			getApiPkgDir: "api",
+			getCliPkgDir: "cli",
+			getCommonPkgDir: "common",
+			getDatabasePkgDir: "database",
+			getDatasetsPkgDir: "datasets",
+			getDatasetsFsPkgDir: "datasets-fs",
+			getDotEnvPkgDir: "dotenv",
+			getEnvPkgDir: "env",
+			getFileServerPkgDir: "file-server",
+			getProcaptchaPkgDir: "procaptcha",
+			getProcaptchaBundlePkgDir: "procaptcha-bundle",
+			getProcaptchaCommonPkgDir: "procaptcha-common",
+			getProcaptchaFrictionlessPkgDir: "procaptcha-frictionless",
+			getProcaptchaPoWPkgDir: "procaptcha-pow",
+			getProcaptchaReactPkgDir: "procaptcha-react",
+			getProviderPkgDir: "provider",
+			getServerPkgDir: "server",
+			getTypesPkgDir: "types",
+			getTypesDatabasePkgDir: "types-database",
+			getTypesEnvPkgDir: "types-env",
+			getUtilPkgDir: "util",
+			getWidgetSkeletonPkgDir: "widget-skeleton",
+			getLocalePkgDir: "locale",
+			getConfigPkgDir: "config",
+			getScriptsPkgDir: "scripts",
+		};
+		for (const [name, leaf] of Object.entries(expected)) {
+			const getter = Reflect.get(projectInfo, name);
+			expect(typeof getter, name).toBe("function");
+			if (typeof getter === "function") {
+				expect(path.basename(String(getter())), name).toBe(leaf);
+			}
+		}
+	});
+});
+
+describe("removed getters stay removed", () => {
+	// demos/client-example and demos/dapp-example no longer exist. Re-adding a
+	// getter for either without the directory would reintroduce a path that
+	// silently resolves to nothing.
+	test.each(["getClientExampleDir", "getDappExampleDir"])(
+		"%s is not exported",
+		(name: string) => {
+			expect(Object.keys(projectInfo)).not.toContain(name);
+		},
+	);
+});

--- a/dev/workspace/src/tests/workspace.test-d.ts
+++ b/dev/workspace/src/tests/workspace.test-d.ts
@@ -1,0 +1,124 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { assertType, describe, expectTypeOf, test } from "vitest";
+// Deliberately the package entrypoint rather than the module: consumers import
+// `@prosopo/workspace`, so that is the surface worth pinning.
+import {
+	WORKSPACE_ROOT_MAX_DEPTH,
+	type WorkspaceRootDeps,
+	findWorkspaceRoot,
+	getCacheDir,
+	getLocalePkgDir,
+	getPackagesDir,
+	getRootDir,
+	getTestResultsDir,
+} from "../index.js";
+
+describe("directory getters", () => {
+	test("take no arguments and return a string", () => {
+		expectTypeOf(getRootDir).toEqualTypeOf<() => string>();
+		expectTypeOf(getRootDir()).toEqualTypeOf<string>();
+		expectTypeOf(getPackagesDir()).toEqualTypeOf<string>();
+		expectTypeOf(getLocalePkgDir()).toEqualTypeOf<string>();
+		expectTypeOf(getCacheDir()).toEqualTypeOf<string>();
+		expectTypeOf(getTestResultsDir()).toEqualTypeOf<string>();
+	});
+
+	test("reject arguments — a path is never parameterised", () => {
+		// @ts-expect-error getRootDir takes no arguments
+		getRootDir("somewhere");
+	});
+
+	test("are not widened to `any`, so string operations stay checked", () => {
+		expectTypeOf(getRootDir()).not.toBeAny();
+		expectTypeOf(getRootDir().split("/")).toEqualTypeOf<string[]>();
+	});
+});
+
+describe("removed getters", () => {
+	test("getClientExampleDir and getDappExampleDir are gone from the surface", async () => {
+		const entrypoint = await import("../index.js");
+		// @ts-expect-error removed: demos/client-example no longer exists
+		expectTypeOf(entrypoint.getClientExampleDir).toBeUndefined();
+		// @ts-expect-error removed: demos/dapp-example no longer exists
+		expectTypeOf(entrypoint.getDappExampleDir).toBeUndefined();
+	});
+});
+
+describe("findWorkspaceRoot", () => {
+	test("returns a string", () => {
+		expectTypeOf(findWorkspaceRoot()).toEqualTypeOf<string>();
+	});
+
+	test("both parameters are optional, preserving the original call shape", () => {
+		assertType<string>(findWorkspaceRoot());
+		assertType<string>(findWorkspaceRoot("@acme/pkg"));
+		expectTypeOf(findWorkspaceRoot)
+			.parameter(0)
+			.toEqualTypeOf<string | undefined>();
+	});
+
+	test("rejects a non-string name", () => {
+		// @ts-expect-error name is a string
+		findWorkspaceRoot(42);
+	});
+
+	test("accepts a full dependency set as the second parameter", () => {
+		const deps: WorkspaceRootDeps = {
+			cwd: () => "/tmp",
+			existsSync: () => false,
+			readFileSync: () => "{}",
+			warn: () => undefined,
+		};
+		assertType<string>(findWorkspaceRoot(undefined, deps));
+	});
+
+	test("rejects a partial dependency set — every seam must be supplied", () => {
+		// A partial object would silently fall through to the real filesystem
+		// for whatever it omitted, which is exactly what the seam exists to
+		// prevent.
+		// @ts-expect-error missing readFileSync and warn
+		findWorkspaceRoot(undefined, {
+			cwd: () => "/tmp",
+			existsSync: () => false,
+		});
+	});
+});
+
+describe("WorkspaceRootDeps", () => {
+	test("pins each seam's signature", () => {
+		expectTypeOf<WorkspaceRootDeps["cwd"]>().toEqualTypeOf<() => string>();
+		expectTypeOf<WorkspaceRootDeps["existsSync"]>().toEqualTypeOf<
+			(target: string) => boolean
+		>();
+		expectTypeOf<WorkspaceRootDeps["warn"]>().toEqualTypeOf<
+			(message: string) => void
+		>();
+	});
+
+	test("readFileSync returns a string, not a Buffer", () => {
+		// The default implementation pins the "utf8" encoding, so callers never
+		// have to deal with a Buffer overload.
+		expectTypeOf<WorkspaceRootDeps["readFileSync"]>().toEqualTypeOf<
+			(target: string) => string
+		>();
+	});
+});
+
+describe("WORKSPACE_ROOT_MAX_DEPTH", () => {
+	test("is a number", () => {
+		expectTypeOf(WORKSPACE_ROOT_MAX_DEPTH).toEqualTypeOf<number>();
+	});
+});

--- a/dev/workspace/vite.test.config.ts
+++ b/dev/workspace/vite.test.config.ts
@@ -1,0 +1,32 @@
+import fs from "node:fs";
+import path from "node:path";
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import { ViteTestConfig } from "@prosopo/config";
+import dotenv from "dotenv";
+process.env.NODE_ENV = "test";
+// if .env.test exists at this level, use it, otherwise use the one at the root
+const envFile = `.env.${process.env.NODE_ENV || "development"}`;
+let envPath = envFile;
+if (fs.existsSync(envFile)) {
+	envPath = path.resolve(envFile);
+} else if (fs.existsSync(`../../${envFile}`)) {
+	envPath = path.resolve(`../../${envFile}`);
+} else {
+	throw new Error(`No ${envFile} file found`);
+}
+
+dotenv.config({ path: envPath });
+
+export default ViteTestConfig();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1064,7 +1064,12 @@
 			"devDependencies": {
 				"@prosopo/config": "3.3.4",
 				"@types/node": "22.10.2",
-				"del-cli": "6.0.0"
+				"@vitest/coverage-v8": "4.1.10",
+				"del-cli": "6.0.0",
+				"dotenv": "16.4.5",
+				"typescript": "5.6.2",
+				"vite": "8.1.5",
+				"vitest": "4.1.10"
 			},
 			"engines": {
 				"node": "^24",


### PR DESCRIPTION
Tenth package in the per-package unit-test sweep, and the first outside `packages/` — `dev/workspace`.

The package had no test setup at all, so this adds `vite.test.config.ts`, a `test` script (which `turbo run test` picks up automatically) and the test dev dependencies.

## Tests

104 tests (92 runtime + 12 type) covering every export.

| metric | |
|---|---|
| statements | 100% |
| functions | 100% |
| lines | 100% |
| branches | 100% |

## Defects fixed

**1. `ViteTestConfig` reported no coverage for any workspace outside `packages/`.** It decided whether it was running inside a package with `cwd.includes("/packages/")`. Workspaces also live in `dev/`, `demos/` and `integration/` (the root `workspaces` field is `["dev/*", "packages/*", "demos/*", "integration/*"]`), and those fell through to the repo-root branch, whose include glob is `packages/*/src/**` — matching nothing. The result was a green run reporting `Statements: Unknown% (0/0)` no matter what the tests actually exercised. This package reproduced it exactly before the fix.

Detection is now "there is a `package.json` and a `src` directory next to the cwd". Neither repo root has a `src`, so it cannot misfire in the other direction. Verified against `@prosopo/locale` (inside `packages/`) that the existing behaviour is unchanged.

**2. `getRootDir` percent-encoded the repository path.** It used `new URL("../../..", import.meta.url).pathname`, which is percent-encoded per the URL spec: a checkout under a path containing a space or a `#` yielded `%20`/`%23`, and since every other getter in the module is a string concatenation hanging off this one value, *every* derived path failed to resolve. Now uses `fileURLToPath`, with `path.resolve` doing the trailing-separator strip the old `.slice(0, -1)` did by hand.

**3. Two getters pointed at directories that no longer exist.** `getClientExampleDir` -> `demos/client-example` and `getDappExampleDir` -> `demos/dapp-example` were both removed from the repository; the getters stayed. Neither had any remaining caller, so both are deleted rather than repointed.

This is the failure mode the module invites — every path is a hand-written string, and a renamed or removed package leaves the getter silently returning something that isn't there. The test suite therefore asserts that **every** exported `*Dir` getter resolves to a directory that actually exists, with a further test that fails if a new getter is added without being added to that list.

## Testability change

`findWorkspaceRoot` reads `process.cwd()`, `fs.existsSync` and `fs.readFileSync`. It now takes an optional `WorkspaceRootDeps` as a second parameter, defaulting to the real implementations, so the directory search can be driven against a synthetic tree — the alternative was either touching the developer's real filesystem or replacing `node:fs` for the whole run. The existing one-argument call in `dev/lint/src/redirects.ts` is unaffected; the type tests pin that both parameters stay optional.

That makes the interesting edge cases reachable: a `package.json` that is unreadable, invalid JSON, `null`, empty, or has a non-string `name` — all of which must be skipped so the ascent continues to a directory higher up rather than aborting — plus the depth limit, and the `path.dirname("/") === "/"` termination that stops the walk looping on itself at the filesystem root.

Alongside it, the `JSON.parse` result was implicitly `any` (project rule: never `any`); it is now typed to the single field the function reads.

## API change

- `WORKSPACE_ROOT_MAX_DEPTH` and the `WorkspaceRootDeps` interface are exported.
- `getClientExampleDir` and `getDappExampleDir` are removed (see above — both were dead and broken).
