### PR TITLE
fix(frictionless): report why the detector bundle was unavailable

### DIFF
--- a/.changeset/detector-import-failure-visibility.md
+++ b/.changeset/detector-import-failure-visibility.md
@@ -1,0 +1,25 @@
+---
+"@prosopo/procaptcha-frictionless": patch
+"@prosopo/procaptcha-bundle": patch
+---
+
+Report why the detector was unavailable instead of swallowing it.
+
+`customDetectBot` wraps provider selection, the assign request and the blob-URL
+import in one `try`, and the `catch` was empty. Falling back is correct — there
+is no bundled detector, so a failure here means the frictionless POST goes out
+with an empty token and the provider decides what to serve. But the reasons are
+not equal: a slow network is routine, whereas a pool bundle that throws on
+import degrades **every** session on that provider to an image captcha, with
+nothing in the client console or the provider logs to say why.
+
+That is not hypothetical. A detector pool built at catcher 3.1.48 emitted
+bundles that died on evaluation with `Class constructor D cannot be invoked
+without 'new'` — an obfuscator seed collision that renamed a class over a live
+binding. Every staging session silently fell back to an image captcha, and the
+only way to find it was to reproduce the blob import by hand in a browser: the
+provider logged a healthy `bundle pool loaded count=20` and served the bundles
+happily, because from its side nothing had failed.
+
+The catch stays broad and the fallback is unchanged; it now `console.error`s
+what it caught, matching how the sibling `procaptcha-common` modules report.

--- a/packages/procaptcha-frictionless/src/customDetectBot.ts
+++ b/packages/procaptcha-frictionless/src/customDetectBot.ts
@@ -235,8 +235,21 @@ const customDetectBot: BotDetectionFunction = async (
 			providerDetect = await DetectorLoaderFromScript(assigned.detectorScript);
 			detectorSessionId = assigned.detectorSessionId;
 		}
-	} catch {
+	} catch (err) {
 		// No detector available — fall through to the PoW request below.
+		//
+		// Report it. Falling back is by design, but the reasons are not equal: a
+		// slow network is routine, whereas a bundle that throws on import means
+		// every session on this provider silently degrades to an image captcha
+		// with nothing in the client or provider logs to say why. That failure
+		// mode shipped undetected once already — an obfuscator seed emitted a
+		// bundle that died with "Class constructor X cannot be invoked without
+		// 'new'", and the only way to see it was to reproduce the import by hand.
+		// The catch stays broad; it just no longer hides what it caught.
+		console.error(
+			"Procaptcha: no detector bundle available, falling back to a server-chosen captcha:",
+			err,
+		);
 	}
 
 	const ExtClass = await extClassPromise;


### PR DESCRIPTION
## Summary

`customDetectBot` wraps provider selection, the assign request and the blob-URL detector import in a single `try`, and the `catch` was empty. Falling back is correct — the widget carries no bundled detector, so the frictionless POST goes out with an empty token and the provider decides what to serve. But the reasons are not equal:

- a slow network or an empty pool is routine
- a pool bundle that **throws on evaluation** degrades *every* session on that provider to an image captcha

The second case was completely invisible. The provider logs `bundle pool loaded count=20` and serves the bundles happily — from its side nothing failed — and the client printed nothing at all.

## How it surfaced

A detector pool built at catcher `3.1.48` produced bundles that died on import with:

```
TypeError: Class constructor D cannot be invoked without 'new'
```

an obfuscator seed collision that renamed a class over a live binding. Every staging session fell back to an image captcha. Diagnosing it meant reproducing the blob import by hand in a browser, because the only observable symptom was `"token":""` and a missing `detectorSessionId` on the frictionless request.

The build-side fix (verifying each pool bundle actually imports) is in captcha-private. This PR is the other half: making the client say when it has no detector and why.

## Changes

- `catch {}` → `catch (err)` with a `console.error`, matching how the sibling `procaptcha-common` modules report failures.
- Fallback behaviour is unchanged and the catch stays deliberately broad.

## Test plan

- [x] `npm run -w @prosopo/procaptcha-frictionless build:tsc`
- [x] Verified against a real staging session: with broken bundles the message names the class-constructor TypeError; with fixed bundles the path is not taken and a real encrypted token is sent.
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EHQkKUZFkBZdBXk9ps1C6W
