### PR TITLE
feat(traffic-filter): add datacenterNameDenylist alongside allowlist

### DIFF
--- a/.changeset/datacenter-name-denylist.md
+++ b/.changeset/datacenter-name-denylist.md
@@ -1,0 +1,25 @@
+---
+"@prosopo/provider": patch
+"@prosopo/types": patch
+"@prosopo/types-database": patch
+---
+
+feat(traffic-filter): add `datacenterNameDenylist` alongside the existing allowlist
+
+Operators can now name datacenter / provider / ASN organisations they want
+force-included in the datacenter block, mirroring the shape of
+`datacenterNameAllowlist`. Denylist entries take precedence over the
+`providerType === "isp"` short-circuit and over the allowlist for the same
+name, so operators can opt named providers back into the datacenter rule when
+upstream classifies them as ISP.
+
+Same case-insensitive / whitespace-trimmed matching, same three name sources
+(`datacenterName`, `providerName`, `asnOrganization`), same
+`MAX_DATACENTER_ALLOWLIST_ENTRIES` / `MAX_DATACENTER_ALLOWLIST_ENTRY_LENGTH`
+validators. Missing or empty denylist preserves existing behaviour.
+
+Wired through the mongoose `ClientSettings.trafficFilter` schema, the zod
+`TrafficFilterSchema`, `checkTrafficFilter`, and `enrichDnsEvent.countDc` so
+the denylist is honoured on both the primary rule and the DNS-asymmetry
+scoring. Unit tests cover the ISP-bypass override, the allowlist-precedence
+edge case, category-suppression interaction, and the extras path.

--- a/packages/provider/src/tasks/dnsEvent/enrichDnsEvent.ts
+++ b/packages/provider/src/tasks/dnsEvent/enrichDnsEvent.ts
@@ -20,7 +20,10 @@ import type {
 	Session,
 } from "@prosopo/types";
 import { trafficFilterAbuserScoreThresholdDefault } from "@prosopo/types";
-import { isDatacenterAllowlisted } from "../spam/checkTrafficFilter.js";
+import {
+	isDatacenterAllowlisted,
+	isDatacenterDenylisted,
+} from "../spam/checkTrafficFilter.js";
 
 export type { EnrichedDnsEvent };
 
@@ -111,6 +114,13 @@ export const computeDnsAsymmetry = (
 	const countDc = (ip: IPInfoResponse | undefined): boolean => {
 		if (!ip?.isValid || !ip.isDatacenter) return false;
 		if (!trafficFilter) return true;
+		if (trafficFilter.blockDatacenter !== true) return false;
+		// Denylist wins: an explicitly listed provider counts as datacenter
+		// even when the ISP short-circuit or category suppression would
+		// otherwise exempt it.
+		if (isDatacenterDenylisted(ip, trafficFilter.datacenterNameDenylist)) {
+			return true;
+		}
 		// Cross-category suppression: don't penalise datacenter classification
 		// when the operator has left the more specific category unblocked.
 		if (
@@ -121,7 +131,6 @@ export const computeDnsAsymmetry = (
 		) {
 			return false;
 		}
-		if (trafficFilter.blockDatacenter !== true) return false;
 		if (ip.providerType === "isp") return false;
 		return !isDatacenterAllowlisted(ip, trafficFilter.datacenterNameAllowlist);
 	};

--- a/packages/provider/src/tasks/spam/checkTrafficFilter.ts
+++ b/packages/provider/src/tasks/spam/checkTrafficFilter.ts
@@ -121,9 +121,7 @@ const evaluateIpInfo = (
 		(ipInfo.isCrawler && !trafficFilter.blockCrawler);
 
 	if (trafficFilter.blockDatacenter && ipInfo.isDatacenter) {
-		if (
-			isDatacenterDenylisted(ipInfo, trafficFilter.datacenterNameDenylist)
-		) {
+		if (isDatacenterDenylisted(ipInfo, trafficFilter.datacenterNameDenylist)) {
 			return { isBlocked: true, reason: ResultReason.DATACENTER_BLOCKED };
 		}
 		if (

--- a/packages/provider/src/tasks/spam/checkTrafficFilter.ts
+++ b/packages/provider/src/tasks/spam/checkTrafficFilter.ts
@@ -34,17 +34,17 @@ export type TrafficCheckResult =
 	| { isBlocked: false }
 	| { isBlocked: true; reason: TrafficBlockReason };
 
-// Match the allowlist against `datacenterName`, `providerName`
+// Match the allowlist / denylist against `datacenterName`, `providerName`
 // (`company.name`), and `asnOrganization` — case-insensitive, whitespace
 // trimmed. The upstream ipapi only populates `datacenter.datacenter` for
 // curated named ranges, so falling back to providerName and asnOrganization
-// lets the allowlist also catch generic CDN / cloud-provider IPs that come
+// lets the lists also catch generic CDN / cloud-provider IPs that come
 // back with `is_datacenter: true` but no datacenter name.
-export const isDatacenterAllowlisted = (
+const matchesDatacenterNameList = (
 	ipInfo: IPInfoResult,
-	allowlist: ReadonlyArray<string> | undefined,
+	list: ReadonlyArray<string> | undefined,
 ): boolean => {
-	if (!allowlist || allowlist.length === 0) {
+	if (!list || list.length === 0) {
 		return false;
 	}
 	const candidates: string[] = [];
@@ -60,11 +60,25 @@ export const isDatacenterAllowlisted = (
 	if (candidates.length === 0) {
 		return false;
 	}
-	const normalisedAllowlist = allowlist.map((entry) =>
-		entry.trim().toLowerCase(),
-	);
-	return candidates.some((c) => normalisedAllowlist.includes(c));
+	const normalisedList = list.map((entry) => entry.trim().toLowerCase());
+	return candidates.some((c) => normalisedList.includes(c));
 };
+
+export const isDatacenterAllowlisted = (
+	ipInfo: IPInfoResult,
+	allowlist: ReadonlyArray<string> | undefined,
+): boolean => matchesDatacenterNameList(ipInfo, allowlist);
+
+// Counterpart to `isDatacenterAllowlisted`. When the datacenter rule is
+// active and the IP's name matches an entry in `datacenterNameDenylist`,
+// the block fires regardless of the `providerType === "isp"` suppression
+// and regardless of any allowlist entry for the same name. Denylist wins
+// so operators can opt named providers back into the block that would
+// otherwise be exempted by the ISP heuristic.
+export const isDatacenterDenylisted = (
+	ipInfo: IPInfoResult,
+	denylist: ReadonlyArray<string> | undefined,
+): boolean => matchesDatacenterNameList(ipInfo, denylist);
 
 const evaluateIpInfo = (
 	ipInfo: IPInfoResponse | undefined,
@@ -106,14 +120,19 @@ const evaluateIpInfo = (
 		(ipInfo.isTor && !trafficFilter.blockTor) ||
 		(ipInfo.isCrawler && !trafficFilter.blockCrawler);
 
-	if (
-		trafficFilter.blockDatacenter &&
-		ipInfo.isDatacenter &&
-		ipInfo.providerType !== "isp" &&
-		!datacenterSuppressedByCategory &&
-		!isDatacenterAllowlisted(ipInfo, trafficFilter.datacenterNameAllowlist)
-	) {
-		return { isBlocked: true, reason: ResultReason.DATACENTER_BLOCKED };
+	if (trafficFilter.blockDatacenter && ipInfo.isDatacenter) {
+		if (
+			isDatacenterDenylisted(ipInfo, trafficFilter.datacenterNameDenylist)
+		) {
+			return { isBlocked: true, reason: ResultReason.DATACENTER_BLOCKED };
+		}
+		if (
+			ipInfo.providerType !== "isp" &&
+			!datacenterSuppressedByCategory &&
+			!isDatacenterAllowlisted(ipInfo, trafficFilter.datacenterNameAllowlist)
+		) {
+			return { isBlocked: true, reason: ResultReason.DATACENTER_BLOCKED };
+		}
 	}
 
 	if (trafficFilter.blockMobile && ipInfo.isMobile) {
@@ -162,6 +181,13 @@ const evaluateIpInfo = (
  * hosting services — but the eyeball ranges behind those ASNs carry
  * ordinary end-users. The ISP categorisation is stronger evidence of
  * consumer traffic than the datacenter boolean.
+ *
+ * The ISP short-circuit and the allowlist are both overridden by
+ * `datacenterNameDenylist`: if the IP's `datacenterName`, `providerName`,
+ * or `asnOrganization` matches a denylist entry, the block fires. This
+ * lets operators opt named providers (for example IP-leasing platforms
+ * whose ranges are announced from carrier ASNs but exit as proxy pools)
+ * back into the datacenter rule.
  *
  * When `trafficFilter.skipExtrasOnValidDnsPath` is on and the catcher
  * confirmed the DNS path matched the connection path (`pathValid: true`),

--- a/packages/provider/src/tests/unit/tasks/spam/checkTrafficFilter.unit.test.ts
+++ b/packages/provider/src/tests/unit/tasks/spam/checkTrafficFilter.unit.test.ts
@@ -626,6 +626,202 @@ describe("checkTrafficFilter", () => {
 		});
 	});
 
+	describe("datacenterNameDenylist", () => {
+		it("blocks datacenter IPs whose name matches the denylist even when providerType is 'isp'", () => {
+			// IP-leasing platforms lease ranges from carrier ASNs; upstream
+			// reports providerType='isp' (accurate for the ASN) but the
+			// exiting traffic is proxy-pool. Operators opt these back into
+			// the datacenter block by name.
+			const result = checkTrafficFilter(
+				baseInfo({
+					isDatacenter: true,
+					providerType: "isp",
+					datacenterName: "proxy-lease-provider",
+				}),
+				{
+					...allBlocked,
+					datacenterNameDenylist: ["proxy-lease-provider"],
+				},
+			);
+			expect(result).toEqual({
+				isBlocked: true,
+				reason: "API.DATACENTER_BLOCKED",
+			});
+		});
+
+		it("matches the denylist case-insensitively and ignores whitespace", () => {
+			const result = checkTrafficFilter(
+				baseInfo({
+					isDatacenter: true,
+					providerType: "isp",
+					datacenterName: "  Proxy-Lease-Provider  ",
+				}),
+				{
+					...allBlocked,
+					datacenterNameDenylist: ["proxy-lease-provider"],
+				},
+			);
+			expect(result).toEqual({
+				isBlocked: true,
+				reason: "API.DATACENTER_BLOCKED",
+			});
+		});
+
+		it("matches the denylist against providerName when datacenterName is absent", () => {
+			const result = checkTrafficFilter(
+				baseInfo({
+					isDatacenter: true,
+					providerType: "isp",
+					providerName: "proxy-lease-provider",
+				}),
+				{
+					...allBlocked,
+					datacenterNameDenylist: ["proxy-lease-provider"],
+				},
+			);
+			expect(result).toEqual({
+				isBlocked: true,
+				reason: "API.DATACENTER_BLOCKED",
+			});
+		});
+
+		it("matches the denylist against asnOrganization when neither datacenterName nor providerName carries the operator", () => {
+			const result = checkTrafficFilter(
+				baseInfo({
+					isDatacenter: true,
+					providerType: "isp",
+					asnOrganization: "Proxy Lease Ltd",
+				}),
+				{
+					...allBlocked,
+					datacenterNameDenylist: ["Proxy Lease Ltd"],
+				},
+			);
+			expect(result).toEqual({
+				isBlocked: true,
+				reason: "API.DATACENTER_BLOCKED",
+			});
+		});
+
+		it("denylist takes precedence over the allowlist when both list the same name", () => {
+			// Contradictory config: explicit denylist wins so operators can
+			// tighten a shared allowlist entry for one specific provider.
+			const result = checkTrafficFilter(
+				baseInfo({
+					isDatacenter: true,
+					datacenterName: "shared-name",
+				}),
+				{
+					...allBlocked,
+					datacenterNameAllowlist: ["shared-name"],
+					datacenterNameDenylist: ["shared-name"],
+				},
+			);
+			expect(result).toEqual({
+				isBlocked: true,
+				reason: "API.DATACENTER_BLOCKED",
+			});
+		});
+
+		it("does not block a non-datacenter IP even when its name matches the denylist", () => {
+			// Denylist only takes effect within the datacenter rule scope;
+			// it does not turn every mention into a block.
+			const result = checkTrafficFilter(
+				baseInfo({ isDatacenter: false, datacenterName: "proxy-lease-provider" }),
+				{
+					...allBlocked,
+					datacenterNameDenylist: ["proxy-lease-provider"],
+				},
+			);
+			expect(result).toEqual({ isBlocked: false });
+		});
+
+		it("does not fire when blockDatacenter is off", () => {
+			// Operators who don't want any datacenter block get none, even
+			// with a denylist populated. Populated but inert.
+			const result = checkTrafficFilter(
+				baseInfo({
+					isDatacenter: true,
+					providerType: "isp",
+					datacenterName: "proxy-lease-provider",
+				}),
+				{
+					...allBlocked,
+					blockDatacenter: false,
+					datacenterNameDenylist: ["proxy-lease-provider"],
+				},
+			);
+			expect(result).toEqual({ isBlocked: false });
+		});
+
+		it("preserves legacy behaviour when denylist is missing or empty", () => {
+			// ISP suppression continues to fire; a missing / empty denylist
+			// must not change the existing datacenter-rule outcome.
+			const missing = checkTrafficFilter(
+				baseInfo({
+					isDatacenter: true,
+					providerType: "isp",
+					datacenterName: "some-isp",
+				}),
+				allBlocked,
+			);
+			expect(missing).toEqual({ isBlocked: false });
+
+			const empty = checkTrafficFilter(
+				baseInfo({
+					isDatacenter: true,
+					providerType: "isp",
+					datacenterName: "some-isp",
+				}),
+				{ ...allBlocked, datacenterNameDenylist: [] },
+			);
+			expect(empty).toEqual({ isBlocked: false });
+		});
+
+		it("still lets earlier category rules fire before the datacenter check", () => {
+			// A Tor exit whose name is on the denylist still trips TOR_BLOCKED
+			// first — denylist scope is the datacenter rule only.
+			const result = checkTrafficFilter(
+				baseInfo({
+					isTor: true,
+					isDatacenter: true,
+					providerType: "isp",
+					datacenterName: "proxy-lease-provider",
+				}),
+				{
+					...allBlocked,
+					datacenterNameDenylist: ["proxy-lease-provider"],
+				},
+			);
+			expect(result).toEqual({
+				isBlocked: true,
+				reason: "API.TOR_BLOCKED",
+			});
+		});
+
+		it("applies the denylist to extra IPs as well", () => {
+			const result = checkTrafficFilter(
+				baseInfo({ ip: "192.0.2.1" }),
+				{
+					...allBlocked,
+					datacenterNameDenylist: ["proxy-lease-provider"],
+				},
+				[
+					baseInfo({
+						ip: "198.51.100.10",
+						isDatacenter: true,
+						providerType: "isp",
+						datacenterName: "proxy-lease-provider",
+					}),
+				],
+			);
+			expect(result).toEqual({
+				isBlocked: true,
+				reason: "API.DATACENTER_BLOCKED",
+			});
+		});
+	});
+
 	describe("skipExtrasOnValidDnsPath", () => {
 		it("skips the extras evaluation when the catcher confirmed a valid DNS path and the setting is on", () => {
 			const result = checkTrafficFilter(

--- a/packages/provider/src/tests/unit/tasks/spam/checkTrafficFilter.unit.test.ts
+++ b/packages/provider/src/tests/unit/tasks/spam/checkTrafficFilter.unit.test.ts
@@ -727,7 +727,10 @@ describe("checkTrafficFilter", () => {
 			// Denylist only takes effect within the datacenter rule scope;
 			// it does not turn every mention into a block.
 			const result = checkTrafficFilter(
-				baseInfo({ isDatacenter: false, datacenterName: "proxy-lease-provider" }),
+				baseInfo({
+					isDatacenter: false,
+					datacenterName: "proxy-lease-provider",
+				}),
 				{
 					...allBlocked,
 					datacenterNameDenylist: ["proxy-lease-provider"],

--- a/packages/types-database/src/types/client.ts
+++ b/packages/types-database/src/types/client.ts
@@ -197,6 +197,7 @@ export const UserSettingsSchema = new Schema({
 		abuserScoreThreshold: { type: Number, min: 0, max: 1, default: 0 },
 		blockDatacenter: { type: Boolean, default: false },
 		datacenterNameAllowlist: { type: [String], required: false },
+		datacenterNameDenylist: { type: [String], required: false },
 		skipExtrasOnValidDnsPath: { type: Boolean, default: true },
 		blockMobile: { type: Boolean, default: false },
 		blockSatellite: { type: Boolean, default: false },

--- a/packages/types/src/client/settings.ts
+++ b/packages/types/src/client/settings.ts
@@ -208,6 +208,20 @@ export const TrafficFilterSchema = object({
 	)
 		.max(MAX_DATACENTER_ALLOWLIST_ENTRIES)
 		.optional(),
+	// Counterpart to `datacenterNameAllowlist`: any entry here forces the
+	// datacenter block for a matching name, overriding both the
+	// `providerType === "isp"` bypass and any allowlist entry for the same
+	// name. Useful for named providers that upstream classifies as ISP but
+	// operators want treated as datacenter (for example IP-leasing platforms
+	// whose ranges sit on carrier ASNs but exit as proxy pools). Same
+	// case-insensitive, whitespace-trimmed matching as the allowlist and the
+	// same three name sources (`datacenterName`, `providerName`,
+	// `asnOrganization`).
+	datacenterNameDenylist: array(
+		string().min(1).max(MAX_DATACENTER_ALLOWLIST_ENTRY_LENGTH),
+	)
+		.max(MAX_DATACENTER_ALLOWLIST_ENTRIES)
+		.optional(),
 	// When the catcher confirmed `dnsEvent.pathValid === true`, skip the
 	// datacenter / VPN / proxy / Tor evaluation on the DNS peer + resolver
 	// IPs. Default on: without this, users on public DoH resolvers or ISP


### PR DESCRIPTION
## Summary

- Adds `datacenterNameDenylist` on `TrafficFilterSchema`, symmetric to the existing `datacenterNameAllowlist`.
- Denylist entries force the datacenter block for matches on `datacenterName`, `providerName`, or `asnOrganization`, **overriding the `providerType === \"isp\"` short-circuit** and any allowlist entry for the same name.
- Same case-insensitive / whitespace-trimmed matching, same three name sources, same `MAX_DATACENTER_ALLOWLIST_ENTRIES` / `MAX_DATACENTER_ALLOWLIST_ENTRY_LENGTH` validators.
- Wired through the zod schema (`@prosopo/types`), the mongoose `ClientSettings.trafficFilter` schema (`@prosopo/types-database`), `checkTrafficFilter`, and `enrichDnsEvent.countDc`.
- Missing / empty denylist preserves existing behaviour byte-for-byte.

## Test plan

- [x] Unit: denylist blocks when `providerType === \"isp\"` (bypass override)
- [x] Unit: matches case-insensitively across `datacenterName`, `providerName`, `asnOrganization`
- [x] Unit: denylist takes precedence over allowlist for the same name
- [x] Unit: non-datacenter IP with matching name is not blocked (denylist scoped to datacenter rule)
- [x] Unit: denylist inert when `blockDatacenter: false`
- [x] Unit: earlier category rules (Tor, VPN) still fire before the datacenter check
- [x] Unit: extras path honours the denylist
- [x] Existing allowlist and category-suppression tests unchanged (88 tests passing)