### PR TITLE
fix(procaptcha-pow): drop undeclared load-balancer import from the manager test

### DIFF
--- a/.changeset/pow-test-load-balancer-dep.md
+++ b/.changeset/pow-test-load-balancer-dep.md
@@ -1,0 +1,5 @@
+---
+"@prosopo/procaptcha-pow": patch
+---
+
+Remove the undeclared `@prosopo/load-balancer` import from the manager unit test, deriving `IpMode` from `procaptcha-common`'s `pickIpMode` instead so `lint:refs` passes.

--- a/packages/procaptcha-pow/src/tests/manager.unit.test.ts
+++ b/packages/procaptcha-pow/src/tests/manager.unit.test.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import type { FingerprintProof } from "@prosopo/fingerprint";
-import type { IpMode } from "@prosopo/load-balancer";
+import type { pickIpMode } from "@prosopo/procaptcha-common";
 import {
 	ApiParams,
 	type BehavioralData,
@@ -46,6 +46,12 @@ import {
 	vi,
 } from "vitest";
 import { Manager } from "../services/Manager.js";
+
+// Taken from procaptcha-common rather than @prosopo/load-balancer directly, so
+// the test does not pull a dependency into this package that the source has no
+// use for.
+type IpMode = ReturnType<typeof pickIpMode>;
+
 import {
 	OTHER_PROVIDER_URL,
 	PROVIDER_URL,


### PR DESCRIPTION
`manager.unit.test.ts` imports `IpMode` from `@prosopo/load-balancer`, which is not declared as a dependency of `@prosopo/procaptcha-pow`, so `lint:refs` fails on main and blocks every open PR.

Derives the type from `procaptcha-common`'s `pickIpMode` return type instead of adding a dependency the source does not need.