### PR TITLE
fix(docker): tell ipinfo to use the mounted config, not the bundled default

### DIFF
--- a/docker/docker-compose.provider.yml
+++ b/docker/docker-compose.provider.yml
@@ -225,6 +225,12 @@ services:
     # IP metadata sidecar
     container_name: ipinfo
     image: prosopo/ipinfo:${IPINFO_VERSION:-0.1.0}
+    # Pass the config path explicitly. The image bakes a default config.json
+    # at /usr/src/app/config.json which getConfigPath() finds before the
+    # mounted /usr/src/app/config/config.json — silently ignoring our
+    # customLists and API key. Passing the path as argv[2] short-circuits
+    # that resolution order.
+    command: ["node", "src/ipapi_is_worker.js", "/usr/src/app/config/config.json"]
     # NET_ADMIN is required to check/create firewall chains, even when
     # enableFirewall is false in config.
     cap_add:


### PR DESCRIPTION
## Summary
`prosopo/ipinfo:0.1.0` ships a default `config.json` baked at `/usr/src/app/config.json`. The container's `getConfigPath()` walks parents from `src/` in this order:

```
1. /usr/src/app/src/config.json                (missing)
2. /usr/src/app/config.json                    ← BUNDLED, wins
3. /usr/src/app/config/config.json             ← MOUNTED, our real config
```

The bundled path preempts the mount. Container silently runs with `customLists: []` and `API_KEY: exampleApiKey` even when the mount is correct. Every IP comes back `is_proxy: false` from customLists, and any client using the real API key gets 401 mismatches against the bundled `exampleApiKey`.

## Fix
Add `command:` to override argv, passing the config path explicitly:

```yaml
command: ["node", "src/ipapi_is_worker.js", "/usr/src/app/config/config.json"]
```

`getConfigPath()` short-circuits when `process.argv[2]` is a valid path, skipping the parent-walking resolution entirely.

## Where this was discovered
Smoke-testing `prosopo/ipinfo-lists` customLists delivery against staging job-runner in prosopo/captcha-private#4046. Container was up, DB loaded, config.json mounted correctly — but customLists IPs still returned `is_proxy: false`. Root cause was the bundled default winning `getConfigPath()`.

## Sister fixes
Same problem, same fix already applied in:
- `docker/docker-compose.jobs.yml` (prosopo/captcha-private#4046)
- `crates/bumblebee/docker-compose.yml` (prosopo/Protect#393)
- `crates/optimus/docker-compose.yml` (prosopo/Protect#393)

This PR completes the set for provider (pronodes).

## Test plan
- [ ] Deploy to one staging pronode via `providerIpInfoRestart.yml`
- [ ] `docker exec ipinfo cat /proc/1/cmdline | tr '\0' ' '` — confirm the config path is passed
- [ ] Check `docker logs ipinfo` at `LOG_LEVEL=3` — should see `Config used: /usr/src/app/config/config.json` (not `.../config.json`)
- [ ] `curl "http://127.0.0.1:3899/?apiKey=<real-key>&q=<known-list-ip>"` returns `is_proxy: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)