### PR TITLE
test(api): unit + type tests for the provider API client

### DIFF
--- a/.changeset/api-tests.md
+++ b/.changeset/api-tests.md
@@ -1,0 +1,5 @@
+---
+"@prosopo/api": patch
+---
+
+Add unit and type tests for the provider API client: transport behaviour (JSON error bodies vs transport errors, 400 handling, parse failures, header merging), the in-flight challenge de-duplication, every client and admin endpoint's path, body and headers, and the frictionless honeypot meta header. 128 tests, 100% statement, branch, function and line coverage. No behaviour changes.

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -22,7 +22,10 @@
 		"build:cross-env": "vite build --config vite.esm.config.ts",
 		"build:tsc": "tsc --build --verbose",
 		"build:cjs": "NODE_ENV=${NODE_ENV:-development}; vite build --config vite.cjs.config.ts --mode $NODE_ENV",
-		"typecheck": "tsc --project tsconfig.types.json"
+		"typecheck": "tsc --project tsconfig.types.json",
+		"test": "NODE_ENV=${NODE_ENV:-test}; npx vitest run --config ./vite.test.config.ts",
+		"test:watch": "NODE_ENV=${NODE_ENV:-test}; npx vitest watch --config ./vite.test.config.ts",
+		"test:coverage": "NODE_ENV=${NODE_ENV:-test}; npx vitest run --coverage --config ./vite.test.config.ts"
 	},
 	"repository": {
 		"type": "git",

--- a/packages/api/src/tests/api.test-d.ts
+++ b/packages/api/src/tests/api.test-d.ts
@@ -1,0 +1,136 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type {
+	ApiResponse,
+	CaptchaResponseBody,
+	GetFrictionlessCaptchaResponse,
+	GetPowCaptchaResponse,
+	ProviderApiInterface,
+	VerificationResponse,
+} from "@prosopo/types";
+import { assertType, describe, expectTypeOf, test } from "vitest";
+import HttpClientBase from "../api/HttpClientBase.js";
+import type { HttpError } from "../api/HttpError.js";
+import ProviderApi, { VERIFY_FORWARDED_HEADER } from "../api/ProviderApi.js";
+import { ApiClient } from "../api/apiClient.js";
+import type * as entrypoint from "../index.js";
+
+describe("the package entrypoint", () => {
+	test("exports exactly the client surface", () => {
+		expectTypeOf<typeof entrypoint.ProviderApi>().toEqualTypeOf<
+			typeof ProviderApi
+		>();
+		expectTypeOf<typeof entrypoint.ApiClient>().toEqualTypeOf<
+			typeof ApiClient
+		>();
+		expectTypeOf<typeof entrypoint.HttpError>().toEqualTypeOf<
+			typeof HttpError
+		>();
+		expectTypeOf<typeof entrypoint.HttpClientBase>().toEqualTypeOf<
+			typeof HttpClientBase
+		>();
+		expectTypeOf<
+			typeof entrypoint.VERIFY_FORWARDED_HEADER
+		>().toExtend<string>();
+	});
+
+	test("the forwarded marker is a string constant callers can set as a header", () => {
+		expectTypeOf(VERIFY_FORWARDED_HEADER).toExtend<string>();
+	});
+});
+
+describe("HttpClientBase's types", () => {
+	test("takes a base URL and an optional prefix", () => {
+		expectTypeOf<ConstructorParameters<typeof HttpClientBase>>().toEqualTypeOf<
+			[baseURL: string, prefix?: string]
+		>();
+	});
+
+	test("the transport methods are not part of the public surface", () => {
+		// They are protected: only subclasses may call them.
+		// @ts-expect-error - fetch is protected.
+		expectTypeOf(new HttpClientBase("url").fetch).toBeCallableWith("/path");
+	});
+});
+
+describe("HttpError's types", () => {
+	test("carries the status, text and URL", () => {
+		expectTypeOf<ConstructorParameters<typeof HttpError>>().toEqualTypeOf<
+			[status: number, statusText: string, url: string]
+		>();
+		expectTypeOf<HttpError["status"]>().toEqualTypeOf<number>();
+		expectTypeOf<HttpError["statusText"]>().toEqualTypeOf<string>();
+		expectTypeOf<HttpError["url"]>().toEqualTypeOf<string>();
+		expectTypeOf<HttpError>().toExtend<Error>();
+	});
+});
+
+describe("ApiClient's types", () => {
+	test("needs both a URL and the account it speaks for", () => {
+		expectTypeOf<ConstructorParameters<typeof ApiClient>>().toEqualTypeOf<
+			[baseUrl: string, account: string]
+		>();
+		// @ts-expect-error - a client with no account cannot set the site key
+		// header, so every request would be unattributable.
+		assertType<ApiClient>(new ApiClient("https://provider.prosopo.io"));
+	});
+});
+
+describe("ProviderApi's types", () => {
+	test("implements the shared provider interface", () => {
+		expectTypeOf<ProviderApi>().toExtend<ProviderApiInterface>();
+		expectTypeOf<ProviderApi>().toExtend<ApiClient>();
+	});
+
+	test("the challenge fetchers take optional session and simd arguments", () => {
+		expectTypeOf<
+			Parameters<ProviderApi["getPowCaptchaChallenge"]>
+		>().toEqualTypeOf<
+			[user: string, dapp: string, sessionId?: string, simdReadings?: string]
+		>();
+		expectTypeOf<
+			ReturnType<ProviderApi["getPowCaptchaChallenge"]>
+		>().toEqualTypeOf<Promise<GetPowCaptchaResponse>>();
+	});
+
+	test("challenge responses all extend the shared ApiResponse", () => {
+		expectTypeOf<GetPowCaptchaResponse>().toExtend<ApiResponse>();
+		expectTypeOf<GetFrictionlessCaptchaResponse>().toExtend<ApiResponse>();
+	});
+
+	test("the image challenge returns the captcha body", () => {
+		expectTypeOf<
+			ReturnType<ProviderApi["getCaptchaChallenge"]>
+		>().toEqualTypeOf<Promise<CaptchaResponseBody>>();
+	});
+
+	test("verification calls resolve to a verification response", () => {
+		expectTypeOf<
+			ReturnType<ProviderApi["submitPowCaptchaVerify"]>
+		>().toEqualTypeOf<Promise<VerificationResponse>>();
+		expectTypeOf<
+			ReturnType<ProviderApi["submitPuzzleCaptchaVerify"]>
+		>().toEqualTypeOf<Promise<VerificationResponse>>();
+		expectTypeOf<ReturnType<ProviderApi["forwardVerify"]>>().toEqualTypeOf<
+			Promise<VerificationResponse>
+		>();
+	});
+
+	test("the in-flight dedupe map is private, not part of the contract", () => {
+		const client = new ProviderApi("url", "account");
+		// @ts-expect-error - callers must not reach into the dedupe state.
+		client.inFlightChallenges;
+	});
+});

--- a/packages/api/src/tests/apiHarness.ts
+++ b/packages/api/src/tests/apiHarness.ts
@@ -1,0 +1,142 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { POW_SEPARATOR, type PoWChallengeId } from "@prosopo/types";
+import { vi } from "vitest";
+
+export interface RecordedRequest {
+	url: string;
+	init: RequestInit | undefined;
+	body: unknown;
+	headers: Record<string, string>;
+}
+
+export interface FetchStub {
+	/** Every request the client made, in order. */
+	requests: RecordedRequest[];
+	/** The single request, when a test only makes one. */
+	last: () => RecordedRequest;
+	/** Resolve the next (and every subsequent) call with this body. */
+	respond: (body: unknown, init?: ResponseInit) => void;
+	/** Resolve the next call only; later calls fall back to the default. */
+	respondOnce: (body: unknown, init?: ResponseInit) => void;
+	/** Reject the next (and every subsequent) call, as a network failure does. */
+	fail: (error: Error) => void;
+	/** Hand control of the next call's outcome to the test. */
+	defer: () => { resolve: (body: unknown) => void; reject: (e: Error) => void };
+	restore: () => void;
+}
+
+const headersOf = (init: RequestInit | undefined): Record<string, string> => {
+	const headers = init?.headers;
+	if (!headers) return {};
+	if (headers instanceof Headers) return Object.fromEntries(headers.entries());
+	if (Array.isArray(headers)) return Object.fromEntries(headers);
+	return { ...headers };
+};
+
+const parseBody = (init: RequestInit | undefined): unknown => {
+	const body = init?.body;
+	if (typeof body !== "string") return undefined;
+	try {
+		return JSON.parse(body);
+	} catch {
+		return body;
+	}
+};
+
+/**
+ * Replaces global fetch. The client under test only ever talks to the network
+ * through it, so this is the whole seam — no transport code is stubbed out.
+ */
+export const stubFetch = (
+	defaultBody: unknown = { status: "ok" },
+): FetchStub => {
+	const requests: RecordedRequest[] = [];
+	type Outcome = () => Promise<Response>;
+	const queue: Outcome[] = [];
+	let fallback: Outcome = () =>
+		Promise.resolve(
+			new Response(JSON.stringify(defaultBody), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			}),
+		);
+
+	const original = globalThis.fetch;
+	const impl = (input: RequestInfo | URL, init?: RequestInit) => {
+		requests.push({
+			url: String(input),
+			init,
+			body: parseBody(init),
+			headers: headersOf(init),
+		});
+		const next = queue.shift();
+		return (next ?? fallback)();
+	};
+	globalThis.fetch = vi.fn(impl) as unknown as typeof globalThis.fetch;
+
+	const responseOf = (body: unknown, init?: ResponseInit): Outcome => {
+		return () =>
+			Promise.resolve(
+				new Response(typeof body === "string" ? body : JSON.stringify(body), {
+					status: 200,
+					headers: { "content-type": "application/json" },
+					...init,
+				}),
+			);
+	};
+
+	return {
+		requests,
+		last: (): RecordedRequest => {
+			const request = requests[requests.length - 1];
+			if (!request) throw new Error("no request was made");
+			return request;
+		},
+		respond: (body: unknown, init?: ResponseInit): void => {
+			fallback = responseOf(body, init);
+		},
+		respondOnce: (body: unknown, init?: ResponseInit): void => {
+			queue.push(responseOf(body, init));
+		},
+		fail: (error: Error): void => {
+			fallback = () => Promise.reject(error);
+		},
+		defer: (): {
+			resolve: (body: unknown) => void;
+			reject: (e: Error) => void;
+		} => {
+			let settle: (outcome: Outcome) => void = () => undefined;
+			const gate = new Promise<Outcome>((resolve) => {
+				settle = resolve;
+			});
+			queue.push(() => gate.then((outcome) => outcome()));
+			return {
+				resolve: (body: unknown): void => settle(responseOf(body)),
+				reject: (e: Error): void => settle(() => Promise.reject(e)),
+			};
+		},
+		restore: (): void => {
+			globalThis.fetch = original;
+		},
+	};
+};
+
+export const BASE_URL = "https://provider.prosopo.io";
+export const SITE_KEY = "5site000000000000000000000000000000000000000000000000";
+export const USER = "5user000000000000000000000000000000000000000000000000";
+
+/** A challenge id has to be four `___`-separated parts, starting with a time. */
+export const CHALLENGE: PoWChallengeId = `1753900000000${POW_SEPARATOR}${USER}${POW_SEPARATOR}${SITE_KEY}${POW_SEPARATOR}salt`;

--- a/packages/api/src/tests/httpClientBase.unit.test.ts
+++ b/packages/api/src/tests/httpClientBase.unit.test.ts
@@ -1,0 +1,356 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import HttpClientBase from "../api/HttpClientBase.js";
+import { HttpError } from "../api/HttpError.js";
+import { ApiClient } from "../api/apiClient.js";
+import { BASE_URL, type FetchStub, stubFetch } from "./apiHarness.js";
+
+/**
+ * The transport methods are protected, so a test subclass exposes them. This
+ * is the same surface every generated client uses.
+ */
+class TestClient extends HttpClientBase {
+	public get<T>(input: RequestInfo, init?: RequestInit): Promise<T> {
+		return this.fetch<T>(input, init);
+	}
+	public send<T, U>(
+		input: RequestInfo,
+		body: U,
+		init?: RequestInit,
+	): Promise<T> {
+		return this.post<T, U>(input, body, init);
+	}
+	public sendWithHeaders<T, U>(
+		input: RequestInfo,
+		body: U,
+		init?: RequestInit,
+	): Promise<{ data: T; headers: Headers }> {
+		return this.postWithHeaders<T, U>(input, body, init);
+	}
+	public url(): string {
+		return this.baseURL;
+	}
+}
+
+let fetchStub: FetchStub;
+
+beforeEach(() => {
+	fetchStub = stubFetch();
+	vi.spyOn(console, "error").mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+	fetchStub.restore();
+	vi.restoreAllMocks();
+});
+
+const client = (prefix?: string): TestClient =>
+	prefix === undefined
+		? new TestClient(BASE_URL)
+		: new TestClient(BASE_URL, prefix);
+
+const json = (body: unknown, status = 200): ResponseInit => ({
+	status,
+	headers: { "content-type": "application/json" },
+	statusText: status === 200 ? "OK" : "Error",
+});
+
+describe("the base URL", () => {
+	test("defaults to no prefix", () => {
+		expect(client().url()).toBe(BASE_URL);
+	});
+
+	test("appends the prefix, so paths stay relative to it", async () => {
+		const withPrefix = client("/v1");
+		expect(withPrefix.url()).toBe(`${BASE_URL}/v1`);
+		await withPrefix.get("/status");
+		expect(fetchStub.last().url).toBe(`${BASE_URL}/v1/status`);
+	});
+
+	test("an empty path still hits the base URL", async () => {
+		await client().get("");
+		expect(fetchStub.last().url).toBe(BASE_URL);
+	});
+});
+
+describe("fetch", () => {
+	test("returns the parsed JSON body", async () => {
+		fetchStub.respond({ registered: true });
+		await expect(client().get("/status")).resolves.toEqual({
+			registered: true,
+		});
+	});
+
+	test("passes the caller's init straight through", async () => {
+		await client().get("/status", { headers: { "X-Test": "1" } });
+		expect(fetchStub.last().headers).toEqual({ "X-Test": "1" });
+	});
+
+	test("throws an HttpError for a non-JSON failure", async () => {
+		fetchStub.respond("gateway down", {
+			status: 502,
+			statusText: "Bad Gateway",
+			headers: { "content-type": "text/plain" },
+		});
+		await expect(client().get("/status")).rejects.toBeInstanceOf(HttpError);
+	});
+
+	test("a JSON error body is handed back instead of thrown, so callers can read the error", async () => {
+		// Providers signal business errors (rate limits, bad site keys) as JSON
+		// with a non-2xx status; those must reach the caller, not be flattened
+		// into a transport error.
+		fetchStub.respond({ error: { message: "rate limited" } }, json({}, 429));
+		await expect(client().get("/status")).resolves.toEqual({
+			error: { message: "rate limited" },
+		});
+	});
+
+	test("a 400 is handed back even without a JSON content type", async () => {
+		fetchStub.respond('{"error":"bad request"}', {
+			status: 400,
+			headers: { "content-type": "text/plain" },
+		});
+		await expect(client().get("/status")).resolves.toEqual({
+			error: "bad request",
+		});
+	});
+
+	test("a response with no content type at all is treated as a failure", async () => {
+		fetchStub.respond("", { status: 500, headers: {} });
+		await expect(client().get("/status")).rejects.toBeInstanceOf(HttpError);
+	});
+
+	test("rejects with the network error when fetch itself fails", async () => {
+		const boom = new Error("network down");
+		fetchStub.fail(boom);
+		await expect(client().get("/status")).rejects.toBe(boom);
+	});
+
+	test("rejects when the body is not valid JSON", async () => {
+		fetchStub.respond("<html>not json</html>", json({}));
+		await expect(client().get("/status")).rejects.toBeInstanceOf(Error);
+	});
+
+	test("an empty 200 body is a parse failure, not a silent undefined", async () => {
+		// A provider that returns 204/empty would otherwise resolve to
+		// undefined and blow up far from the cause.
+		fetchStub.respond("", json({}));
+		await expect(client().get("/status")).rejects.toBeInstanceOf(Error);
+	});
+});
+
+describe("post", () => {
+	test("sends the body as JSON with the right method", async () => {
+		await client().send("/solve", { nonce: 1 });
+		const request = fetchStub.last();
+		expect(request.init?.method).toBe("POST");
+		expect(request.body).toEqual({ nonce: 1 });
+		expect(request.headers["Content-Type"]).toBe("application/json");
+	});
+
+	test("caller headers are merged on top of the content type", async () => {
+		await client().send(
+			"/solve",
+			{},
+			{ headers: { "Prosopo-Site-Key": "key" } },
+		);
+		expect(fetchStub.last().headers).toEqual({
+			"Content-Type": "application/json",
+			"Prosopo-Site-Key": "key",
+		});
+	});
+
+	test("a caller may override the content type", async () => {
+		await client().send(
+			"/solve",
+			{},
+			{ headers: { "Content-Type": "text/*" } },
+		);
+		expect(fetchStub.last().headers["Content-Type"]).toBe("text/*");
+	});
+
+	test("headers survive an init that also carries other options", async () => {
+		// `init` is spread after `headers` is computed, so a caller passing
+		// `headers` inside init must not clobber the merged set.
+		await client().send(
+			"/solve",
+			{},
+			{ keepalive: true, headers: { "X-A": "1" } },
+		);
+		const request = fetchStub.last();
+		expect(request.init?.keepalive).toBe(true);
+		expect(request.headers["Content-Type"]).toBe("application/json");
+		expect(request.headers["X-A"]).toBe("1");
+	});
+
+	test("an undefined body still produces a request", async () => {
+		await client().send("/solve", undefined);
+		expect(fetchStub.last().init?.body).toBeUndefined();
+	});
+
+	test("a zero-length array body is sent, not dropped", async () => {
+		await client().send("/events", []);
+		expect(fetchStub.last().init?.body).toBe("[]");
+	});
+
+	test("returns the parsed response", async () => {
+		fetchStub.respond({ verified: true });
+		await expect(client().send("/solve", {})).resolves.toEqual({
+			verified: true,
+		});
+	});
+
+	test("throws an HttpError for a non-JSON failure", async () => {
+		fetchStub.respond("nope", { status: 503, headers: {} });
+		await expect(client().send("/solve", {})).rejects.toBeInstanceOf(HttpError);
+	});
+
+	test("hands back a 400 JSON body", async () => {
+		fetchStub.respond({ error: "bad" }, json({}, 400));
+		await expect(client().send("/solve", {})).resolves.toEqual({
+			error: "bad",
+		});
+	});
+
+	test("rejects with the network error", async () => {
+		const boom = new Error("offline");
+		fetchStub.fail(boom);
+		await expect(client().send("/solve", {})).rejects.toBe(boom);
+	});
+});
+
+describe("postWithHeaders", () => {
+	test("returns the body and the response headers together", async () => {
+		fetchStub.respond({ captchaType: "pow" }, {
+			status: 200,
+			headers: {
+				"content-type": "application/json",
+				"x-prosopo-meta": "encoded",
+			},
+		} satisfies ResponseInit);
+		const { data, headers } = await client().sendWithHeaders<
+			{ captchaType: string },
+			object
+		>("/frictionless", {});
+		expect(data).toEqual({ captchaType: "pow" });
+		expect(headers.get("x-prosopo-meta")).toBe("encoded");
+	});
+
+	test("sends JSON with the merged headers", async () => {
+		await client().sendWithHeaders("/frictionless", { token: "t" }, {
+			headers: { "Prosopo-User": "user" },
+		} satisfies RequestInit);
+		const request = fetchStub.last();
+		expect(request.init?.method).toBe("POST");
+		expect(request.body).toEqual({ token: "t" });
+		expect(request.headers).toEqual({
+			"Content-Type": "application/json",
+			"Prosopo-User": "user",
+		});
+	});
+
+	test("a missing meta header is absent rather than an error", async () => {
+		const { headers } = await client().sendWithHeaders("/frictionless", {});
+		expect(headers.get("x-prosopo-meta")).toBeNull();
+	});
+
+	test("throws an HttpError for a non-JSON failure", async () => {
+		fetchStub.respond("nope", { status: 500, headers: {} });
+		await expect(
+			client().sendWithHeaders("/frictionless", {}),
+		).rejects.toBeInstanceOf(HttpError);
+	});
+
+	test("hands back a 400 JSON body with its headers", async () => {
+		fetchStub.respond({ error: "bad" }, json({}, 400));
+		const { data } = await client().sendWithHeaders("/frictionless", {});
+		expect(data).toEqual({ error: "bad" });
+	});
+
+	test("rejects when the body cannot be parsed", async () => {
+		fetchStub.respond("not json", json({}));
+		await expect(
+			client().sendWithHeaders("/frictionless", {}),
+		).rejects.toBeInstanceOf(Error);
+	});
+
+	test("rejects with the network error", async () => {
+		const boom = new Error("offline");
+		fetchStub.fail(boom);
+		await expect(client().sendWithHeaders("/frictionless", {})).rejects.toBe(
+			boom,
+		);
+	});
+});
+
+describe("HttpError", () => {
+	test("carries the status, text and URL a caller needs to triage", () => {
+		const error = new HttpError(429, "Too Many Requests", `${BASE_URL}/pow`);
+		expect(error.status).toBe(429);
+		expect(error.statusText).toBe("Too Many Requests");
+		expect(error.url).toBe(`${BASE_URL}/pow`);
+		expect(error.name).toBe("HttpError");
+		expect(error).toBeInstanceOf(Error);
+		expect(error.message).toBe(
+			`HTTP error! status: 429 (Too Many Requests) for URL: ${BASE_URL}/pow`,
+		);
+	});
+
+	test("is distinguishable from any other error at a catch site", () => {
+		expect(new HttpError(500, "", "")).toBeInstanceOf(HttpError);
+		expect(new Error("plain")).not.toBeInstanceOf(HttpError);
+	});
+});
+
+describe("ApiClient", () => {
+	test("keeps an explicit protocol", () => {
+		const api = new ApiClient("http://localhost:9229", "account");
+		expect(new TestClient("http://localhost:9229").url()).toBe(
+			"http://localhost:9229",
+		);
+		expect(api).toBeInstanceOf(HttpClientBase);
+	});
+
+	test("assumes HTTPS when the URL has no protocol", async () => {
+		class Probe extends ApiClient {
+			public go(): Promise<unknown> {
+				return this.fetch("/status");
+			}
+		}
+		await new Probe("provider.prosopo.io", "account").go();
+		expect(fetchStub.last().url).toBe("https://provider.prosopo.io/status");
+	});
+
+	test("does not upgrade an https URL twice", async () => {
+		class Probe extends ApiClient {
+			public go(): Promise<unknown> {
+				return this.fetch("/status");
+			}
+		}
+		await new Probe("https://provider.prosopo.io", "account").go();
+		expect(fetchStub.last().url).toBe("https://provider.prosopo.io/status");
+	});
+
+	test("an empty base URL becomes a relative https URL, not a crash", async () => {
+		class Probe extends ApiClient {
+			public go(): Promise<unknown> {
+				return this.fetch("/status");
+			}
+		}
+		await new Probe("", "account").go();
+		expect(fetchStub.last().url).toBe("https:///status");
+	});
+});

--- a/packages/api/src/tests/providerApi.unit.test.ts
+++ b/packages/api/src/tests/providerApi.unit.test.ts
@@ -1,0 +1,878 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {
+	AdminApiPaths,
+	ApiParams,
+	CaptchaType,
+	ClientApiPaths,
+	type ClientMetaData,
+	DecisionMachineKind,
+	DecisionMachineLanguage,
+	DecisionMachineRuntime,
+	DecisionMachineScope,
+	type GetPowCaptchaResponse,
+	type GetPuzzleCaptchaResponse,
+	type IUserSettings,
+	ModeEnum,
+	PublicApiPaths,
+	type RandomProvider,
+	type RemoveSitekeysBodyTypeOutput,
+	type StoredEvents,
+	Tier,
+} from "@prosopo/types";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { HttpError } from "../api/HttpError.js";
+import ProviderApi, { VERIFY_FORWARDED_HEADER } from "../api/ProviderApi.js";
+import {
+	BASE_URL,
+	CHALLENGE,
+	type FetchStub,
+	SITE_KEY,
+	USER,
+	stubFetch,
+} from "./apiHarness.js";
+
+let fetchStub: FetchStub;
+
+const api = (): ProviderApi => new ProviderApi(BASE_URL, SITE_KEY);
+
+const randomProvider: RandomProvider = {
+	providerAccount: "5provider",
+	provider: {
+		url: BASE_URL,
+		datasetId: "0xdataset",
+		datasetIdContent: "0xcontent",
+	},
+} as unknown as RandomProvider;
+
+const powChallenge: GetPowCaptchaResponse = {
+	status: "ok",
+	[ApiParams.challenge]: CHALLENGE,
+	[ApiParams.difficulty]: 4,
+	[ApiParams.timestamp]: "1753900000000",
+	[ApiParams.signature]: {
+		[ApiParams.provider]: { [ApiParams.challenge]: "0xproviderchallengesig" },
+	},
+};
+
+const puzzleChallenge: GetPuzzleCaptchaResponse = {
+	status: "ok",
+	[ApiParams.challenge]: CHALLENGE,
+	[ApiParams.targetX]: 10,
+	[ApiParams.targetY]: 20,
+	[ApiParams.originX]: 1,
+	[ApiParams.originY]: 2,
+	[ApiParams.tolerance]: 5,
+	[ApiParams.timestamp]: "1753900000000",
+	[ApiParams.signature]: {
+		[ApiParams.provider]: { [ApiParams.challenge]: "0xproviderchallengesig" },
+	},
+};
+
+const clientMetaData: ClientMetaData = {
+	widgetHeight: 1,
+	widgetWidth: 2,
+} as unknown as ClientMetaData;
+
+const body = (): Record<string, unknown> =>
+	fetchStub.last().body as Record<string, unknown>;
+
+beforeEach(() => {
+	fetchStub = stubFetch();
+	vi.spyOn(console, "error").mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+	fetchStub.restore();
+	vi.restoreAllMocks();
+});
+
+describe("identifying headers", () => {
+	test("every client call names the site key, so the provider can scope it", async () => {
+		await api().getCaptchaChallenge(USER, randomProvider);
+		expect(fetchStub.last().headers["Prosopo-Site-Key"]).toBe(SITE_KEY);
+		expect(fetchStub.last().headers["Prosopo-User"]).toBe(USER);
+	});
+
+	test("calls with no user still carry the site key", async () => {
+		await api().submitUserEvents(
+			{ events: [] } as unknown as StoredEvents,
+			"s",
+		);
+		expect(fetchStub.last().headers["Prosopo-Site-Key"]).toBe(SITE_KEY);
+		expect(fetchStub.last().headers["Prosopo-User"]).toBeUndefined();
+	});
+});
+
+describe("getCaptchaChallenge", () => {
+	test("posts the site key and user to the image challenge path", async () => {
+		await api().getCaptchaChallenge(USER, randomProvider);
+		expect(fetchStub.last().url).toBe(
+			`${BASE_URL}${ClientApiPaths.GetImageCaptchaChallenge}`,
+		);
+		expect(body()).toEqual({
+			[ApiParams.dapp]: SITE_KEY,
+			[ApiParams.user]: USER,
+		});
+	});
+
+	test("omits the optional fields when they are absent", async () => {
+		await api().getCaptchaChallenge(USER, randomProvider, undefined, undefined);
+		expect(body()[ApiParams.sessionId]).toBeUndefined();
+		expect(body()[ApiParams.simdReadings]).toBeUndefined();
+	});
+
+	test("includes the session id and simd readings when given", async () => {
+		await api().getCaptchaChallenge(
+			USER,
+			randomProvider,
+			"session",
+			"readings",
+		);
+		expect(body()[ApiParams.sessionId]).toBe("session");
+		expect(body()[ApiParams.simdReadings]).toBe("readings");
+	});
+
+	test("an empty session id is treated as absent", async () => {
+		// Empty strings come from callers that always pass the field; they carry
+		// no server-side session, so they must not be sent or deduped on.
+		await api().getCaptchaChallenge(USER, randomProvider, "", "");
+		expect(body()[ApiParams.sessionId]).toBeUndefined();
+		expect(body()[ApiParams.simdReadings]).toBeUndefined();
+	});
+
+	test("returns the provider's body", async () => {
+		fetchStub.respond({ captchas: [] });
+		await expect(
+			api().getCaptchaChallenge(USER, randomProvider),
+		).resolves.toEqual({ captchas: [] });
+	});
+
+	test("propagates a transport failure", async () => {
+		fetchStub.fail(new Error("offline"));
+		await expect(
+			api().getCaptchaChallenge(USER, randomProvider),
+		).rejects.toThrow("offline");
+	});
+});
+
+describe("in-flight de-duplication of challenge fetches", () => {
+	test("a second call with the same session id joins the first request", async () => {
+		const deferred = fetchStub.defer();
+		const client = api();
+		const first = client.getPowCaptchaChallenge(USER, SITE_KEY, "session");
+		const second = client.getPowCaptchaChallenge(USER, SITE_KEY, "session");
+		expect(fetchStub.requests).toHaveLength(1);
+		deferred.resolve(powChallenge);
+		expect(await first).toEqual(await second);
+	});
+
+	test("different session ids are separate requests", async () => {
+		const client = api();
+		await Promise.all([
+			client.getPowCaptchaChallenge(USER, SITE_KEY, "a"),
+			client.getPowCaptchaChallenge(USER, SITE_KEY, "b"),
+		]);
+		expect(fetchStub.requests).toHaveLength(2);
+	});
+
+	test("the same session id on a different path is a separate request", async () => {
+		const client = api();
+		await Promise.all([
+			client.getPowCaptchaChallenge(USER, SITE_KEY, "session"),
+			client.getPuzzleCaptchaChallenge(USER, SITE_KEY, "session"),
+		]);
+		expect(fetchStub.requests).toHaveLength(2);
+	});
+
+	test("calls without a session id are never deduped", async () => {
+		const client = api();
+		await Promise.all([
+			client.getPowCaptchaChallenge(USER, SITE_KEY),
+			client.getPowCaptchaChallenge(USER, SITE_KEY),
+		]);
+		expect(fetchStub.requests).toHaveLength(2);
+	});
+
+	test("a retry after the first call settles starts a fresh request", async () => {
+		// Only in-flight calls share; caching a settled result would mask a
+		// genuine retry after a network error.
+		const client = api();
+		await client.getPowCaptchaChallenge(USER, SITE_KEY, "session");
+		await client.getPowCaptchaChallenge(USER, SITE_KEY, "session");
+		expect(fetchStub.requests).toHaveLength(2);
+	});
+
+	test("a failed call is dropped from the in-flight map, so a retry can proceed", async () => {
+		const client = api();
+		fetchStub.fail(new Error("offline"));
+		await expect(
+			client.getPowCaptchaChallenge(USER, SITE_KEY, "session"),
+		).rejects.toThrow("offline");
+		fetchStub.respond(powChallenge);
+		await expect(
+			client.getPowCaptchaChallenge(USER, SITE_KEY, "session"),
+		).resolves.toEqual(powChallenge);
+		expect(fetchStub.requests).toHaveLength(2);
+	});
+
+	test("both joined callers see the same failure", async () => {
+		const deferred = fetchStub.defer();
+		const client = api();
+		const first = client.getPowCaptchaChallenge(USER, SITE_KEY, "session");
+		const second = client.getPowCaptchaChallenge(USER, SITE_KEY, "session");
+		deferred.reject(new Error("offline"));
+		await expect(first).rejects.toThrow("offline");
+		await expect(second).rejects.toThrow("offline");
+	});
+
+	test("two clients do not share an in-flight map", async () => {
+		// The map is per-instance; separate widgets talking to the same
+		// provider are separate sessions from the map's point of view.
+		const first = api().getPowCaptchaChallenge(USER, SITE_KEY, "session");
+		const second = api().getPowCaptchaChallenge(USER, SITE_KEY, "session");
+		expect(fetchStub.requests).toHaveLength(2);
+		await Promise.all([first, second]);
+	});
+
+	test("image challenges dedupe on their own path too", async () => {
+		fetchStub.defer();
+		const client = api();
+		void client.getCaptchaChallenge(USER, randomProvider, "session");
+		void client.getCaptchaChallenge(USER, randomProvider, "session");
+		expect(fetchStub.requests).toHaveLength(1);
+	});
+});
+
+describe("submitCaptchaSolution", () => {
+	const submit = (
+		behavioralData?: string,
+		simdReadings?: string,
+		meta?: ClientMetaData,
+	) =>
+		api().submitCaptchaSolution(
+			[],
+			"0xrequesthash",
+			USER,
+			"1753900000000",
+			"0xproviderhashsig",
+			"0xusertimestampsig",
+			behavioralData,
+			simdReadings,
+			meta,
+		);
+
+	test("posts the solution with both signatures", async () => {
+		await submit();
+		expect(fetchStub.last().url).toBe(
+			`${BASE_URL}${ClientApiPaths.SubmitImageCaptchaSolution}`,
+		);
+		expect(body()).toEqual({
+			[ApiParams.user]: USER,
+			[ApiParams.dapp]: SITE_KEY,
+			[ApiParams.captchas]: [],
+			[ApiParams.requestHash]: "0xrequesthash",
+			[ApiParams.timestamp]: "1753900000000",
+			[ApiParams.signature]: {
+				[ApiParams.user]: { [ApiParams.timestamp]: "0xusertimestampsig" },
+				[ApiParams.provider]: { [ApiParams.requestHash]: "0xproviderhashsig" },
+			},
+		});
+	});
+
+	test("an empty solution list is still submitted, not short-circuited", async () => {
+		await submit();
+		expect(body()[ApiParams.captchas]).toEqual([]);
+	});
+
+	test("attaches the optional telemetry when present", async () => {
+		await submit("behaviour", "readings", clientMetaData);
+		expect(body()[ApiParams.behavioralData]).toBe("behaviour");
+		expect(body()[ApiParams.simdReadings]).toBe("readings");
+		expect(body()[ApiParams.clientMetaData]).toEqual(clientMetaData);
+	});
+
+	test("empty telemetry strings are omitted rather than sent blank", async () => {
+		await submit("", "");
+		expect(ApiParams.behavioralData in body()).toBe(false);
+		expect(ApiParams.simdReadings in body()).toBe(false);
+	});
+});
+
+describe("verifyDappUser", () => {
+	test("posts the token, signature and ip", async () => {
+		await api().verifyDappUser("token", "0xsig", USER, undefined, "1.2.3.4");
+		expect(fetchStub.last().url).toBe(
+			`${BASE_URL}${ClientApiPaths.VerifyImageCaptchaSolutionDapp}`,
+		);
+		expect(body()).toEqual({
+			[ApiParams.token]: "token",
+			[ApiParams.dappSignature]: "0xsig",
+			[ApiParams.ip]: "1.2.3.4",
+		});
+	});
+
+	test("includes maxVerifiedTime and email when given", async () => {
+		await api().verifyDappUser(
+			"token",
+			"0xsig",
+			USER,
+			60_000,
+			"1.2.3.4",
+			"user@example.com",
+		);
+		expect(body()[ApiParams.maxVerifiedTime]).toBe(60_000);
+		expect(body()[ApiParams.email]).toBe("user@example.com");
+	});
+
+	test("a zero maxVerifiedTime is dropped, so the provider applies its default", async () => {
+		await api().verifyDappUser("token", "0xsig", USER, 0);
+		expect(ApiParams.maxVerifiedTime in body()).toBe(false);
+	});
+
+	test("an omitted ip is sent as undefined rather than a placeholder", async () => {
+		await api().verifyDappUser("token", "0xsig", USER);
+		expect(ApiParams.ip in body()).toBe(false);
+	});
+});
+
+describe("pow challenge and solution", () => {
+	test("requests a challenge for the user and site key", async () => {
+		await api().getPowCaptchaChallenge(USER, SITE_KEY);
+		expect(fetchStub.last().url).toBe(
+			`${BASE_URL}${ClientApiPaths.GetPowCaptchaChallenge}`,
+		);
+		expect(body()).toEqual({
+			[ApiParams.user]: USER,
+			[ApiParams.dapp]: SITE_KEY,
+		});
+	});
+
+	test("submits the nonce with the provider's challenge signature", async () => {
+		await api().submitPowCaptchaSolution(
+			powChallenge,
+			USER,
+			SITE_KEY,
+			42,
+			"0xusertimestampsig",
+		);
+		expect(fetchStub.last().url).toBe(
+			`${BASE_URL}${ClientApiPaths.SubmitPowCaptchaSolution}`,
+		);
+		expect(body()).toMatchObject({
+			[ApiParams.challenge]: CHALLENGE,
+			[ApiParams.difficulty]: 4,
+			[ApiParams.nonce]: 42,
+			[ApiParams.user]: USER,
+			[ApiParams.dapp]: SITE_KEY,
+			[ApiParams.signature]: {
+				[ApiParams.provider]: {
+					[ApiParams.challenge]: "0xproviderchallengesig",
+				},
+				[ApiParams.user]: { [ApiParams.timestamp]: "0xusertimestampsig" },
+			},
+		});
+	});
+
+	test("passes simd readings on the challenge request when present", async () => {
+		await api().getPowCaptchaChallenge(USER, SITE_KEY, undefined, "readings");
+		expect(body()[ApiParams.simdReadings]).toBe("readings");
+	});
+
+	test("a nonce of zero is submitted, not treated as missing", async () => {
+		await api().submitPowCaptchaSolution(powChallenge, USER, SITE_KEY, 0, "s");
+		expect(body()[ApiParams.nonce]).toBe(0);
+	});
+
+	test("attaches the optional proof fields when present", async () => {
+		await api().submitPowCaptchaSolution(
+			powChallenge,
+			USER,
+			SITE_KEY,
+			1,
+			"s",
+			"behaviour",
+			"salt",
+			"readings",
+			clientMetaData,
+			"proof",
+		);
+		expect(body()).toMatchObject({
+			[ApiParams.behavioralData]: "behaviour",
+			[ApiParams.salt]: "salt",
+			[ApiParams.simdReadings]: "readings",
+			[ApiParams.fingerprintProof]: "proof",
+		});
+	});
+
+	test("the schema strips anything it does not declare", async () => {
+		// The body is parsed before sending, so a field the provider's schema
+		// does not accept never reaches the wire.
+		await api().submitPowCaptchaSolution(powChallenge, USER, SITE_KEY, 1, "s");
+		expect(ApiParams.timestamp in body()).toBe(false);
+	});
+
+	test("a malformed challenge is rejected before any request is made", async () => {
+		const bad: GetPowCaptchaResponse = {
+			...powChallenge,
+			[ApiParams.challenge]:
+				"not-a-challenge" as GetPowCaptchaResponse["challenge"],
+		};
+		expect(() =>
+			api().submitPowCaptchaSolution(bad, USER, SITE_KEY, 1, "s"),
+		).toThrow();
+		expect(fetchStub.requests).toHaveLength(0);
+	});
+});
+
+describe("puzzle challenge and solution", () => {
+	test("requests a puzzle challenge", async () => {
+		await api().getPuzzleCaptchaChallenge(
+			USER,
+			SITE_KEY,
+			"session",
+			"readings",
+		);
+		expect(fetchStub.last().url).toBe(
+			`${BASE_URL}${ClientApiPaths.GetPuzzleCaptchaChallenge}`,
+		);
+		expect(body()).toEqual({
+			[ApiParams.user]: USER,
+			[ApiParams.dapp]: SITE_KEY,
+			[ApiParams.sessionId]: "session",
+			[ApiParams.simdReadings]: "readings",
+		});
+	});
+
+	test("submits the final position and the drag trail", async () => {
+		await api().submitPuzzleCaptchaSolution(
+			puzzleChallenge,
+			USER,
+			SITE_KEY,
+			11,
+			22,
+			[{ x: 1, y: 2, t: 3 }],
+			"0xusertimestampsig",
+		);
+		expect(fetchStub.last().url).toBe(
+			`${BASE_URL}${ClientApiPaths.SubmitPuzzleCaptchaSolution}`,
+		);
+		expect(body()).toMatchObject({
+			[ApiParams.finalX]: 11,
+			[ApiParams.finalY]: 22,
+			[ApiParams.puzzleEvents]: [{ x: 1, y: 2, t: 3 }],
+		});
+	});
+
+	test("an empty event trail is submitted, and the provider decides", async () => {
+		await api().submitPuzzleCaptchaSolution(
+			puzzleChallenge,
+			USER,
+			SITE_KEY,
+			0,
+			0,
+			[],
+			"s",
+		);
+		expect(body()[ApiParams.puzzleEvents]).toEqual([]);
+	});
+
+	test("attaches the optional puzzle telemetry when present", async () => {
+		await api().submitPuzzleCaptchaSolution(
+			puzzleChallenge,
+			USER,
+			SITE_KEY,
+			1,
+			2,
+			[],
+			"s",
+			"behaviour",
+			"salt",
+			"readings",
+			clientMetaData,
+		);
+		expect(body()).toMatchObject({
+			[ApiParams.behavioralData]: "behaviour",
+			[ApiParams.salt]: "salt",
+			[ApiParams.simdReadings]: "readings",
+		});
+		// The metadata schema strips anything it does not declare, so the
+		// field is present but carries only the declared keys.
+		expect(body()[ApiParams.clientMetaData]).toBeDefined();
+	});
+
+	test("verifies a puzzle token, with the email only when supplied", async () => {
+		await api().submitPuzzleCaptchaVerify("token", "0xsig", USER, "1.2.3.4");
+		expect(fetchStub.last().url).toBe(
+			`${BASE_URL}${ClientApiPaths.VerifyPuzzleCaptchaSolution}`,
+		);
+		expect(ApiParams.email in body()).toBe(false);
+		await api().submitPuzzleCaptchaVerify(
+			"token",
+			"0xsig",
+			USER,
+			"1.2.3.4",
+			"user@example.com",
+		);
+		expect(body()[ApiParams.email]).toBe("user@example.com");
+	});
+});
+
+describe("getFrictionlessCaptcha", () => {
+	const frictionlessBody = { status: "ok", [ApiParams.captchaType]: "pow" };
+
+	test("posts the token and head hash", async () => {
+		fetchStub.respond(frictionlessBody);
+		await api().getFrictionlessCaptcha("token", "0xhead", SITE_KEY, USER);
+		expect(fetchStub.last().url).toBe(
+			`${BASE_URL}${ClientApiPaths.GetFrictionlessCaptchaChallenge}`,
+		);
+		expect(body()).toEqual({
+			[ApiParams.token]: "token",
+			[ApiParams.headHash]: "0xhead",
+			[ApiParams.dapp]: SITE_KEY,
+			[ApiParams.user]: USER,
+		});
+	});
+
+	test("includes the optional context when supplied", async () => {
+		fetchStub.respond(frictionlessBody);
+		await api().getFrictionlessCaptcha(
+			"token",
+			"0xhead",
+			SITE_KEY,
+			USER,
+			ModeEnum.invisible,
+			"readings",
+			"https://site.example/page",
+			"https://iframe.example",
+		);
+		expect(body()).toMatchObject({
+			[ApiParams.mode]: ModeEnum.invisible,
+			[ApiParams.simdReadings]: "readings",
+			[ApiParams.currentUrl]: "https://site.example/page",
+			[ApiParams.iframeUrl]: "https://iframe.example",
+		});
+	});
+
+	test("moves the honeypot from the meta header onto the response", async () => {
+		fetchStub.respond(frictionlessBody, {
+			status: 200,
+			headers: {
+				"content-type": "application/json",
+				"x-prosopo-meta": "encoded-honeypot",
+			},
+		});
+		const response = await api().getFrictionlessCaptcha(
+			"token",
+			"0xhead",
+			SITE_KEY,
+			USER,
+		);
+		expect(response[ApiParams.hp]).toBe("encoded-honeypot");
+	});
+
+	test("leaves the body untouched when there is no meta header", async () => {
+		fetchStub.respond(frictionlessBody);
+		const response = await api().getFrictionlessCaptcha(
+			"token",
+			"0xhead",
+			SITE_KEY,
+			USER,
+		);
+		expect(ApiParams.hp in response).toBe(false);
+	});
+
+	test("an empty meta header is treated as absent", async () => {
+		fetchStub.respond(frictionlessBody, {
+			status: 200,
+			headers: { "content-type": "application/json", "x-prosopo-meta": "" },
+		});
+		const response = await api().getFrictionlessCaptcha(
+			"token",
+			"0xhead",
+			SITE_KEY,
+			USER,
+		);
+		expect(response[ApiParams.hp]).toBeUndefined();
+	});
+
+	test("is not deduped: a frictionless call always reaches the provider", async () => {
+		// It carries no sessionId — the session is what it hands back.
+		const client = api();
+		fetchStub.respond(frictionlessBody);
+		await Promise.all([
+			client.getFrictionlessCaptcha("token", "0xhead", SITE_KEY, USER),
+			client.getFrictionlessCaptcha("token", "0xhead", SITE_KEY, USER),
+		]);
+		expect(fetchStub.requests).toHaveLength(2);
+	});
+
+	test("propagates a transport failure", async () => {
+		fetchStub.respond("nope", { status: 500, headers: {} });
+		await expect(
+			api().getFrictionlessCaptcha("token", "0xhead", SITE_KEY, USER),
+		).rejects.toBeInstanceOf(HttpError);
+	});
+});
+
+describe("status and details", () => {
+	test("reads the provider status", async () => {
+		fetchStub.respond({ status: "ok" });
+		await api().getProviderStatus();
+		expect(fetchStub.last().url).toBe(
+			`${BASE_URL}${ClientApiPaths.GetProviderStatus}`,
+		);
+		expect(fetchStub.last().init?.method).toBeUndefined();
+	});
+
+	test("reads the public provider details", async () => {
+		await api().getProviderDetails();
+		expect(fetchStub.last().url).toBe(
+			`${BASE_URL}${PublicApiPaths.GetProviderDetails}`,
+		);
+	});
+
+	test("submits user events", async () => {
+		const events = { events: [] } as unknown as StoredEvents;
+		await api().submitUserEvents(events, "0xstring");
+		expect(fetchStub.last().url).toBe(
+			`${BASE_URL}${ClientApiPaths.SubmitUserEvents}`,
+		);
+		expect(body()).toEqual({ events, string: "0xstring" });
+	});
+});
+
+describe("forwardVerify", () => {
+	test("marks the request as forwarded so the receiver does not forward again", async () => {
+		await api().forwardVerify(
+			ClientApiPaths.VerifyPowCaptchaSolution,
+			{ [ApiParams.token]: "token" },
+			USER,
+		);
+		expect(fetchStub.last().url).toBe(
+			`${BASE_URL}${ClientApiPaths.VerifyPowCaptchaSolution}`,
+		);
+		expect(fetchStub.last().headers[VERIFY_FORWARDED_HEADER]).toBe("true");
+	});
+
+	test("the marker header is lowercase, to match express's normalised keys", () => {
+		expect(VERIFY_FORWARDED_HEADER).toBe(VERIFY_FORWARDED_HEADER.toLowerCase());
+	});
+
+	test("forwards the body verbatim", async () => {
+		const forwarded = { [ApiParams.token]: "token", extra: "kept" };
+		await api().forwardVerify(
+			ClientApiPaths.VerifyImageCaptchaSolutionDapp,
+			forwarded,
+			USER,
+		);
+		expect(body()).toEqual(forwarded);
+	});
+});
+
+describe("submitPowCaptchaVerify", () => {
+	test("posts the token and signature", async () => {
+		await api().submitPowCaptchaVerify("token", "0xsig", USER, "1.2.3.4");
+		expect(fetchStub.last().url).toBe(
+			`${BASE_URL}${ClientApiPaths.VerifyPowCaptchaSolution}`,
+		);
+		expect(body()).toEqual({
+			[ApiParams.token]: "token",
+			[ApiParams.dappSignature]: "0xsig",
+			[ApiParams.ip]: "1.2.3.4",
+		});
+	});
+
+	test("adds the email only when one is supplied", async () => {
+		await api().submitPowCaptchaVerify("token", "0xsig", USER);
+		expect(ApiParams.email in body()).toBe(false);
+		await api().submitPowCaptchaVerify(
+			"token",
+			"0xsig",
+			USER,
+			undefined,
+			"user@example.com",
+		);
+		expect(body()[ApiParams.email]).toBe("user@example.com");
+	});
+});
+
+describe("the admin endpoints", () => {
+	const JWT = "jwt-token";
+	const settings: IUserSettings = {
+		captchaType: CaptchaType.pow,
+		domains: ["example.com"],
+		frictionlessThreshold: 0.5,
+		powDifficulty: 4,
+	} as unknown as IUserSettings;
+
+	const auth = (): Record<string, string> => fetchStub.last().headers;
+
+	test("every admin call is bearer-authorised and site-key scoped", async () => {
+		await api().registerSiteKey(SITE_KEY, Tier.Free, settings, JWT);
+		expect(auth().Authorization).toBe(`Bearer ${JWT}`);
+		expect(auth()["Prosopo-Site-Key"]).toBe(SITE_KEY);
+	});
+
+	test("registers one site key", async () => {
+		await api().registerSiteKey(SITE_KEY, Tier.Free, settings, JWT);
+		expect(fetchStub.last().url).toBe(
+			`${BASE_URL}${AdminApiPaths.SiteKeyRegister}`,
+		);
+		expect(body()).toEqual({ siteKey: SITE_KEY, tier: Tier.Free, settings });
+	});
+
+	test("registers a batch of site keys verbatim", async () => {
+		const batch = [{ siteKey: SITE_KEY, tier: Tier.Free, settings }];
+		await api().registerSiteKeys(batch, JWT);
+		expect(fetchStub.last().url).toBe(
+			`${BASE_URL}${AdminApiPaths.SiteKeysRegister}`,
+		);
+		expect(body()).toEqual(batch);
+	});
+
+	test("removes one site key", async () => {
+		await api().removeSiteKey(SITE_KEY, JWT);
+		expect(fetchStub.last().url).toBe(
+			`${BASE_URL}${AdminApiPaths.SiteKeyRemove}`,
+		);
+		expect(body()).toEqual({ siteKey: SITE_KEY });
+	});
+
+	test("removes a batch of site keys", async () => {
+		await api().removeSiteKeys([{ siteKey: SITE_KEY }], JWT);
+		expect(fetchStub.last().url).toBe(
+			`${BASE_URL}${AdminApiPaths.SiteKeysRemove}`,
+		);
+		expect(body()).toEqual([{ siteKey: SITE_KEY }]);
+	});
+
+	test("an invalid removal batch never leaves the client", async () => {
+		expect(() =>
+			api().removeSiteKeys(
+				[{ siteKey: 1 }] as unknown as RemoveSitekeysBodyTypeOutput,
+				JWT,
+			),
+		).toThrow();
+		expect(fetchStub.requests).toHaveLength(0);
+	});
+
+	test("updates the detector key", async () => {
+		await api().updateDetectorKey("0xdetector", JWT);
+		expect(fetchStub.last().url).toBe(
+			`${BASE_URL}${AdminApiPaths.UpdateDetectorKey}`,
+		);
+		expect(body()).toEqual({ detectorKey: "0xdetector" });
+	});
+
+	test("removes a detector key, with an optional expiry", async () => {
+		await api().removeDetectorKey("0xdetector", JWT);
+		expect(fetchStub.last().url).toBe(
+			`${BASE_URL}${AdminApiPaths.RemoveDetectorKey}`,
+		);
+		expect(body()).toMatchObject({ detectorKey: "0xdetector" });
+		await api().removeDetectorKey("0xdetector", JWT, 60);
+		expect(body()).toMatchObject({ expirationInSeconds: 60 });
+	});
+
+	test("updates a decision machine with its full descriptor", async () => {
+		await api().updateDecisionMachine(
+			DecisionMachineScope.Dapp,
+			DecisionMachineRuntime.Node,
+			"export default () => true",
+			JWT,
+			SITE_KEY,
+			DecisionMachineLanguage.JavaScript,
+			"machine",
+			"1.0.0",
+			CaptchaType.pow,
+			DecisionMachineKind.Decision,
+		);
+		expect(fetchStub.last().url).toBe(
+			`${BASE_URL}${AdminApiPaths.UpdateDecisionMachine}`,
+		);
+		expect(body()).toMatchObject({
+			[ApiParams.decisionMachineScope]: DecisionMachineScope.Dapp,
+			[ApiParams.decisionMachineRuntime]: DecisionMachineRuntime.Node,
+			[ApiParams.decisionMachineSource]: "export default () => true",
+			[ApiParams.dapp]: SITE_KEY,
+		});
+	});
+
+	test("reads all decision machines with an empty body", async () => {
+		await api().getAllDecisionMachines(JWT);
+		expect(fetchStub.last().url).toBe(
+			`${BASE_URL}${AdminApiPaths.GetAllDecisionMachines}`,
+		);
+		expect(body()).toEqual({});
+	});
+
+	test("reads one decision machine by id", async () => {
+		await api().getDecisionMachine("machine-id", JWT);
+		expect(fetchStub.last().url).toBe(
+			`${BASE_URL}${AdminApiPaths.GetDecisionMachine}`,
+		);
+		expect(body()).toEqual({ id: "machine-id" });
+	});
+
+	test("removes one decision machine by id", async () => {
+		await api().removeDecisionMachine("machine-id", JWT);
+		expect(fetchStub.last().url).toBe(
+			`${BASE_URL}${AdminApiPaths.RemoveDecisionMachine}`,
+		);
+		expect(body()).toEqual({ id: "machine-id" });
+	});
+
+	test("removes all decision machines", async () => {
+		await api().removeAllDecisionMachines(JWT);
+		expect(fetchStub.last().url).toBe(
+			`${BASE_URL}${AdminApiPaths.RemoveAllDecisionMachines}`,
+		);
+		expect(body()).toEqual({});
+	});
+
+	test("clears counters, optionally for a single site key", async () => {
+		await api().clearAllCounters(JWT);
+		expect(fetchStub.last().url).toBe(
+			`${BASE_URL}${AdminApiPaths.ClearAllCounters}`,
+		);
+		await api().clearAllCounters(JWT, SITE_KEY);
+		expect(body()).toMatchObject({ [ApiParams.dapp]: SITE_KEY });
+	});
+
+	test("toggles maintenance mode with a signed timestamp instead of a JWT", async () => {
+		await api().toggleMaintenanceMode(true, "1753900000000", "0xsig");
+		expect(fetchStub.last().url).toBe(
+			`${BASE_URL}${AdminApiPaths.ToggleMaintenanceMode}`,
+		);
+		expect(body()).toEqual({ enabled: true });
+		expect(fetchStub.last().headers.timestamp).toBe("1753900000000");
+		expect(fetchStub.last().headers.signature).toBe("0xsig");
+		expect(fetchStub.last().headers.Authorization).toBeUndefined();
+	});
+
+	test("disabling maintenance mode is sent as false, not omitted", async () => {
+		await api().toggleMaintenanceMode(false, "1753900000000", "0xsig");
+		expect(body()).toEqual({ enabled: false });
+	});
+
+	test("an admin failure surfaces as an HttpError", async () => {
+		fetchStub.respond("forbidden", { status: 403, headers: {} });
+		await expect(api().getAllDecisionMachines(JWT)).rejects.toBeInstanceOf(
+			HttpError,
+		);
+	});
+});

--- a/packages/api/vite.test.config.ts
+++ b/packages/api/vite.test.config.ts
@@ -1,0 +1,19 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { ViteTestConfig } from "@prosopo/config";
+
+process.env.NODE_ENV = "test";
+
+export default ViteTestConfig();


### PR DESCRIPTION
Adds vitest unit and type tests for `packages/api` — 128 tests, 100% statements/branches/functions/lines. No behaviour changes.

Covers:
- `HttpClientBase`: base URL/prefix handling, header merging, JSON error bodies handed back vs transport errors thrown, 400 passthrough, empty/invalid body parse failures, network failures.
- `postWithHeaders` and the frictionless `x-prosopo-meta` honeypot header (present, missing, empty).
- In-flight challenge de-duplication: same session joins, different session/path/instance do not, settled and failed calls drop out of the map so retries proceed.
- Every client and admin endpoint: path, body shape, optional-field omission, and the site key / bearer / signed-timestamp headers.
- Type tests for the entrypoint surface, constructor signatures, the `ProviderApiInterface` conformance and the private dedupe state.