### PR TITLE
test(types-database): unit and type tests for the mongoose schemas

### DIFF
--- a/packages/types-database/package.json
+++ b/packages/types-database/package.json
@@ -20,6 +20,7 @@
 		"clean": "del-cli --verbose dist tsconfig.tsbuildinfo",
 		"build": "npm run build:cross-env -- --mode ${NODE_ENV:-development}",
 		"build:cross-env": "vite build --config vite.esm.config.ts",
+		"test": "NODE_ENV=${NODE_ENV:-test}; npx vitest run --config ./vite.test.config.ts",
 		"build:tsc": "tsc --build --verbose",
 		"build:cjs": "NODE_ENV=${NODE_ENV:-development}; vite build --config vite.cjs.config.ts --mode $NODE_ENV",
 		"typecheck": "tsc --project tsconfig.types.json"

--- a/packages/types-database/src/tests/clientSettings.unit.test.ts
+++ b/packages/types-database/src/tests/clientSettings.unit.test.ts
@@ -1,0 +1,273 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {
+	CaptchaType,
+	ContextType,
+	DEFAULT_POW_CAPTCHA_SOLUTION_TIMEOUT,
+	DEFAULT_POW_CAPTCHA_VERIFIED_TIMEOUT,
+	abuseScoreThresholdDefault,
+	captchaTypeDefault,
+	distanceThresholdKmDefault,
+	frictionlessThresholdDefault,
+	imageMaxRoundsDefault,
+	imageThresholdDefault,
+	powDifficultyDefault,
+	requireAllConditionsDefault,
+} from "@prosopo/types";
+import mongoose from "mongoose";
+import { describe, expect, test } from "vitest";
+import {
+	AccountSchema,
+	IPValidationRulesSchema,
+	UserDataSchema,
+	UserSettingsSchema,
+} from "../types/client.js";
+
+// Mongoose only applies defaults and validators through a model, and models
+// are global to the connection, so each schema is registered once here under a
+// name no production code uses.
+const settings = mongoose.model("test-user-settings", UserSettingsSchema);
+const ipRules = mongoose.model("test-ip-rules", IPValidationRulesSchema);
+const userData = mongoose.model("test-user-data", UserDataSchema);
+const account = mongoose.model("test-account", AccountSchema);
+
+type SettingsDoc = ReturnType<typeof settings.prototype.toObject>;
+
+const defaults = (): SettingsDoc => new settings({}).toObject();
+
+describe("what a client gets when it sets nothing", () => {
+	test("is served the default captcha type", () => {
+		expect(defaults().captchaType).toBe(captchaTypeDefault);
+	});
+
+	test("inherits the shared proof-of-work timeouts", () => {
+		// These are the only place the stored value can come from, so a drift
+		// from the shared constant silently changes how long a token lives.
+		const doc = defaults();
+		expect(doc.verifiedTimeout).toBe(DEFAULT_POW_CAPTCHA_VERIFIED_TIMEOUT);
+		expect(doc.solutionTimeout).toBe(DEFAULT_POW_CAPTCHA_SOLUTION_TIMEOUT);
+	});
+
+	test("inherits the shared difficulty and thresholds", () => {
+		const doc = defaults();
+		expect(doc.powDifficulty).toBe(powDifficultyDefault);
+		expect(doc.frictionlessThreshold).toBe(frictionlessThresholdDefault);
+		expect(doc.imageThreshold).toBe(imageThresholdDefault);
+		expect(doc.imageMaxRounds).toBe(imageMaxRoundsDefault);
+	});
+
+	test("has no domain allowlist entries of its own", () => {
+		expect(defaults().domains).toEqual([]);
+	});
+
+	test("has no puzzle tolerance, so the caller must decide", () => {
+		expect(defaults().puzzleTolerance).toBeUndefined();
+	});
+});
+
+describe("the protections a client has to opt into", () => {
+	test("web views are allowed until they are disallowed", () => {
+		expect(defaults().disallowWebView).toBe(false);
+	});
+
+	test("context awareness is off but pre-populated", () => {
+		// The contexts map is defaulted even while disabled so that enabling it
+		// does not also require sending thresholds.
+		const doc = defaults();
+		expect(doc.contextAware.enabled).toBe(false);
+		expect(doc.contextAware.contexts[ContextType.Default].type).toBe(
+			ContextType.Default,
+		);
+		expect(doc.contextAware.contexts[ContextType.Webview].type).toBe(
+			ContextType.Webview,
+		);
+	});
+
+	test("spam email domain checking is off", () => {
+		expect(defaults().spamEmailDomainCheckEnabled).toBe(false);
+	});
+
+	test("the spam filter and its email rules are both off", () => {
+		const doc = defaults();
+		expect(doc.spamFilter.enabled).toBe(false);
+		expect(doc.spamFilter.emailRules.enabled).toBe(false);
+		expect(doc.spamFilter.emailRules.normaliseGmail).toBe(false);
+		expect(doc.spamFilter.emailRules.useDefaultPatterns).toBe(false);
+		expect(doc.spamFilter.emailRules.customRegexBlocklist).toEqual([]);
+	});
+
+	test("metadata is not stored", () => {
+		expect(defaults().storeMetadata).toBe(false);
+	});
+
+	test("the honeypot is off and encodes as morse when enabled", () => {
+		const doc = defaults();
+		expect(doc.honeypot.enabled).toBe(false);
+		expect(doc.honeypot.encodingType).toBe("morse");
+	});
+
+	test("rejects an encoding the widget cannot render", () => {
+		const doc = new settings({ honeypot: { encodingType: "braille" } });
+		expect(doc.validateSync()?.errors["honeypot.encodingType"]).toBeDefined();
+	});
+
+	test("rejects a captcha type that is not one of the known ones", () => {
+		expect(
+			new settings({ captchaType: "sudoku" }).validateSync()?.errors
+				.captchaType,
+		).toBeDefined();
+	});
+
+	test("accepts every captcha type the shared enum defines", () => {
+		for (const type of Object.values(CaptchaType)) {
+			expect(
+				new settings({ captchaType: type }).validateSync(),
+			).toBeUndefined();
+		}
+	});
+});
+
+describe("the traffic filter defaults", () => {
+	test("blocks known abusers and nothing else", () => {
+		// Abusers are the one category with a low enough false-positive rate to
+		// be on for everybody; the rest would lock out legitimate users.
+		const filter = defaults().trafficFilter;
+		expect(filter.blockAbuser).toBe(true);
+		expect(filter.blockVpn).toBe(false);
+		expect(filter.blockProxy).toBe(false);
+		expect(filter.blockTor).toBe(false);
+		expect(filter.blockDatacenter).toBe(false);
+		expect(filter.blockMobile).toBe(false);
+		expect(filter.blockSatellite).toBe(false);
+		expect(filter.blockCrawler).toBe(false);
+	});
+
+	test("starts the abuser score at zero, so any score counts", () => {
+		expect(defaults().trafficFilter.abuserScoreThreshold).toBe(0);
+	});
+
+	test("skips the extra checks once DNS has already vouched for the client", () => {
+		expect(defaults().trafficFilter.skipExtrasOnValidDnsPath).toBe(true);
+	});
+
+	test("keeps the abuser score inside the zero-to-one range it is scored on", () => {
+		expect(
+			new settings({
+				trafficFilter: { abuserScoreThreshold: 1.5 },
+			}).validateSync()?.errors["trafficFilter.abuserScoreThreshold"],
+		).toBeDefined();
+		expect(
+			new settings({
+				trafficFilter: { abuserScoreThreshold: -0.1 },
+			}).validateSync()?.errors["trafficFilter.abuserScoreThreshold"],
+		).toBeDefined();
+		expect(
+			new settings({
+				trafficFilter: { abuserScoreThreshold: 1 },
+			}).validateSync(),
+		).toBeUndefined();
+	});
+
+	test("starts the datacenter allow and deny lists empty", () => {
+		// Empty rather than absent, so a caller can push a name without first
+		// having to create the array.
+		const filter = defaults().trafficFilter;
+		expect(filter.datacenterNameAllowlist).toEqual([]);
+		expect(filter.datacenterNameDenylist).toEqual([]);
+	});
+});
+
+describe("the ip validation rules", () => {
+	test("are off until switched on", () => {
+		expect(new ipRules({}).toObject().enabled).toBe(false);
+	});
+
+	test("carry the shared defaults for every action", () => {
+		const doc = new ipRules({}).toObject();
+		expect(doc.distanceThresholdKm).toBe(distanceThresholdKmDefault);
+		expect(doc.abuseScoreThreshold).toBe(abuseScoreThresholdDefault);
+		expect(doc.requireAllConditions).toBe(requireAllConditionsDefault);
+	});
+
+	test("do not force a consistent ip by default", () => {
+		// Mobile clients change IP mid-session routinely.
+		expect(new ipRules({}).toObject().forceConsistentIp).toBe(false);
+	});
+
+	test("have no country overrides at all, rather than an empty map", () => {
+		// An empty map and "no overrides" have to stay distinguishable, because
+		// the read path treats a present map as an intentional override set.
+		expect(new ipRules({}).toObject().countryOverrides).toBeUndefined();
+	});
+
+	test("reject negative distances and abuse scores", () => {
+		expect(
+			new ipRules({ distanceThresholdKm: -1 }).validateSync()?.errors
+				.distanceThresholdKm,
+		).toBeDefined();
+		expect(
+			new ipRules({ abuseScoreThreshold: -1 }).validateSync()?.errors
+				.abuseScoreThreshold,
+		).toBeDefined();
+	});
+
+	test("accept a per-country override of the global thresholds", () => {
+		const doc = new ipRules({
+			countryOverrides: { GB: { distanceThresholdKm: 5 } },
+		});
+		expect(doc.validateSync()).toBeUndefined();
+		expect(
+			doc.toObject().countryOverrides?.get("GB")?.distanceThresholdKm,
+		).toBe(5);
+	});
+
+	test("are attached to a client's settings", () => {
+		const doc = new settings({ ipValidationRules: { enabled: true } });
+		expect(doc.toObject().ipValidationRules?.enabled).toBe(true);
+	});
+});
+
+describe("user and account records", () => {
+	test("a user may exist before it has any settings", () => {
+		// Signup writes the user first; settings arrive with the first site.
+		const doc = new userData({ email: "a@b.com", account: "acc" });
+		expect(doc.validateSync()).toBeUndefined();
+		expect(doc.toObject().settings).toBeUndefined();
+	});
+
+	test("a user's settings are defaulted once the object exists", () => {
+		const doc = new userData({ account: "acc", settings: {} });
+		expect(doc.toObject().settings.captchaType).toBe(captchaTypeDefault);
+	});
+
+	test("an account carries no users or sites until they are added", () => {
+		const doc = new account({ signupEmail: "a@b.com" }).toObject();
+		expect(doc.users).toEqual([]);
+		expect(doc.sites).toEqual([]);
+	});
+
+	test("a site keeps its own copy of the ip rules", () => {
+		const doc = new account({
+			sites: [{ siteKey: "key", settings: { ipValidationRules: {} } }],
+		}).toObject();
+		expect(doc.sites?.[0]?.settings?.ipValidationRules?.enabled).toBe(false);
+	});
+
+	test("account timestamps are numbers, not dates", () => {
+		// They are compared against epoch millis in the billing queries.
+		const doc = new account({ createdAt: 1700000000000 }).toObject();
+		expect(typeof doc.createdAt).toBe("number");
+	});
+});

--- a/packages/types-database/src/tests/compositeIp.unit.test.ts
+++ b/packages/types-database/src/tests/compositeIp.unit.test.ts
@@ -1,0 +1,118 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { IpAddressType } from "@prosopo/types";
+import { Long } from "mongodb";
+import mongoose, { Schema } from "mongoose";
+import { describe, expect, test } from "vitest";
+import { CompositeIpAddressRecordSchemaObj } from "../types/provider.js";
+
+const model = mongoose.model(
+	"test-composite-ip",
+	new Schema(CompositeIpAddressRecordSchemaObj),
+);
+
+/**
+ * An IPv6 address is stored as two 64-bit halves. The halves arrive from three
+ * different places — application code (bigint), the mongo driver on read-back
+ * (BSON Long), and JSON (string) — and every one of them has to land on the
+ * same Decimal128, or the same address stops matching itself across writes.
+ */
+const store = (lower: bigint | number | string | Long): string | undefined =>
+	new model({ lower, type: IpAddressType.v6 }).get("lower")?.toString();
+
+describe("storing the halves of an ip address", () => {
+	test("keeps a bigint exact instead of rounding it through a double", () => {
+		// 2^64-1 is beyond Number.MAX_SAFE_INTEGER; the naive path would lose
+		// the low bits and collapse distinct addresses onto one another.
+		expect(store(18446744073709551615n)).toBe("18446744073709551615");
+	});
+
+	test("keeps zero as zero rather than dropping the required field", () => {
+		expect(store(0n)).toBe("0");
+	});
+
+	test("reads a BSON Long back as the unsigned value it was written as", () => {
+		// Long.fromBits defaults to signed, so the top-bit-set case is where a
+		// missing `unsigned` flag shows up: it would come back negative.
+		expect(store(Long.fromString("18446744073709551615", true))).toBe(
+			"18446744073709551615",
+		);
+	});
+
+	test("recognises a Long from a different bson copy by its _bsontype", () => {
+		// The driver may deserialise with its own bundled bson, so an
+		// instanceof check would silently skip normalisation. This stand-in has
+		// the right shape and brand but no shared class identity.
+		const foreign = { _bsontype: "Long", low: -1, high: -1 };
+		expect(
+			new model({ lower: foreign, type: IpAddressType.v6 })
+				.get("lower")
+				?.toString(),
+		).toBe("18446744073709551615");
+	});
+
+	test("passes a decimal string straight through", () => {
+		expect(store("12345678901234567890")).toBe("12345678901234567890");
+	});
+
+	test("passes a small number through unharmed", () => {
+		expect(store(3232235777)).toBe("3232235777");
+	});
+
+	test("treats an object that merely looks like a Long as an ordinary value", () => {
+		// Without the _bsontype brand it is handed to the Decimal128 cast as-is,
+		// which rejects it — better than silently storing the wrong number.
+		const notLong = { low: 1, high: 0 };
+		expect(
+			new model({ lower: notLong, type: IpAddressType.v6 }).validateSync()
+				?.errors.lower,
+		).toBeDefined();
+	});
+});
+
+describe("what a composite ip record has to carry", () => {
+	test("insists on the lower half and the address type", () => {
+		const errors = new model({}).validateSync()?.errors;
+		expect(errors?.lower).toBeDefined();
+		expect(errors?.type).toBeDefined();
+	});
+
+	test("leaves the upper half optional, since v4 has only one", () => {
+		const doc = new model({ lower: 3232235777n, type: IpAddressType.v4 });
+		expect(doc.validateSync()).toBeUndefined();
+		expect(doc.get("upper")).toBeUndefined();
+	});
+
+	test("normalises the upper half the same way as the lower", () => {
+		const doc = new model({
+			lower: 0n,
+			upper: Long.fromString("18446744073709551615", true),
+			type: IpAddressType.v6,
+		});
+		expect(doc.get("upper")?.toString()).toBe("18446744073709551615");
+	});
+
+	test("rejects an address type outside the known set", () => {
+		expect(
+			new model({ lower: 1n, type: "v5" }).validateSync()?.errors.type,
+		).toBeDefined();
+	});
+
+	test("accepts every address type the shared enum defines", () => {
+		for (const type of Object.values(IpAddressType)) {
+			expect(new model({ lower: 1n, type }).validateSync()).toBeUndefined();
+		}
+	});
+});

--- a/packages/types-database/src/tests/records.unit.test.ts
+++ b/packages/types-database/src/tests/records.unit.test.ts
@@ -1,0 +1,248 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { CaptchaStatus, ScheduledTaskStatus } from "@prosopo/types";
+import type { IndexDefinition, IndexOptions, Schema } from "mongoose";
+import mongoose from "mongoose";
+import { describe, expect, test } from "vitest";
+import { BannedDomainRecordSchema } from "../types/bannedDomain.js";
+import {
+	StoredPoWCaptchaRecordSchema,
+	StoredPuzzleCaptchaRecordSchema,
+	StoredSessionRecordSchema,
+	StoredUserCommitmentRecordSchema,
+} from "../types/captcha.js";
+import {
+	DecisionMachineArtifactRecordSchema,
+	DetectorRecordSchema,
+	PoWCaptchaRecordSchema,
+	ScheduledTaskRecordSchema,
+	SessionRecordSchema,
+	UserSolutionRecordSchema,
+} from "../types/provider.js";
+import { SpamEmailDomainRecordSchema } from "../types/spamEmailDomain.js";
+
+type IndexEntry = [IndexDefinition, IndexOptions];
+
+const indexes = (schema: Schema): IndexEntry[] =>
+	schema.indexes() as IndexEntry[];
+
+const findIndex = (
+	schema: Schema,
+	keys: Record<string, number>,
+): IndexEntry | undefined =>
+	indexes(schema).find(
+		([definition]) => JSON.stringify(definition) === JSON.stringify(keys),
+	);
+
+describe("indexes that exist for a specific query", () => {
+	test("the pending-stage sweep scans only pending rows", () => {
+		// A full index here would make the sweep touch every powcaptcha ever
+		// written; the partial filter keeps it to the small rolling set.
+		const entry = findIndex(PoWCaptchaRecordSchema, { pendingStage: 1 });
+		expect(entry?.[1].partialFilterExpression).toEqual({ pendingStage: true });
+	});
+
+	test("the backfill sweeps index the whole field, not a partial", () => {
+		// These serve `{ $exists: false }`, which a partial filter cannot
+		// express, so the index has to include documents missing the field.
+		for (const field of ["ipInfo", "parsedUserAgentInfo"]) {
+			const entry = findIndex(PoWCaptchaRecordSchema, { [field]: 1 });
+			expect(entry).toBeDefined();
+			expect(entry?.[1].partialFilterExpression).toBeUndefined();
+		}
+	});
+
+	test("both halves of the composite ip are searchable independently", () => {
+		expect(
+			findIndex(PoWCaptchaRecordSchema, { "ipAddress.lower": 1 }),
+		).toBeDefined();
+		expect(
+			findIndex(PoWCaptchaRecordSchema, { "ipAddress.upper": 1 }),
+		).toBeDefined();
+	});
+
+	test("expired detector keys are removed by mongo rather than by a job", () => {
+		const entry = findIndex(DetectorRecordSchema, { expiresAt: 1 });
+		expect(entry?.[1].expireAfterSeconds).toBe(0);
+	});
+
+	test("only one decision machine artifact may exist per scope", () => {
+		const entry = findIndex(DecisionMachineArtifactRecordSchema, {
+			scope: 1,
+			dappAccount: 1,
+			kind: 1,
+		});
+		expect(entry?.[1].unique).toBe(true);
+	});
+
+	test("a domain cannot be banned twice", () => {
+		expect(BannedDomainRecordSchema.path("domain").options.unique).toBe(true);
+		expect(SpamEmailDomainRecordSchema.path("domain").options.unique).toBe(
+			true,
+		);
+	});
+});
+
+describe("records that expire on their own", () => {
+	test("a user solution is dropped four weeks after it is created", () => {
+		const path = UserSolutionRecordSchema.path("createdAt");
+		expect(path.options.expires).toBe(28 * 24 * 60 * 60);
+		expect(path.options.default).toBe(Date.now);
+	});
+
+	test("a scheduled task record is dropped after a week", () => {
+		expect(ScheduledTaskRecordSchema.path("datetime").options.expires).toBe(
+			7 * 24 * 60 * 60,
+		);
+	});
+
+	test("a captcha record only expires once it has been stored", () => {
+		// `storedAtTimestamp` is unset until the record is staged, and mongo's
+		// TTL monitor ignores documents whose indexed field is missing — so an
+		// unstaged record is never silently deleted.
+		const path = PoWCaptchaRecordSchema.path("storedAtTimestamp");
+		expect(path.options.required).toBe(false);
+		expect(path.options.expires).toBe(28 * 24 * 60 * 60);
+	});
+});
+
+describe("validating a proof-of-work record", () => {
+	const model = mongoose.model("test-pow", PoWCaptchaRecordSchema);
+
+	const complete = (): Record<string, unknown> => ({
+		challenge: "c",
+		dappAccount: "d",
+		userAccount: "u",
+		requestedAtTimestamp: new Date(0),
+		result: { status: CaptchaStatus.pending },
+		difficulty: 4,
+		ipAddress: { lower: 1n, type: "v4" },
+		headers: {},
+		ja4: "ja4",
+		userSubmitted: false,
+		serverChecked: false,
+		providerSignature: "sig",
+	});
+
+	test("accepts a record carrying only the required fields", () => {
+		expect(new model(complete()).validateSync()).toBeUndefined();
+	});
+
+	test("refuses a record with no signature from the provider", () => {
+		const { providerSignature: _omitted, ...rest } = complete();
+		expect(
+			new model(rest).validateSync()?.errors.providerSignature,
+		).toBeDefined();
+	});
+
+	test("refuses a status that is not a known captcha status", () => {
+		expect(
+			new model({ ...complete(), result: { status: "maybe" } }).validateSync()
+				?.errors["result.status"],
+		).toBeDefined();
+	});
+
+	test("does not currently restrict the failure reason to a translation key", () => {
+		// The intent of `enum: TranslationKeysSchema.options` is to keep the
+		// reason renderable, but that list comes back empty — `getLeafFieldPath`
+		// in @prosopo/locale returns `[]` for a leaf, so every key is dropped
+		// and the enum constrains nothing. Pinned as the current behaviour;
+		// fixing it in locale would narrow the `TranslationKey` type from
+		// `string` to a real union and is a change for that package to make.
+		expect(PoWCaptchaRecordSchema.path("result.reason").options.enum).toEqual(
+			[],
+		);
+		expect(
+			new model({
+				...complete(),
+				result: { status: CaptchaStatus.disapproved, reason: "not.a.key" },
+			}).validateSync(),
+		).toBeUndefined();
+	});
+
+	test("leaves the label fields empty until a human labels the record", () => {
+		const doc = new model(complete());
+		expect(doc.get("label")).toBeUndefined();
+		expect(doc.get("labelledBy")).toBeUndefined();
+		expect(doc.get("labelledAt")).toBeUndefined();
+	});
+
+	test("refuses a label outside the known set", () => {
+		expect(
+			new model({ ...complete(), label: "spam" }).validateSync()?.errors.label,
+		).toBeDefined();
+	});
+});
+
+describe("validating a scheduled task record", () => {
+	const model = mongoose.model(
+		"test-scheduled-task",
+		ScheduledTaskRecordSchema,
+	);
+
+	test("insists on a name, a time and a status", () => {
+		const errors = new model({}).validateSync()?.errors;
+		expect(errors?.processName).toBeDefined();
+		expect(errors?.datetime).toBeDefined();
+		expect(errors?.status).toBeDefined();
+	});
+
+	test("refuses a status the runner does not understand", () => {
+		expect(
+			new model({ status: "halfway" }).validateSync()?.errors.status,
+		).toBeDefined();
+	});
+
+	test("accepts every status the runner emits", () => {
+		for (const status of Object.values(ScheduledTaskStatus)) {
+			expect(
+				new model({ status }).validateSync()?.errors.status,
+			).toBeUndefined();
+		}
+	});
+
+	test("stores a result only once the task has produced one", () => {
+		expect(new model({}).get("result")).toBeUndefined();
+	});
+});
+
+describe("the stored copies of the captcha schemas", () => {
+	test("a stored session is the very same schema as a live one", () => {
+		// The two were merged; keeping them identical by reference is what
+		// stops the stored copy drifting when the live one gains a field.
+		expect(StoredSessionRecordSchema).toBe(SessionRecordSchema);
+	});
+
+	test("each stored copy carries every field of the record it stores", () => {
+		expect(Object.keys(StoredPoWCaptchaRecordSchema.obj)).toEqual(
+			Object.keys(PoWCaptchaRecordSchema.obj),
+		);
+	});
+
+	test("each stored copy is indexed by the session that produced it", () => {
+		for (const schema of [
+			StoredPoWCaptchaRecordSchema,
+			StoredPuzzleCaptchaRecordSchema,
+			StoredUserCommitmentRecordSchema,
+		]) {
+			expect(findIndex(schema, { sessionId: 1 })).toBeDefined();
+		}
+	});
+
+	test("a stored copy is a distinct schema, so its indexes stay separate", () => {
+		expect(StoredPoWCaptchaRecordSchema).not.toBe(PoWCaptchaRecordSchema);
+		expect(findIndex(PoWCaptchaRecordSchema, { sessionId: 1 })).toBeUndefined();
+	});
+});

--- a/packages/types-database/src/tests/typesDatabase.test-d.ts
+++ b/packages/types-database/src/tests/typesDatabase.test-d.ts
@@ -1,0 +1,144 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { Logger } from "@prosopo/logger";
+import type { Connection, Document } from "mongoose";
+import { assertType, describe, expectTypeOf, test } from "vitest";
+import type {
+	BannedDomain,
+	BannedDomainRecord,
+	BrowserInfo,
+	IDatabase,
+	OSInfo,
+	SpamEmailDomain,
+	SpamEmailDomainRecord,
+	StoredSession,
+	UserAgentInfo,
+} from "../index.js";
+import type { SessionRecord } from "../types/provider.js";
+
+describe("the database handle every caller is given", () => {
+	test("hands back a live connection, never an optional one", () => {
+		// `connection` is optional because it does not exist before connect(),
+		// but getConnection() is the accessor callers use and it must not make
+		// them null-check.
+		expectTypeOf<
+			IDatabase["getConnection"]
+		>().returns.toEqualTypeOf<Connection>();
+		expectTypeOf<IDatabase["connection"]>().toEqualTypeOf<
+			Connection | undefined
+		>();
+	});
+
+	test("connects and closes asynchronously", () => {
+		expectTypeOf<IDatabase["connect"]>().returns.toEqualTypeOf<Promise<void>>();
+		expectTypeOf<IDatabase["close"]>().returns.toEqualTypeOf<Promise<void>>();
+	});
+
+	test("always carries a logger and a connected flag", () => {
+		expectTypeOf<IDatabase["logger"]>().toEqualTypeOf<Logger>();
+		expectTypeOf<IDatabase["connected"]>().toEqualTypeOf<boolean>();
+		expectTypeOf<IDatabase["url"]>().toEqualTypeOf<string>();
+		expectTypeOf<IDatabase["dbname"]>().toEqualTypeOf<string>();
+	});
+
+	test("cannot be satisfied by an object missing the accessors", () => {
+		// @ts-expect-error - a bag of fields is not a database
+		const partial: IDatabase = {
+			url: "mongodb://localhost",
+			dbname: "db",
+			connected: false,
+		};
+		void partial;
+	});
+});
+
+describe("the records that are just a document plus their fields", () => {
+	test("a banned domain record is a mongoose document", () => {
+		expectTypeOf<BannedDomainRecord>().toMatchTypeOf<Document>();
+		expectTypeOf<BannedDomainRecord>().toMatchTypeOf<BannedDomain>();
+		expectTypeOf<BannedDomain>().toEqualTypeOf<{ domain: string }>();
+	});
+
+	test("a spam email domain record is shaped the same way", () => {
+		expectTypeOf<SpamEmailDomainRecord>().toMatchTypeOf<Document>();
+		expectTypeOf<SpamEmailDomain>().toEqualTypeOf<{ domain: string }>();
+	});
+
+	test("the two domain records stay distinct types despite the same shape", () => {
+		// They live in different collections; only the plain payloads coincide.
+		expectTypeOf<BannedDomain>().toEqualTypeOf<SpamEmailDomain>();
+		assertType<BannedDomain>({ domain: "example.com" });
+	});
+
+	test("a domain is required, not optional", () => {
+		// @ts-expect-error - a record with no domain identifies nothing
+		const empty: BannedDomain = {};
+		void empty;
+	});
+});
+
+describe("a stored session", () => {
+	test("is the live session record itself, not a copy of its fields", () => {
+		// The schemas were merged; if these ever diverge, the stored alias has
+		// silently stopped tracking the live one.
+		expectTypeOf<StoredSession>().toEqualTypeOf<SessionRecord>();
+	});
+});
+
+describe("the parsed user agent", () => {
+	test("guarantees a raw string and a named browser and os", () => {
+		// Everything else about a user agent is best-effort, but these three
+		// are what the detector rules key off, so they are not optional.
+		expectTypeOf<UserAgentInfo["ua"]>().toEqualTypeOf<string>();
+		expectTypeOf<BrowserInfo["name"]>().toEqualTypeOf<string>();
+		expectTypeOf<OSInfo["name"]>().toEqualTypeOf<string>();
+	});
+
+	test("leaves every version and detail optional", () => {
+		expectTypeOf<BrowserInfo["version"]>().toEqualTypeOf<string | undefined>();
+		expectTypeOf<OSInfo["version"]>().toEqualTypeOf<string | undefined>();
+		expectTypeOf<UserAgentInfo["device"]["model"]>().toEqualTypeOf<
+			string | undefined
+		>();
+		expectTypeOf<UserAgentInfo["cpu"]["architecture"]>().toEqualTypeOf<
+			string | undefined
+		>();
+	});
+
+	test("still requires the sub-objects even when they are empty", () => {
+		// A parse always produces every section, so consumers can read
+		// `info.device.type` without guarding the intermediate.
+		assertType<UserAgentInfo>({
+			ua: "Mozilla/5.0",
+			browser: { name: "Firefox" },
+			cpu: {},
+			device: {},
+			engine: {},
+			os: { name: "Linux" },
+		});
+	});
+
+	test("rejects a parse with no browser section at all", () => {
+		// @ts-expect-error - browser is not optional
+		const noBrowser: UserAgentInfo = {
+			ua: "Mozilla/5.0",
+			cpu: {},
+			device: {},
+			engine: {},
+			os: { name: "Linux" },
+		};
+		void noBrowser;
+	});
+});

--- a/packages/types-database/vite.test.config.ts
+++ b/packages/types-database/vite.test.config.ts
@@ -1,0 +1,19 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { ViteTestConfig } from "@prosopo/config";
+
+process.env.NODE_ENV = "test";
+
+export default ViteTestConfig();


### PR DESCRIPTION
Wires `@prosopo/types-database` into CI (`test` script + `vite.test.config.ts`) and adds 91 tests — 78 unit, 13 type.

## Covered

- **Client settings defaults** — every default a client inherits when it sends nothing, pinned against the shared constants in `@prosopo/types` so a drift in either shows up. Includes the traffic filter (only `blockAbuser` is on by default), the 0–1 abuser score range, `skipExtrasOnValidDnsPath`, the honeypot encoding enum, and the context-aware map being pre-populated while disabled.
- **IP validation rules** — defaults, negative-value rejection, per-country overrides, and `countryOverrides` staying `undefined` rather than an empty map (the read path treats a present map as an intentional override set).
- **The composite IP Decimal128 setter** — the interesting logic in `provider.ts`. An IPv6 half arrives as a bigint, a BSON `Long`, or a string, and all three have to land on the same value: 2^64-1 stays exact rather than rounding through a double, a `Long` comes back unsigned rather than negative, and a `Long` from a *different* bson copy is still recognised by its `_bsontype` brand (an `instanceof` check would silently skip normalisation).
- **Index intent** — that the pending-stage sweep is a partial index, that the `$exists: false` backfill indexes are deliberately *not* partial, the detector TTL index, and the unique constraints.
- **TTLs** — user solutions and stored captchas expire after four weeks, scheduled tasks after a week, and an unstaged captcha never expires because `storedAtTimestamp` is unset.
- **Record validation** — required fields, enum rejection, and the label fields staying empty until a human sets them.
- **Type tests** — the `IDatabase` contract (`getConnection()` returns a non-optional `Connection` even though `connection` is optional), the domain record shapes, `StoredSession` still being the very same type as `SessionRecord` after the schema merge, and which `UserAgentInfo` fields are guaranteed.

## Noted, not fixed

`PoWCaptchaRecordSchema.result.reason` sets `enum: TranslationKeysSchema.options`, but that list comes back **empty**, so the constraint is inert and any string is accepted. The cause is `getLeafFieldPath` in `@prosopo/locale`, which returns `[]` for a leaf and therefore drops every key. Fixing it would narrow `TranslationKey` from `string` to a real union and break callers across the repo, so it belongs in its own change to that package. A test pins the current behaviour with this explanation rather than asserting an enforcement that does not happen.