### PR TITLE
feat(provider): headHash into userScope on challenge endpoints

### DIFF
--- a/.changeset/session-headhash-in-userscope.md
+++ b/.changeset/session-headhash-in-userscope.md
@@ -1,0 +1,5 @@
+---
+"@prosopo/provider": patch
+---
+
+Populate `userScope.headHash` from the frictionless session record in the three captcha-challenge endpoints (`getPoWCaptchaChallenge`, `getImageCaptchaChallenge`, `getPuzzleCaptchaChallenge`). Previously all three hardcoded `undefined` for the headHash slot, so access-policy rules keyed on `headHash` could only take effect at server-verify time — after the challenge was already issued at the client-configured type / difficulty. With `sessionId` in hand each endpoint now does one indexed `getSessionRecordBySessionId` lookup and forwards `sessionRecord?.decryptedHeadHash` into `getRequestUserScope`, so headHash rules can restrict or adjust the challenge at issuance. No change when the request omits `sessionId` (direct-pow etc.).

--- a/packages/provider/src/api/captcha/getImageCaptchaChallenge.ts
+++ b/packages/provider/src/api/captcha/getImageCaptchaChallenge.ts
@@ -139,12 +139,21 @@ export default (
 					? req.ipInfo.asnNumber
 					: undefined;
 
+			// Pull decryptedHeadHash off the frictionless session so
+			// headHash-scoped access rules can match at challenge time —
+			// otherwise they can only fire at server-verify, after the
+			// challenge has already been issued with the client-configured
+			// image count / threshold.
+			const sessionRecord = sessionId
+				? await tasks.db.getSessionRecordBySessionId(sessionId)
+				: undefined;
+
 			const userScope = getRequestUserScope(
 				flatten(req.headers),
 				req.ja4,
 				normalizedIp,
 				user,
-				undefined, // headHash
+				sessionRecord?.decryptedHeadHash,
 				undefined, // coords
 				countryCode,
 				asn,

--- a/packages/provider/src/api/captcha/getPoWCaptchaChallenge.ts
+++ b/packages/provider/src/api/captcha/getPoWCaptchaChallenge.ts
@@ -105,12 +105,21 @@ export default (
 					? req.ipInfo.asnNumber
 					: undefined;
 
+			// Pull decryptedHeadHash off the frictionless session (indexed
+			// lookup on sessionId) so headHash-scoped access rules can match
+			// at challenge time — otherwise a rule keyed on the hash can only
+			// fire at server-verify, by which point the challenge has already
+			// been issued at the client-configured difficulty.
+			const sessionRecord = sessionId
+				? await tasks.db.getSessionRecordBySessionId(sessionId)
+				: undefined;
+
 			const userScope = getRequestUserScope(
 				flatten(req.headers),
 				req.ja4,
 				normalizedIp,
 				user,
-				undefined, // headHash
+				sessionRecord?.decryptedHeadHash,
 				undefined, // coords
 				countryCode,
 				asn,

--- a/packages/provider/src/api/captcha/getPuzzleCaptchaChallenge.ts
+++ b/packages/provider/src/api/captcha/getPuzzleCaptchaChallenge.ts
@@ -105,12 +105,18 @@ export default (
 					? req.ipInfo.asnNumber
 					: undefined;
 
+			// Pull decryptedHeadHash off the frictionless session so
+			// headHash-scoped access rules can match at challenge time.
+			const sessionRecord = sessionId
+				? await tasks.db.getSessionRecordBySessionId(sessionId)
+				: undefined;
+
 			const userScope = getRequestUserScope(
 				flatten(req.headers),
 				req.ja4,
 				normalizedIp,
 				user,
-				undefined, // headHash
+				sessionRecord?.decryptedHeadHash,
 				undefined, // coords
 				countryCode,
 				asn,


### PR DESCRIPTION
The three captcha-challenge endpoints hardcoded \`undefined\` for the \`headHash\` slot in \`getRequestUserScope\`, so access-policy rules keyed on head-hash could only fire at server-verify — after the challenge had already been issued at the client-configured type/difficulty. With \`sessionId\` in hand each endpoint now does one indexed \`getSessionRecordBySessionId\` lookup and forwards \`sessionRecord?.decryptedHeadHash\`.

- \`getPoWCaptchaChallenge\`
- \`getImageCaptchaChallenge\`
- \`getPuzzleCaptchaChallenge\`

No change when the request omits \`sessionId\` (direct-pow etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)