### PR TITLE
fix(release): bump @prosopo/cli so the next release cuts 3.7.1

### DIFF
--- a/.changeset/bump-cli-for-3-7-1.md
+++ b/.changeset/bump-cli-for-3-7-1.md
@@ -1,0 +1,14 @@
+---
+"@prosopo/cli": patch
+---
+
+Bump `@prosopo/cli` so the next release cuts 3.7.1.
+
+`create_release_pr` derives the repo version from this package:
+
+```bash
+root_version=$(npm -w @prosopo/cli pkg get version | jq -r '.["@prosopo/cli"]')
+npm pkg set version="$root_version"
+```
+
+The changesets pending after v3.7.0 target `@prosopo/procaptcha-bundle`, `@prosopo/procaptcha-frictionless` and `@prosopo/client-bundle-example`. `@prosopo/cli` depends on none of them, so `changeset version` left it at 3.7.0 and the release re-cut 3.7.0 rather than 3.7.1.


### PR DESCRIPTION
The release run after v3.7.0 produced **3.7.0 again** rather than 3.7.1.

### Cause

`create_release_pr` derives the repo version from `@prosopo/cli`, not from the root package:

```bash
root_version=$(npm -w @prosopo/cli pkg get version | jq -r '.["@prosopo/cli"]')
npm pkg set version="$root_version"
```

The changesets pending after v3.7.0 target:

- `@prosopo/procaptcha-bundle`
- `@prosopo/procaptcha-frictionless`
- `@prosopo/client-bundle-example`

`@prosopo/cli` **depends on none of them**, and `.changeset/config.json` has `"fixed": []` / `"linked": []`, so nothing drags it along. `changeset version` bumped those three, left `cli` at 3.7.0, and the workflow copied 3.7.0 straight back into the root — a release that re-cut the same version.

No changeset has ever targeted the root `@prosopo/captcha` package, so this is the intended lever rather than a workaround.

### Fix

A patch changeset against `@prosopo/cli`, taking it to 3.7.1, which the workflow then copies into the root.

### After merging

Re-run `create_release_pr` and it should cut **3.7.1**, picking up the three already-pending changesets alongside this one — including prosopo/captcha#2971, the `detector/assign` prefetch.

Worth considering separately: if the repo version is meant to track the whole monorepo, deriving it from one leaf package will keep producing this whenever a release touches nothing `cli` depends on. Adding `@prosopo/cli` to `fixed` alongside the packages that should move together, or deriving the version from the root, would remove the footgun.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XJ7KiTDKiu3mxQ4iuLFK2y