### PR TITLE
test(api-express-router): cover the router factory, endpoint adapter and middleware

### DIFF
--- a/.changeset/api-express-router-tests.md
+++ b/.changeset/api-express-router-tests.md
@@ -1,0 +1,5 @@
+---
+"@prosopo/api-express-router": patch
+---
+
+Add unit and type test coverage for the router factory, the default endpoint adapter, the auth and request-logger middleware, and the package barrel.

--- a/packages/api-express-router/src/tests/apiExpressRouter.test-d.ts
+++ b/packages/api-express-router/src/tests/apiExpressRouter.test-d.ts
@@ -1,0 +1,190 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { ApiEndpoint, ApiRoutesProvider } from "@prosopo/api-route";
+import type { LogLevel } from "@prosopo/logger";
+import type { KeyringPair } from "@prosopo/types";
+import type {
+	NextFunction,
+	Request,
+	RequestHandler,
+	Response,
+	Router,
+} from "express";
+import { assertType, describe, expectTypeOf, test } from "vitest";
+import type { ZodType } from "zod";
+import type * as barrel from "../index.js";
+import {
+	type ApiExpressEndpointAdapter,
+	apiExpressRouterFactory,
+	authMiddleware,
+	createApiExpressDefaultEndpointAdapter,
+	handleErrors,
+	requestLoggerMiddleware,
+	verifySignature,
+} from "../index.js";
+
+/**
+ * These pin the package's public type surface. Consumers wire routers and
+ * middleware from this barrel alone, so a widened parameter or a dropped export
+ * is a break they would only find at their own call sites.
+ */
+
+describe("the barrel's shape", () => {
+	test("exports exactly the intended names", () => {
+		expectTypeOf<keyof typeof barrel>().toEqualTypeOf<
+			| "apiExpressRouterFactory"
+			| "createApiExpressDefaultEndpointAdapter"
+			| "handleErrors"
+			| "authMiddleware"
+			| "verifySignature"
+			| "requestLoggerMiddleware"
+		>();
+	});
+});
+
+describe("createApiExpressDefaultEndpointAdapter", () => {
+	test("takes a log level and an optional status code", () => {
+		expectTypeOf(
+			createApiExpressDefaultEndpointAdapter,
+		).parameters.toEqualTypeOf<
+			[logLevel: LogLevel, errorStatusCode?: number]
+		>();
+	});
+
+	test("returns the interface, not the concrete class", () => {
+		// Callers depend on the interface so an alternative adapter can be
+		// substituted without a cast.
+		expectTypeOf(
+			createApiExpressDefaultEndpointAdapter,
+		).returns.toEqualTypeOf<ApiExpressEndpointAdapter>();
+	});
+
+	test("rejects a log level that is not one of the known levels", () => {
+		// @ts-expect-error - an arbitrary string is not a LogLevel
+		createApiExpressDefaultEndpointAdapter("chatty");
+	});
+
+	test("rejects a non-numeric status code", () => {
+		// @ts-expect-error - the status code is a number
+		createApiExpressDefaultEndpointAdapter("info", "500");
+	});
+});
+
+describe("the router factory", () => {
+	test("takes a routes provider and an adapter, and returns a Router", () => {
+		expectTypeOf(apiExpressRouterFactory.createRouter).toEqualTypeOf<
+			(
+				apiRoutesProvider: ApiRoutesProvider,
+				apiExpressEndpointAdapter: ApiExpressEndpointAdapter,
+			) => Router
+		>();
+	});
+
+	test("rejects a bare routes object in place of a provider", () => {
+		const adapter: ApiExpressEndpointAdapter = {
+			handleRequest: async () => undefined,
+		};
+		// @ts-expect-error - the factory wants a provider, not the routes it returns
+		apiExpressRouterFactory.createRouter({}, adapter);
+	});
+});
+
+describe("the endpoint adapter interface", () => {
+	test("takes the endpoint and the express trio and resolves to void", () => {
+		expectTypeOf<ApiExpressEndpointAdapter["handleRequest"]>().toEqualTypeOf<
+			(
+				endpoint: ApiEndpoint<ZodType | undefined>,
+				request: Request,
+				response: Response,
+				next: NextFunction,
+			) => Promise<void>
+		>();
+	});
+
+	test("is satisfied by any object with a matching handleRequest", () => {
+		// Structural, deliberately: a consumer can supply its own adapter
+		// without importing or extending the default class.
+		assertType<ApiExpressEndpointAdapter>({
+			handleRequest: async (): Promise<void> => undefined,
+		});
+	});
+});
+
+describe("the middleware", () => {
+	test("authMiddleware takes an optional pair and an optional auth account", () => {
+		expectTypeOf(authMiddleware).parameters.toEqualTypeOf<
+			[pair: KeyringPair | undefined, authAccount?: KeyringPair | undefined]
+		>();
+	});
+
+	test("authMiddleware returns an async express handler", () => {
+		expectTypeOf(authMiddleware).returns.toEqualTypeOf<
+			(req: Request, res: Response, next: NextFunction) => Promise<void>
+		>();
+	});
+
+	test("authMiddleware still requires the first argument to be passed", () => {
+		// It is `KeyringPair | undefined` rather than optional, so a provider
+		// with no key has to say so explicitly instead of forgetting to wire it.
+		// @ts-expect-error - the first parameter is required
+		authMiddleware();
+	});
+
+	test("requestLoggerMiddleware returns a synchronous express handler", () => {
+		expectTypeOf(requestLoggerMiddleware).returns.toEqualTypeOf<
+			(req: Request, res: Response, next: NextFunction) => void
+		>();
+	});
+
+	test("the handler each factory builds is usable as express middleware", () => {
+		// The exports are factories, so it is what they return — not the
+		// factories themselves — that gets mounted with app.use().
+		assertType<RequestHandler>(
+			requestLoggerMiddleware(
+				{} as Parameters<typeof requestLoggerMiddleware>[0],
+			),
+		);
+		assertType<RequestHandler>(authMiddleware(undefined));
+	});
+
+	test("verifySignature takes a signature, a message and a pair, and returns void", () => {
+		expectTypeOf(verifySignature).parameters.toEqualTypeOf<
+			[signature: string, message: string, pair: KeyringPair]
+		>();
+		expectTypeOf(verifySignature).returns.toEqualTypeOf<void>();
+	});
+
+	test("verifySignature rejects a byte-array signature", () => {
+		// The hex string is decoded internally; passing bytes would be decoded
+		// a second time and silently verify the wrong value.
+		// @ts-expect-error - the signature is a hex string
+		verifySignature(new Uint8Array([1]), "msg", {} as KeyringPair);
+	});
+});
+
+describe("the error handler", () => {
+	test("takes an error first, which is what makes express treat it as one", () => {
+		// A three-parameter handler would be mounted as ordinary middleware and
+		// never see an error at all.
+		expectTypeOf(handleErrors).parameters.toMatchTypeOf<
+			[unknown, Request, Response, NextFunction]
+		>();
+	});
+
+	test("rejects being mounted as an ordinary handler", () => {
+		// @ts-expect-error - the first parameter is an error, not a request
+		assertType<RequestHandler>(handleErrors);
+	});
+});

--- a/packages/api-express-router/src/tests/unit/apiExpressDefaultEndpointAdapter.unit.test.ts
+++ b/packages/api-express-router/src/tests/unit/apiExpressDefaultEndpointAdapter.unit.test.ts
@@ -1,0 +1,395 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {
+	type ApiEndpoint,
+	type ApiEndpointResponse,
+	ApiEndpointResponseStatus,
+} from "@prosopo/api-route";
+import { ProsopoApiError } from "@prosopo/common";
+import { LogLevel, type Logger } from "@prosopo/logger";
+import type { Request, Response } from "express";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { type ZodType, z } from "zod";
+import { ApiExpressDefaultEndpointAdapter } from "../../endpointAdapter/apiExpressDefaultEndpointAdapter.js";
+import { type NextCapture, captureNext } from "./testDoubles.js";
+
+/**
+ * The adapter is the only place request bodies are validated and the only place
+ * an endpoint's throw is turned into a response, so the split matters: a bad
+ * body must reach the error handler through next(), while a failure inside the
+ * endpoint must be answered directly with a 500.
+ */
+
+interface Harness {
+	adapter: ApiExpressDefaultEndpointAdapter;
+	request: Request;
+	response: Response;
+	next: NextCapture;
+	logger: Logger;
+	json: ReturnType<typeof vi.fn<(body: unknown) => Response>>;
+	status: ReturnType<typeof vi.fn<(code: number) => Response>>;
+	send: ReturnType<typeof vi.fn<(body: unknown) => Response>>;
+	logged: ReturnType<typeof vi.fn<(entry: () => unknown) => void>>;
+}
+
+const build = (body: unknown = {}, errorStatusCode = 500): Harness => {
+	const logged = vi.fn<(entry: () => unknown) => void>();
+	const logger = {
+		error: logged,
+		info: vi.fn<(entry: () => unknown) => void>(),
+		debug: vi.fn<(entry: () => unknown) => void>(),
+		warn: vi.fn<(entry: () => unknown) => void>(),
+	} as unknown as Logger;
+
+	const json = vi.fn<(payload: unknown) => Response>();
+	const send = vi.fn<(payload: unknown) => Response>();
+	const status = vi.fn<(code: number) => Response>();
+	const response = { json, send, status } as unknown as Response;
+	status.mockReturnValue(response);
+
+	return {
+		adapter: new ApiExpressDefaultEndpointAdapter(
+			LogLevel.enum.info,
+			errorStatusCode,
+		),
+		request: { body, logger } as unknown as Request,
+		response,
+		next: captureNext(),
+		logger,
+		json,
+		status,
+		send,
+		logged,
+	};
+};
+
+const endpoint = (
+	schema: ZodType | undefined,
+	process: ApiEndpoint<ZodType | undefined>["processRequest"] = async () => ({
+		status: ApiEndpointResponseStatus.SUCCESS,
+	}),
+): ApiEndpoint<ZodType | undefined> => ({
+	getRequestArgsSchema: () => schema,
+	processRequest:
+		vi.fn<ApiEndpoint<ZodType | undefined>["processRequest"]>(process),
+});
+
+let harness: Harness;
+
+beforeEach(() => {
+	harness = build();
+});
+
+describe("a request the endpoint accepts", () => {
+	test("parses the body and passes the parsed value on", async () => {
+		harness = build({ count: "5" });
+		const schema = z.object({ count: z.coerce.number() });
+		const target = endpoint(schema);
+
+		await harness.adapter.handleRequest(
+			target,
+			harness.request,
+			harness.response,
+			harness.next.fn,
+		);
+
+		// The parsed value, not the raw body: coercion has to survive the trip.
+		expect(target.processRequest).toHaveBeenCalledWith(
+			{ count: 5 },
+			harness.logger,
+		);
+	});
+
+	test("passes undefined args when the endpoint declares no schema", async () => {
+		const target = endpoint(undefined);
+		await harness.adapter.handleRequest(
+			target,
+			harness.request,
+			harness.response,
+			harness.next.fn,
+		);
+		expect(target.processRequest).toHaveBeenCalledWith(
+			undefined,
+			harness.logger,
+		);
+	});
+
+	test("hands the endpoint the request's own logger", async () => {
+		const target = endpoint(undefined);
+		await harness.adapter.handleRequest(
+			target,
+			harness.request,
+			harness.response,
+			harness.next.fn,
+		);
+		expect(vi.mocked(target.processRequest).mock.calls[0]?.[1]).toBe(
+			harness.logger,
+		);
+	});
+
+	test("answers with the endpoint's response as JSON", async () => {
+		await harness.adapter.handleRequest(
+			endpoint(undefined, async () => ({
+				status: ApiEndpointResponseStatus.SUCCESS,
+				data: { value: 1 },
+			})),
+			harness.request,
+			harness.response,
+			harness.next.fn,
+		);
+		expect(harness.json).toHaveBeenCalledWith({
+			status: ApiEndpointResponseStatus.SUCCESS,
+			data: { value: 1 },
+		});
+		expect(harness.next.calls).toHaveLength(0);
+	});
+
+	test("stringifies bigints, which res.json() cannot serialise", async () => {
+		await harness.adapter.handleRequest(
+			endpoint(undefined, async () => ({
+				status: ApiEndpointResponseStatus.SUCCESS,
+				data: { big: 10n },
+			})),
+			harness.request,
+			harness.response,
+			harness.next.fn,
+		);
+		expect(harness.json).toHaveBeenCalledWith({
+			status: ApiEndpointResponseStatus.SUCCESS,
+			data: { big: "10" },
+		});
+	});
+
+	test("passes an empty data payload straight through", async () => {
+		// Nothing coerces an empty result into a body, so the client sees
+		// exactly what the endpoint returned.
+		await harness.adapter.handleRequest(
+			endpoint(undefined, async () => ({
+				status: ApiEndpointResponseStatus.SUCCESS,
+				data: {},
+			})),
+			harness.request,
+			harness.response,
+			harness.next.fn,
+		);
+		expect(harness.json).toHaveBeenCalledWith({
+			status: ApiEndpointResponseStatus.SUCCESS,
+			data: {},
+		});
+	});
+
+	test("an absent request body is still handed to the schema", async () => {
+		// Express only populates req.body when a body parser is mounted, so an
+		// endpoint whose schema tolerates undefined has to keep working.
+		harness.request.body = undefined;
+		const schema = z.object({ a: z.string() }).optional();
+		const target = endpoint(schema);
+		await harness.adapter.handleRequest(
+			target,
+			harness.request,
+			harness.response,
+			harness.next.fn,
+		);
+		expect(target.processRequest).toHaveBeenCalledWith(
+			undefined,
+			harness.logger,
+		);
+		expect(harness.json).toHaveBeenCalledWith({
+			status: ApiEndpointResponseStatus.SUCCESS,
+		});
+	});
+});
+
+describe("a body the schema rejects", () => {
+	test("goes to the error handler rather than being answered here", async () => {
+		harness = build({ count: "not a number" });
+		const target = endpoint(z.object({ count: z.number() }));
+
+		await harness.adapter.handleRequest(
+			target,
+			harness.request,
+			harness.response,
+			harness.next.fn,
+		);
+
+		expect(harness.next.calls).toHaveLength(1);
+		expect(harness.json).not.toHaveBeenCalled();
+		expect(target.processRequest).not.toHaveBeenCalled();
+	});
+
+	test("is reported as a 400 parse error carrying the cause", async () => {
+		harness = build({ count: "not a number" });
+		await harness.adapter.handleRequest(
+			endpoint(z.object({ count: z.number() })),
+			harness.request,
+			harness.response,
+			harness.next.fn,
+		);
+
+		const [forwarded] = harness.next.calls[0] ?? [];
+		expect(forwarded).toBeInstanceOf(ProsopoApiError);
+		const error = forwarded as ProsopoApiError;
+		expect(error.context?.code).toBe(400);
+		expect(error.context?.error).toBeDefined();
+	});
+
+	test("a schema that throws something other than a ZodError is treated the same", async () => {
+		// getRequestArgsSchema().parse is only known to throw; nothing depends
+		// on it being a ZodError, so a custom schema cannot escape the 400.
+		const schema = {
+			parse: () => {
+				throw new Error("custom validator exploded");
+			},
+		} as unknown as ZodType;
+
+		await harness.adapter.handleRequest(
+			endpoint(schema),
+			harness.request,
+			harness.response,
+			harness.next.fn,
+		);
+
+		expect(harness.next.calls).toHaveLength(1);
+		expect(harness.next.calls[0]?.[0]).toBeInstanceOf(ProsopoApiError);
+	});
+
+	test("an endpoint that fails while building its schema is caught too", async () => {
+		// getRequestArgsSchema() is called inside the same try as parse(), so a
+		// broken schema factory is reported as a bad request rather than
+		// escaping handleRequest as an unhandled rejection.
+		const target: ApiEndpoint<ZodType | undefined> = {
+			getRequestArgsSchema: () => {
+				throw new Error("schema construction failed");
+			},
+			processRequest:
+				vi.fn<ApiEndpoint<ZodType | undefined>["processRequest"]>(),
+		};
+
+		await harness.adapter.handleRequest(
+			target,
+			harness.request,
+			harness.response,
+			harness.next.fn,
+		);
+
+		expect(harness.next.calls[0]?.[0]).toBeInstanceOf(ProsopoApiError);
+		expect(target.processRequest).not.toHaveBeenCalled();
+	});
+});
+
+describe("an endpoint that fails", () => {
+	test("is answered with a 500 and a generic message", async () => {
+		await harness.adapter.handleRequest(
+			endpoint(undefined, async () => {
+				throw new Error("database down");
+			}),
+			harness.request,
+			harness.response,
+			harness.next.fn,
+		);
+
+		expect(harness.status).toHaveBeenCalledWith(500);
+		expect(harness.send).toHaveBeenCalledWith(
+			"An internal server error occurred.",
+		);
+	});
+
+	test("does not leak the failure's message to the client", async () => {
+		await harness.adapter.handleRequest(
+			endpoint(undefined, async () => {
+				throw new Error("connection string: postgres://user:secret@host");
+			}),
+			harness.request,
+			harness.response,
+			harness.next.fn,
+		);
+		expect(String(harness.send.mock.calls[0]?.[0])).not.toContain("secret");
+	});
+
+	test("logs the failure against the request's logger", async () => {
+		const failure = new Error("database down");
+		await harness.adapter.handleRequest(
+			endpoint(undefined, async () => {
+				throw failure;
+			}),
+			harness.request,
+			harness.response,
+			harness.next.fn,
+		);
+
+		expect(harness.logged).toHaveBeenCalledTimes(1);
+		const entry = harness.logged.mock.calls[0]?.[0];
+		expect(entry?.()).toEqual({ err: failure });
+	});
+
+	test("does not also call next(), so the error handler is not double-run", async () => {
+		await harness.adapter.handleRequest(
+			endpoint(undefined, async () => {
+				throw new Error("database down");
+			}),
+			harness.request,
+			harness.response,
+			harness.next.fn,
+		);
+		expect(harness.next.calls).toHaveLength(0);
+	});
+
+	test("ignores the configured errorStatusCode and always answers 500", async () => {
+		// The constructor takes an errorStatusCode that the handler never reads.
+		// Pinned here so the behaviour is visible rather than assumed; the fix
+		// is in flight separately.
+		harness = build({}, 503);
+		await harness.adapter.handleRequest(
+			endpoint(undefined, async () => {
+				throw new Error("unavailable");
+			}),
+			harness.request,
+			harness.response,
+			harness.next.fn,
+		);
+		expect(harness.status).toHaveBeenCalledWith(500);
+		expect(harness.status).not.toHaveBeenCalledWith(503);
+	});
+
+	test("a rejection with a non-Error value is handled just the same", async () => {
+		await harness.adapter.handleRequest(
+			endpoint(undefined, async () => {
+				throw "a bare string";
+			}),
+			harness.request,
+			harness.response,
+			harness.next.fn,
+		);
+		expect(harness.status).toHaveBeenCalledWith(500);
+		expect(harness.logged).toHaveBeenCalledTimes(1);
+	});
+
+	test("a failure while serialising the response is caught too", async () => {
+		// stringifyBigInts walks the response, so a getter that throws lands in
+		// the same catch as an endpoint failure rather than escaping.
+		const hostile: ApiEndpointResponse = {
+			get status(): ApiEndpointResponseStatus {
+				throw new Error("getter exploded");
+			},
+		};
+		await harness.adapter.handleRequest(
+			endpoint(undefined, async () => hostile),
+			harness.request,
+			harness.response,
+			harness.next.fn,
+		);
+		expect(harness.status).toHaveBeenCalledWith(500);
+	});
+});

--- a/packages/api-express-router/src/tests/unit/apiExpressRouterFactory.unit.test.ts
+++ b/packages/api-express-router/src/tests/unit/apiExpressRouterFactory.unit.test.ts
@@ -1,0 +1,215 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {
+	type ApiEndpoint,
+	ApiEndpointResponseStatus,
+	type ApiRoutes,
+	type ApiRoutesProvider,
+} from "@prosopo/api-route";
+import type { NextFunction, Request, Response, Router } from "express";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import type { ZodType } from "zod";
+import { ApiExpressRouterFactory } from "../../apiExpressRouterFactory.js";
+import type { ApiExpressEndpointAdapter } from "../../endpointAdapter/apiExpressEndpointAdapter.js";
+import { handleErrors } from "../../errorHandler.js";
+import { captureNext } from "./testDoubles.js";
+
+/**
+ * The factory is the wiring between a routes provider and express. What matters
+ * is that every declared route reaches the adapter untouched, that the error
+ * handler is mounted last, and that a provider handing back nothing still
+ * produces a usable router rather than throwing.
+ */
+
+type Handler = (
+	request: Request,
+	response: Response,
+	next: NextFunction,
+) => Promise<void>;
+
+const endpoint = (): ApiEndpoint<ZodType | undefined> => ({
+	getRequestArgsSchema: vi.fn<() => ZodType | undefined>(() => undefined),
+	processRequest: vi.fn<ApiEndpoint<ZodType | undefined>["processRequest"]>(
+		async () => ({ status: ApiEndpointResponseStatus.SUCCESS }),
+	),
+});
+
+const provider = (routes: ApiRoutes): ApiRoutesProvider => ({
+	getRoutes: (): ApiRoutes => routes,
+});
+
+const adapter = (): ApiExpressEndpointAdapter => ({
+	handleRequest: vi.fn<ApiExpressEndpointAdapter["handleRequest"]>(
+		async () => undefined,
+	),
+});
+
+/** The (path, handler) pairs the factory registered as POST routes. */
+const postRoutes = (router: Router): [string, Handler][] => {
+	const registered: [string, Handler][] = [];
+	for (const layer of router.stack) {
+		const route = layer.route;
+		if (!route) continue;
+		const handler = route.stack[route.stack.length - 1]?.handle as
+			| Handler
+			| undefined;
+		if (handler) registered.push([route.path, handler]);
+	}
+	return registered;
+};
+
+let factory: ApiExpressRouterFactory;
+
+beforeEach(() => {
+	factory = new ApiExpressRouterFactory();
+});
+
+describe("createRouter", () => {
+	test("registers one POST route per entry the provider declares", () => {
+		const router = factory.createRouter(
+			provider({ "/a": endpoint(), "/b": endpoint() }),
+			adapter(),
+		);
+		expect(postRoutes(router).map(([path]) => path)).toEqual(["/a", "/b"]);
+	});
+
+	test("registers the routes as POST only", () => {
+		// express records the verbs it accepted on the route itself; anything
+		// beyond post here would widen the API surface silently.
+		const router = factory.createRouter(
+			provider({ "/a": endpoint() }),
+			adapter(),
+		);
+		const route = router.stack.find((layer) => layer.route)?.route as
+			| { methods: Record<string, boolean> }
+			| undefined;
+		expect(route?.methods).toEqual({ post: true });
+	});
+
+	test("a provider with no routes still yields a router", () => {
+		// An empty route table is a legitimate state during start-up, so it must
+		// not throw: the router simply has nothing but the error handler on it.
+		const router = factory.createRouter(provider({}), adapter());
+		expect(postRoutes(router)).toEqual([]);
+		expect(router.stack).toHaveLength(1);
+	});
+
+	test("mounts the error handler last, after every route", () => {
+		// Express only reaches an error handler declared after the handlers that
+		// might fail, so its position is load-bearing rather than cosmetic.
+		const router = factory.createRouter(
+			provider({ "/a": endpoint(), "/b": endpoint() }),
+			adapter(),
+		);
+		const last = router.stack[router.stack.length - 1];
+		expect(last?.handle).toBe(handleErrors);
+		expect(last?.route).toBeUndefined();
+	});
+
+	test("asks the provider for its routes exactly once", () => {
+		const getRoutes = vi.fn<() => ApiRoutes>(() => ({ "/a": endpoint() }));
+		factory.createRouter({ getRoutes }, adapter());
+		expect(getRoutes).toHaveBeenCalledTimes(1);
+	});
+
+	test("each call builds a fresh router", () => {
+		const routes = provider({ "/a": endpoint() });
+		expect(factory.createRouter(routes, adapter())).not.toBe(
+			factory.createRouter(routes, adapter()),
+		);
+	});
+
+	test("routes named oddly are passed to express verbatim", () => {
+		// The factory does no normalising of its own, so a provider is free to
+		// use path parameters or a bare root route.
+		const router = factory.createRouter(
+			provider({ "/": endpoint(), "/nested/:id": endpoint() }),
+			adapter(),
+		);
+		expect(postRoutes(router).map(([path]) => path)).toEqual([
+			"/",
+			"/nested/:id",
+		]);
+	});
+});
+
+describe("the handler each route is given", () => {
+	test("hands the endpoint and the express trio to the adapter", async () => {
+		const target = endpoint();
+		const endpointAdapter = adapter();
+		const router = factory.createRouter(
+			provider({ "/a": target }),
+			endpointAdapter,
+		);
+		const request = {} as Request;
+		const response = {} as Response;
+		const next = captureNext();
+
+		const handler = postRoutes(router)[0]?.[1];
+		await handler?.(request, response, next.fn);
+
+		expect(endpointAdapter.handleRequest).toHaveBeenCalledWith(
+			target,
+			request,
+			response,
+			next.fn,
+		);
+	});
+
+	test("routes each path to its own endpoint, not the last one registered", () => {
+		// A loop that closes over the wrong variable would send every request to
+		// whichever endpoint happened to be last.
+		const first = endpoint();
+		const second = endpoint();
+		const endpointAdapter = adapter();
+		const router = factory.createRouter(
+			provider({ "/first": first, "/second": second }),
+			endpointAdapter,
+		);
+
+		for (const [, handler] of postRoutes(router)) {
+			void handler({} as Request, {} as Response, captureNext().fn);
+		}
+
+		const handled = vi.mocked(endpointAdapter.handleRequest).mock.calls;
+		expect(handled.map(([called]) => called)).toEqual([first, second]);
+	});
+
+	test("propagates a rejection from the adapter to the caller", async () => {
+		// The handler returns the adapter's promise, so express receives the
+		// rejection rather than it becoming an unhandled one.
+		const endpointAdapter = adapter();
+		vi.mocked(endpointAdapter.handleRequest).mockRejectedValue(
+			new Error("adapter blew up"),
+		);
+		const router = factory.createRouter(
+			provider({ "/a": endpoint() }),
+			endpointAdapter,
+		);
+
+		const handler = postRoutes(router)[0]?.[1];
+		await expect(
+			handler?.({} as Request, {} as Response, captureNext().fn),
+		).rejects.toThrow("adapter blew up");
+	});
+
+	test("does not call the endpoint itself — that is the adapter's job", async () => {
+		const target = endpoint();
+		const router = factory.createRouter(provider({ "/a": target }), adapter());
+		const handler = postRoutes(router)[0]?.[1];
+		await handler?.({} as Request, {} as Response, captureNext().fn);
+		expect(target.processRequest).not.toHaveBeenCalled();
+	});
+});

--- a/packages/api-express-router/src/tests/unit/index.unit.test.ts
+++ b/packages/api-express-router/src/tests/unit/index.unit.test.ts
@@ -1,0 +1,95 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { ApiRoutes, ApiRoutesProvider } from "@prosopo/api-route";
+import { LogLevel } from "@prosopo/logger";
+import type { NextFunction, Request, Response } from "express";
+import { describe, expect, test, vi } from "vitest";
+import {
+	apiExpressRouterFactory,
+	authMiddleware,
+	createApiExpressDefaultEndpointAdapter,
+	handleErrors,
+	requestLoggerMiddleware,
+} from "../../index.js";
+
+/**
+ * The barrel is what every consuming package imports, so the shape of it is
+ * part of the contract — a missing re-export or a changed default breaks
+ * callers without touching any of the implementations.
+ */
+
+describe("createApiExpressDefaultEndpointAdapter", () => {
+	test("builds an adapter exposing handleRequest", () => {
+		const adapter = createApiExpressDefaultEndpointAdapter(LogLevel.enum.info);
+		expect(typeof adapter.handleRequest).toBe("function");
+	});
+
+	test("builds a fresh adapter per call", () => {
+		expect(createApiExpressDefaultEndpointAdapter(LogLevel.enum.info)).not.toBe(
+			createApiExpressDefaultEndpointAdapter(LogLevel.enum.info),
+		);
+	});
+
+	test("defaults the error status code so callers may omit it", () => {
+		expect(() =>
+			createApiExpressDefaultEndpointAdapter(LogLevel.enum.debug),
+		).not.toThrow();
+	});
+
+	test("accepts an explicit error status code", () => {
+		expect(() =>
+			createApiExpressDefaultEndpointAdapter(LogLevel.enum.debug, 503),
+		).not.toThrow();
+	});
+});
+
+describe("apiExpressRouterFactory", () => {
+	test("is exported as a single shared instance", () => {
+		// It holds no per-router state, so one instance is enough — but callers
+		// import the value rather than the class, so it must stay a singleton.
+		expect(typeof apiExpressRouterFactory.createRouter).toBe("function");
+	});
+
+	test("builds a router from a provider", () => {
+		const provider: ApiRoutesProvider = {
+			getRoutes: (): ApiRoutes => ({}),
+		};
+		const router = apiExpressRouterFactory.createRouter(provider, {
+			handleRequest: vi.fn<
+				(
+					endpoint: never,
+					request: Request,
+					response: Response,
+					next: NextFunction,
+				) => Promise<void>
+			>(async () => undefined),
+		});
+		expect(typeof router).toBe("function");
+	});
+});
+
+describe("the re-exported middleware", () => {
+	test("exposes the error handler", () => {
+		expect(typeof handleErrors).toBe("function");
+	});
+
+	test("exposes the auth middleware", () => {
+		expect(typeof authMiddleware).toBe("function");
+	});
+
+	test("exposes the request logger middleware", () => {
+		expect(typeof requestLoggerMiddleware).toBe("function");
+	});
+});

--- a/packages/api-express-router/src/tests/unit/middlewares/authMiddleware.unit.test.ts
+++ b/packages/api-express-router/src/tests/unit/middlewares/authMiddleware.unit.test.ts
@@ -12,172 +12,331 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { hexToU8a, isHex } from "@polkadot/util";
-import { ProsopoEnvError } from "@prosopo/common";
-import { type Logger, getLogger } from "@prosopo/logger";
+import type { IncomingHttpHeaders } from "node:http";
+import { ProsopoApiError } from "@prosopo/common";
+import type { Logger } from "@prosopo/logger";
 import type { KeyringPair } from "@prosopo/types";
-import type { JWTVerifyResult } from "@prosopo/util-crypto";
-import type { NextFunction, Request, Response } from "express";
-import { describe, expect, it, vi } from "vitest";
-import { authMiddleware } from "../../../middlewares/authMiddleware.js";
+import type { JWT } from "@prosopo/util-crypto";
+import type { Request, Response } from "express";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import {
+	authMiddleware,
+	verifySignature,
+} from "../../../middlewares/authMiddleware.js";
+import { type NextCapture, captureNext } from "../testDoubles.js";
 
-const loggerOuter = getLogger("info", "test:auth-middleware");
+/**
+ * Everything this middleware protects is behind a single decision: call next()
+ * or answer 401. It must never fall through to the handler when a token is
+ * absent, malformed, or verified by neither key — including when verification
+ * itself throws.
+ */
 
-const mockLogger = {
-	debug: vi.fn().mockImplementation(loggerOuter.debug.bind(loggerOuter)),
-	log: vi.fn().mockImplementation(loggerOuter.log.bind(loggerOuter)),
-	info: vi.fn().mockImplementation(loggerOuter.info.bind(loggerOuter)),
-	error: vi.fn().mockImplementation(loggerOuter.error.bind(loggerOuter)),
-	trace: vi.fn().mockImplementation(loggerOuter.trace.bind(loggerOuter)),
-	fatal: vi.fn().mockImplementation(loggerOuter.fatal.bind(loggerOuter)),
-	warn: vi.fn().mockImplementation(loggerOuter.warn.bind(loggerOuter)),
-} as unknown as Logger;
+type Verify = (jwt: JWT) => { isValid: boolean };
 
-vi.mock("@polkadot/util", async (importOriginal) => {
-	const actual = await importOriginal();
+/** A pair that only implements the parts the middleware actually calls. */
+const pairThat = (verify: Verify): KeyringPair =>
+	({
+		jwtVerify: vi.fn<Verify>(verify),
+		address: "5Test",
+		publicKey: new Uint8Array([1, 2, 3]),
+		verify: vi.fn<
+			(message: string, signature: Uint8Array, key: Uint8Array) => boolean
+		>(() => true),
+	}) as unknown as KeyringPair;
 
-	return {
-		// @ts-ignore
-		...actual,
-		hexToU8a: vi.fn(),
-		isHex: vi.fn(),
-	};
-});
+const accepts = (): KeyringPair => pairThat(() => ({ isValid: true }));
+const rejects = (): KeyringPair => pairThat(() => ({ isValid: false }));
+const explodes = (): KeyringPair =>
+	pairThat(() => {
+		throw new Error("verifier unavailable");
+	});
 
-const mockPair = {
-	publicKey: "mockPublicKey",
-	verify: vi.fn(),
-	jwtVerify: vi.fn(),
-} as unknown as KeyringPair;
-const mockEnv = {
-	pair: mockPair,
-	authAccount: mockPair,
-	logger: mockLogger,
-	jwtVerify: vi.fn(),
+interface Harness {
+	req: Request;
+	res: Response;
+	next: NextCapture;
+	status: ReturnType<typeof vi.fn<(code: number) => Response>>;
+	json: ReturnType<typeof vi.fn<(body: unknown) => Response>>;
+	logged: ReturnType<typeof vi.fn<(entry: () => unknown) => void>>;
+}
+
+const build = (headers: IncomingHttpHeaders = {}): Harness => {
+	const json = vi.fn<(body: unknown) => Response>();
+	const status = vi.fn<(code: number) => Response>();
+	const res = { status, json } as unknown as Response;
+	status.mockReturnValue(res);
+
+	const logged = vi.fn<(entry: () => unknown) => void>();
+	const req = {
+		headers,
+		logger: { error: logged } as unknown as Logger,
+	} as unknown as Request;
+
+	return { req, res, next: captureNext(), status, json, logged };
 };
 
-describe("authMiddleware", () => {
-	it("should call next() if signature is valid", async () => {
-		const mockLogger = {
-			debug: vi.fn().mockImplementation(loggerOuter.debug.bind(loggerOuter)),
-			log: vi.fn().mockImplementation(loggerOuter.log.bind(loggerOuter)),
-			info: vi.fn().mockImplementation(loggerOuter.info.bind(loggerOuter)),
-			error: vi.fn().mockImplementation(loggerOuter.error.bind(loggerOuter)),
-			trace: vi.fn().mockImplementation(loggerOuter.trace.bind(loggerOuter)),
-			fatal: vi.fn().mockImplementation(loggerOuter.fatal.bind(loggerOuter)),
-			warn: vi.fn().mockImplementation(loggerOuter.warn.bind(loggerOuter)),
-		} as unknown as Logger;
-		const mockReq = {
-			url: "/v1/prosopo/provider/captcha/image",
-			originalUrl: "/v1/prosopo/provider/captcha/image",
-			headers: {
-				Authorization: "Bearer mockToken",
-			},
-			logger: mockLogger,
-		} as unknown as Request;
+const bearer = (token: string): IncomingHttpHeaders => ({
+	authorization: `Bearer ${token}`,
+});
 
-		const mockRes = {
-			status: vi.fn().mockReturnThis(),
-			json: vi.fn(),
-		} as unknown as Response;
+let harness: Harness;
 
-		const mockNext = vi.fn() as unknown as NextFunction;
+beforeEach(() => {
+	harness = build(bearer("token-1"));
+});
 
-		vi.mocked(isHex).mockReturnValue(true);
-		vi.mocked(hexToU8a).mockReturnValue(new Uint8Array());
-		vi.mocked(mockPair.jwtVerify).mockReturnValue({
-			isValid: true,
-		} as unknown as JWTVerifyResult);
+const run = async (
+	pair: KeyringPair | undefined,
+	authAccount?: KeyringPair | undefined,
+): Promise<void> => {
+	await authMiddleware(pair, authAccount)(
+		harness.req,
+		harness.res,
+		harness.next.fn,
+	);
+};
 
-		const middleware = authMiddleware(mockEnv.pair, mockEnv.authAccount);
-		await middleware(mockReq, mockRes, mockNext);
-
-		expect(mockNext).toHaveBeenCalled();
-		expect(mockRes.status).not.toHaveBeenCalled();
+describe("a token one of the keys accepts", () => {
+	test("passes the request through on the auth account", async () => {
+		await run(rejects(), accepts());
+		expect(harness.next.calls).toHaveLength(1);
+		expect(harness.status).not.toHaveBeenCalled();
 	});
 
-	it("should return 401 if jwt is invalid", async () => {
-		const mockLogger = {
-			debug: vi.fn().mockImplementation(loggerOuter.debug.bind(loggerOuter)),
-			log: vi.fn().mockImplementation(loggerOuter.log.bind(loggerOuter)),
-			info: vi.fn().mockImplementation(loggerOuter.info.bind(loggerOuter)),
-			error: vi.fn().mockImplementation(loggerOuter.error.bind(loggerOuter)),
-			trace: vi.fn().mockImplementation(loggerOuter.trace.bind(loggerOuter)),
-			fatal: vi.fn().mockImplementation(loggerOuter.fatal.bind(loggerOuter)),
-			warn: vi.fn().mockImplementation(loggerOuter.warn.bind(loggerOuter)),
-		} as unknown as Logger;
-		const mockReq = {
-			url: "/v1/prosopo/provider/captcha/image",
-			originalUrl: "/v1/prosopo/provider/captcha/image",
-			headers: {
-				Authorization: "Bearer mockToken",
-			},
-			logger: mockLogger,
-			i18n: vi.fn().mockReturnValue({
-				t: (key: string) => key,
-			}),
-		} as unknown as Request;
-
-		const mockRes = {
-			status: vi.fn().mockReturnThis(),
-			json: vi.fn(),
-		} as unknown as Response;
-
-		const mockNext = vi.fn() as unknown as NextFunction;
-
-		vi.mocked(isHex).mockReturnValue(true);
-		vi.mocked(hexToU8a).mockReturnValue(new Uint8Array());
-		vi.mocked(mockPair.jwtVerify).mockReturnValue({
-			isValid: false,
-		} as unknown as JWTVerifyResult);
-
-		const middleware = authMiddleware(mockEnv.pair, mockEnv.authAccount);
-		await middleware(mockReq, mockRes, mockNext);
-
-		expect(mockNext).not.toHaveBeenCalled();
-		expect(mockRes.status).toHaveBeenCalledWith(401);
-		expect(mockRes.json).toHaveBeenCalledWith({
-			error: new ProsopoEnvError("API.UNAUTHORIZED", {
-				context: { i18n: mockReq.i18n, code: 401 },
-			}),
-		});
+	test("passes the request through on the provider pair", async () => {
+		await run(accepts(), rejects());
+		expect(harness.next.calls).toHaveLength(1);
 	});
 
-	it("should return 401 if key pair is missing", async () => {
-		const mockLogger = {
-			debug: vi.fn().mockImplementation(loggerOuter.debug.bind(loggerOuter)),
-			log: vi.fn().mockImplementation(loggerOuter.log.bind(loggerOuter)),
-			info: vi.fn().mockImplementation(loggerOuter.info.bind(loggerOuter)),
-			error: vi.fn().mockImplementation(loggerOuter.error.bind(loggerOuter)),
-			trace: vi.fn().mockImplementation(loggerOuter.trace.bind(loggerOuter)),
-			fatal: vi.fn().mockImplementation(loggerOuter.fatal.bind(loggerOuter)),
-			warn: vi.fn().mockImplementation(loggerOuter.warn.bind(loggerOuter)),
-		} as unknown as Logger;
-		const mockReq = {
-			url: "/v1/prosopo/provider/captcha/image",
-			originalUrl: "/v1/prosopo/provider/captcha/image",
-			headers: {
-				Authorization: "Bearer mockToken",
-			},
-			logger: mockLogger,
-		} as unknown as Request;
+	test("does not consult the provider pair once the auth account accepts", async () => {
+		// Short-circuiting matters: the second verify is a signature check and
+		// there is no reason to pay for it twice.
+		const pair = accepts();
+		await run(pair, accepts());
+		expect(pair.jwtVerify).not.toHaveBeenCalled();
+	});
 
-		const mockRes = {
-			status: vi.fn().mockReturnThis(),
-			json: vi.fn(),
-		} as unknown as Response;
+	test("works when only the provider pair is configured", async () => {
+		await run(accepts(), undefined);
+		expect(harness.next.calls).toHaveLength(1);
+	});
 
-		const mockNext = vi.fn() as unknown as NextFunction;
+	test("works when only the auth account is configured", async () => {
+		await run(undefined, accepts());
+		expect(harness.next.calls).toHaveLength(1);
+	});
 
-		const middleware = authMiddleware(undefined, undefined);
-		await middleware(mockReq, mockRes, mockNext);
+	test("hands the verifier the token without its Bearer prefix", async () => {
+		const pair = accepts();
+		await run(pair, undefined);
+		expect(pair.jwtVerify).toHaveBeenCalledWith("token-1");
+	});
+});
 
-		expect(mockNext).not.toHaveBeenCalled();
-		expect(mockRes.status).toHaveBeenCalledWith(401);
-		expect(mockRes.json).toHaveBeenCalledWith({
-			error: new ProsopoEnvError("API.UNAUTHORIZED", {
-				context: { i18n: mockReq.i18n, code: 401 },
-			}),
+describe("a token neither key accepts", () => {
+	beforeEach(async () => {
+		await run(rejects(), rejects());
+	});
+
+	test("is answered 401 and never reaches the handler", () => {
+		expect(harness.status).toHaveBeenCalledWith(401);
+		expect(harness.next.calls).toHaveLength(0);
+	});
+
+	test("is answered with an error body carrying the 401 code", () => {
+		const body = harness.json.mock.calls[0]?.[0] as { error: ProsopoApiError };
+		expect(body.error.context?.code).toBe(401);
+	});
+});
+
+describe("a request with no usable credentials", () => {
+	test("no configured keys at all is rejected, not allowed through", async () => {
+		// A misconfigured provider must fail closed.
+		await run(undefined, undefined);
+		expect(harness.status).toHaveBeenCalledWith(401);
+		expect(harness.next.calls).toHaveLength(0);
+	});
+
+	test("a missing Authorization header is rejected", async () => {
+		harness = build({});
+		await run(accepts(), accepts());
+		expect(harness.status).toHaveBeenCalledWith(401);
+		expect(harness.next.calls).toHaveLength(0);
+	});
+
+	test("an Authorization header that is not a string is rejected", async () => {
+		// Node hands back an array for a repeated header; verifying that would
+		// throw deeper in, so it is refused here.
+		harness = build({
+			authorization: ["Bearer a", "Bearer b"] as unknown as string,
 		});
+		await run(accepts(), accepts());
+		expect(harness.status).toHaveBeenCalledWith(401);
+	});
+
+	test("an empty Authorization header is rejected", async () => {
+		harness = build({ authorization: "" });
+		await run(accepts(), accepts());
+		expect(harness.status).toHaveBeenCalledWith(401);
+	});
+
+	test("a Bearer prefix with no token after it is rejected", async () => {
+		harness = build({ authorization: "Bearer " });
+		await run(accepts(), accepts());
+		expect(harness.status).toHaveBeenCalledWith(401);
+		expect(harness.next.calls).toHaveLength(0);
+	});
+
+	test("the verifier is never reached for a malformed header", async () => {
+		harness = build({});
+		const pair = accepts();
+		await run(pair, undefined);
+		expect(pair.jwtVerify).not.toHaveBeenCalled();
+	});
+
+	test("a header rejection is logged", async () => {
+		harness = build({});
+		await run(accepts(), undefined);
+		expect(harness.logged).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe("header handling quirks worth pinning down", () => {
+	test("a bare token with no Bearer prefix is accepted as the token", async () => {
+		// The prefix is stripped rather than required, so a client that omits it
+		// still authenticates. Recorded so a change here is deliberate.
+		harness = build({ authorization: "token-1" });
+		const pair = accepts();
+		await run(pair, undefined);
+		expect(pair.jwtVerify).toHaveBeenCalledWith("token-1");
+		expect(harness.next.calls).toHaveLength(1);
+	});
+
+	test("a capitalised Authorization key is read as well as the lowercase one", async () => {
+		// Node normalises real inbound header names to lowercase, so only the
+		// second lookup fires in production — but both are honoured, which is
+		// what lets a hand-built request object work in a test or a shim.
+		harness = build({ Authorization: "Bearer token-1" } as IncomingHttpHeaders);
+		const pair = accepts();
+		await run(pair, undefined);
+		expect(pair.jwtVerify).toHaveBeenCalledWith("token-1");
+		expect(harness.next.calls).toHaveLength(1);
+	});
+
+	test("a Bearer prefix appearing inside the token is also stripped", async () => {
+		// replace() is unanchored, so it removes the first occurrence wherever it
+		// sits rather than only at the front.
+		harness = build({ authorization: "abcBearer xyz" });
+		const pair = accepts();
+		await run(pair, undefined);
+		expect(pair.jwtVerify).toHaveBeenCalledWith("abcxyz");
+	});
+});
+
+describe("a verifier that throws", () => {
+	test("is answered 401 rather than crashing the request", async () => {
+		// A key backend being unavailable must not turn into a 500 or an
+		// unhandled rejection.
+		await run(explodes(), undefined);
+		expect(harness.status).toHaveBeenCalledWith(401);
+		expect(harness.next.calls).toHaveLength(0);
+	});
+
+	test("is logged against the request logger", async () => {
+		await run(explodes(), undefined);
+		expect(harness.logged).toHaveBeenCalledTimes(1);
+		const entry = harness.logged.mock.calls[0]?.[0] as () => {
+			msg: string;
+			err: unknown;
+		};
+		expect(entry().msg).toBe("Auth Middleware Error");
+	});
+
+	test("a throwing auth account does not fall through to the provider pair", async () => {
+		// The throw escapes the whole chain, so a working second key cannot
+		// rescue the request.
+		const pair = accepts();
+		await run(pair, explodes());
+		expect(pair.jwtVerify).not.toHaveBeenCalled();
+		expect(harness.next.calls).toHaveLength(0);
+	});
+
+	test("does not resolve before it has answered", async () => {
+		const middleware = authMiddleware(explodes(), undefined);
+		await middleware(harness.req, harness.res, harness.next.fn);
+		expect(harness.json).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe("verifySignature", () => {
+	const message = "sign me";
+	const signature = "0x0102";
+
+	test("returns quietly when the pair verifies the signature", () => {
+		const pair = pairThat(() => ({ isValid: true }));
+		expect(() => verifySignature(signature, message, pair)).not.toThrow();
+	});
+
+	test("passes the decoded signature bytes to the pair", () => {
+		const pair = pairThat(() => ({ isValid: true }));
+		verifySignature(signature, message, pair);
+		expect(pair.verify).toHaveBeenCalledWith(
+			message,
+			new Uint8Array([1, 2]),
+			pair.publicKey,
+		);
+	});
+
+	test("throws a 401 error when verification fails", () => {
+		const pair = pairThat(() => ({ isValid: true }));
+		vi.mocked(pair.verify).mockReturnValue(false);
+		try {
+			verifySignature(signature, message, pair);
+			expect.unreachable("verifySignature should have thrown");
+		} catch (error) {
+			expect(error).toBeInstanceOf(ProsopoApiError);
+			expect((error as ProsopoApiError).context?.code).toBe(401);
+		}
+	});
+
+	test("reports which account and message failed", () => {
+		// Without the account in the context a failure is untraceable across the
+		// several keys a provider holds.
+		const pair = pairThat(() => ({ isValid: true }));
+		vi.mocked(pair.verify).mockReturnValue(false);
+		try {
+			verifySignature(signature, message, pair);
+			expect.unreachable("verifySignature should have thrown");
+		} catch (error) {
+			const context = (error as ProsopoApiError).context;
+			expect(context?.account).toBe("5Test");
+			expect(context?.message).toBe(message);
+			expect(context?.signature).toBe(signature);
+		}
+	});
+
+	test("a non-hex signature is decoded to garbage rather than rejected", () => {
+		// hexToU8a is lenient: it silently produces bytes for input that is not
+		// hex at all. Nothing here validates the shape, so a malformed signature
+		// reaches the pair and fails there instead of being refused up front.
+		const pair = pairThat(() => ({ isValid: true }));
+		vi.mocked(pair.verify).mockReturnValue(false);
+		expect(() => verifySignature("not hex", message, pair)).toThrow(
+			ProsopoApiError,
+		);
+		expect(pair.verify).toHaveBeenCalledTimes(1);
+	});
+
+	test("an empty message is still passed through to the pair", () => {
+		// Nothing guards against it, so an empty message verifies or fails purely
+		// on the pair's answer rather than being rejected up front.
+		const pair = pairThat(() => ({ isValid: true }));
+		verifySignature(signature, "", pair);
+		expect(pair.verify).toHaveBeenCalledWith(
+			"",
+			new Uint8Array([1, 2]),
+			pair.publicKey,
+		);
 	});
 });

--- a/packages/api-express-router/src/tests/unit/middlewares/requestLoggerMiddleware.unit.test.ts
+++ b/packages/api-express-router/src/tests/unit/middlewares/requestLoggerMiddleware.unit.test.ts
@@ -1,0 +1,368 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { EventEmitter } from "node:events";
+import type { IncomingHttpHeaders } from "node:http";
+import type { ProviderEnvironment } from "@prosopo/env";
+import type { Logger } from "@prosopo/logger";
+import type { Request, Response } from "express";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { requestLoggerMiddleware } from "../../../middlewares/requestLoggerMiddleware.js";
+import { type NextCapture, captureNext } from "../testDoubles.js";
+
+/**
+ * This middleware is the only thing that gives a request an identity, so what
+ * matters is that the id is stable across the request, that it is reused when an
+ * upstream proxy already assigned one, and that exactly one "Response sent" line
+ * is emitted no matter which express event fires.
+ */
+
+interface LogEntry {
+	msg?: string;
+	data?: Record<string, unknown>;
+}
+
+/** The `.with()` bindings and every info() payload the middleware produced. */
+interface Recorded {
+	bindings: Record<string, unknown>;
+	infos: LogEntry[];
+}
+
+const recorded: Recorded = { bindings: {}, infos: [] };
+
+const { getLoggerMock } = vi.hoisted(() => ({
+	getLoggerMock: vi.fn(),
+}));
+
+vi.mock("@prosopo/logger", async () => {
+	const actual =
+		await vi.importActual<typeof import("@prosopo/logger")>("@prosopo/logger");
+	return { ...actual, getLogger: getLoggerMock };
+});
+
+const makeLogger = (): Logger => {
+	const logger = {
+		with: (bindings: Record<string, unknown>): Logger => {
+			recorded.bindings = bindings;
+			return logger;
+		},
+		info: (entry: () => LogEntry): void => {
+			recorded.infos.push(entry());
+		},
+		error: vi.fn<(entry: () => LogEntry) => void>(),
+		debug: vi.fn<(entry: () => LogEntry) => void>(),
+		warn: vi.fn<(entry: () => LogEntry) => void>(),
+	} as unknown as Logger;
+	return logger;
+};
+
+const env = { config: { logLevel: "info" } } as unknown as ProviderEnvironment;
+
+interface Harness {
+	req: Request;
+	res: Response & EventEmitter;
+	next: NextCapture;
+	setHeader: ReturnType<
+		typeof vi.fn<(name: string, value: string) => Response>
+	>;
+}
+
+const build = (
+	overrides: {
+		headers?: IncomingHttpHeaders;
+		body?: unknown;
+		path?: string;
+		method?: string;
+		statusCode?: number;
+	} = {},
+): Harness => {
+	const emitter = new EventEmitter();
+	const setHeader = vi.fn<(name: string, value: string) => Response>();
+	const res = Object.assign(emitter, {
+		setHeader,
+		statusCode: overrides.statusCode ?? 200,
+	}) as unknown as Response & EventEmitter;
+
+	const req = {
+		headers: overrides.headers ?? {},
+		body: overrides.body,
+		path: overrides.path ?? "/verify",
+		method: overrides.method ?? "POST",
+	} as unknown as Request;
+
+	return { req, res, next: captureNext(), setHeader };
+};
+
+const run = (harness: Harness): void => {
+	requestLoggerMiddleware(env)(harness.req, harness.res, harness.next.fn);
+};
+
+beforeEach(() => {
+	recorded.bindings = {};
+	recorded.infos = [];
+	getLoggerMock.mockReset();
+	getLoggerMock.mockImplementation(() => makeLogger());
+});
+
+describe("the request id", () => {
+	test("reuses the id an upstream proxy already assigned", () => {
+		// Caddy stamps x-request-id; reusing it is what lets a proxy log line and
+		// an app log line be joined together.
+		const harness = build({ headers: { "x-request-id": "caddy-123" } });
+		run(harness);
+		expect(harness.req.requestId).toBe("caddy-123");
+		expect(recorded.bindings.requestId).toBe("caddy-123");
+	});
+
+	test("generates an e-prefixed uuid when there is no inbound id", () => {
+		const harness = build();
+		run(harness);
+		expect(harness.req.requestId).toMatch(
+			/^e-[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+		);
+	});
+
+	test("generates a fresh id per request", () => {
+		const first = build();
+		const second = build();
+		run(first);
+		run(second);
+		expect(first.req.requestId).not.toBe(second.req.requestId);
+	});
+
+	test("falls back for an empty inbound id rather than using a blank one", () => {
+		// A blank header is worse than no header: it would group every such
+		// request under the same empty id.
+		const harness = build({ headers: { "x-request-id": "" } });
+		run(harness);
+		expect(harness.req.requestId).toMatch(/^e-/);
+	});
+
+	test("mirrors the id back onto the response", () => {
+		const harness = build({ headers: { "x-request-id": "caddy-123" } });
+		run(harness);
+		expect(harness.setHeader).toHaveBeenCalledWith("x-request-id", "caddy-123");
+	});
+
+	test("mirrors the generated id too, not just an inbound one", () => {
+		const harness = build();
+		run(harness);
+		expect(harness.setHeader).toHaveBeenCalledWith(
+			"x-request-id",
+			harness.req.requestId,
+		);
+	});
+});
+
+describe("the log bindings", () => {
+	test("carry the user and site key headers when present", () => {
+		const harness = build({
+			headers: { "prosopo-user": "alice", "prosopo-site-key": "site-1" },
+		});
+		run(harness);
+		expect(recorded.bindings.user).toBe("alice");
+		expect(recorded.bindings.siteKey).toBe("site-1");
+	});
+
+	test("omit absent fields entirely rather than binding undefined", () => {
+		// A bound `user: undefined` would show up as a field in every log line
+		// for anonymous traffic.
+		const harness = build();
+		run(harness);
+		expect(Object.keys(recorded.bindings)).toEqual(["requestId"]);
+	});
+
+	test("omit headers present but empty", () => {
+		const harness = build({
+			headers: { "prosopo-user": "", "prosopo-site-key": "" },
+		});
+		run(harness);
+		expect(Object.keys(recorded.bindings)).toEqual(["requestId"]);
+	});
+
+	test("collapse a repeated header to a single string", () => {
+		// Node hands back an array when a header appears twice; binding the array
+		// itself would break the log schema.
+		const harness = build({
+			headers: { "prosopo-user": ["alice", "bob"] as unknown as string },
+		});
+		run(harness);
+		expect(recorded.bindings.user).toBe("alice,bob");
+	});
+
+	test("carry the session id off the request body", () => {
+		const harness = build({ body: { sessionId: "sess-9" } });
+		run(harness);
+		expect(recorded.bindings.sessionId).toBe("sess-9");
+	});
+
+	test("tolerate a missing body", () => {
+		// Body parsing is mounted per-route, so the middleware can run before a
+		// body exists at all.
+		const harness = build({ body: undefined });
+		expect(() => run(harness)).not.toThrow();
+		expect(recorded.bindings.sessionId).toBeUndefined();
+	});
+
+	test("tolerate a body that is not an object", () => {
+		const harness = build({ body: "raw text" });
+		expect(() => run(harness)).not.toThrow();
+		expect(recorded.bindings.sessionId).toBeUndefined();
+	});
+
+	test("omit an empty session id", () => {
+		const harness = build({ body: { sessionId: "" } });
+		run(harness);
+		expect(recorded.bindings.sessionId).toBeUndefined();
+	});
+
+	test("attach the bound logger to the request for handlers downstream", () => {
+		const harness = build();
+		run(harness);
+		expect(harness.req.logger).toBeDefined();
+	});
+});
+
+describe("envelope logging", () => {
+	test("logs a request-received line before calling next", () => {
+		const harness = build({ path: "/verify", method: "POST" });
+		run(harness);
+		expect(recorded.infos[0]).toEqual({
+			msg: "Request received",
+			data: { method: "POST", path: "/verify" },
+		});
+		expect(harness.next.calls).toHaveLength(1);
+	});
+
+	test("logs a response-sent line with status and outcome when finish fires", () => {
+		const harness = build({ statusCode: 201 });
+		run(harness);
+		harness.res.emit("finish");
+
+		const sent = recorded.infos[1];
+		expect(sent?.msg).toBe("Response sent");
+		expect(sent?.data?.status).toBe(201);
+		expect(sent?.data?.outcome).toBe("finish");
+		expect(typeof sent?.data?.durationMs).toBe("number");
+	});
+
+	test("records a client disconnect as a close outcome", () => {
+		const harness = build();
+		run(harness);
+		harness.res.emit("close");
+		expect(recorded.infos[1]?.data?.outcome).toBe("close");
+	});
+
+	test("logs the response only once when both events fire", () => {
+		// Express emits close after finish on a normal response, so without the
+		// guard every request would be counted twice.
+		const harness = build();
+		run(harness);
+		harness.res.emit("finish");
+		harness.res.emit("close");
+		expect(
+			recorded.infos.filter((e) => e.msg === "Response sent"),
+		).toHaveLength(1);
+	});
+
+	test("keeps the first outcome when close follows finish", () => {
+		const harness = build();
+		run(harness);
+		harness.res.emit("finish");
+		harness.res.emit("close");
+		expect(recorded.infos[1]?.data?.outcome).toBe("finish");
+	});
+
+	test("reads the status at emit time, not at middleware time", () => {
+		// The handler sets the status after this middleware has already run, so a
+		// value captured up front would always read 200.
+		const harness = build({ statusCode: 200 });
+		run(harness);
+		harness.res.statusCode = 500;
+		harness.res.emit("finish");
+		expect(recorded.infos[1]?.data?.status).toBe(500);
+	});
+
+	test("reports a non-negative duration", () => {
+		const harness = build();
+		run(harness);
+		harness.res.emit("finish");
+		expect(recorded.infos[1]?.data?.durationMs).toBeGreaterThanOrEqual(0);
+	});
+});
+
+describe("health probes", () => {
+	test.each(["/healthz", "/health", "/readyz"])(
+		"%s is not envelope-logged",
+		(path: string) => {
+			// These are polled continuously; logging them would bury real traffic.
+			const harness = build({ path });
+			run(harness);
+			harness.res.emit("finish");
+			expect(recorded.infos).toEqual([]);
+			expect(harness.next.calls).toHaveLength(1);
+		},
+	);
+
+	test("a health probe still gets a request id and a logger", () => {
+		const harness = build({ path: "/healthz" });
+		run(harness);
+		expect(harness.req.requestId).toMatch(/^e-/);
+		expect(harness.req.logger).toBeDefined();
+		expect(harness.setHeader).toHaveBeenCalledWith(
+			"x-request-id",
+			harness.req.requestId,
+		);
+	});
+
+	test("a path that merely looks like a probe is still logged", () => {
+		// The match is exact, so nothing under a probe-like prefix is silently
+		// dropped from the logs.
+		const harness = build({ path: "/healthz/deep" });
+		run(harness);
+		expect(recorded.infos[0]?.msg).toBe("Request received");
+	});
+
+	test("registers no response listeners for a probe", () => {
+		const harness = build({ path: "/healthz" });
+		run(harness);
+		expect(harness.res.listenerCount("finish")).toBe(0);
+		expect(harness.res.listenerCount("close")).toBe(0);
+	});
+});
+
+describe("the environment it is built from", () => {
+	test("builds its logger under the provider:request scope at the configured level", () => {
+		const harness = build();
+		run(harness);
+		expect(getLoggerMock).toHaveBeenCalledWith("info", "provider:request");
+	});
+
+	test("reads the log level from the environment on every request", () => {
+		// The middleware is built once at start-up but the level is read per
+		// request, so a config change takes effect without a restart.
+		const mutable = {
+			config: { logLevel: "info" },
+		} as unknown as ProviderEnvironment;
+		const middleware = requestLoggerMiddleware(mutable);
+		const first = build();
+		middleware(first.req, first.res, first.next.fn);
+
+		mutable.config.logLevel = "debug";
+		const second = build();
+		middleware(second.req, second.res, second.next.fn);
+
+		expect(getLoggerMock).toHaveBeenLastCalledWith("debug", "provider:request");
+	});
+});

--- a/packages/api-express-router/src/tests/unit/testDoubles.ts
+++ b/packages/api-express-router/src/tests/unit/testDoubles.ts
@@ -1,0 +1,39 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { NextFunction } from "express";
+
+/**
+ * A recording stand-in for express's `next`.
+ *
+ * `vi.fn<NextFunction>()` cannot be passed where a `NextFunction` is wanted —
+ * the type is overloaded and Mock collapses it to a single signature — so the
+ * spy is a plain closure that records its arguments instead.
+ */
+interface NextCapture {
+	fn: NextFunction;
+	calls: unknown[][];
+}
+
+const captureNext = (): NextCapture => {
+	const calls: unknown[][] = [];
+	return {
+		fn: (...args: unknown[]): void => {
+			calls.push(args);
+		},
+		calls,
+	};
+};
+
+export { captureNext, type NextCapture };


### PR DESCRIPTION
Adds unit and type tests for `packages/api-express-router`.

- router factory: route registration per provider entry, POST-only methods, empty routes, error handler mounted last, per-path endpoint binding, adapter rejection propagation
- default endpoint adapter: schema parsing and coercion, bigint stringification, schema rejection -> 400 via `next`, endpoint failure -> 500 without leaking the message, non-Error throws
- auth middleware: auth-account short-circuit, either provider key, malformed/missing/array headers, fail-closed with no keys configured, throwing verifiers surfacing as 401 rather than 500
- request logger middleware: request id reuse vs generation, binding omission for absent fields, finish/close outcome handling, health-probe exemptions, per-request log level
- type tests pinning the barrel's export names and every public signature

Coverage: 26.37% -> 100% statements / 100% branches / 100% functions / 100% lines. 119 tests.