### PR TITLE
chore(oo): single instance per host and drop Vector self-metrics

### DIFF
--- a/docker/docker-compose.oo1.yml
+++ b/docker/docker-compose.oo1.yml
@@ -60,32 +60,6 @@ services:
             - 8.8.8.8
             - 1.1.1.1
             - 208.67.222.222
-    oo2:
-        container_name: oo2
-        profiles:
-            - production
-            - staging
-        image: public.ecr.aws/zinclabs/openobserve:latest
-        ports:
-            - "5081:5080"
-        env_file:
-            - ../.env.${NODE_ENV}
-        labels:
-            - "oo.docker=true" # log docker events
-        restart: unless-stopped # unless the container has been stopped, it will be restarted, even on reboot
-        volumes:
-            - /data/oo:/data
-        networks:
-            - internal
-        logging:
-            driver: 'json-file'
-            options:
-                max-size: '100m'
-                max-file: '1'
-        dns:
-            - 8.8.8.8
-            - 1.1.1.1
-            - 208.67.222.222
 networks:
     internal:
         name: internal

--- a/docker/images/vector/src/vector.toml
+++ b/docker/images/vector/src/vector.toml
@@ -911,26 +911,6 @@ source = '''
 '''
 
 # =============================================================================
-# VECTOR INTERNAL METRICS
-# =============================================================================
-
-# Source: Collect Vector's own internal metrics
-# Includes performance metrics, error rates, and pipeline statistics
-[sources.vector_metrics]
-type = "internal_metrics"
-scrape_interval_secs = 30
-
-# Transform: Add host and environment tags to Vector metrics
-# Helps monitor Vector's health and performance across different environments
-[transforms.vector_metrics_format]
-type = "remap"
-inputs = ["vector_metrics"]
-source = '''
-.tags.host=get_env_var!("OO_HOST")
-.tags.env=get_env_var!("NODE_ENV")
-'''
-
-# =============================================================================
 # CADVISOR CONTAINER METRICS
 # =============================================================================
 
@@ -1020,7 +1000,7 @@ source = '''
 # Uses Prometheus Remote Write protocol for efficient metric transmission
 [sinks.oo_metrics]
 type = "prometheus_remote_write"
-inputs = ["host_metrics_format", "vector_metrics_format", "cadvisor_metrics_format", "mongodb_metrics_format", "redis_metrics_format", "caddy_metrics_format"]
+inputs = ["host_metrics_format", "cadvisor_metrics_format", "mongodb_metrics_format", "redis_metrics_format", "caddy_metrics_format"]
 endpoint = "https://oo.prosopo.io/api/dev_organization_29569_u24VnjrjN7XrP35/prometheus/api/v1/write"
 
 [sinks.oo_metrics.auth]
@@ -1047,7 +1027,7 @@ when_full = "drop_newest"
 # Backup destination for metrics redundancy and disaster recovery
 [sinks.oo2_metrics]
 type = "prometheus_remote_write"
-inputs = ["host_metrics_format", "vector_metrics_format", "cadvisor_metrics_format", "mongodb_metrics_format", "redis_metrics_format", "caddy_metrics_format"]
+inputs = ["host_metrics_format", "cadvisor_metrics_format", "mongodb_metrics_format", "redis_metrics_format", "caddy_metrics_format"]
 endpoint = "https://oo2.prosopo.io/api/default/prometheus/api/v1/write"
 
 [sinks.oo2_metrics.auth]

--- a/docker/oo1.Caddyfile
+++ b/docker/oo1.Caddyfile
@@ -48,13 +48,8 @@
 			log_key
 		}
 
-		# reverse proxy to the provider container
-		reverse_proxy {$CADDY_OO_CONTAINER_NAME:oo1}:{$CADDY_OO_PORT:5080} {$CADDY_OO_CONTAINER_NAME:oo2}:{$CADDY_OO_PORT2:5081} {
-            lb_policy first
-            lb_try_duration 3s
-            lb_try_interval 1s
-            fail_duration 20s
-		}
+		# reverse proxy to the openobserve container
+		reverse_proxy {$CADDY_OO_CONTAINER_NAME:oo1}:{$CADDY_OO_PORT:5080}
 	}
 
 	log {


### PR DESCRIPTION
## Summary

- `oo1.prosopo.io` and `oo2.prosopo.io` are separate machines, but `docker-compose.oo1.yml` was starting **both** an `oo1` and an `oo2` container on the same host, sharing `/data/oo`. Two openobserve processes were racing each other over the same WAL and parquet tree, doubling CPU and disk writes on tiger-stairs. Caddy's fallback upstream also targeted `oo2:5081`, but 5081 is the host-side mapping — the container listens on 5080 internally, so the fallback never actually worked.
- Simplified `oo1.Caddyfile` `reverse_proxy` to a single upstream (`oo1:5080`), no `lb_policy` block.
- Removed Vector's `internal_metrics` source + transform from `vector.toml`, and stripped `vector_metrics_format` from both `prometheus_remote_write` sink `inputs` arrays. Vector fans every histogram bucket into its own Prometheus series → its own OpenObserve stream; this was responsible for ~1,000 low-value metric streams that dominated metastore size and compaction cost.

Only Vector's *metrics* pipeline is affected. All log pipelines (provider, mongo, caddy, redis, docker events, Vector's own `internal_logs`) are untouched. Host / cAdvisor / Redis / Mongo / Caddy exporter metrics still ship as before.

## Test plan

- [ ] `docker compose -f captcha/docker/docker-compose.oo1.yml --profile production config` parses cleanly
- [ ] Deploy on tiger-stairs (oo1 host): only `oo1` + `caddy` come up; `oo.prosopo.io` still serves the UI and ingest endpoints
- [ ] Vector agent on a provider restarts cleanly with the new config; log pipelines still land in the expected `*_provider_*` streams in OpenObserve
- [ ] No new `vector_*` metric streams created after the Vector image is rolled out to a provider

🤖 Generated with [Claude Code](https://claude.com/claude-code)