### PR TITLE
test(client-example-server): unit + type tests, fix exposed defects

### DIFF
--- a/.changeset/client-example-server-tests.md
+++ b/.changeset/client-example-server-tests.md
@@ -1,0 +1,12 @@
+---
+"@prosopo/client-example-server": patch
+---
+
+Add unit and type tests for the client example server, and fix the defects they exposed:
+
+- `getRoutes` built one module-level router shared by every call, so a second call stacked handlers on the first call's bound config.
+- `isAuth` could fall through without sending a response, and could send twice for a malformed `Authorization` header.
+- The `if (passwordHash)` guard in signup had no else branch, leaving a request hanging when it was falsy.
+- A `serverUrl` without a port resolved to `NaN`, so the server listened on an arbitrary free port; it now falls back to 9228.
+- Removed the unreachable `OPTIONS` handler (`cors()` already answers preflight) and leftover debug logging.
+- `app.ts` no longer boots a server on import; it exports `createApp`, `startServer` and `main`, and only runs when executed directly.

--- a/demos/client-example-server/package.json
+++ b/demos/client-example-server/package.json
@@ -25,6 +25,9 @@
 		"build:tsc": "tsc --build --verbose",
 		"build:cjs": "NODE_ENV=${NODE_ENV:-development}; vite build --config vite.cjs.config.ts --mode $NODE_ENV",
 		"typecheck": "tsc --project tsconfig.types.json",
+		"test": "NODE_ENV=${NODE_ENV:-test}; npx vitest run --config ./vite.test.config.ts",
+		"test:watch": "NODE_ENV=${NODE_ENV:-test}; npx vitest --config ./vite.test.config.ts",
+		"test:coverage": "NODE_ENV=${NODE_ENV:-test}; npx vitest run --coverage --config ./vite.test.config.ts",
 		"bundle": "NODE_ENV=${NODE_ENV:-development}; vite build --config vite.config.ts --mode $NODE_ENV"
 	},
 	"repository": {

--- a/demos/client-example-server/src/app.ts
+++ b/demos/client-example-server/src/app.ts
@@ -40,13 +40,14 @@ const logger = getLogger("info", "client-example-server:app");
 
 /**
  * The siteverify endpoint the deployment talks to. Non-production
- * environments get their name as a subdomain prefix.
+ * environments get their name as a subdomain prefix. An unset NODE_ENV is
+ * treated as production: prefixing it produced `undefined-api.prosopo.io`,
+ * a host that does not exist.
  */
 export const resolveVerifyEndpoint = (): string => {
+	const environment = process.env.NODE_ENV;
 	const apiPrefix =
-		process.env.NODE_ENV && process.env.NODE_ENV === "production"
-			? ""
-			: `${process.env.NODE_ENV}-`;
+		!environment || environment === "production" ? "" : `${environment}-`;
 	return (
 		process.env.PROSOPO_VERIFY_ENDPOINT ||
 		`https://${apiPrefix}api.prosopo.io/siteverify`
@@ -202,6 +203,8 @@ if (isMain(import.meta.url)) {
 		})
 		.catch((err) => {
 			logger.error(() => ({ err }));
-			process.exit();
+			// Non-zero, so a boot failure is visible to whatever supervises the
+			// process rather than reading as a clean shutdown.
+			process.exit(1);
 		});
 }

--- a/demos/client-example-server/src/app.ts
+++ b/demos/client-example-server/src/app.ts
@@ -14,6 +14,7 @@
 
 import fs from "node:fs";
 import http from "node:http";
+import type { Server } from "node:http";
 import https from "node:https";
 import type { ServerOptions } from "node:https";
 import path from "node:path";
@@ -22,41 +23,49 @@ import { ProsopoEnvError } from "@prosopo/common";
 import { loadEnv } from "@prosopo/dotenv";
 import { getLogger } from "@prosopo/logger";
 import { getServerConfig } from "@prosopo/server";
-import { at } from "@prosopo/util";
+import type { ProsopoServerConfigOutput } from "@prosopo/types";
+import { at, isMain } from "@prosopo/util";
 import cors from "cors";
 import express from "express";
 import routesFactory from "./routes/routes.js";
 import connectionFactory from "./utils/connection.js";
 import memoryServerSetup from "./utils/database.js";
 
-loadEnv();
-
-enum ProsopoVerificationType {
+export enum ProsopoVerificationType {
 	api = "api",
 	local = "local",
 }
 
 const logger = getLogger("info", "client-example-server:app");
 
-async function main() {
-	loadEnv();
-
+/**
+ * The siteverify endpoint the deployment talks to. Non-production
+ * environments get their name as a subdomain prefix.
+ */
+export const resolveVerifyEndpoint = (): string => {
 	const apiPrefix =
 		process.env.NODE_ENV && process.env.NODE_ENV === "production"
 			? ""
 			: `${process.env.NODE_ENV}-`;
-	const verifyEndpoint =
+	return (
 		process.env.PROSOPO_VERIFY_ENDPOINT ||
-		`https://${apiPrefix}api.prosopo.io/siteverify`;
+		`https://${apiPrefix}api.prosopo.io/siteverify`
+	);
+};
 
-	logger.info(() => ({ data: { verifyEndpoint } }));
-
-	const verifyType: ProsopoVerificationType = Object.keys(
-		ProsopoVerificationType,
-	).includes(process.env.PROSOPO_VERIFICATION_TYPE as string)
+/** Anything the enum doesn't name falls back to the hosted API. */
+export const resolveVerifyType = (): ProsopoVerificationType =>
+	Object.keys(ProsopoVerificationType).includes(
+		process.env.PROSOPO_VERIFICATION_TYPE as string,
+	)
 		? (process.env.PROSOPO_VERIFICATION_TYPE as ProsopoVerificationType)
 		: ProsopoVerificationType.api;
 
+export const isDevelopmentOrTest = (): boolean =>
+	process.env.NODE_ENV === "development" || process.env.NODE_ENV === "test";
+
+/** The express app, minus the routes, which need a database connection. */
+export const createApp = (): express.Express => {
 	const app = express();
 
 	// https://express-rate-limit.mintlify.app/guides/troubleshooting-proxy-issues
@@ -81,15 +90,79 @@ async function main() {
 		next();
 	});
 
-	app.options("/*", (_, res) => {
-		res.sendStatus(200);
-	});
+	// No explicit OPTIONS handler: cors() above already answers preflight
+	// requests with a 204 and never calls through, so the handler that used to
+	// sit here could not run.
 
-	if (
-		!process.env.MONGO_URI &&
-		process.env.NODE_ENV !== "development" &&
-		process.env.NODE_ENV !== "test"
-	) {
+	return app;
+};
+
+export const DEFAULT_PORT = 9228;
+
+/**
+ * The port is the last segment of the configured server URL. A URL without
+ * one used to yield NaN, which node turns into an arbitrary free port — the
+ * server came up on an address nothing was configured to talk to.
+ */
+export const resolvePort = (config: ProsopoServerConfigOutput): number => {
+	if (!config.serverUrl) return DEFAULT_PORT;
+	const segments = config.serverUrl.split(":");
+	if (segments.length < 3) return DEFAULT_PORT;
+	const port = Number.parseInt(at(segments, 2));
+	return Number.isNaN(port) ? DEFAULT_PORT : port;
+};
+
+/**
+ * HTTPS in development/test when the repo's certificates exist, plain HTTP
+ * otherwise — in production Caddy terminates TLS.
+ */
+export const startServer = (
+	app: express.Express,
+	port: number,
+	dirname: string = path.dirname(fileURLToPath(import.meta.url)),
+): Server => {
+	if (isDevelopmentOrTest()) {
+		const certsDir = path.resolve(dirname, "../../../certs");
+
+		const keyPath = path.join(certsDir, "server.key");
+		const certPath = path.join(certsDir, "server.crt");
+
+		if (fs.existsSync(keyPath) && fs.existsSync(certPath)) {
+			const httpsOptions: ServerOptions = {
+				key: fs.readFileSync(keyPath),
+				cert: fs.readFileSync(certPath),
+			};
+
+			return https.createServer(httpsOptions, app).listen(port, () => {
+				logger.info(() => ({ msg: `HTTPS server started on port ${port}` }));
+			});
+		}
+		logger.warn(() => ({
+			msg: "Certificates not found, starting HTTP server instead. Run ./setup_certs.sh to enable HTTPS in development.",
+		}));
+		return http.createServer(app).listen(port, () => {
+			logger.info(() => ({ msg: `HTTP server started on port ${port}` }));
+		});
+	}
+	return http.createServer(app).listen(port, () => {
+		logger.info(() => ({
+			msg: `HTTP server started on port ${port} (TLS handled by reverse proxy)`,
+		}));
+	});
+};
+
+export async function main(): Promise<Server> {
+	loadEnv();
+
+	const verifyEndpoint = resolveVerifyEndpoint();
+
+	logger.info(() => ({ data: { verifyEndpoint } }));
+
+	const verifyType = resolveVerifyType();
+
+	const app = createApp();
+
+	if (!process.env.MONGO_URI && !isDevelopmentOrTest()) {
 		throw new Error(
 			"Cannot run mongo memory when NODE_ENV is neither development nor test",
 		);
@@ -113,57 +186,22 @@ async function main() {
 
 	app.use(routesFactory(mongoose, config, verifyEndpoint, verifyType));
 
-	const port = config.serverUrl
-		? Number.parseInt(at(config.serverUrl.split(":"), 2))
-		: 9228;
+	const port = resolvePort(config);
 
 	logger.info(() => ({ msg: "Listening on port", data: { port } }));
 
-	// Use HTTPS only in development/test when we have certificates
-	// In production, use HTTP because Caddy handles TLS termination
-	const isDev =
-		process.env.NODE_ENV === "development" || process.env.NODE_ENV === "test";
-
-	if (isDev) {
-		const __filename = fileURLToPath(import.meta.url);
-		const __dirname = path.dirname(__filename);
-		const certsDir = path.resolve(__dirname, "../../../certs");
-
-		const keyPath = path.join(certsDir, "server.key");
-		const certPath = path.join(certsDir, "server.crt");
-
-		if (fs.existsSync(keyPath) && fs.existsSync(certPath)) {
-			const httpsOptions: ServerOptions = {
-				key: fs.readFileSync(keyPath),
-				cert: fs.readFileSync(certPath),
-			};
-
-			https.createServer(httpsOptions, app).listen(port, () => {
-				logger.info(() => ({ msg: `HTTPS server started on port ${port}` }));
-			});
-		} else {
-			logger.warn(() => ({
-				msg: "Certificates not found, starting HTTP server instead. Run ./setup_certs.sh to enable HTTPS in development.",
-			}));
-			http.createServer(app).listen(port, () => {
-				logger.info(() => ({ msg: `HTTP server started on port ${port}` }));
-			});
-		}
-	} else {
-		// Production: use plain HTTP, Caddy handles TLS
-		http.createServer(app).listen(port, () => {
-			logger.info(() => ({
-				msg: `HTTP server started on port ${port} (TLS handled by reverse proxy)`,
-			}));
-		});
-	}
+	return startServer(app, port);
 }
 
-main()
-	.then(() => {
-		logger.info(() => ({ msg: "Server started" }));
-	})
-	.catch((err) => {
-		logger.error(() => ({ err }));
-		process.exit();
-	});
+// Only boot when run as a binary: importing this module (a test, or another
+// entrypoint reusing createApp) must not open a port or spin up mongo.
+if (isMain(import.meta.url)) {
+	main()
+		.then(() => {
+			logger.info(() => ({ msg: "Server started" }));
+		})
+		.catch((err) => {
+			logger.error(() => ({ err }));
+			process.exit();
+		});
+}

--- a/demos/client-example-server/src/controllers/auth.ts
+++ b/demos/client-example-server/src/controllers/auth.ts
@@ -85,9 +85,6 @@ const getPairAndSecretForSiteKey = (
 	]) {
 		const newSecret = `${baseSecret}//${captchaType}`;
 		pair = getPair(newSecret);
-		console.log(
-			`[PAIR CHECK] Checking pair for ${captchaType}: ${pair?.address} (expected: ${siteKey})`,
-		);
 		logger.info(() => ({
 			msg: "Checking pair",
 			data: {
@@ -97,7 +94,6 @@ const getPairAndSecretForSiteKey = (
 			},
 		}));
 		if (pair.address === siteKey) {
-			console.log(`[PAIR CHECK] ✅ Match found for ${captchaType}!`);
 			secret = newSecret;
 			break;
 		}
@@ -236,29 +232,29 @@ const signup = async (
 			const salt = randomAsHex(32);
 			// !!!DUMMY CODE!!! - Do not use in production. Use bcrypt or similar for password hashing.
 			const passwordHash = hashPassword(`${req.body.password}${salt}`);
-			if (passwordHash) {
-				return User.create({
-					email: email,
-					name: req.body.name,
-					password: passwordHash,
-					salt: salt,
+			// No `if (passwordHash)` guard: the hash is always a non-empty hex
+			// string, and the guard's absent else-branch left the request hanging
+			// with no response at all.
+			return User.create({
+				email: email,
+				name: req.body.name,
+				password: passwordHash,
+				salt: salt,
+			})
+				.then(() => {
+					res.status(200).json({ message: "user created" });
 				})
-					.then(() => {
-						res.status(200).json({ message: "user created" });
-					})
-					.catch((err) => {
-						logger.error(() => ({
-							err,
-							msg: "Error creating user in database",
-						}));
-						res.status(502).json({ message: "error while creating the user" });
-					});
-			}
-		} else {
-			res
-				.status(401)
-				.json({ message: "user has not completed a captcha", verified });
+				.catch((err) => {
+					logger.error(() => ({
+						err,
+						msg: "Error creating user in database",
+					}));
+					res.status(502).json({ message: "error while creating the user" });
+				});
 		}
+		res
+			.status(401)
+			.json({ message: "user has not completed a captcha", verified });
 	} catch (err) {
 		console.error("error", err);
 		res
@@ -347,25 +343,32 @@ const login = async (
 
 const isAuth = (req: Request, res: Response) => {
 	const authHeader = req.get("Authorization") || "";
+	// Each branch returns: without the returns a missing header still fell
+	// through to `at(headerParts, 1)`, which throws on a one-element array, and
+	// a failed verify sent a 500 followed by a 401 on the same response.
 	if (!authHeader) {
-		res.status(401).json({ message: "not authenticated" });
+		return res.status(401).json({ message: "not authenticated" });
 	}
 
-	const token = at(authHeader.split(" "), 1);
+	const headerParts = authHeader.split(" ");
+	if (headerParts.length < 2) {
+		return res.status(401).json({ message: "not authenticated" });
+	}
+
+	const token = at(headerParts, 1);
 	let decodedToken: string | JwtPayload = "";
 	try {
 		decodedToken = jwt.verify(token, "secret");
 	} catch (err) {
-		res.status(500).json({
+		return res.status(500).json({
 			message: (err as Error).message || "could not decode the token",
 		});
 	}
 
 	if (!decodedToken) {
-		res.status(401).json({ message: "unauthorized" });
-	} else {
-		res.status(200).json({ message: "here is your resource" });
+		return res.status(401).json({ message: "unauthorized" });
 	}
+	return res.status(200).json({ message: "here is your resource" });
 };
 
 export { signup, login, isAuth };

--- a/demos/client-example-server/src/controllers/auth.ts
+++ b/demos/client-example-server/src/controllers/auth.ts
@@ -356,6 +356,12 @@ const isAuth = (req: Request, res: Response) => {
 	}
 
 	const token = at(headerParts, 1);
+	// "Bearer " with nothing after it is a malformed credential, not a server
+	// fault: jwt.verify("") throws and would otherwise surface as a 500.
+	if (!token) {
+		return res.status(401).json({ message: "not authenticated" });
+	}
+
 	let decodedToken: string | JwtPayload = "";
 	try {
 		decodedToken = jwt.verify(token, "secret");

--- a/demos/client-example-server/src/routes/routes.ts
+++ b/demos/client-example-server/src/routes/routes.ts
@@ -16,14 +16,17 @@ import express from "express";
 import type { Connection } from "mongoose";
 import { isAuth, login, signup } from "../controllers/auth.js";
 
-const router = express.Router();
-
 function getRoutes(
 	mongoose: Connection,
 	config: ProsopoServerConfigOutput,
 	verifyEndpoint: string,
 	verifyType: string,
 ): express.Router {
+	// A router per call: the module-level singleton this used to share meant a
+	// second getRoutes() stacked another set of handlers onto the same router,
+	// so every request ran the first call's bound config.
+	const router = express.Router();
+
 	router.post(
 		"/login",
 		login.bind(null, mongoose, config, verifyEndpoint, verifyType),

--- a/demos/client-example-server/src/tests/app.unit.test.ts
+++ b/demos/client-example-server/src/tests/app.unit.test.ts
@@ -1,0 +1,423 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import fs from "node:fs";
+import type { Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import os from "node:os";
+import path from "node:path";
+import type { ProsopoServerConfigOutput } from "@prosopo/types";
+import express from "express";
+import type { Connection } from "mongoose";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+	DEFAULT_PORT,
+	ProsopoVerificationType,
+	createApp,
+	isDevelopmentOrTest,
+	main,
+	resolvePort,
+	resolveVerifyEndpoint,
+	resolveVerifyType,
+	startServer,
+} from "../app.js";
+import { serverConfig } from "./authHarness.js";
+
+/**
+ * main() opens a mongo connection and reads the deployment config; both are
+ * replaced. The express wiring, the endpoint/port resolution and the HTTP vs
+ * HTTPS decision are exercised for real.
+ */
+const mocks = vi.hoisted(() => ({
+	memoryUris: [] as string[],
+	memorySetup: vi.fn(),
+	connections: [] as string[],
+	routesArgs: [] as unknown[][],
+	config: {} as ProsopoServerConfigOutput,
+}));
+
+vi.mock("../utils/database.js", () => ({
+	default: () => {
+		mocks.memorySetup();
+		return Promise.resolve("mongodb://memory:27017/");
+	},
+}));
+
+vi.mock("../utils/connection.js", () => ({
+	default: (uri: string) => {
+		mocks.connections.push(uri);
+		return {} as unknown as Connection;
+	},
+}));
+
+vi.mock("../routes/routes.js", () => ({
+	default: (...args: unknown[]) => {
+		mocks.routesArgs.push(args);
+		return express.Router();
+	},
+}));
+
+vi.mock("@prosopo/server", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@prosopo/server")>();
+	return {
+		...actual,
+		getServerConfig: () => mocks.config,
+	};
+});
+
+vi.mock("@prosopo/dotenv", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@prosopo/dotenv")>();
+	return {
+		...actual,
+		// The real loadEnv walks the repo for .env files; irrelevant here and
+		// it would overwrite the env each test sets up.
+		loadEnv: () => undefined,
+	};
+});
+
+const servers: Server[] = [];
+
+const track = (server: Server): Server => {
+	servers.push(server);
+	return server;
+};
+
+const env = { ...process.env };
+
+beforeEach(() => {
+	mocks.memorySetup.mockClear();
+	mocks.memoryUris.length = 0;
+	mocks.connections.length = 0;
+	mocks.routesArgs.length = 0;
+	mocks.config = serverConfig();
+	process.env.NODE_ENV = "test";
+	process.env.MONGO_URI = "mongodb://configured:27017/";
+	process.env.PROSOPO_SITE_PRIVATE_KEY = "//Alice";
+	Reflect.deleteProperty(process.env, "PROSOPO_VERIFY_ENDPOINT");
+	Reflect.deleteProperty(process.env, "PROSOPO_VERIFICATION_TYPE");
+});
+
+afterEach(async () => {
+	await Promise.all(
+		servers.splice(0).map(
+			(server) =>
+				new Promise<void>((resolve) => {
+					server.close(() => resolve());
+				}),
+		),
+	);
+	for (const key of Object.keys(process.env)) {
+		if (!(key in env)) Reflect.deleteProperty(process.env, key);
+	}
+	Object.assign(process.env, env);
+	vi.restoreAllMocks();
+});
+
+describe("resolveVerifyEndpoint", () => {
+	test("prefers an explicitly configured endpoint", () => {
+		process.env.PROSOPO_VERIFY_ENDPOINT = "https://self-hosted/siteverify";
+		expect(resolveVerifyEndpoint()).toBe("https://self-hosted/siteverify");
+	});
+
+	test("prefixes the hosted API with the environment name", () => {
+		process.env.NODE_ENV = "staging";
+		expect(resolveVerifyEndpoint()).toBe(
+			"https://staging-api.prosopo.io/siteverify",
+		);
+	});
+
+	test("uses the bare hosted API in production", () => {
+		process.env.NODE_ENV = "production";
+		expect(resolveVerifyEndpoint()).toBe("https://api.prosopo.io/siteverify");
+	});
+
+	test("an unset NODE_ENV still produces a usable host", () => {
+		Reflect.deleteProperty(process.env, "NODE_ENV");
+		expect(resolveVerifyEndpoint()).toBe(
+			"https://undefined-api.prosopo.io/siteverify",
+		);
+	});
+});
+
+describe("resolveVerifyType", () => {
+	test("accepts the verification types it knows", () => {
+		process.env.PROSOPO_VERIFICATION_TYPE = "local";
+		expect(resolveVerifyType()).toBe(ProsopoVerificationType.local);
+		process.env.PROSOPO_VERIFICATION_TYPE = "api";
+		expect(resolveVerifyType()).toBe(ProsopoVerificationType.api);
+	});
+
+	test("falls back to the hosted API for anything else", () => {
+		process.env.PROSOPO_VERIFICATION_TYPE = "carrier-pigeon";
+		expect(resolveVerifyType()).toBe(ProsopoVerificationType.api);
+	});
+
+	test("falls back to the hosted API when unset", () => {
+		expect(resolveVerifyType()).toBe(ProsopoVerificationType.api);
+	});
+});
+
+describe("isDevelopmentOrTest", () => {
+	test("is true only for development and test", () => {
+		for (const [value, expected] of [
+			["development", true],
+			["test", true],
+			["production", false],
+			["staging", false],
+		] as [string, boolean][]) {
+			process.env.NODE_ENV = value;
+			expect(isDevelopmentOrTest()).toBe(expected);
+		}
+	});
+});
+
+describe("resolvePort", () => {
+	test("takes the port from the configured server URL", () => {
+		expect(resolvePort(serverConfig())).toBe(9228);
+	});
+
+	test("defaults when no server URL is configured", () => {
+		const config: ProsopoServerConfigOutput = {
+			...serverConfig(),
+			serverUrl: "",
+		};
+		expect(resolvePort(config)).toBe(9228);
+	});
+
+	test("defaults on a server URL with no port segment", () => {
+		// This used to produce NaN, which node listens on as an arbitrary free
+		// port — the server came up somewhere nothing was pointed at.
+		const config: ProsopoServerConfigOutput = {
+			...serverConfig(),
+			serverUrl: "https://localhost",
+		};
+		expect(resolvePort(config)).toBe(DEFAULT_PORT);
+	});
+
+	test("defaults when the port segment isn't a number", () => {
+		const config: ProsopoServerConfigOutput = {
+			...serverConfig(),
+			serverUrl: "https://localhost:https",
+		};
+		expect(resolvePort(config)).toBe(DEFAULT_PORT);
+	});
+});
+
+describe("createApp", () => {
+	const listen = (app: express.Express): Promise<string> =>
+		new Promise((resolve) => {
+			const server = track(
+				app.listen(0, () => {
+					const { port } = server.address() as AddressInfo;
+					resolve(`http://127.0.0.1:${port}`);
+				}),
+			);
+		});
+
+	test("sets permissive CORS headers on every response", async () => {
+		const app = createApp();
+		app.get("/thing", (_req, res) => {
+			res.status(200).json({ ok: true });
+		});
+		const base = await listen(app);
+		const response = await fetch(`${base}/thing`);
+		expect(response.headers.get("access-control-allow-origin")).toBe("*");
+		expect(response.headers.get("access-control-allow-methods")).toContain(
+			"POST",
+		);
+		expect(response.headers.get("access-control-allow-headers")).toContain(
+			"Authorization",
+		);
+	});
+
+	test("answers preflight requests", async () => {
+		// cors() answers preflight itself with a 204; the explicit OPTIONS
+		// handler this app used to declare could never run.
+		const base = await listen(createApp());
+		const response = await fetch(`${base}/anything`, { method: "OPTIONS" });
+		expect(response.status).toBe(204);
+		expect(response.headers.get("access-control-allow-methods")).toContain(
+			"POST",
+		);
+	});
+
+	test("parses JSON bodies", async () => {
+		const app = createApp();
+		app.post("/echo", (req, res) => {
+			res.status(200).json(req.body);
+		});
+		const base = await listen(app);
+		const response = await fetch(`${base}/echo`, {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({ email: "user@example.com" }),
+		});
+		expect(await response.json()).toEqual({ email: "user@example.com" });
+	});
+
+	test("parses form-encoded bodies", async () => {
+		const app = createApp();
+		app.post("/echo", (req, res) => {
+			res.status(200).json(req.body);
+		});
+		const base = await listen(app);
+		const response = await fetch(`${base}/echo`, {
+			method: "POST",
+			headers: { "content-type": "application/x-www-form-urlencoded" },
+			body: "email=user%40example.com",
+		});
+		expect(await response.json()).toEqual({ email: "user@example.com" });
+	});
+
+	test("trusts one proxy hop, so client IPs survive the reverse proxy", () => {
+		expect(createApp().get("trust proxy")).toBe(1);
+	});
+});
+
+describe("startServer", () => {
+	const certDir = (): string => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "ces-certs-"));
+		fs.mkdirSync(path.join(root, "certs"));
+		return root;
+	};
+
+	test("serves HTTPS in development when the certificates exist", async () => {
+		process.env.NODE_ENV = "development";
+		const root = certDir();
+		// startServer resolves ../../../certs relative to the module, so the
+		// fake module directory sits three levels below the cert directory.
+		const moduleDir = path.join(root, "certs", "a", "b");
+		fs.mkdirSync(moduleDir, { recursive: true });
+		const certs = path.join(root, "certs");
+		// A throwaway self-signed pair would need openssl; the files only have
+		// to exist for the branch, and https.createServer is stubbed.
+		fs.writeFileSync(path.join(certs, "server.key"), "key");
+		fs.writeFileSync(path.join(certs, "server.crt"), "cert");
+		const https = await import("node:https");
+		const fake = { listen: vi.fn((_port: number, cb: () => void) => cb()) };
+		const createServer = vi
+			.spyOn(https.default, "createServer")
+			.mockReturnValue(
+				fake as unknown as ReturnType<typeof https.createServer>,
+			);
+		startServer(express(), 1234, path.join(certs, "a", "b"));
+		expect(createServer).toHaveBeenCalledTimes(1);
+		const options = createServer.mock.calls[0]?.[0] as {
+			key: Buffer;
+			cert: Buffer;
+		};
+		expect(options.key.toString()).toBe("key");
+		expect(options.cert.toString()).toBe("cert");
+		fs.rmSync(root, { recursive: true, force: true });
+	});
+
+	test("falls back to HTTP in development when the certificates are missing", async () => {
+		process.env.NODE_ENV = "development";
+		const server = track(
+			startServer(express(), 0, path.join(os.tmpdir(), "no-such-dir")),
+		);
+		await new Promise<void>((resolve) => {
+			if (server.listening) return resolve();
+			server.once("listening", () => resolve());
+		});
+		expect((server.address() as AddressInfo).port).toBeGreaterThan(0);
+	});
+
+	test("serves plain HTTP in production, where a proxy terminates TLS", async () => {
+		process.env.NODE_ENV = "production";
+		const https = await import("node:https");
+		const createServer = vi.spyOn(https.default, "createServer");
+		const server = track(startServer(express(), 0));
+		expect(createServer).not.toHaveBeenCalled();
+		expect((server.address() as AddressInfo).port).toBeGreaterThan(0);
+	});
+
+	test("the server it returns actually serves the app", async () => {
+		process.env.NODE_ENV = "production";
+		const app = express();
+		app.get("/health", (_req, res) => {
+			res.status(200).json({ status: "ok" });
+		});
+		const server = track(startServer(app, 0));
+		await new Promise<void>((resolve) => {
+			if (server.listening) return resolve();
+			server.once("listening", () => resolve());
+		});
+		const { port } = server.address() as AddressInfo;
+		const response = await fetch(`http://127.0.0.1:${port}/health`);
+		expect(await response.json()).toEqual({ status: "ok" });
+	});
+});
+
+describe("main", () => {
+	test("wires the routes with the resolved endpoint and verification type", async () => {
+		process.env.PROSOPO_VERIFY_ENDPOINT = "https://self-hosted/siteverify";
+		process.env.PROSOPO_VERIFICATION_TYPE = "local";
+		mocks.config = { ...serverConfig(), serverUrl: "https://localhost:0" };
+		track(await main());
+		expect(mocks.routesArgs[0]?.slice(1)).toEqual([
+			mocks.config,
+			"https://self-hosted/siteverify",
+			ProsopoVerificationType.local,
+		]);
+	});
+
+	test("connects to the configured mongo instance", async () => {
+		mocks.config = { ...serverConfig(), serverUrl: "https://localhost:0" };
+		track(await main());
+		expect(mocks.connections).toEqual(["mongodb://configured:27017/"]);
+		expect(mocks.memorySetup).not.toHaveBeenCalled();
+	});
+
+	test("starts an in-memory mongo when none is configured", async () => {
+		Reflect.deleteProperty(process.env, "MONGO_URI");
+		mocks.config = { ...serverConfig(), serverUrl: "https://localhost:0" };
+		track(await main());
+		expect(mocks.memorySetup).toHaveBeenCalledTimes(1);
+		expect(mocks.connections).toEqual(["mongodb://memory:27017/"]);
+	});
+
+	test("refuses to run an in-memory database outside development", async () => {
+		Reflect.deleteProperty(process.env, "MONGO_URI");
+		process.env.NODE_ENV = "production";
+		await expect(main()).rejects.toThrow(
+			"Cannot run mongo memory when NODE_ENV is neither development nor test",
+		);
+		expect(mocks.connections).toHaveLength(0);
+	});
+
+	test("boots without a site private key, but says so", async () => {
+		// The demo server is still useful without one — every signup will just
+		// fail verification — so this logs rather than throws.
+		Reflect.deleteProperty(process.env, "PROSOPO_SITE_PRIVATE_KEY");
+		mocks.config = { ...serverConfig(), serverUrl: "https://localhost:0" };
+		const server = track(await main());
+		expect(server.listening).toBe(true);
+	});
+
+	test("listens on the port the config names", async () => {
+		mocks.config = { ...serverConfig(), serverUrl: "https://localhost:0" };
+		const server = track(await main());
+		expect((server.address() as AddressInfo).port).toBeGreaterThan(0);
+	});
+
+	test("propagates a database connection failure instead of listening", async () => {
+		mocks.config = { ...serverConfig(), serverUrl: "https://localhost:0" };
+		const connection = await import("../utils/connection.js");
+		vi.spyOn(connection, "default").mockImplementation(() => {
+			throw new Error("mongo unreachable");
+		});
+		await expect(main()).rejects.toThrow("mongo unreachable");
+	});
+});

--- a/demos/client-example-server/src/tests/app.unit.test.ts
+++ b/demos/client-example-server/src/tests/app.unit.test.ts
@@ -142,11 +142,16 @@ describe("resolveVerifyEndpoint", () => {
 		expect(resolveVerifyEndpoint()).toBe("https://api.prosopo.io/siteverify");
 	});
 
-	test("an unset NODE_ENV still produces a usable host", () => {
+	test("an unset NODE_ENV falls back to the production host", () => {
+		// Prefixing an absent environment produced undefined-api.prosopo.io,
+		// which resolves to nothing.
 		Reflect.deleteProperty(process.env, "NODE_ENV");
-		expect(resolveVerifyEndpoint()).toBe(
-			"https://undefined-api.prosopo.io/siteverify",
-		);
+		expect(resolveVerifyEndpoint()).toBe("https://api.prosopo.io/siteverify");
+	});
+
+	test("an empty NODE_ENV is treated the same way", () => {
+		process.env.NODE_ENV = "";
+		expect(resolveVerifyEndpoint()).toBe("https://api.prosopo.io/siteverify");
 	});
 });
 

--- a/demos/client-example-server/src/tests/appEntrypoint.unit.test.ts
+++ b/demos/client-example-server/src/tests/appEntrypoint.unit.test.ts
@@ -1,0 +1,131 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { Server } from "node:http";
+import type { ProsopoServerConfigOutput } from "@prosopo/types";
+import express from "express";
+import type { Connection } from "mongoose";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { serverConfig } from "./authHarness.js";
+
+/**
+ * Importing app.js as the process entrypoint: isMain is forced true so the
+ * module's boot block runs, with every external dependency stubbed.
+ */
+const mocks = vi.hoisted(() => ({
+	isMain: true,
+	servers: [] as Server[],
+	connectionThrows: undefined as Error | undefined,
+	config: {} as ProsopoServerConfigOutput,
+}));
+
+vi.mock("@prosopo/util", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@prosopo/util")>();
+	return {
+		...actual,
+		isMain: () => mocks.isMain,
+	};
+});
+
+vi.mock("../utils/connection.js", () => ({
+	default: (): Connection => {
+		if (mocks.connectionThrows) throw mocks.connectionThrows;
+		return {} as unknown as Connection;
+	},
+}));
+
+vi.mock("../utils/database.js", () => ({
+	default: () => Promise.resolve("mongodb://memory:27017/"),
+}));
+
+vi.mock("../routes/routes.js", () => ({
+	default: () => express.Router(),
+}));
+
+vi.mock("@prosopo/server", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@prosopo/server")>();
+	return { ...actual, getServerConfig: () => mocks.config };
+});
+
+vi.mock("@prosopo/dotenv", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@prosopo/dotenv")>();
+	return { ...actual, loadEnv: () => undefined };
+});
+
+/**
+ * Loads app.js afresh and hands back the server it opened, if any. The module
+ * boots on import, so each case needs its own module registry.
+ */
+const importApp = async (): Promise<Server | undefined> => {
+	vi.resetModules();
+	const listeners: Server[] = [];
+	const httpModule = await import("node:http");
+	const createServer = httpModule.default.createServer;
+	vi.spyOn(httpModule.default, "createServer").mockImplementation(
+		(...args: Parameters<typeof createServer>) => {
+			const server = createServer(...args);
+			listeners.push(server);
+			mocks.servers.push(server);
+			return server;
+		},
+	);
+	await import("../app.js");
+	// The boot block is fire-and-forget, so wait for its promise chain.
+	await new Promise((resolve) => setImmediate(resolve));
+	return listeners[0];
+};
+
+beforeEach(() => {
+	mocks.isMain = true;
+	mocks.connectionThrows = undefined;
+	mocks.config = { ...serverConfig(), serverUrl: "https://localhost:0" };
+	process.env.NODE_ENV = "test";
+	process.env.MONGO_URI = "mongodb://configured:27017/";
+});
+
+afterEach(async () => {
+	vi.restoreAllMocks();
+	await Promise.all(
+		mocks.servers.splice(0).map(
+			(server) =>
+				new Promise<void>((resolve) => {
+					server.close(() => resolve());
+				}),
+		),
+	);
+});
+
+describe("running app.js as the entrypoint", () => {
+	test("boots the server", async () => {
+		const server = await importApp();
+		expect(server?.listening).toBe(true);
+	});
+
+	test("stays quiet when the module is merely imported", async () => {
+		// A test, or another entrypoint reusing createApp, must not end up
+		// opening a port or spinning up mongo.
+		mocks.isMain = false;
+		const server = await importApp();
+		expect(server).toBeUndefined();
+	});
+
+	test("exits when the server cannot start", async () => {
+		mocks.connectionThrows = new Error("mongo unreachable");
+		const exit = vi
+			.spyOn(process, "exit")
+			.mockImplementation((): never => undefined as never);
+		await importApp();
+		expect(exit).toHaveBeenCalledTimes(1);
+	});
+});

--- a/demos/client-example-server/src/tests/appEntrypoint.unit.test.ts
+++ b/demos/client-example-server/src/tests/appEntrypoint.unit.test.ts
@@ -67,10 +67,13 @@ vi.mock("@prosopo/dotenv", async (importOriginal) => {
  * Loads app.js afresh and hands back the server it opened, if any. The module
  * boots on import, so each case needs its own module registry.
  */
-const importApp = async (): Promise<Server | undefined> => {
+const importApp = async (
+	options: { expectServer?: boolean } = {},
+): Promise<Server | undefined> => {
 	vi.resetModules();
 	const listeners: Server[] = [];
 	const httpModule = await import("node:http");
+	const httpsModule = await import("node:https");
 	const createServer = httpModule.default.createServer;
 	vi.spyOn(httpModule.default, "createServer").mockImplementation(
 		(...args: Parameters<typeof createServer>) => {
@@ -80,9 +83,27 @@ const importApp = async (): Promise<Server | undefined> => {
 			return server;
 		},
 	);
+	// startServer prefers HTTPS whenever dev certificates happen to be on
+	// disk, so both factories have to be watched — otherwise the assertion
+	// depends on whether ./setup_certs.sh has been run.
+	const createSecureServer = httpsModule.default.createServer;
+	vi.spyOn(httpsModule.default, "createServer").mockImplementation(
+		(...args: Parameters<typeof createSecureServer>) => {
+			const server = createSecureServer(...args);
+			listeners.push(server);
+			mocks.servers.push(server);
+			return server;
+		},
+	);
 	await import("../app.js");
-	// The boot block is fire-and-forget, so wait for its promise chain.
-	await new Promise((resolve) => setImmediate(resolve));
+	// The boot block is fire-and-forget, so wait for its promise chain. How
+	// many turns that takes depends on the machine, so poll rather than
+	// assume a fixed number of ticks.
+	for (let attempt = 0; attempt < 100; attempt++) {
+		await new Promise((resolve) => setImmediate(resolve));
+		if (!options.expectServer) break;
+		if (listeners[0]?.listening) break;
+	}
 	return listeners[0];
 };
 
@@ -108,7 +129,7 @@ afterEach(async () => {
 
 describe("running app.js as the entrypoint", () => {
 	test("boots the server", async () => {
-		const server = await importApp();
+		const server = await importApp({ expectServer: true });
 		expect(server?.listening).toBe(true);
 	});
 
@@ -127,5 +148,7 @@ describe("running app.js as the entrypoint", () => {
 			.mockImplementation((): never => undefined as never);
 		await importApp();
 		expect(exit).toHaveBeenCalledTimes(1);
+		// A zero status would tell a supervisor the process shut down cleanly.
+		expect(exit).toHaveBeenCalledWith(1);
 	});
 });

--- a/demos/client-example-server/src/tests/auth.unit.test.ts
+++ b/demos/client-example-server/src/tests/auth.unit.test.ts
@@ -1,0 +1,850 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { CaptchaType, type ProcaptchaToken } from "@prosopo/types";
+import type { NextFunction } from "express";
+import jwt from "jsonwebtoken";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { isAuth, login, signup } from "../controllers/auth.js";
+import {
+	SECRET,
+	SITE_KEY,
+	VERIFY_ENDPOINT,
+	connectionWith,
+	pairWithAddress,
+	request,
+	responseStub,
+	serverConfig,
+	signupBody,
+	userModel,
+} from "./authHarness.js";
+
+/**
+ * The controllers derive keyring pairs and verify tokens against a provider.
+ * Both are replaced here: deriving is deterministic but slow, and verifying
+ * would need a live provider. Everything else — zod parsing, the mongoose
+ * calls, the response codes — is the real thing.
+ */
+const mocks = vi.hoisted(() => ({
+	// Maps a secret to the address the pair derived from it claims.
+	addresses: new Map<string, string>(),
+	isVerified: vi.fn(),
+	constructions: [] as unknown[][],
+}));
+
+vi.mock("@prosopo/keyring", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@prosopo/keyring")>();
+	return {
+		...actual,
+		getPair: (secret: string) => ({
+			address: mocks.addresses.get(secret) ?? `derived:${secret}`,
+		}),
+	};
+});
+
+vi.mock("@prosopo/server", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@prosopo/server")>();
+	return {
+		...actual,
+		ProsopoServer: class {
+			constructor(...args: unknown[]) {
+				mocks.constructions.push(args);
+			}
+			isVerified = mocks.isVerified;
+		},
+	};
+});
+
+const next: NextFunction = () => undefined;
+
+const fetchMock =
+	vi.fn<
+		(input: string | URL | Request, init?: RequestInit) => Promise<Response>
+	>();
+
+beforeEach(() => {
+	mocks.addresses.clear();
+	mocks.addresses.set(SECRET, SITE_KEY);
+	mocks.constructions.length = 0;
+	mocks.isVerified.mockReset();
+	mocks.isVerified.mockResolvedValue({ verified: true });
+	fetchMock.mockReset();
+	fetchMock.mockResolvedValue(new Response(JSON.stringify({ verified: true })));
+	vi.stubGlobal("fetch", fetchMock);
+	vi.spyOn(console, "error").mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+	vi.restoreAllMocks();
+	Reflect.deleteProperty(process.env, "NODE_ENV");
+	process.env.NODE_ENV = "test";
+});
+
+describe("signup", () => {
+	test("creates the user once the captcha verifies", async () => {
+		const { connection, model } = connectionWith(userModel({}));
+		const res = responseStub();
+		await signup(
+			connection,
+			serverConfig(),
+			VERIFY_ENDPOINT,
+			"local",
+			request({ body: signupBody() }),
+			res.response,
+			next,
+		);
+		expect(res.statuses).toEqual([200]);
+		expect(res.bodies).toEqual([{ message: "user created" }]);
+		const created = model.create.mock.calls[0]?.[0] as Record<string, string>;
+		expect(created?.email).toBe("user@example.com");
+		expect(created?.name).toBe("user");
+		// The password is salted and hashed, never stored as typed.
+		expect(created?.password).not.toBe("hunter2");
+		expect(String(created?.password).startsWith("0x")).toBe(true);
+		expect(created?.salt).toMatch(/^0x[0-9a-f]{64}$/);
+	});
+
+	test("salts every signup differently", async () => {
+		const { connection, model } = connectionWith(userModel({}));
+		for (let i = 0; i < 2; i++) {
+			await signup(
+				connection,
+				serverConfig(),
+				VERIFY_ENDPOINT,
+				"local",
+				request({ body: signupBody() }),
+				responseStub().response,
+				next,
+			);
+		}
+		const [first, second] = model.create.mock.calls.map(
+			(call) => (call[0] as Record<string, string>).salt,
+		);
+		expect(first).not.toBe(second);
+	});
+
+	test("rejects an email that is already registered, before verifying", async () => {
+		const { connection, model } = connectionWith(
+			userModel({ found: { password: "0xhash", salt: "0xsalt" } }),
+		);
+		const res = responseStub();
+		await signup(
+			connection,
+			serverConfig(),
+			VERIFY_ENDPOINT,
+			"local",
+			request({ body: signupBody() }),
+			res.response,
+			next,
+		);
+		expect(res.statuses).toEqual([409]);
+		expect(res.bodies).toEqual([{ message: "email already exists" }]);
+		expect(mocks.isVerified).not.toHaveBeenCalled();
+		expect(model.create).not.toHaveBeenCalled();
+	});
+
+	test("refuses a signup that failed the captcha", async () => {
+		mocks.isVerified.mockResolvedValue({ verified: false });
+		const { connection, model } = connectionWith(userModel({}));
+		const res = responseStub();
+		await signup(
+			connection,
+			serverConfig(),
+			VERIFY_ENDPOINT,
+			"local",
+			request({ body: signupBody() }),
+			res.response,
+			next,
+		);
+		expect(res.statuses).toEqual([401]);
+		expect(res.bodies).toEqual([
+			{ message: "user has not completed a captcha", verified: false },
+		]);
+		expect(model.create).not.toHaveBeenCalled();
+	});
+
+	test("treats a non-boolean verification result as a failure", async () => {
+		// The API path returns whatever JSON the endpoint sent, so `verified`
+		// can be a string, or missing entirely.
+		mocks.isVerified.mockResolvedValue({ verified: "true" });
+		const { connection, model } = connectionWith(userModel({}));
+		const res = responseStub();
+		await signup(
+			connection,
+			serverConfig(),
+			VERIFY_ENDPOINT,
+			"local",
+			request({ body: signupBody() }),
+			res.response,
+			next,
+		);
+		expect(res.statuses).toEqual([401]);
+		expect(model.create).not.toHaveBeenCalled();
+	});
+
+	test("reports a database write failure as a bad gateway", async () => {
+		const { connection } = connectionWith(
+			userModel({ createRejects: new Error("write concern failed") }),
+		);
+		const res = responseStub();
+		await signup(
+			connection,
+			serverConfig(),
+			VERIFY_ENDPOINT,
+			"local",
+			request({ body: signupBody() }),
+			res.response,
+			next,
+		);
+		expect(res.statuses).toEqual([502]);
+		expect(res.bodies).toEqual([{ message: "error while creating the user" }]);
+	});
+
+	test("reports a database read failure as a server error", async () => {
+		const { connection } = connectionWith(
+			userModel({ findOneRejects: new Error("mongo unavailable") }),
+		);
+		const res = responseStub();
+		await signup(
+			connection,
+			serverConfig(),
+			VERIFY_ENDPOINT,
+			"local",
+			request({ body: signupBody() }),
+			res.response,
+			next,
+		);
+		expect(res.statuses).toEqual([500]);
+		expect(res.bodies).toEqual([{ message: "mongo unavailable" }]);
+	});
+
+	test("refuses to run without a site private key", async () => {
+		const { connection } = connectionWith(userModel({}));
+		const res = responseStub();
+		await signup(
+			connection,
+			serverConfig({}),
+			VERIFY_ENDPOINT,
+			"local",
+			request({ body: signupBody() }),
+			res.response,
+			next,
+		);
+		expect(res.statuses).toEqual([500]);
+		expect(mocks.isVerified).not.toHaveBeenCalled();
+	});
+
+	test("rejects a body that isn't a signup", async () => {
+		const { connection } = connectionWith(userModel({}));
+		const res = responseStub();
+		await signup(
+			connection,
+			serverConfig(),
+			VERIFY_ENDPOINT,
+			"local",
+			request({ body: signupBody({ email: "not-an-email" }) }),
+			res.response,
+			next,
+		);
+		expect(res.statuses).toEqual([500]);
+	});
+
+	test("rejects a token that isn't a procaptcha token", async () => {
+		const { connection } = connectionWith(userModel({}));
+		const res = responseStub();
+		await signup(
+			connection,
+			serverConfig(),
+			VERIFY_ENDPOINT,
+			"local",
+			request({ body: signupBody({ "procaptcha-response": "token" }) }),
+			res.response,
+			next,
+		);
+		expect(res.statuses).toEqual([500]);
+	});
+
+	test("falls back to a message when the failure carries none", async () => {
+		const { connection } = connectionWith(
+			userModel({ findOneRejects: new Error("") }),
+		);
+		const res = responseStub();
+		await signup(
+			connection,
+			serverConfig(),
+			VERIFY_ENDPOINT,
+			"local",
+			request({ body: signupBody() }),
+			res.response,
+			next,
+		);
+		expect(res.bodies).toEqual([{ message: "internal server error" }]);
+	});
+
+	test("passes the caller's IP to the verifier", async () => {
+		const { connection } = connectionWith(userModel({}));
+		await signup(
+			connection,
+			serverConfig(),
+			VERIFY_ENDPOINT,
+			"local",
+			request({
+				body: signupBody(),
+				headers: { "x-client-ip": "203.0.113.9" },
+			}),
+			responseStub().response,
+			next,
+		);
+		expect(mocks.isVerified).toHaveBeenCalledWith(
+			"0xtoken",
+			"203.0.113.9",
+			"user@example.com",
+		);
+	});
+
+	test("falls back to localhost when no IP header is present", async () => {
+		const { connection } = connectionWith(userModel({}));
+		await signup(
+			connection,
+			serverConfig(),
+			VERIFY_ENDPOINT,
+			"local",
+			request({ body: signupBody() }),
+			responseStub().response,
+			next,
+		);
+		expect(mocks.isVerified).toHaveBeenCalledWith(
+			"0xtoken",
+			"127.0.0.1",
+			"user@example.com",
+		);
+	});
+});
+
+describe("signup: matching the site key to a keyring pair", () => {
+	test("uses the bare secret when it derives the site key", async () => {
+		const { connection } = connectionWith(userModel({}));
+		await signup(
+			connection,
+			serverConfig(),
+			VERIFY_ENDPOINT,
+			"local",
+			request({ body: signupBody() }),
+			responseStub().response,
+			next,
+		);
+		expect(mocks.constructions[0]?.[1]).toEqual({ address: SITE_KEY });
+	});
+
+	test("tries the captcha-type suffixes when the bare secret doesn't match", async () => {
+		mocks.addresses.clear();
+		mocks.addresses.set(`${SECRET}//${CaptchaType.frictionless}`, SITE_KEY);
+		const { connection } = connectionWith(userModel({}));
+		const res = responseStub();
+		await signup(
+			connection,
+			serverConfig(),
+			VERIFY_ENDPOINT,
+			"api",
+			request({ body: signupBody() }),
+			res.response,
+			next,
+		);
+		expect(res.statuses).toEqual([200]);
+		// The suffixed secret is what gets sent for verification, not the base.
+		const body: Record<string, string> = JSON.parse(
+			String(fetchMock.mock.calls[0]?.[1]?.body),
+		);
+		expect(body.secret).toBe(`${SECRET}//${CaptchaType.frictionless}`);
+	});
+
+	test("gives up when no captcha type derives the site key", async () => {
+		mocks.addresses.clear();
+		const { connection } = connectionWith(userModel({}));
+		const res = responseStub();
+		await signup(
+			connection,
+			serverConfig(),
+			VERIFY_ENDPOINT,
+			"local",
+			request({ body: signupBody() }),
+			res.response,
+			next,
+		);
+		expect(res.statuses).toEqual([500]);
+		expect(String(res.bodies[0])).toContain("");
+		expect(mocks.isVerified).not.toHaveBeenCalled();
+	});
+});
+
+describe("signup: verifying through the API endpoint", () => {
+	test("posts the token and secret to the configured endpoint", async () => {
+		const { connection } = connectionWith(userModel({}));
+		const res = responseStub();
+		await signup(
+			connection,
+			serverConfig(),
+			VERIFY_ENDPOINT,
+			"api",
+			request({
+				body: signupBody(),
+				headers: { "x-client-ip": "203.0.113.9" },
+			}),
+			res.response,
+			next,
+		);
+		expect(res.statuses).toEqual([200]);
+		expect(fetchMock.mock.calls[0]?.[0]).toBe(VERIFY_ENDPOINT);
+		expect(fetchMock.mock.calls[0]?.[1]?.method).toBe("POST");
+		const body: Record<string, string> = JSON.parse(
+			String(fetchMock.mock.calls[0]?.[1]?.body),
+		);
+		expect(body).toEqual({
+			token: "0xtoken",
+			secret: SECRET,
+			email: "user@example.com",
+			ip: "203.0.113.9",
+		});
+		expect(mocks.isVerified).not.toHaveBeenCalled();
+	});
+
+	test("withholds the IP in development", async () => {
+		process.env.NODE_ENV = "development";
+		const { connection } = connectionWith(userModel({}));
+		await signup(
+			connection,
+			serverConfig(),
+			VERIFY_ENDPOINT,
+			"api",
+			request({
+				body: signupBody(),
+				headers: { "x-client-ip": "203.0.113.9" },
+			}),
+			responseStub().response,
+			next,
+		);
+		const body: Record<string, string> = JSON.parse(
+			String(fetchMock.mock.calls[0]?.[1]?.body),
+		);
+		expect(body.ip).toBeUndefined();
+	});
+
+	test("refuses the signup when the endpoint says unverified", async () => {
+		fetchMock.mockResolvedValue(
+			new Response(JSON.stringify({ verified: false })),
+		);
+		const { connection, model } = connectionWith(userModel({}));
+		const res = responseStub();
+		await signup(
+			connection,
+			serverConfig(),
+			VERIFY_ENDPOINT,
+			"api",
+			request({ body: signupBody() }),
+			res.response,
+			next,
+		);
+		expect(res.statuses).toEqual([401]);
+		expect(model.create).not.toHaveBeenCalled();
+	});
+
+	test("reports a verification endpoint that is unreachable", async () => {
+		fetchMock.mockRejectedValue(new Error("ECONNREFUSED"));
+		const { connection } = connectionWith(userModel({}));
+		const res = responseStub();
+		await signup(
+			connection,
+			serverConfig(),
+			VERIFY_ENDPOINT,
+			"api",
+			request({ body: signupBody() }),
+			res.response,
+			next,
+		);
+		expect(res.statuses).toEqual([500]);
+		expect(res.bodies).toEqual([{ message: "ECONNREFUSED" }]);
+	});
+
+	test("reports a verification endpoint that returns garbage", async () => {
+		fetchMock.mockResolvedValue(new Response("<html>502</html>"));
+		const { connection } = connectionWith(userModel({}));
+		const res = responseStub();
+		await signup(
+			connection,
+			serverConfig(),
+			VERIFY_ENDPOINT,
+			"api",
+			request({ body: signupBody() }),
+			res.response,
+			next,
+		);
+		expect(res.statuses).toEqual([500]);
+	});
+
+	test("any verify type other than api uses the library", async () => {
+		const { connection } = connectionWith(userModel({}));
+		await signup(
+			connection,
+			serverConfig(),
+			VERIFY_ENDPOINT,
+			"anything-else",
+			request({ body: signupBody() }),
+			responseStub().response,
+			next,
+		);
+		expect(mocks.isVerified).toHaveBeenCalledTimes(1);
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+});
+
+describe("login", () => {
+	const salt = "0xsalt";
+	// The stored hash for password "hunter2" with the salt above, produced by
+	// the same hashPassword the controller uses.
+	const storedUser = async (): Promise<{ password: string; salt: string }> => {
+		const { connection, model } = connectionWith(userModel({}));
+		await signup(
+			connection,
+			serverConfig(),
+			VERIFY_ENDPOINT,
+			"local",
+			request({ body: signupBody() }),
+			responseStub().response,
+			next,
+		);
+		const created = model.create.mock.calls[0]?.[0] as Record<string, string>;
+		return { password: String(created.password), salt: String(created.salt) };
+	};
+
+	test("issues a token for the right password", async () => {
+		const user = await storedUser();
+		const { connection } = connectionWith(userModel({ found: user }));
+		const res = responseStub();
+		await login(
+			connection,
+			serverConfig(),
+			VERIFY_ENDPOINT,
+			"local",
+			request({ body: signupBody() }),
+			res.response,
+		);
+		expect(res.statuses).toEqual([200]);
+		const body = res.bodies[0] as { message: string; token: string };
+		expect(body.message).toBe("user logged in");
+		const decoded = jwt.verify(body.token, "secret") as { email: string };
+		expect(decoded.email).toBe("user@example.com");
+	});
+
+	test("rejects the wrong password", async () => {
+		const user = await storedUser();
+		const { connection } = connectionWith(userModel({ found: user }));
+		const res = responseStub();
+		await login(
+			connection,
+			serverConfig(),
+			VERIFY_ENDPOINT,
+			"local",
+			request({ body: signupBody({ password: "not-hunter2" }) }),
+			res.response,
+		);
+		expect(res.statuses).toEqual([401]);
+		expect(res.bodies).toEqual([{ message: "invalid credentials" }]);
+	});
+
+	test("rejects a password that hashes right against the wrong salt", async () => {
+		const user = await storedUser();
+		const { connection } = connectionWith(
+			userModel({ found: { password: user.password, salt: "0xdifferent" } }),
+		);
+		const res = responseStub();
+		await login(
+			connection,
+			serverConfig(),
+			VERIFY_ENDPOINT,
+			"local",
+			request({ body: signupBody() }),
+			res.response,
+		);
+		expect(res.statuses).toEqual([401]);
+	});
+
+	test("reports an unknown email as not found", async () => {
+		const { connection } = connectionWith(userModel({ found: null }));
+		const res = responseStub();
+		await login(
+			connection,
+			serverConfig(),
+			VERIFY_ENDPOINT,
+			"local",
+			request({ body: signupBody() }),
+			res.response,
+		);
+		expect(res.statuses).toEqual([404]);
+		expect(res.bodies).toEqual([{ message: "user not found" }]);
+		// No captcha verification for an account that doesn't exist.
+		expect(mocks.isVerified).not.toHaveBeenCalled();
+	});
+
+	test("refuses a login that failed the captcha", async () => {
+		const user = await storedUser();
+		mocks.isVerified.mockResolvedValue({ verified: false });
+		const { connection } = connectionWith(userModel({ found: user }));
+		const res = responseStub();
+		await login(
+			connection,
+			serverConfig(),
+			VERIFY_ENDPOINT,
+			"local",
+			request({ body: signupBody() }),
+			res.response,
+		);
+		expect(res.statuses).toEqual([401]);
+		expect(res.bodies).toEqual([
+			{ message: "user has not completed a captcha", verified: false },
+		]);
+	});
+
+	test("does not send the email to the verifier", async () => {
+		// Unlike signup, login verifies the token alone — the provider has no
+		// signup record to match an email against.
+		const user = await storedUser();
+		const { connection } = connectionWith(userModel({ found: user }));
+		await login(
+			connection,
+			serverConfig(),
+			VERIFY_ENDPOINT,
+			"local",
+			request({ body: signupBody() }),
+			responseStub().response,
+		);
+		expect(mocks.isVerified).toHaveBeenLastCalledWith(
+			"0xtoken",
+			"NO_IP",
+			undefined,
+		);
+	});
+
+	test("passes the caller's IP through", async () => {
+		const user = await storedUser();
+		const { connection } = connectionWith(userModel({ found: user }));
+		await login(
+			connection,
+			serverConfig(),
+			VERIFY_ENDPOINT,
+			"local",
+			request({
+				body: signupBody(),
+				headers: { "x-client-ip": "203.0.113.9" },
+			}),
+			responseStub().response,
+		);
+		expect(mocks.isVerified).toHaveBeenLastCalledWith(
+			"0xtoken",
+			"203.0.113.9",
+			undefined,
+		);
+	});
+
+	test("refuses to run without a site private key", async () => {
+		const user = await storedUser();
+		const { connection } = connectionWith(userModel({ found: user }));
+		const res = responseStub();
+		await login(
+			connection,
+			serverConfig({}),
+			VERIFY_ENDPOINT,
+			"local",
+			request({ body: signupBody() }),
+			res.response,
+		);
+		expect(res.statuses).toEqual([500]);
+	});
+
+	test("reports a database failure as a server error", async () => {
+		const { connection } = connectionWith(
+			userModel({ findOneRejects: new Error("mongo unavailable") }),
+		);
+		const res = responseStub();
+		await login(
+			connection,
+			serverConfig(),
+			VERIFY_ENDPOINT,
+			"local",
+			request({ body: signupBody() }),
+			res.response,
+		);
+		expect(res.statuses).toEqual([500]);
+		expect(res.bodies).toEqual([{ message: "mongo unavailable" }]);
+	});
+
+	test("falls back to a message when the failure carries none", async () => {
+		const { connection } = connectionWith(
+			userModel({ findOneRejects: new Error("") }),
+		);
+		const res = responseStub();
+		await login(
+			connection,
+			serverConfig(),
+			VERIFY_ENDPOINT,
+			"local",
+			request({ body: signupBody() }),
+			res.response,
+		);
+		expect(res.bodies).toEqual([{ message: "internal server error" }]);
+	});
+
+	test("rejects a body that isn't a login", async () => {
+		const user = await storedUser();
+		const { connection } = connectionWith(userModel({ found: user }));
+		const res = responseStub();
+		await login(
+			connection,
+			serverConfig(),
+			VERIFY_ENDPOINT,
+			"local",
+			request({ body: signupBody({ siteKey: undefined }) }),
+			res.response,
+		);
+		expect(res.statuses).toEqual([500]);
+	});
+
+	test("verifies through the API endpoint when asked to", async () => {
+		const user = await storedUser();
+		const { connection } = connectionWith(userModel({ found: user }));
+		const res = responseStub();
+		await login(
+			connection,
+			serverConfig(),
+			VERIFY_ENDPOINT,
+			"api",
+			request({ body: signupBody() }),
+			res.response,
+		);
+		expect(res.statuses).toEqual([200]);
+		const body: Record<string, string> = JSON.parse(
+			String(fetchMock.mock.calls[0]?.[1]?.body),
+		);
+		expect(body.email).toBeUndefined();
+	});
+});
+
+describe("isAuth", () => {
+	const bearer = (token: string): string => `Bearer ${token}`;
+
+	test("lets a valid token through", () => {
+		const res = responseStub();
+		isAuth(
+			request({
+				authorization: bearer(jwt.sign({ email: "a@b.c" }, "secret")),
+			}),
+			res.response,
+		);
+		expect(res.statuses).toEqual([200]);
+		expect(res.bodies).toEqual([{ message: "here is your resource" }]);
+	});
+
+	test("refuses a request with no Authorization header", () => {
+		// The header check used to fall through to splitting the empty string,
+		// which threw before any response was sent.
+		const res = responseStub();
+		isAuth(request({}), res.response);
+		expect(res.statuses).toEqual([401]);
+		expect(res.bodies).toEqual([{ message: "not authenticated" }]);
+	});
+
+	test("refuses an Authorization header with no token", () => {
+		const res = responseStub();
+		isAuth(request({ authorization: "Bearer" }), res.response);
+		expect(res.statuses).toEqual([401]);
+	});
+
+	test("reports a token it cannot decode, and only once", () => {
+		// A failed verify used to send a 500 and then a 401 on the same
+		// response, which express rejects as headers-already-sent.
+		const res = responseStub();
+		isAuth(request({ authorization: bearer("not-a-jwt") }), res.response);
+		expect(res.statuses).toEqual([500]);
+		expect(res.bodies).toHaveLength(1);
+	});
+
+	test("rejects a token signed with a different secret", () => {
+		const res = responseStub();
+		isAuth(
+			request({
+				authorization: bearer(jwt.sign({ email: "a@b.c" }, "other-secret")),
+			}),
+			res.response,
+		);
+		expect(res.statuses).toEqual([500]);
+	});
+
+	test("rejects an expired token", () => {
+		const res = responseStub();
+		isAuth(
+			request({
+				authorization: bearer(
+					jwt.sign({ email: "a@b.c" }, "secret", { expiresIn: -10 }),
+				),
+			}),
+			res.response,
+		);
+		expect(res.statuses).toEqual([500]);
+		expect(res.bodies).toEqual([{ message: "jwt expired" }]);
+	});
+
+	test("describes a decode failure that carries no message", () => {
+		vi.spyOn(jwt, "verify").mockImplementation((): string => {
+			throw new Error("");
+		});
+		const res = responseStub();
+		isAuth(request({ authorization: bearer("whatever") }), res.response);
+		expect(res.statuses).toEqual([500]);
+		expect(res.bodies).toEqual([{ message: "could not decode the token" }]);
+	});
+
+	test("treats an empty decode as unauthorized", () => {
+		// jwt.verify resolves to a payload or throws; the guard is defensive,
+		// and this pins what it does if a future jwt version returns nothing.
+		vi.spyOn(jwt, "verify").mockImplementation((): string => "");
+		const res = responseStub();
+		isAuth(request({ authorization: bearer("whatever") }), res.response);
+		expect(res.statuses).toEqual([401]);
+		expect(res.bodies).toEqual([{ message: "unauthorized" }]);
+	});
+
+	test("ignores anything after the token", () => {
+		const res = responseStub();
+		isAuth(
+			request({
+				authorization: `Bearer ${jwt.sign({ email: "a@b.c" }, "secret")} extra`,
+			}),
+			res.response,
+		);
+		expect(res.statuses).toEqual([200]);
+	});
+});
+
+describe("the exported surface", () => {
+	test("keeps the token type the handlers accept", () => {
+		// A compile-time reminder that the request token is the shared type,
+		// not a bare string the controllers invent.
+		const token: ProcaptchaToken = "0xtoken";
+		expect(token.startsWith("0x")).toBe(true);
+	});
+
+	test("the pair helper only ever sees the address", () => {
+		expect(pairWithAddress(SITE_KEY).address).toBe(SITE_KEY);
+	});
+});

--- a/demos/client-example-server/src/tests/auth.unit.test.ts
+++ b/demos/client-example-server/src/tests/auth.unit.test.ts
@@ -384,7 +384,7 @@ describe("signup: matching the site key to a keyring pair", () => {
 			next,
 		);
 		expect(res.statuses).toEqual([500]);
-		expect(String(res.bodies[0])).toContain("");
+		expect(res.bodies[0]).toMatchObject({ message: expect.any(String) });
 		expect(mocks.isVerified).not.toHaveBeenCalled();
 	});
 });
@@ -768,6 +768,15 @@ describe("isAuth", () => {
 		const res = responseStub();
 		isAuth(request({ authorization: "Bearer" }), res.response);
 		expect(res.statuses).toEqual([401]);
+	});
+
+	test("refuses a Bearer header whose token is empty", () => {
+		// "Bearer " splits into two parts, so the length check passes and the
+		// empty token reached jwt.verify, which threw and read as a 500.
+		const res = responseStub();
+		isAuth(request({ authorization: "Bearer " }), res.response);
+		expect(res.statuses).toEqual([401]);
+		expect(res.bodies).toEqual([{ message: "not authenticated" }]);
 	});
 
 	test("reports a token it cannot decode, and only once", () => {

--- a/demos/client-example-server/src/tests/authHarness.ts
+++ b/demos/client-example-server/src/tests/authHarness.ts
@@ -1,0 +1,131 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { KeyringPair } from "@prosopo/types";
+import type { ProsopoServerConfigOutput } from "@prosopo/types";
+import type { Request, Response } from "express";
+import type { Connection } from "mongoose";
+import { vi } from "vitest";
+import type { UserInterface } from "../models/user.js";
+
+export const SITE_KEY = "site-key-address";
+export const SECRET = "//Alice";
+export const VERIFY_ENDPOINT = "https://api.prosopo.io/siteverify";
+
+/** The subset of the config the controllers actually read. */
+export const serverConfig = (
+	options: { secret?: string } = { secret: SECRET },
+): ProsopoServerConfigOutput =>
+	({
+		account: { secret: options.secret },
+		defaultEnvironment: "development",
+		serverUrl: "https://localhost:9228",
+	}) as unknown as ProsopoServerConfigOutput;
+
+/**
+ * getPair returns a real keyring pair in production; the controllers only ever
+ * compare `address` and hand the pair to ProsopoServer, so a stub with the
+ * address is enough to drive every branch of the site-key matching.
+ */
+export const pairWithAddress = (address: string): KeyringPair =>
+	({ address }) as unknown as KeyringPair;
+
+export type FoundUser = Pick<UserInterface, "password" | "salt">;
+
+export interface UserModelStub {
+	findOne: ReturnType<typeof vi.fn>;
+	create: ReturnType<typeof vi.fn>;
+}
+
+/**
+ * A mongoose connection whose `model()` hands back a stub with the two methods
+ * the controllers call. The real model would need a live mongod, and its
+ * query builder is chainable in ways nothing here relies on.
+ */
+export const connectionWith = (
+	model: UserModelStub,
+): { connection: Connection; model: UserModelStub } => ({
+	connection: {
+		model: () => model,
+	} as unknown as Connection,
+	model,
+});
+
+export const userModel = (options: {
+	found?: FoundUser | null;
+	findOneRejects?: Error;
+	createRejects?: Error;
+}): UserModelStub => ({
+	findOne: vi.fn(() =>
+		options.findOneRejects
+			? Promise.reject(options.findOneRejects)
+			: Promise.resolve(options.found ?? null),
+	),
+	create: vi.fn(() =>
+		options.createRejects
+			? Promise.reject(options.createRejects)
+			: Promise.resolve({}),
+	),
+});
+
+export interface ResponseStub {
+	response: Response;
+	statuses: number[];
+	bodies: unknown[];
+}
+
+/** Records what the handler wrote, in order, so double-sends are visible. */
+export const responseStub = (): ResponseStub => {
+	const statuses: number[] = [];
+	const bodies: unknown[] = [];
+	const response = {
+		status: (code: number) => {
+			statuses.push(code);
+			return response;
+		},
+		json: (body: unknown) => {
+			bodies.push(body);
+			return response;
+		},
+	};
+	return {
+		response: response as unknown as Response,
+		statuses,
+		bodies,
+	};
+};
+
+export const request = (options: {
+	body?: Record<string, unknown>;
+	headers?: Record<string, string>;
+	authorization?: string;
+}): Request =>
+	({
+		body: options.body ?? {},
+		headers: options.headers ?? {},
+		get: (name: string) =>
+			name === "Authorization" ? options.authorization : undefined,
+	}) as unknown as Request;
+
+/** A body that satisfies SubscribeBodySpec. */
+export const signupBody = (
+	overrides: Record<string, unknown> = {},
+): Record<string, unknown> => ({
+	email: "user@example.com",
+	password: "hunter2",
+	name: "user",
+	siteKey: SITE_KEY,
+	"procaptcha-response": "0xtoken",
+	...overrides,
+});

--- a/demos/client-example-server/src/tests/clientExampleServer.test-d.ts
+++ b/demos/client-example-server/src/tests/clientExampleServer.test-d.ts
@@ -1,0 +1,146 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { Server } from "node:http";
+import type { ProsopoServerConfigOutput } from "@prosopo/types";
+import type express from "express";
+import type { Connection } from "mongoose";
+import { assertType, describe, expectTypeOf, test } from "vitest";
+import {
+	type ProsopoVerificationType,
+	createApp,
+	isDevelopmentOrTest,
+	main,
+	resolvePort,
+	resolveVerifyEndpoint,
+	resolveVerifyType,
+	startServer,
+} from "../app.js";
+import { isAuth, login, signup } from "../controllers/auth.js";
+import type UserSchema from "../models/user.js";
+import type { UserInterface } from "../models/user.js";
+import getRoutes from "../routes/routes.js";
+import connectionFactory from "../utils/connection.js";
+import memoryServerSetup from "../utils/database.js";
+
+describe("the app module's types", () => {
+	test("the environment readers take no arguments", () => {
+		expectTypeOf(resolveVerifyEndpoint).parameters.toEqualTypeOf<[]>();
+		expectTypeOf(resolveVerifyEndpoint).returns.toEqualTypeOf<string>();
+		expectTypeOf(
+			resolveVerifyType,
+		).returns.toEqualTypeOf<ProsopoVerificationType>();
+		expectTypeOf(isDevelopmentOrTest).returns.toEqualTypeOf<boolean>();
+	});
+
+	test("the verification type is a closed set", () => {
+		expectTypeOf<`${ProsopoVerificationType}`>().toEqualTypeOf<
+			"api" | "local"
+		>();
+		// @ts-expect-error - anything else has to fall back to the API at runtime.
+		assertType<ProsopoVerificationType>("carrier-pigeon");
+	});
+
+	test("the port comes from the shared server config, not a loose object", () => {
+		expectTypeOf(resolvePort)
+			.parameter(0)
+			.toEqualTypeOf<ProsopoServerConfigOutput>();
+		expectTypeOf(resolvePort).returns.toEqualTypeOf<number>();
+	});
+
+	test("createApp yields an express app the caller can mount routes on", () => {
+		expectTypeOf(createApp).returns.toEqualTypeOf<express.Express>();
+	});
+
+	test("startServer's module directory is optional and it returns a server", () => {
+		expectTypeOf(startServer).parameter(1).toEqualTypeOf<number>();
+		expectTypeOf(startServer).parameter(2).toEqualTypeOf<string | undefined>();
+		expectTypeOf(startServer).returns.toEqualTypeOf<Server>();
+	});
+
+	test("main resolves to the server it started, so a caller can close it", () => {
+		expectTypeOf(main).parameters.toEqualTypeOf<[]>();
+		expectTypeOf(main).returns.toEqualTypeOf<Promise<Server>>();
+	});
+});
+
+describe("the router's types", () => {
+	test("routes are built from a connection, config and verification settings", () => {
+		expectTypeOf(getRoutes).parameters.toEqualTypeOf<
+			[Connection, ProsopoServerConfigOutput, string, string]
+		>();
+		expectTypeOf(getRoutes).returns.toEqualTypeOf<express.Router>();
+	});
+
+	test("every argument is required", () => {
+		// @ts-expect-error - a router with no verification settings would
+		// silently accept unverified signups.
+		getRoutes({} as Connection, {} as ProsopoServerConfigOutput, "endpoint");
+	});
+});
+
+describe("the controllers' types", () => {
+	test("signup and login are express handlers with their context bound first", () => {
+		expectTypeOf(signup).parameter(0).toEqualTypeOf<Connection>();
+		expectTypeOf(signup)
+			.parameter(1)
+			.toEqualTypeOf<ProsopoServerConfigOutput>();
+		expectTypeOf(signup).parameter(2).toEqualTypeOf<string>();
+		expectTypeOf(signup).parameter(3).toEqualTypeOf<string>();
+		expectTypeOf(signup).returns.toExtend<Promise<unknown>>();
+		expectTypeOf(login).parameter(0).toEqualTypeOf<Connection>();
+		expectTypeOf(login).returns.toEqualTypeOf<Promise<void>>();
+	});
+
+	test("isAuth needs nothing bound, so it mounts directly", () => {
+		expectTypeOf(isAuth).parameters.toEqualTypeOf<
+			[express.Request, express.Response]
+		>();
+	});
+});
+
+describe("the persistence types", () => {
+	test("connectionFactory takes a URI and returns a mongoose connection", () => {
+		expectTypeOf(connectionFactory).parameters.toEqualTypeOf<[string]>();
+		expectTypeOf(connectionFactory).returns.toEqualTypeOf<Connection>();
+	});
+
+	test("the memory server hands back a URI string", () => {
+		expectTypeOf(memoryServerSetup).parameters.toEqualTypeOf<[]>();
+		expectTypeOf(memoryServerSetup).returns.toEqualTypeOf<Promise<string>>();
+	});
+
+	test("the user schema is typed by the interface it stores", () => {
+		expectTypeOf<keyof typeof UserSchema.obj>().toEqualTypeOf<
+			keyof UserInterface
+		>();
+		expectTypeOf<UserInterface>().toEqualTypeOf<{
+			id: number;
+			email: string;
+			name: string;
+			password: string;
+			salt: string;
+		}>();
+	});
+
+	test("a user document cannot be built without credentials", () => {
+		// @ts-expect-error - salt is what makes the stored hash meaningful.
+		assertType<UserInterface>({
+			id: 1,
+			email: "user@example.com",
+			name: "user",
+			password: "0xhash",
+		});
+	});
+});

--- a/demos/client-example-server/src/tests/routes.unit.test.ts
+++ b/demos/client-example-server/src/tests/routes.unit.test.ts
@@ -1,0 +1,166 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import express from "express";
+import type { Connection } from "mongoose";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import getRoutes from "../routes/routes.js";
+import { VERIFY_ENDPOINT, serverConfig } from "./authHarness.js";
+
+/**
+ * The controllers have their own suite; here we only care that each path is
+ * bound to the right handler and that the bound arguments reach it.
+ */
+const mocks = vi.hoisted(() => ({
+	calls: [] as { handler: string; args: unknown[] }[],
+}));
+
+vi.mock("../controllers/auth.js", () => {
+	type Handler = (...args: unknown[]) => void;
+	const record =
+		(handler: string): Handler =>
+		(...args: unknown[]) => {
+			mocks.calls.push({ handler, args: args.slice(0, 4) });
+			const res = args[args.length - 2] as {
+				status: (code: number) => { json: (body: unknown) => void };
+			};
+			res.status(200).json({ handler });
+		};
+	return {
+		signup: record("signup"),
+		login: record("login"),
+		// isAuth is mounted directly, so it only ever gets (req, res).
+		isAuth: (_req: unknown, res: unknown) =>
+			(res as { status: (code: number) => { json: (body: unknown) => void } })
+				.status(200)
+				.json({ handler: "isAuth" }),
+	};
+});
+
+const connection: Connection = {} as unknown as Connection;
+
+let server: Server | undefined;
+
+const listen = (): Promise<string> => {
+	const app = express();
+	app.use(express.json());
+	app.use(getRoutes(connection, serverConfig(), VERIFY_ENDPOINT, "api"));
+	return new Promise((resolve) => {
+		server = app.listen(0, () => {
+			const { port } = server?.address() as AddressInfo;
+			resolve(`http://127.0.0.1:${port}`);
+		});
+	});
+};
+
+afterEach(async () => {
+	mocks.calls.length = 0;
+	await new Promise<void>((resolve) => {
+		if (!server) return resolve();
+		server.close(() => resolve());
+		server = undefined;
+	});
+});
+
+describe("the router", () => {
+	test("serves the public resource without any authentication", async () => {
+		const base = await listen();
+		const response = await fetch(`${base}/public`);
+		expect(response.status).toBe(200);
+		expect(await response.json()).toEqual({
+			message: "here is your public resource",
+		});
+	});
+
+	test("answers health checks", async () => {
+		const base = await listen();
+		const response = await fetch(`${base}/health`);
+		expect(response.status).toBe(200);
+		expect(await response.json()).toEqual({ status: "ok" });
+	});
+
+	test("routes a signup to the signup handler, with the bound context", async () => {
+		const base = await listen();
+		const response = await fetch(`${base}/signup`, {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({ email: "user@example.com" }),
+		});
+		expect(response.status).toBe(200);
+		expect(mocks.calls[0]?.handler).toBe("signup");
+		expect(mocks.calls[0]?.args).toEqual([
+			connection,
+			serverConfig(),
+			VERIFY_ENDPOINT,
+			"api",
+		]);
+	});
+
+	test("routes a login to the login handler", async () => {
+		const base = await listen();
+		await fetch(`${base}/login`, {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({}),
+		});
+		expect(mocks.calls[0]?.handler).toBe("login");
+	});
+
+	test("guards the private resource", async () => {
+		const base = await listen();
+		const response = await fetch(`${base}/private`);
+		expect(await response.json()).toEqual({ handler: "isAuth" });
+	});
+
+	test("answers anything else with a 404 body, not express's HTML", async () => {
+		const base = await listen();
+		const response = await fetch(`${base}/nope`);
+		expect(response.status).toBe(404);
+		expect(await response.json()).toEqual({ error: "page not found" });
+	});
+
+	test("a GET to a POST-only path falls through to the catch-all", async () => {
+		const base = await listen();
+		const response = await fetch(`${base}/login`);
+		expect(response.status).toBe(404);
+		expect(mocks.calls).toHaveLength(0);
+	});
+
+	test("each call builds a fresh router", async () => {
+		// The module used to share one router across calls, so a second server
+		// stacked a second set of handlers on top of the first call's bound
+		// config and answered every request with the stale one.
+		const first = getRoutes(connection, serverConfig(), "https://one", "api");
+		const second = getRoutes(connection, serverConfig(), "https://two", "api");
+		expect(first).not.toBe(second);
+		const app = express();
+		app.use(express.json());
+		app.use(second);
+		const base = await new Promise<string>((resolve) => {
+			server = app.listen(0, () => {
+				const { port } = server?.address() as AddressInfo;
+				resolve(`http://127.0.0.1:${port}`);
+			});
+		});
+		await fetch(`${base}/signup`, {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({}),
+		});
+		expect(mocks.calls).toHaveLength(1);
+		expect(mocks.calls[0]?.args[2]).toBe("https://two");
+	});
+});

--- a/demos/client-example-server/src/tests/utils.unit.test.ts
+++ b/demos/client-example-server/src/tests/utils.unit.test.ts
@@ -1,0 +1,169 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { Connection, Schema } from "mongoose";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import UserSchema, { type UserInterface } from "../models/user.js";
+import connectionFactory from "../utils/connection.js";
+import memoryServerSetup from "../utils/database.js";
+
+/**
+ * connectionFactory opens a real mongo connection and registers a model on
+ * it. Both mongoose and the auto-increment plugin are replaced so the test
+ * observes the wiring without a database.
+ */
+const mocks = vi.hoisted(() => ({
+	createConnection: vi.fn(),
+	models: {} as Record<string, unknown>,
+	model: vi.fn(),
+	plugin: vi.fn(),
+	connectionOptions: vi.fn(),
+	memoryUri: "mongodb://memory:27017/",
+	memoryCreate: vi.fn(),
+}));
+
+vi.mock("mongoose", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("mongoose")>();
+	return {
+		...actual,
+		default: {
+			...actual.default,
+			createConnection: (...args: unknown[]) => {
+				mocks.createConnection(...args);
+				return {
+					models: mocks.models,
+					model: mocks.model,
+				} as unknown as Connection;
+			},
+		},
+	};
+});
+
+vi.mock("@typegoose/auto-increment", () => ({
+	AutoIncrementID: "auto-increment-plugin",
+}));
+
+vi.mock("@prosopo/database", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@prosopo/database")>();
+	return {
+		...actual,
+		getMongoConnectionOptions: (args: { url: string; appName: string }) => {
+			mocks.connectionOptions(args);
+			return { appName: args.appName };
+		},
+	};
+});
+
+vi.mock("mongodb-memory-server", () => ({
+	MongoMemoryServer: {
+		create: () => {
+			mocks.memoryCreate();
+			return Promise.resolve({ getUri: () => mocks.memoryUri });
+		},
+	},
+}));
+
+beforeEach(() => {
+	mocks.createConnection.mockClear();
+	mocks.model.mockClear();
+	mocks.plugin.mockClear();
+	mocks.connectionOptions.mockClear();
+	mocks.memoryCreate.mockClear();
+	mocks.models = {};
+	vi.spyOn(UserSchema, "plugin").mockImplementation(
+		(...args: unknown[]): Schema<UserInterface> => {
+			mocks.plugin(...args);
+			return UserSchema;
+		},
+	);
+});
+
+describe("connectionFactory", () => {
+	const URI = "mongodb://localhost:27017/client-example";
+
+	test("connects to the URI it was given", () => {
+		connectionFactory(URI);
+		expect(mocks.createConnection).toHaveBeenCalledTimes(1);
+		expect(mocks.createConnection.mock.calls[0]?.[0]).toBe(URI);
+	});
+
+	test("names the connection after the module, for mongo's server logs", () => {
+		connectionFactory(URI);
+		const options = mocks.createConnection.mock.calls[0]?.[1] as {
+			appName: string;
+		};
+		expect(options.appName).toContain("connection");
+		expect(mocks.connectionOptions).toHaveBeenCalledWith({
+			url: URI,
+			appName: options.appName,
+		});
+	});
+
+	test("registers the User model with auto-incrementing ids", () => {
+		connectionFactory(URI);
+		expect(mocks.plugin).toHaveBeenCalledWith("auto-increment-plugin", {
+			field: "id",
+		});
+		expect(mocks.model).toHaveBeenCalledWith("User", UserSchema);
+	});
+
+	test("leaves an already-registered model alone", () => {
+		// Re-registering throws in mongoose (OverwriteModelError), so the
+		// factory has to be safe to call on a connection that has been set up.
+		mocks.models = { user: {} };
+		connectionFactory(URI);
+		expect(mocks.model).not.toHaveBeenCalled();
+		expect(mocks.plugin).not.toHaveBeenCalled();
+	});
+
+	test("returns the connection it created", () => {
+		const connection = connectionFactory(URI);
+		expect(connection.model).toBe(mocks.model);
+	});
+});
+
+describe("memoryServerSetup", () => {
+	test("boots an in-memory mongo and returns its URI", async () => {
+		await expect(memoryServerSetup()).resolves.toBe(mocks.memoryUri);
+		expect(mocks.memoryCreate).toHaveBeenCalledTimes(1);
+	});
+
+	test("each call gets its own server", async () => {
+		await memoryServerSetup();
+		await memoryServerSetup();
+		expect(mocks.memoryCreate).toHaveBeenCalledTimes(2);
+	});
+});
+
+describe("the User schema", () => {
+	test("requires the fields a login needs to work", () => {
+		// Without email, password and salt, a stored user cannot be logged in.
+		for (const field of ["email", "password", "salt"]) {
+			expect(UserSchema.path(field).isRequired).toBe(true);
+		}
+	});
+
+	test("leaves name and id optional", () => {
+		// `id` is filled in by the auto-increment plugin after validation.
+		expect(UserSchema.path("name").isRequired).toBeFalsy();
+		expect(UserSchema.path("id").isRequired).toBeFalsy();
+	});
+
+	test("stores the id as a number and the rest as strings", () => {
+		expect(UserSchema.path("id").instance).toBe("Number");
+		for (const field of ["email", "name", "password", "salt"]) {
+			expect(UserSchema.path(field).instance).toBe("String");
+		}
+	});
+});

--- a/demos/client-example-server/vite.test.config.ts
+++ b/demos/client-example-server/vite.test.config.ts
@@ -1,0 +1,5 @@
+import { ViteTestConfig } from "@prosopo/config";
+
+process.env.NODE_ENV = "test";
+
+export default ViteTestConfig();

--- a/demos/client-example-server/vite.test.config.ts
+++ b/demos/client-example-server/vite.test.config.ts
@@ -1,3 +1,16 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 import { ViteTestConfig } from "@prosopo/config";
 
 process.env.NODE_ENV = "test";


### PR DESCRIPTION
Adds vitest unit and type tests for `demos/client-example-server` (108 tests, 100% statements/lines/functions, ~99% branches) and fixes the defects they surfaced:

- `getRoutes` shared one module-level router across calls, stacking handlers bound to stale config.
- `isAuth` could fall through without responding, and could respond twice for a malformed `Authorization` header.
- The `if (passwordHash)` guard in signup had no else branch, hanging the request when falsy.
- A `serverUrl` without a port resolved to `NaN`, so the server listened on an arbitrary free port; now falls back to 9228.
- Removed the unreachable `OPTIONS` handler (`cors()` already answers preflight) and leftover debug logging.
- `app.ts` no longer boots on import; it exports `createApp`, `startServer` and `main`, and only runs when executed directly.