### PR TITLE
ci: select runners through the GH_RUNNER org variables

### DIFF
--- a/.github/workflows/auto-update-pr.yml
+++ b/.github/workflows/auto-update-pr.yml
@@ -37,7 +37,7 @@ defaults:
 
 jobs:
   update-stale-pr:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.GH_RUNNER || '"ubuntu-latest"') }}
     env:
       GH_TOKEN: ${{ secrets.PROSOPONATOR_PAT }}
       REPO: ${{ github.repository }}

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -27,7 +27,7 @@ defaults:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.GH_RUNNER || '"ubuntu-latest"') }}
     steps:
       - name: Print contexts
         uses: prosopo/github_actions/.github/actions/print_contexts@a8f2d18145fedb774d5aacbde7b617c6c8852475 # main

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -29,7 +29,7 @@ defaults:
 jobs:
   check:
     name: check
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.GH_RUNNER || '"ubuntu-latest"') }}
     # Skip if PR title starts with "Release v"
     if: ${{ !startsWith(github.event.pull_request.title, 'Release v') }}
     steps:

--- a/.github/workflows/create_release_pr.yml
+++ b/.github/workflows/create_release_pr.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   create-pr:
     name: Create Release PR
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.GH_RUNNER || '"ubuntu-latest"') }}
     steps:
       - name: Get token for gh app
         id: app_token

--- a/.github/workflows/cypress-baselines.yml
+++ b/.github/workflows/cypress-baselines.yml
@@ -36,7 +36,7 @@ defaults:
 
 jobs:
   regenerate:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.GH_RUNNER || '"ubuntu-latest"') }}
     steps:
       - name: Set NX_PARALLEL environment variable
         run: echo "NX_PARALLEL=$(nproc)" >> $GITHUB_ENV

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -35,7 +35,7 @@ defaults:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.GH_RUNNER || '"ubuntu-latest"') }}
     if: github.event.pull_request.draft == false
     steps:
       - name: Print contexts

--- a/.github/workflows/dependabot-changeset.yml
+++ b/.github/workflows/dependabot-changeset.yml
@@ -40,7 +40,7 @@ defaults:
 jobs:
   changeset:
     name: changeset
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.GH_RUNNER || '"ubuntu-latest"') }}
     if: ${{ github.actor == 'dependabot[bot]' }}
     env:
       BASE_REF: ${{ github.event.pull_request.base.ref }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,7 +32,7 @@ defaults:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.GH_RUNNER || '"ubuntu-latest"') }}
     if: github.event.pull_request.draft == false
     steps:
       - name: Print contexts

--- a/.github/workflows/pinned-versions.yml
+++ b/.github/workflows/pinned-versions.yml
@@ -31,7 +31,7 @@ defaults:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.GH_RUNNER || '"ubuntu-latest"') }}
     # Skip draft PRs, but still allow manual workflow_dispatch runs (where
     # github.event.pull_request is undefined).
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false

--- a/.github/workflows/provider_image.yml
+++ b/.github/workflows/provider_image.yml
@@ -33,7 +33,7 @@ defaults:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.GH_RUNNER || '"ubuntu-latest"') }}
     if: github.event.pull_request.draft == false
     steps:
       - name: Print contexts

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -29,7 +29,7 @@ env:
 jobs:
   publish:
     name: Publish Release
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.GH_RUNNER || '"ubuntu-latest"') }}
     steps:
       - name: Get token for gh app
         id: app_token

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ env:
 jobs:
   release:
     name: release
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.GH_RUNNER || '"ubuntu-latest"') }}
     steps:
       - name: Print contexts
         uses: prosopo/github_actions/.github/actions/print_contexts@a8f2d18145fedb774d5aacbde7b617c6c8852475 # main

--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -17,7 +17,7 @@ defaults:
 jobs:
   tag:
     name: Tag Release
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.GH_RUNNER || '"ubuntu-latest"') }}
     # Only run if PR was merged and title starts with "Release"
     if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.title, 'Release v')
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ defaults:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.GH_RUNNER || '"ubuntu-latest"') }}
     if: github.event.pull_request.draft == false
     steps:
       - name: Print contexts

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -33,7 +33,7 @@ defaults:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.GH_RUNNER || '"ubuntu-latest"') }}
     if: github.event.pull_request.draft == false
     steps:
       - name: Print contexts


### PR DESCRIPTION
Points every workflow's `runs-on` at an org variable instead of a hard-coded GitHub-hosted label, so capacity can be moved between GitHub-hosted and self-hosted runners without editing workflows.

- `runs-on: ${{ fromJSON(vars.GH_RUNNER || '"ubuntu-latest"') }}` — the value is JSON, so it is either a single label (`"ubuntu-latest"`) or a label set (`["self-hosted","linux","x64"]`)
- `GH_RUNNER_WINDOWS` / `GH_RUNNER_MACOS` for the non-Linux jobs
- the inline fallback keeps each workflow runnable if a variable is ever unset

Org variables are already set: `GH_RUNNER="ubuntu-24.04"`, `GH_RUNNER_WINDOWS="windows-latest"`, `GH_RUNNER_MACOS="macos-latest"`.

`ios-sdk.yml` keeps its `macos-15` pin — that is a deliberate Xcode-version pin, not a default.