### PR TITLE
chore: bump @prosopo/cli so 3.7.3 can be released

### DIFF
--- a/.changeset/release-3-7-3-version-carrier.md
+++ b/.changeset/release-3-7-3-version-carrier.md
@@ -1,0 +1,25 @@
+---
+"@prosopo/cli": patch
+---
+
+Bump `@prosopo/cli` so the frictionless detector-logging fix can ship as a release.
+
+There is no cli change here. This exists purely to move the release number, and
+the reason is structural rather than incidental.
+
+`create_release_pr` sets the root and `docker/images/provider` versions to
+whatever `@prosopo/cli` is after `changeset version`. The only pending changeset
+bumps `@prosopo/procaptcha-frictionless` (2.13.2 → 2.13.3) and
+`@prosopo/procaptcha-bundle` (4.1.46 → 4.1.47). Neither is in cli's dependency
+tree — cli depends on `@prosopo/provider`, `api`, `types` and friends, which is
+why ordinary releases bump it by cascade and this one does not. So
+`changeset version` leaves cli, and therefore the root, at 3.7.2, the release PR
+comes out titled "Release v3.7.2" again, and no new tag is cut.
+
+That matters beyond a cosmetic version number, because captcha-private's own
+`create_release_pr` derives its version from this repo's latest `v*.*.*` tag and
+then **checks the submodule out at it**. Without a new tag it would pin the
+submodule back to v3.7.2 — reverting the very fix this release is meant to carry.
+
+The provider image published for this release is therefore functionally
+identical to 3.7.2; the payload is the widget bundle.


### PR DESCRIPTION
## Summary

Adds a `@prosopo/cli` patch changeset so 3.7.3 can actually be cut. **There is no cli code change** — this exists solely to move the release number, and the need for it is structural.

## Why it's needed

`create_release_pr` sets the root and `docker/images/provider` versions to whatever `@prosopo/cli` is *after* `changeset version`:

```bash
root_version=$(npm -w @prosopo/cli pkg get version | jq -r '.["@prosopo/cli"]')
npm pkg set version="$root_version"
```

The only changeset pending on `main` bumps `@prosopo/procaptcha-frictionless` and `@prosopo/procaptcha-bundle` (from #3005). Neither is in cli's dependency tree — cli depends on `@prosopo/provider`, `api`, `types` and friends, which is why ordinary releases bump it by cascade and this one doesn't.

Simulated `changeset version` against `main` in a throwaway worktree:

| package | before → after |
|---|---|
| `@prosopo/procaptcha-bundle` | 4.1.46 → 4.1.47 |
| `@prosopo/procaptcha-frictionless` | 2.13.2 → 2.13.3 |
| `@prosopo/cli` | 3.7.2 → **unchanged** |
| root | 3.7.2 → **unchanged** |

So the release PR would come out titled "Release v3.7.2" again and **no new tag would be cut**.

That matters beyond a cosmetic version number. captcha-private's own `create_release_pr` derives its version from this repo's latest `v*.*.*` tag and then **checks the submodule out at that tag**. With no v3.7.3, it would pin the submodule back to v3.7.2 — reverting the very fix the release is meant to carry.

## Verification

Simulated the full workflow sequence on this branch:

```
changeset version           → @prosopo/cli 3.7.2 → 3.7.3
root_version resolution     → 3.7.3
npm pkg set version         → root 3.7.3, docker/images/provider 3.7.3
```

## Note for the reviewer

The provider image published for 3.7.3 will be **functionally identical to 3.7.2** — no server-side code changed. The payload of this release is the widget bundle (`procaptcha-bundle` 4.1.47), which carries the detector-import failure logging from #3005.

## Release sequence after this merges

1. `create_release_pr` here → "Release v3.7.3" → merge → `tag_release` cuts `v3.7.3` → `publish_release`
2. `create_release_pr` in captcha-private, which will now find `v3.7.3` as the latest tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EHQkKUZFkBZdBXk9ps1C6W
