### PR TITLE
fix(provider): remove the EADDRINUSE race in the integration suites

### DIFF
--- a/.changeset/provider-listen-await.md
+++ b/.changeset/provider-listen-await.md
@@ -1,0 +1,7 @@
+---
+"@prosopo/provider": patch
+---
+
+`startProviderApi` now resolves once the server is actually listening, and rejects if the bind fails. It previously returned the server straight from `.listen()`, which resolves before the socket is bound — a bind failure such as `EADDRINUSE` then surfaced as an `'error'` event with nothing waiting on it, i.e. an uncaught exception rather than a rejection the caller could handle.
+
+Integration suites reserve a port from the OS instead of guessing one. Six suites picked a port from `process.pid` plus a random offset with no availability check, while CI runs a real provider alongside the tests; a collision failed the whole run with an uncaught `EADDRINUSE` even though every test passed. The retry loops that tried to work around this are gone — they retried into another unchecked port and, because the failure was never a rejection, never ran at all.

--- a/packages/provider/src/api/startProviderApi.ts
+++ b/packages/provider/src/api/startProviderApi.ts
@@ -130,6 +130,21 @@ export const getUserFromJWT = (req: Request): string | undefined => {
 };
 
 /**
+ * `.listen()` returns before the socket is bound, so a bind failure such as
+ * EADDRINUSE arrives later as an 'error' event — an uncaught exception unless
+ * something is waiting on it. Settle on whichever event comes first so the
+ * caller gets a rejection it can handle.
+ */
+const awaitListening = (server: Server): Promise<void> =>
+	new Promise((resolve, reject) => {
+		server.once("error", reject);
+		server.once("listening", () => {
+			server.removeListener("error", reject);
+			resolve();
+		});
+	});
+
+/**
  * Start the Prosopo Provider API server
  *
  * This function creates and configures an Express server with all necessary middleware
@@ -436,19 +451,22 @@ export async function startProviderApi(
 			key: fs.readFileSync(keyPath),
 			cert: fs.readFileSync(crtPath),
 		};
-		const httpsServer = https.createServer(httpsOptions, apiApp);
-		return httpsServer.listen(apiPort, () => {
-			env.logger.info(() => ({
-				data: { apiPort, protocol: "https" },
-				msg: "Prosopo app listening with HTTPS",
-			}));
-		});
+		const httpsServer = https
+			.createServer(httpsOptions, apiApp)
+			.listen(apiPort);
+		await awaitListening(httpsServer);
+		env.logger.info(() => ({
+			data: { apiPort, protocol: "https" },
+			msg: "Prosopo app listening with HTTPS",
+		}));
+		return httpsServer;
 	}
 
-	return apiApp.listen(apiPort, () => {
-		env.logger.info(() => ({
-			data: { apiPort },
-			msg: "Prosopo app listening",
-		}));
-	});
+	const server = apiApp.listen(apiPort);
+	await awaitListening(server);
+	env.logger.info(() => ({
+		data: { apiPort },
+		msg: "Prosopo app listening",
+	}));
+	return server;
 }

--- a/packages/provider/src/tests/integration/decisionMachines.integration.test.ts
+++ b/packages/provider/src/tests/integration/decisionMachines.integration.test.ts
@@ -35,12 +35,7 @@ import {
 import { randomAsHex } from "@prosopo/util-crypto";
 import { GenericContainer, type StartedTestContainer } from "testcontainers";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-
-// Function to get a random available port
-function getRandomPort(): number {
-	// Use a random port in the range 10000-60000 to avoid conflicts
-	return Math.floor(Math.random() * 50000) + 10000;
-}
+import { reservePort } from "./testUtils.js";
 
 /**
  * Register a site key directly in the database using Tasks
@@ -77,9 +72,7 @@ describe("Decision Machine Database Integration Tests", () => {
 	let adminJwt: string;
 
 	beforeAll(async () => {
-		// Get a unique port for this test suite using a more unique identifier
-		// Use process.pid and timestamp to ensure uniqueness across parallel test runs
-		testPort = 20000 + (process.pid % 10000) + Math.floor(Math.random() * 5000);
+		testPort = await reservePort();
 		const protocol = isTlsAvailable() ? "https" : "http";
 		baseUrl = `${protocol}://localhost:${testPort}`;
 
@@ -217,79 +210,11 @@ describe("Decision Machine Database Integration Tests", () => {
 		);
 		adminJwt = adminPair.jwtIssue();
 
-		// Start the provider API server with retry logic
+		// Start the provider API server.
 		env.logger.info(() => ({
 			msg: `Starting provider API on port ${testPort}`,
 		}));
-
-		let retries = 0;
-		const maxRetries = 3;
-		while (retries < maxRetries) {
-			try {
-				server = await startProviderApi(env, true, testPort);
-
-				// Wait for server to be ready by checking if it's listening
-				await new Promise<void>((resolve, reject) => {
-					if (!server) {
-						reject(new Error("Server is not running."));
-						return;
-					}
-
-					const checkInterval = setInterval(() => {
-						if (server?.listening) {
-							clearInterval(checkInterval);
-							resolve();
-						}
-					}, 100);
-
-					// Timeout after 5 seconds
-					setTimeout(() => {
-						clearInterval(checkInterval);
-						if (!server?.listening) {
-							reject(
-								new Error("Server failed to start listening within timeout"),
-							);
-						}
-					}, 5000);
-				});
-
-				env.logger.info(() => ({
-					msg: `Provider API started successfully on port ${testPort}`,
-				}));
-				break;
-			} catch (error) {
-				retries++;
-				env.logger.warn(() => ({
-					msg: `Failed to start server (attempt ${retries}/${maxRetries})`,
-					err: error,
-				}));
-
-				// Close server if it was created but failed
-				if (server) {
-					await new Promise<void>((resolve) => {
-						server?.close(() => resolve());
-					});
-					server = undefined;
-				}
-
-				if (retries >= maxRetries) {
-					throw new Error(
-						`Failed to start server after ${maxRetries} attempts: ${error}`,
-					);
-				}
-
-				// Try a different port
-				testPort =
-					20000 + (process.pid % 10000) + Math.floor(Math.random() * 5000);
-				baseUrl = `${protocol}://localhost:${testPort}`;
-				env.logger.info(() => ({
-					msg: `Retrying with port ${testPort}`,
-				}));
-
-				// Wait before retrying
-				await new Promise((resolve) => setTimeout(resolve, 1000));
-			}
-		}
+		server = await startProviderApi(env, true, testPort);
 	}, 120_000);
 
 	afterAll(async () => {

--- a/packages/provider/src/tests/integration/escalationPeekBeforeConsume.integration.test.ts
+++ b/packages/provider/src/tests/integration/escalationPeekBeforeConsume.integration.test.ts
@@ -30,7 +30,7 @@ import {
 import { randomAsHex } from "@prosopo/util-crypto";
 import { GenericContainer, type StartedTestContainer } from "testcontainers";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
-import { testFetch } from "./testUtils.js";
+import { reservePort, testFetch } from "./testUtils.js";
 
 // Reproduces the production NO_SESSION_FOUND → INCORRECT_CAPTCHA_TYPE
 // follow-on bug. The /captcha/pow handler calls `isValidRequest`, which
@@ -50,7 +50,7 @@ describe("Escalation peek-before-consume integration test", () => {
 	let baseUrl: string;
 
 	beforeAll(async () => {
-		testPort = 30000 + (process.pid % 10000) + Math.floor(Math.random() * 5000);
+		testPort = await reservePort();
 		const protocol = isTlsAvailable() ? "https" : "http";
 		baseUrl = `${protocol}://localhost:${testPort}`;
 

--- a/packages/provider/src/tests/integration/imgCaptcha.integration.test.ts
+++ b/packages/provider/src/tests/integration/imgCaptcha.integration.test.ts
@@ -40,15 +40,10 @@ import { randomAsHex } from "@prosopo/util-crypto";
 import { GenericContainer, type StartedTestContainer } from "testcontainers";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { dummyUserAccount } from "./mocks/solvedTestCaptchas.js";
+import { reservePort } from "./testUtils.js";
 
 const solutions = datasetWithSolutionHashes;
 const userAccount = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty";
-
-// Function to get a random available port
-function getRandomPort(): number {
-	// Use a random port in the range 10000-60000 to avoid conflicts
-	return Math.floor(Math.random() * 50000) + 10000;
-}
 
 /**
  * Register a site key directly in the database using Tasks
@@ -85,9 +80,7 @@ describe("Image Captcha Integration Tests", () => {
 	let builtDataset: Awaited<ReturnType<typeof buildDataset>>;
 
 	beforeAll(async () => {
-		// Get a unique port for this test suite using a more unique identifier
-		// Use process.pid and timestamp to ensure uniqueness across parallel test runs
-		testPort = 40000 + (process.pid % 10000) + Math.floor(Math.random() * 5000);
+		testPort = await reservePort();
 		const protocol = isTlsAvailable() ? "https" : "http";
 		baseUrl = `${protocol}://localhost:${testPort}`;
 
@@ -194,80 +187,11 @@ describe("Image Captcha Integration Tests", () => {
 		await tasks.datasetManager.providerSetDataset(datasetWithSolutionHashes);
 		builtDataset = await buildDataset(datasetWithSolutionHashes);
 
-		// Start the provider API server with retry logic
-		// This mimics the CLI start functionality
+		// Start the provider API server. This mimics the CLI start functionality.
 		env.logger.info(() => ({
 			msg: `Starting provider API on port ${testPort}`,
 		}));
-
-		let retries = 0;
-		const maxRetries = 3;
-		while (retries < maxRetries) {
-			try {
-				server = await startProviderApi(env, true, testPort);
-
-				// Wait for server to be ready by checking if it's listening
-				await new Promise<void>((resolve, reject) => {
-					if (!server) {
-						reject(new Error("Server is not running."));
-						return;
-					}
-
-					const checkInterval = setInterval(() => {
-						if (server?.listening) {
-							clearInterval(checkInterval);
-							resolve();
-						}
-					}, 100);
-
-					// Timeout after 5 seconds
-					setTimeout(() => {
-						clearInterval(checkInterval);
-						if (!server?.listening) {
-							reject(
-								new Error("Server failed to start listening within timeout"),
-							);
-						}
-					}, 5000);
-				});
-
-				env.logger.info(() => ({
-					msg: `Provider API started successfully on port ${testPort}`,
-				}));
-				break;
-			} catch (error) {
-				retries++;
-				env.logger.warn(() => ({
-					msg: `Failed to start server (attempt ${retries}/${maxRetries})`,
-					err: error,
-				}));
-
-				// Close server if it was created but failed
-				if (server) {
-					await new Promise<void>((resolve) => {
-						server?.close(() => resolve());
-					});
-					server = undefined;
-				}
-
-				if (retries >= maxRetries) {
-					throw new Error(
-						`Failed to start server after ${maxRetries} attempts: ${error}`,
-					);
-				}
-
-				// Try a different port
-				testPort =
-					40000 + (process.pid % 10000) + Math.floor(Math.random() * 5000);
-				baseUrl = `${protocol}://localhost:${testPort}`;
-				env.logger.info(() => ({
-					msg: `Retrying with port ${testPort}`,
-				}));
-
-				// Wait before retrying
-				await new Promise((resolve) => setTimeout(resolve, 1000));
-			}
-		}
+		server = await startProviderApi(env, true, testPort);
 	}, 120_000);
 
 	beforeEach(async () => {

--- a/packages/provider/src/tests/integration/maintenanceModeAdmin.integration.test.ts
+++ b/packages/provider/src/tests/integration/maintenanceModeAdmin.integration.test.ts
@@ -52,6 +52,7 @@ import { randomAsHex } from "@prosopo/util-crypto";
 import { GenericContainer, type StartedTestContainer } from "testcontainers";
 import { Agent, fetch } from "undici";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { reservePort } from "./testUtils.js";
 
 interface AdminResponse {
 	status: ApiEndpointResponseStatus;
@@ -107,7 +108,7 @@ describe("Maintenance mode — admin endpoints stay available", () => {
 		// time by the handlers and (now) drives the background DB connect.
 		process.env.MAINTENANCE_MODE = "true";
 
-		testPort = 30000 + (process.pid % 10000) + Math.floor(Math.random() * 5000);
+		testPort = await reservePort();
 		const protocol = isTlsAvailable() ? "https" : "http";
 		baseUrl = `${protocol}://localhost:${testPort}`;
 		dispatcher = buildDispatcher();

--- a/packages/provider/src/tests/integration/powCaptcha.integration.test.ts
+++ b/packages/provider/src/tests/integration/powCaptcha.integration.test.ts
@@ -37,16 +37,11 @@ import { randomAsHex } from "@prosopo/util-crypto";
 import { GenericContainer, type StartedTestContainer } from "testcontainers";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { dummyUserAccount } from "./mocks/solvedTestCaptchas.js";
+import { reservePort } from "./testUtils.js";
 
 // Define the endpoint paths
 const getPowCaptchaChallengePath = ClientApiPaths.GetPowCaptchaChallenge;
 const userId = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty";
-
-// Function to get a random available port
-function getRandomPort(): number {
-	// Use a random port in the range 10000-60000 to avoid conflicts
-	return Math.floor(Math.random() * 50000) + 10000;
-}
 
 /**
  * Register a site key directly in the database using Tasks
@@ -122,9 +117,7 @@ describe("PoW Integration Tests", () => {
 	let baseUrl: string;
 
 	beforeAll(async () => {
-		// Get a unique port for this test suite using a more unique identifier
-		// Use process.pid and timestamp to ensure uniqueness across parallel test runs
-		testPort = 30000 + (process.pid % 10000) + Math.floor(Math.random() * 5000);
+		testPort = await reservePort();
 		const protocol = isTlsAvailable() ? "https" : "http";
 		baseUrl = `${protocol}://localhost:${testPort}`;
 
@@ -230,80 +223,11 @@ describe("PoW Integration Tests", () => {
 		env.logger.info(() => ({ msg: "Setting up provider dataset" }));
 		await tasks.datasetManager.providerSetDataset(datasetWithSolutionHashes);
 
-		// Start the provider API server with retry logic
-		// This mimics the CLI start functionality
+		// Start the provider API server. This mimics the CLI start functionality.
 		env.logger.info(() => ({
 			msg: `Starting provider API on port ${testPort}`,
 		}));
-
-		let retries = 0;
-		const maxRetries = 3;
-		while (retries < maxRetries) {
-			try {
-				server = await startProviderApi(env, true, testPort);
-
-				// Wait for server to be ready by checking if it's listening
-				await new Promise<void>((resolve, reject) => {
-					if (!server) {
-						reject(new Error("Server is not running."));
-						return;
-					}
-
-					const checkInterval = setInterval(() => {
-						if (server?.listening) {
-							clearInterval(checkInterval);
-							resolve();
-						}
-					}, 100);
-
-					// Timeout after 5 seconds
-					setTimeout(() => {
-						clearInterval(checkInterval);
-						if (!server?.listening) {
-							reject(
-								new Error("Server failed to start listening within timeout"),
-							);
-						}
-					}, 5000);
-				});
-
-				env.logger.info(() => ({
-					msg: `Provider API started successfully on port ${testPort}`,
-				}));
-				break;
-			} catch (error) {
-				retries++;
-				env.logger.warn(() => ({
-					msg: `Failed to start server (attempt ${retries}/${maxRetries})`,
-					err: error,
-				}));
-
-				// Close server if it was created but failed
-				if (server) {
-					await new Promise<void>((resolve) => {
-						server?.close(() => resolve());
-					});
-					server = undefined;
-				}
-
-				if (retries >= maxRetries) {
-					throw new Error(
-						`Failed to start server after ${maxRetries} attempts: ${error}`,
-					);
-				}
-
-				// Try a different port
-				testPort =
-					30000 + (process.pid % 10000) + Math.floor(Math.random() * 5000);
-				baseUrl = `${protocol}://localhost:${testPort}`;
-				env.logger.info(() => ({
-					msg: `Retrying with port ${testPort}`,
-				}));
-
-				// Wait before retrying
-				await new Promise((resolve) => setTimeout(resolve, 1000));
-			}
-		}
+		server = await startProviderApi(env, true, testPort);
 	}, 120_000);
 
 	afterAll(async () => {

--- a/packages/provider/src/tests/integration/routingDecisionMachines.integration.test.ts
+++ b/packages/provider/src/tests/integration/routingDecisionMachines.integration.test.ts
@@ -33,7 +33,7 @@ import {
 } from "@prosopo/types";
 import { randomAsHex } from "@prosopo/util-crypto";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { testFetch } from "./testUtils.js";
+import { reservePort, testFetch } from "./testUtils.js";
 
 const REDIS_URL = process.env.REDIS_CONNECTION_URL ?? "redis://localhost:6379";
 const REDIS_PASSWORD = process.env.REDIS_CONNECTION_PASSWORD ?? "root";
@@ -59,7 +59,7 @@ describe("Routing Decision Machines (live local Mongo + Redis)", () => {
 	let adminJwt: string;
 
 	beforeAll(async () => {
-		testPort = 20000 + (process.pid % 10000) + Math.floor(Math.random() * 5000);
+		testPort = await reservePort();
 		const protocol = isTlsAvailable() ? "https" : "http";
 		baseUrl = `${protocol}://localhost:${testPort}`;
 

--- a/packages/provider/src/tests/integration/testUtils.ts
+++ b/packages/provider/src/tests/integration/testUtils.ts
@@ -12,7 +12,32 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { createServer } from "node:net";
 import { Agent } from "undici";
+
+/**
+ * Reserve a port the OS says is free, rather than guessing one.
+ *
+ * The suites need a port before the ProviderEnvironment is built (it goes into
+ * the config and the base URL), so they cannot bind :0 on the real server and
+ * read it back afterwards. Binding :0 on a throwaway socket gets the same
+ * guarantee up front — the kernel avoids ports currently in use, including the
+ * provider CI starts alongside the tests.
+ */
+export const reservePort = (): Promise<number> =>
+	new Promise((resolve, reject) => {
+		const probe = createServer();
+		probe.once("error", reject);
+		probe.listen(0, () => {
+			const address = probe.address();
+			if (typeof address !== "object" || address === null) {
+				probe.close();
+				reject(new Error("could not determine a free port"));
+				return;
+			}
+			probe.close(() => resolve(address.port));
+		});
+	});
 
 // Create an Agent that ignores certificate validation for integration tests
 // This is needed because integration tests connect to https://localhost with self-signed certificates

--- a/packages/provider/src/tests/integration/testUtils.unit.test.ts
+++ b/packages/provider/src/tests/integration/testUtils.unit.test.ts
@@ -1,0 +1,59 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { type Server, createServer } from "node:net";
+import { afterEach, describe, expect, it } from "vitest";
+import { reservePort } from "./testUtils.js";
+
+const open: Server[] = [];
+
+const listenOn = (port: number): Promise<Server> =>
+	new Promise((resolve, reject) => {
+		const server = createServer();
+		server.once("error", reject);
+		server.listen(port, () => {
+			open.push(server);
+			resolve(server);
+		});
+	});
+
+afterEach(async () => {
+	await Promise.all(
+		open.splice(0).map(
+			(server) =>
+				new Promise<void>((resolve) => {
+					server.close(() => resolve());
+				}),
+		),
+	);
+});
+
+describe("reservePort", () => {
+	it("returns a port that is free to bind", async () => {
+		const port = await reservePort();
+
+		await expect(listenOn(port)).resolves.toBeDefined();
+	});
+
+	it("never hands out a port that is already in use", async () => {
+		const taken = await reservePort();
+		await listenOn(taken);
+
+		const subsequent = await Promise.all(
+			Array.from({ length: 20 }, () => reservePort()),
+		);
+
+		expect(subsequent).not.toContain(taken);
+	});
+});


### PR DESCRIPTION
## The flake

Seen on #3001, and it can hit any PR:

```
Test Files  13 passed (13)
      Tests  66 passed (66)
Type Errors  no errors
      Errors  1 error

Error: listen EADDRINUSE: address already in use :::40716
 ❯ startProviderApi src/api/startProviderApi.ts:440:22
 ❯ src/tests/integration/powCaptcha.integration.test.ts:243:14
```

Every test passed; the job still exited 1 because Vitest counts the uncaught exception. Two independent causes.

**1. `startProviderApi` never awaited the bind.** It returned the server straight out of `.listen()`, which resolves before the socket is bound. A bind failure therefore arrives later as an `'error'` event on the server with nothing listening for it — an uncaught exception, not a rejection. That is also why the suites' own `try/catch` retry loops never fired: there was never anything to catch.

**2. Six integration suites guessed their port.** `testPort = 30000 + (process.pid % 10000) + Math.floor(Math.random() * 5000)` with no availability check, while the same CI job runs a real provider from `npm run start:provider`. `getRandomPort()` sat alongside it in three files as dead code — declared, never called.

## The fix

- `startProviderApi` awaits `listening` and rejects on `error`, so a bind failure is a normal rejection the caller can handle.
- New `reservePort()` in `tests/integration/testUtils.ts` binds `:0` on a throwaway socket and returns the port the kernel picked. The suites need the port before the `ProviderEnvironment` is built (it goes into the config and the base URL), so they can't bind `:0` on the real server and read it back afterwards — this gets the same guarantee up front.
- The three retry loops are deleted. With a reserved port and an honest promise they are dead weight, and as written they retried into another unchecked port anyway.

Net **−183 lines**.

## Tests

`testUtils.unit.test.ts` covers `reservePort()`: the port it returns is bindable, and it never hands back a port already in use (reserve, bind it, then reserve 20 more and assert none collide) — the exact collision this flake was.

Full provider unit suite green: **990 tests, 71 files, no type errors**. The integration suites need Docker and run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYTuagg8yqWK3VevMtJbxm