### PR TITLE
fix(database): include bundleId in getSessionRecordBySessionId projection

### DIFF
--- a/.changeset/session-projection-bundleid.md
+++ b/.changeset/session-projection-bundleid.md
@@ -1,0 +1,9 @@
+---
+"@prosopo/database": patch
+---
+
+Include `bundleId` in the `getSessionRecordBySessionId` projection.
+
+`bundleId` was added to `SessionRecordSchema` for the per-session detector pool but never added to the projection. `CaptchaManager.resolveBundleBySessionId` reads it via `getSessionRecordBySessionId` on every pow / puzzle / image submit whenever the Redis session cache misses, so the fallback returned `undefined` even though the record on disk carried a valid bundleId. Downstream `decryptBehavioralData` and `decryptSimdReadings` then dropped their payloads, so `pow.behavioralDataPacked`, `pow.deviceCapability`, and `session.simdReadings` were persisted at ~0% fleet-wide.
+
+Regression test extends `sessionRecordProjection.integration.test.ts` to seed and read back a `bundleId`.

--- a/packages/database/src/databases/provider.ts
+++ b/packages/database/src/databases/provider.ts
@@ -1716,6 +1716,7 @@ export class ProviderDatabase
 				solvedImagesCount: 1,
 				userSitekeyIpHash: 1,
 				simdReadings: 1,
+				bundleId: 1,
 				dnsEvent: 1,
 				currentUrl: 1,
 				iframeUrl: 1,

--- a/packages/database/src/tests/integration/sessionRecordProjection.integration.test.ts
+++ b/packages/database/src/tests/integration/sessionRecordProjection.integration.test.ts
@@ -219,6 +219,34 @@ describe("getSessionRecordBySessionId projection", () => {
 		).resolves.toBeDefined();
 	});
 
+	// Regression for the 2026-08-06 deploy: `bundleId` was added to
+	// SessionRecordSchema for the per-session detector pool but not to the
+	// projection here. `resolveBundleBySessionId` reads it on the pow /
+	// puzzle / image submit path to resolve the decrypt bundle; on a Redis
+	// cache miss the DB fallback returned `undefined` even though the
+	// session record on disk carried a valid bundleId, so every subsequent
+	// `decryptBehavioralData` / `decryptSimdReadings` failed at the bundle
+	// resolve step and both fields were dropped fleet-wide.
+	it("returns bundleId so resolveBundleBySessionId can decrypt behavioural data", async () => {
+		const sessionId = "session-bundleid-roundtrip";
+		await db.tables.session.create({
+			sessionId,
+			createdAt: new Date(),
+			token: "tok-bundleid",
+			score: 0.1,
+			threshold: 0.5,
+			scoreComponents: { baseScore: 0.1 },
+			ipAddress: ipv4Composite(16843009n),
+			captchaType: CaptchaType.pow,
+			webView: false,
+			iFrame: false,
+			bundleId: "bundle-42",
+		});
+
+		const got = await db.getSessionRecordBySessionId(sessionId);
+		expect(got?.bundleId).toBe("bundle-42");
+	});
+
 	// Schema-contract guard: any field marked `required: true` on
 	// SessionRecordSchema must be present in the projection — otherwise
 	// callers like buildEscalation that forward the field into a new


### PR DESCRIPTION
## Summary
- Add `bundleId: 1` to the `getSessionRecordBySessionId` Mongoose projection. The field was added to `SessionRecordSchema` for the per-session detector pool but never added to the projection, so `resolveBundleBySessionId` returned `undefined` on every Redis session-cache miss even though the record on disk carried a valid bundleId.
- Downstream `decryptBehavioralData` and `decryptSimdReadings` were consequently no-oping fleet-wide (~0% persist rate for `pow.behavioralDataPacked`, `pow.deviceCapability`, and `session.simdReadings` on submit).
- Extend the existing `sessionRecordProjection.integration.test.ts` with a focused test that seeds and reads back a `bundleId`.

## Test plan
- [ ] `npm run -w @prosopo/database build:tsc`
- [ ] `npm run -w @prosopo/database test -- sessionRecordProjection.integration`
- [ ] Post-deploy: OO count of `"No detector bundle resolved for behavioral data — dropping field"` on `production_provider_node` falls toward zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)