### PR TITLE
perf(procaptcha-bundle): collapse the i18n stack into one chunk

### DIFF
--- a/.changeset/flatten-i18n-chunk-waterfall.md
+++ b/.changeset/flatten-i18n-chunk-waterfall.md
@@ -1,0 +1,18 @@
+---
+"@prosopo/procaptcha-bundle": patch
+---
+
+Collapse the i18n stack into a single chunk.
+
+Left to split automatically it forms the longest serial chain in the widget's module graph. Measured on a staging demo load, each level costs a round trip because the browser cannot discover the next module until the previous one has parsed:
+
+```
+751 ms  translations
+877 ms  i18nFrontend
+919 ms  i18next
+983 ms  translation.json
+1029 ms captchaRenderer
+1057 ms ProviderApi        <- the chunk that issues detector/assign
+```
+
+The widget needs all of it before it can render a label, so splitting buys nothing and costs four round trips. One chunk is one round trip.

--- a/packages/procaptcha-bundle/vite.config.ts
+++ b/packages/procaptcha-bundle/vite.config.ts
@@ -169,6 +169,22 @@ export default defineConfig(async ({ command, mode }) => {
 						if (id.includes("packages/util-crypto/dist")) {
 							return sharedBrowserChunkName;
 						}
+						// Collapse the i18n stack into a single chunk. Left to split
+						// automatically it forms the longest serial chain in the
+						// graph — measured on a staging demo load, `translations`
+						// (751ms) -> `i18nFrontend` (877ms) -> `i18next` (919ms) ->
+						// `translation.json` (983ms) -> `captchaRenderer` (1029ms),
+						// each level costing a round trip because the browser cannot
+						// discover the next module until the previous one has parsed.
+						// One chunk is one round trip, and the widget needs all of it
+						// before it can render a label anyway.
+						if (
+							id.includes("i18next") ||
+							id.includes("packages/locale/dist") ||
+							id.includes("packages/i18n/dist")
+						) {
+							return "i18nChunk";
+						}
 						if (id.includes("@noble/hash") || id.includes("@noble/curves")) {
 							return "nobleChunk";
 						}


### PR DESCRIPTION
Left to split automatically, i18n forms the **longest serial chain** in the widget's module graph. Measured on a staging demo load with headless Chromium — each level is a round trip, because the browser cannot discover the next module until the previous one has parsed:

```
 466 ms  procaptcha.bundle.js
 632 ms  commonChunk / web2Chunk / theme / language
 727 ms  rolldown-runtime / utilChunk
 751 ms  translations        ┐
 877 ms  i18nFrontend        │ four round trips
 919 ms  i18next             │ for one thing
 983 ms  translation.json    ┘
1029 ms  captchaRenderer
1057 ms  ProviderApi          <- the chunk that issues detector/assign
1513 ms  detector/assign starts
```

The widget needs all of i18n before it can render a label, so splitting it buys nothing and costs four round trips on the critical path. One chunk is one round trip.

This is the third of three changes against the same measurement (staging 4928 ms vs production 1744 ms to a clickable checkbox); the others are prosopo/captcha#2971 and prosopo/captcha-private#4042.

### Verification status — please read

The build succeeds and the chunks collapse as intended (`i18nChunk-*.js` replaces `translations`, `i18nFrontend`, `i18next`, `translation.json`).

I have **not** verified runtime behaviour locally — my static-server harness failed to serve the bundle and I did not get a clean load test. That matters here specifically: the `util-crypto` rule immediately below this one documents a previous chunk merge in this graph producing an evaluation cycle, which presented as *"init_dist is not a function"* and the widget dying on load — **not** as a build error.

Cypress exercises the built bundle in a real browser, so it is the actual gate for this change. If it goes green this is safe; if it fails on widget init, that is the cycle and the merge needs narrowing (e.g. keeping `translation.json` separate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XJ7KiTDKiu3mxQ4iuLFK2y