### PR TITLE
fix(compose): add restart:unless-stopped to ipinfo and redis-stack

### DIFF
--- a/docker/docker-compose.provider.yml
+++ b/docker/docker-compose.provider.yml
@@ -177,6 +177,7 @@ services:
     container_name: redis-stack
     # unlike "redis/redis-stack-server" this image includes Insights
     image: redis/redis-stack:${REDIS_IMAGE}
+    restart: unless-stopped
     env_file:
       - ../.env.1.${NODE_ENV}
     volumes:
@@ -225,6 +226,7 @@ services:
     # IP metadata sidecar
     container_name: ipinfo
     image: prosopo/ipinfo:${IPINFO_VERSION:-0.1.0}
+    restart: unless-stopped
     # Pass the config path explicitly. The image bakes a default config.json
     # at /usr/src/app/config.json which getConfigPath() finds before the
     # mounted /usr/src/app/config/config.json — silently ignoring our


### PR DESCRIPTION
## Summary
- Every other core service in `docker/docker-compose.provider.yml` already has `restart: unless-stopped`; `ipinfo` and `redis-stack` were the only two without it.
- On pronode14 `ipinfo` exited with code 255 on 2026-08-03 03:38 UTC and sat down for ~37 hours before we noticed. Docker's default no-restart policy took over, and no ipinfo means no MaxMind lookups on that node — silently degrading detection quality.

## Test plan
- [ ] `docker compose ... config ipinfo` renders `restart: unless-stopped`
- [ ] `docker compose ... config redis-stack` renders `restart: unless-stopped`
- [ ] After next ansible deploy: `docker inspect ipinfo --format '{{.HostConfig.RestartPolicy.Name}}'` returns `unless-stopped` on every pronode
- [ ] Same check for redis-stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)