### PR TITLE
fix(database): upsert session records in saveCaptchas to stop duplicates

### DIFF
--- a/.changeset/dedup-session-inserts.md
+++ b/.changeset/dedup-session-inserts.md
@@ -1,0 +1,5 @@
+---
+"@prosopo/database": patch
+---
+
+Fix `CaptchaDatabase.saveCaptchas` to upsert session events by `sessionId` instead of `insertOne`, matching the pattern already used for image/pow/puzzle records in the same method. The blind insert stacked a duplicate on central every time the sweep in `clientTasks.storeCommitmentsExternal` re-drained a record that `CentralDbStreamer.streamSessionRecord` had already landed — a live snapshot showed ~64% of sessionIds in `captchastorage.sessions` had 2+ docs. Safe now that sessionIds are `pronode<N>-<uuidv4>` (cross-pronode collision impossible, same-pronode uuidv4 collision 2^-122), which wasn't the case when the original `updateOne + upsert` was swapped to `insertOne` in #1811. Added `saveCaptchasSessionUpsert.integration.test.ts` as a regression guard.

--- a/packages/database/src/databases/captcha.ts
+++ b/packages/database/src/databases/captcha.ts
@@ -203,19 +203,31 @@ export class CaptchaDatabase extends MongoDatabase implements ICaptchaDatabase {
 	) {
 		await this.connect();
 		if (sessionEvents.length) {
+			// Upsert by sessionId (same pattern as image/pow/puzzle below).
+			// The prior `insertOne` blindly re-inserted every time the sweep
+			// picked up an "unstored" record, so any record that had already
+			// been streamed via CentralDbStreamer.streamSessionRecord got a
+			// duplicate written on every sweep pass. In the current
+			// captchastorage.sessions collection ~64% of sessionIds have
+			// 2+ docs and up to 7 have been observed on a single sessionId.
 			const result = await this.tables.session.bulkWrite(
 				sessionEvents.map((document) => {
 					const { _id, ...safeDoc } = document;
+					const normalised = CaptchaDatabase.normaliseDocCompositeIps(safeDoc);
 					return {
-						insertOne: {
-							document: CaptchaDatabase.normaliseDocCompositeIps(safeDoc),
+						updateOne: {
+							filter: { sessionId: normalised.sessionId },
+							update: { $set: normalised },
+							upsert: true,
 						},
 					};
 				}),
 			);
 			logger.info(() => ({
 				data: {
-					insertedCount: result.insertedCount,
+					upsertedCount: result.upsertedCount,
+					matchedCount: result.matchedCount,
+					modifiedCount: result.modifiedCount,
 					totalProcessed: sessionEvents.length,
 				},
 				msg: "Mongo Saved Session Events",

--- a/packages/database/src/databases/captcha.ts
+++ b/packages/database/src/databases/captcha.ts
@@ -204,12 +204,29 @@ export class CaptchaDatabase extends MongoDatabase implements ICaptchaDatabase {
 		await this.connect();
 		if (sessionEvents.length) {
 			// Upsert by sessionId (same pattern as image/pow/puzzle below).
-			// The prior `insertOne` blindly re-inserted every time the sweep
-			// picked up an "unstored" record, so any record that had already
-			// been streamed via CentralDbStreamer.streamSessionRecord got a
-			// duplicate written on every sweep pass. In the current
-			// captchastorage.sessions collection ~64% of sessionIds have
-			// 2+ docs and up to 7 have been observed on a single sessionId.
+			// Was intentionally swapped to `insertOne` in #1811 back when
+			// sessionIds were bare UUIDs: two pronodes could roll the same
+			// id, and an upsert-by-sessionId would let the second pronode's
+			// `$set` clobber the first pronode's session record. Insert-only
+			// preserved both docs at the cost of accepting duplicates.
+			//
+			// Now every sessionId is `pronode<N>-<uuidv4>` (see
+			// `getSessionIDPrefix` in frictionlessTasks.ts), so cross-pronode
+			// collision is impossible and within a single pronode the uuidv4
+			// collision probability is 2^-122 — the only doc this upsert
+			// can `$set` over is one the same pronode wrote earlier for the
+			// same session. Safe to restore.
+			//
+			// The bug this actually fixes: `saveCaptchas` is called from the
+			// sweep in `clientTasks.storeCommitmentsExternal`, which drains
+			// records marked "unstored" from local Mongo. The same central
+			// collection is also written fire-and-forget by
+			// `CentralDbStreamer.streamSessionRecord` from
+			// `ProviderDatabase.storeSessionRecord`. Every time the sweep
+			// picked up a record the streamer had already landed on central,
+			// the old `insertOne` wrote a duplicate. In a live 1h snapshot
+			// of `captchastorage.sessions` ~64% of sessionIds have 2+ docs
+			// and up to 7 have been observed on a single sessionId.
 			const result = await this.tables.session.bulkWrite(
 				sessionEvents.map((document) => {
 					const { _id, ...safeDoc } = document;

--- a/packages/database/src/tests/integration/saveCaptchasSessionUpsert.integration.test.ts
+++ b/packages/database/src/tests/integration/saveCaptchasSessionUpsert.integration.test.ts
@@ -1,0 +1,141 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { LogLevel, getLogger } from "@prosopo/logger";
+import {
+	CaptchaType,
+	type CompositeIpAddress,
+	IpAddressType,
+} from "@prosopo/types";
+import type { StoredSession } from "@prosopo/types-database";
+import { MongoMemoryServer } from "mongodb-memory-server";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { CaptchaDatabase } from "../../databases/captcha.js";
+
+// Regression guard for the session-duplication bug observed on
+// captchastorage.sessions (mongo1.prosopo.io). Snapshot from a live
+// 1h window on 2026-08-01:
+//
+//   copies_per_sessionId : count_of_sessionIds
+//     1 :   9,913
+//     2 :  17,917
+//     3 :   1,060
+//     4 :      57
+//     5 :      16
+//     6 :       5
+//     7 :       1
+//
+// ~64% of sessionIds have 2+ docs. Root cause: `CaptchaDatabase.saveCaptchas`
+// was writing session events with a `bulkWrite([{ insertOne: ... }])` — a
+// blind insert with no dedup on `sessionId`. Meanwhile the same central
+// collection is *also* written by `CentralDbStreamer.streamSessionRecord`
+// (upsert on sessionId, called fire-and-forget from
+// `ProviderDatabase.storeSessionRecord`). Every time the sweep in
+// `clientTasks.storeCommitmentsExternal` re-drained an "unstored" record
+// that the streamer had already landed on central, a duplicate got
+// written. Retries and streamer racy re-runs stacked more copies.
+//
+// Fix: `saveCaptchas` now upserts sessions by `sessionId`, matching the
+// pattern already used for image/pow/puzzle records in the same method.
+// This test seeds one session, calls `saveCaptchas` for the same
+// sessionId three times, and asserts only ONE doc exists at the end.
+// With the bug in place the test would see three docs.
+
+const logger = getLogger(LogLevel.enum.error, "saveCaptchasSessionUpsert.test");
+
+const ipv4Composite = (lower: bigint): CompositeIpAddress => ({
+	lower,
+	type: IpAddressType.v4,
+});
+
+const makeSession = (sessionId: string, score: number): StoredSession =>
+	({
+		sessionId,
+		createdAt: new Date(),
+		token: "tok",
+		score,
+		threshold: 0.5,
+		scoreComponents: { baseScore: score },
+		ipAddress: ipv4Composite(16843009n),
+		captchaType: CaptchaType.pow,
+		userSitekeyIpHash: "hash-abc",
+		webView: false,
+		iFrame: false,
+		decryptedHeadHash: "head-hash",
+		siteKey: "site-key-1",
+		headers: { "user-agent": "test" },
+	}) as unknown as StoredSession;
+
+describe("CaptchaDatabase.saveCaptchas — session upsert by sessionId", () => {
+	let mongod: MongoMemoryServer;
+	let central: CaptchaDatabase;
+
+	beforeAll(async () => {
+		mongod = await MongoMemoryServer.create();
+		central = new CaptchaDatabase(
+			mongod.getUri(),
+			"captchastorage",
+			undefined,
+			logger,
+		);
+		await central.connect();
+	});
+
+	afterAll(async () => {
+		await central.close();
+		await mongod.stop();
+	});
+
+	it("does not duplicate when the same sessionId is written twice by successive sweep passes", async () => {
+		const sessionId = "session-upsert-repeat";
+
+		await central.saveCaptchas([makeSession(sessionId, 0.1)], [], []);
+		await central.saveCaptchas([makeSession(sessionId, 0.2)], [], []);
+		await central.saveCaptchas([makeSession(sessionId, 0.3)], [], []);
+
+		// Reconnect: `saveCaptchas` closes the connection when it's done
+		// (via bulkWrite → close pattern inherited from MongoDatabase).
+		// The test's own `central` handle is still bound to the same URI
+		// but may have a stale connection; call `connect` again to be safe.
+		await central.connect();
+		const docs = await central.tables.session
+			.find({ sessionId })
+			.lean<StoredSession[]>();
+
+		expect(docs.length).toBe(1);
+
+		// Last write wins — the third call's score should be the persisted
+		// value, confirming the upsert `$set` semantics are in play (not
+		// e.g. an `$setOnInsert` that would freeze the first write).
+		const persisted = docs[0] as unknown as { score: number };
+		expect(persisted.score).toBe(0.3);
+	});
+
+	it("distinct sessionIds each get their own doc (guardrail against overly-broad filter)", async () => {
+		const ids = ["session-a", "session-b", "session-c"];
+		await central.saveCaptchas(
+			ids.map((id, i) => makeSession(id, 0.1 * (i + 1))),
+			[],
+			[],
+		);
+
+		await central.connect();
+		for (const id of ids) {
+			const docs = await central.tables.session
+				.find({ sessionId: id })
+				.lean<StoredSession[]>();
+			expect(docs.length, `expected exactly one doc for ${id}`).toBe(1);
+		}
+	});
+});


### PR DESCRIPTION
## Summary

`CaptchaDatabase.saveCaptchas` was writing session events with `bulkWrite([{ insertOne: ... }])` — a blind insert with no dedup on `sessionId`. The same central `sessions` collection is also written by `CentralDbStreamer.streamSessionRecord` (upsert on `sessionId`, called fire-and-forget from `ProviderDatabase.storeSessionRecord`), so every time the sweep in `clientTasks.storeCommitmentsExternal` re-drained an "unstored" record that the streamer had already landed on central, a duplicate was written. Retries + streamer re-runs stacked more copies.

## Evidence (live snapshot, `captchastorage.sessions`, 1h window on 2026-08-01)

| copies per sessionId | count of sessionIds |
|---:|---:|
| 1 | 9,913 |
| 2 | **17,917** |
| 3 | 1,060 |
| 4 | 57 |
| 5 | 16 |
| 6 | 5 |
| 7 | 1 |

**~64% of sessionIds have 2+ docs.**

Docs for the same sessionId are progressively enriched (first has only baseline fields, later ones have `storedAtTimestamp` + `dnsEvent` + more) — exactly what you'd see if the streamer wrote first, then the sweep re-inserted after `markSessionRecordsStored` didn't propagate in time or a subsequent DNS event triggered another streamer pass.

## Fix

- Change the session branch of `saveCaptchas` from `insertOne` → `updateOne + { $set }, upsert: true, filter: { sessionId }`. Matches the pattern already used for image/pow/puzzle records in the same method.
- Log line now includes `upsertedCount / matchedCount / modifiedCount` (same fields the other three branches log).

## Test plan

- [x] New integration test `saveCaptchasSessionUpsert.integration.test.ts` seeds one session, calls `saveCaptchas` for the same `sessionId` three times, asserts only 1 doc at end (+ last write wins on `score`). Also a guardrail test that 3 distinct `sessionId`s produce 3 docs.
- [x] Negative-control verified: reverting the code change reproduces `AssertionError: expected 3 to be 1` on the first test.
- [x] Full `@prosopo/database` suite: 82/82 tests pass.
- [x] Full `@prosopo/provider` unit suite: 983/983 tests pass.
- [x] Biome lint clean on changed files.

## Not in this PR (follow-up)

1. **Backfill dedup migration** for the ~18K duplicate rows already in `captchastorage.sessions`. The fix stops NEW dupes; existing ones still need removal (keep highest-`_id` per `sessionId`).
2. **Add unique index on `sessionId`** in `packages/database-private/src/models/Session.ts:549-552`. Currently non-unique with the comment "because sessionId can have duplicates in the collection" — that comment can go once the migration lands. Adding the unique index would guarantee this bug can never recur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)