### PR TITLE
fix(provider): session captchaType wins over restrict-policy at /captcha/{type} gate

### DIFF
--- a/.changeset/session-captcha-type-precedence.md
+++ b/.changeset/session-captcha-type-precedence.md
@@ -1,0 +1,17 @@
+---
+"@prosopo/provider": patch
+---
+
+fix(provider): session captchaType takes precedence over restrict-policy captchaType at `/captcha/{type}` gate
+
+`isValidRequest` was rejecting `/captcha/{type}` calls whenever an active restrict-to-image rule pinned a different captchaType from the one the widget requested — even when a valid session existed that had been minted legitimately before the rule appeared. The check ran before the sessionId lookup, so any anomaly detector inserting a rule between the widget's `/frictionless` response and its `/captcha/pow` call surfaced as `INCORRECT_CAPTCHA_TYPE` (400).
+
+Observed impact: ~150/hr fleet-wide, concentrated on pimeyes / eyematch / …RsJ2zsy39, with the `IP_CLIENT_CROSSOVER` detector as the most common trigger (24h aggregation, restrict-to-image, global clientId).
+
+Fix: session record is authoritative for captchaType when a sessionId is present. The policy still fires at verify time via `decisionMachineRunner` + `checkForHardBlock`. Sessionless requests still enforce the policy captchaType (preserves the pre-fix behaviour for direct-entry callers).
+
+Regression guards added to `captchaManager.unit.test.ts`:
+- session's captchaType wins when a restrict policy materialises mid-flight
+- session with mismatched captchaType still rejects (not the policy-race case)
+- sessionless request still rejected on policy captchaType mismatch
+- sessionless request with matching policy captchaType passes

--- a/packages/provider/src/tasks/captchaManager.ts
+++ b/packages/provider/src/tasks/captchaManager.ts
@@ -297,32 +297,28 @@ export class CaptchaManager {
 			},
 		}));
 
-		// User Access Policies override default behaviour. Only enforce the
-		// captchaType check when the policy actually pins a captchaType —
-		// Block policies have their captchaType stripped by
-		// sanitizeAccessPolicy on write, and a policy without a pinned
-		// captchaType should apply to all captcha types (not reject all of
-		// them). Callers should filter out `deferToVerify` policies before
-		// passing them here — see getImageCaptchaChallenge et al. — but
-		// this defensive guard also stops a mis-filtered deferToVerify
-		// Block from breaking every /captcha/* request.
-		if (
-			userAccessPolicy?.captchaType !== undefined &&
-			userAccessPolicy.captchaType !== requestedCaptchaType
-		) {
-			this.logger.warn(() => ({
-				msg: "Invalid captcha type for user access policy",
-				data: {
-					account: clientSettings.account,
-					captchaType: userAccessPolicy.captchaType,
-				},
-			}));
-			return {
-				valid: false,
-				reason: ResultReason.INCORRECT_CAPTCHA_TYPE,
-				type: requestedCaptchaType,
-			};
-		}
+		// User Access Policies override default behaviour, but only for
+		// sessionless requests. When a sessionId is present the session record
+		// is authoritative for captchaType: it was minted by frictionless /
+		// handleAccessPolicy considering the policy state at that time, so a
+		// policy that materialises AFTER a valid session was issued must not
+		// invalidate the widget's in-flight solve. The policy still fires at
+		// verify time (decisionMachineRunner + checkForHardBlock), so the
+		// abuse signal is not lost — only the false-positive
+		// INCORRECT_CAPTCHA_TYPE on the widget's second call is avoided.
+		//
+		// Historical shape (removed 2026-08-06): the check ran up here BEFORE
+		// the sessionId lookup, so any restrict-to-image rule inserted by an
+		// anomaly detector between /frictionless and /captcha/pow surfaced
+		// as a sustained baseline of INCORRECT_CAPTCHA_TYPE 400s. The
+		// specific race is captured in captchaManager.unit.test.ts under
+		// "user access policy precedence over session".
+		//
+		// Block policies have their captchaType stripped by sanitizeAccessPolicy
+		// on write, and a policy without a pinned captchaType applies to all
+		// captcha types (not rejects all of them). deferToVerify policies are
+		// filtered by callers — see getImageCaptchaChallenge et al.
+		//
 		// Session ID
 		// All client flows now go through the unified /frictionless entry point,
 		// so a sessionId may accompany any configured captchaType (frictionless
@@ -534,6 +530,31 @@ export class CaptchaManager {
 		}
 
 		// No Session ID
+
+		// Sessionless request: policy captchaType (if pinned by an active
+		// restrict rule) still takes precedence over the client's configured
+		// captchaType, because there's no minted-in-context session to trust.
+		// This preserves the pre-2026-08-06 behaviour for the direct-entry
+		// case (widget hitting /captcha/{type} without going through
+		// /frictionless first).
+		if (
+			userAccessPolicy?.captchaType !== undefined &&
+			userAccessPolicy.captchaType !== requestedCaptchaType
+		) {
+			this.logger.warn(() => ({
+				msg: "Invalid captcha type for user access policy (sessionless)",
+				data: {
+					account: clientSettings.account,
+					captchaType: userAccessPolicy.captchaType,
+					requestedCaptchaType,
+				},
+			}));
+			return {
+				valid: false,
+				reason: ResultReason.INCORRECT_CAPTCHA_TYPE,
+				type: requestedCaptchaType,
+			};
+		}
 
 		// To pass here a user must be requesting the captchaType that is stored on the client's settings.
 		// - If `captchaType` is `image` and there is no `sessionId` then `clientSettings?.settings?.captchaType,` must be set to `image`

--- a/packages/provider/src/tests/unit/tasks/captchaManager.unit.test.ts
+++ b/packages/provider/src/tests/unit/tasks/captchaManager.unit.test.ts
@@ -1056,6 +1056,147 @@ describe("CaptchaManager", () => {
 				sessionId: "sessionId",
 			});
 		});
+
+		// Regression guard for the class of INCORRECT_CAPTCHA_TYPE errors
+		// observed on prod at ~150/hr, concentrated on pimeyes / eyematch /
+		// 5G1hy. An anomaly detector inserts an IP restrict-to-image rule
+		// (e.g. IP_CLIENT_CROSSOVER) between the user's /frictionless response
+		// and their subsequent /captcha/pow call, so the widget's in-flight
+		// pow-typed session gets 400'd at the /captcha/pow entry gate even
+		// though the session was minted legitimately before the rule appeared.
+		//
+		// The fix: when a valid sessionId is present, the session record is
+		// authoritative for captchaType. The policy still fires at verify
+		// time via the decisionMachineRunner + checkForHardBlock, so the
+		// abuse signal is not lost.
+		describe("user access policy precedence over session", () => {
+			it("honours the session's captchaType when a restrict-to-image policy materialises between /frictionless and /captcha/{type}", async () => {
+				// Session was minted with pow (before the rule existed).
+				(
+					db.checkAndRemoveSession as unknown as ReturnType<typeof vi.fn>
+				).mockResolvedValue({
+					sessionId: "sessionId",
+					captchaType: CaptchaType.pow,
+				} as Pick<Session, "sessionId" | "captchaType">);
+
+				// Rule fires AFTER: restrict-to-image now active on this IP.
+				const restrictImagePolicy: AccessPolicy = {
+					type: AccessPolicyType.Restrict,
+					captchaType: CaptchaType.image,
+				} as AccessPolicy;
+
+				const result = await captchaManager.isValidRequest(
+					{
+						account: "account",
+						tier: Tier.Free,
+						settings: {
+							...defaultUserSettings,
+							captchaType: CaptchaType.frictionless,
+						},
+					},
+					CaptchaType.pow, // widget hits /captcha/pow with the in-flight session
+					mockEnv,
+					"sessionId",
+					restrictImagePolicy,
+					"127.0.0.1",
+				);
+
+				// Before the fix this returned INCORRECT_CAPTCHA_TYPE; after,
+				// the session's own captchaType wins because it's the
+				// authoritative record and the policy will still fire at
+				// verify time via other paths.
+				expect(result).toEqual({
+					valid: true,
+					type: CaptchaType.pow,
+					sessionId: "sessionId",
+				});
+			});
+
+			it("still rejects a session whose own captchaType does not match the requested type", async () => {
+				// Session's captchaType is image, widget hits /captcha/pow —
+				// this is a genuine mismatch (not a policy race) and must
+				// still return INCORRECT_CAPTCHA_TYPE.
+				(
+					db.checkAndRemoveSession as unknown as ReturnType<typeof vi.fn>
+				).mockResolvedValue({
+					sessionId: "sessionId",
+					captchaType: CaptchaType.image,
+				} as Pick<Session, "sessionId" | "captchaType">);
+
+				const result = await captchaManager.isValidRequest(
+					{
+						account: "account",
+						tier: Tier.Free,
+						settings: {
+							...defaultUserSettings,
+							captchaType: CaptchaType.frictionless,
+						},
+					},
+					CaptchaType.pow,
+					mockEnv,
+					"sessionId",
+					undefined,
+					"127.0.0.1",
+				);
+
+				expect(result.valid).toBe(false);
+				expect(result.reason).toBe(ResultReason.INCORRECT_CAPTCHA_TYPE);
+			});
+
+			it("enforces policy captchaType on sessionless requests (direct /captcha/{type} with no /frictionless minted session)", async () => {
+				// No sessionId, policy pins image, widget asks for pow.
+				// Sessionless callers have no minted-in-context session to
+				// trust, so policy still wins here — preserves the pre-fix
+				// behaviour for the direct-entry case.
+				const restrictImagePolicy: AccessPolicy = {
+					type: AccessPolicyType.Restrict,
+					captchaType: CaptchaType.image,
+				} as AccessPolicy;
+
+				const result = await captchaManager.isValidRequest(
+					{
+						account: "account",
+						tier: Tier.Free,
+						settings: {
+							...defaultUserSettings,
+							captchaType: CaptchaType.pow,
+						},
+					},
+					CaptchaType.pow,
+					mockEnv,
+					undefined, // no sessionId
+					restrictImagePolicy,
+				);
+
+				expect(result.valid).toBe(false);
+				expect(result.reason).toBe(ResultReason.INCORRECT_CAPTCHA_TYPE);
+			});
+
+			it("allows sessionless requests when the policy captchaType matches", async () => {
+				const restrictImagePolicy: AccessPolicy = {
+					type: AccessPolicyType.Restrict,
+					captchaType: CaptchaType.image,
+				} as AccessPolicy;
+
+				const result = await captchaManager.isValidRequest(
+					{
+						account: "account",
+						tier: Tier.Free,
+						settings: {
+							...defaultUserSettings,
+							captchaType: CaptchaType.image,
+						},
+					},
+					CaptchaType.image,
+					mockEnv,
+					undefined,
+					restrictImagePolicy,
+				);
+
+				expect(result.valid).toBe(true);
+				expect(result.type).toBe(CaptchaType.image);
+			});
+		});
 	});
 	describe("getVerificationResponse", () => {
 		it("should return a verification response with a score if the tier is not free", async () => {


### PR DESCRIPTION
## Summary

`isValidRequest` was rejecting `/captcha/{type}` calls with `INCORRECT_CAPTCHA_TYPE` whenever an active restrict-to-image rule pinned a different captchaType from the one the widget requested — even when a valid session existed that had been minted legitimately before the rule appeared. The check ran before the `sessionId` lookup, so any anomaly detector that inserted a rule between the widget's `/frictionless` response and its `/captcha/pow` call surfaced as a 400.

## Observed impact

Sustained baseline of these 400s on the provider logs, concentrated on a handful of dapps. The most common trigger is an IP-scoped restrict-to-image rule that materialises between the widget's frictionless call and its follow-up `/captcha/{type}` call.

## Change

Session record is authoritative for captchaType when a sessionId is present. The policy still fires at verify time via `decisionMachineRunner` and `checkForHardBlock`, so the abuse signal is not lost. Sessionless requests still enforce policy captchaType (preserves the pre-fix behaviour for direct-entry callers).

## Test plan
- [x] `npm run -w @prosopo/provider test:unit` — `captchaManager.unit.test.ts` passes (48/48).
- [ ] Post-deploy: `err = 'API.INCORRECT_CAPTCHA_TYPE'` rate on the provider node stream falls toward zero within one detector-cycle window.

## Regression guards added
- Session's captchaType wins when a restrict policy materialises mid-flight — the exact race.
- Session with mismatched captchaType still rejects (not the policy-race case).
- Sessionless request still rejected on policy captchaType mismatch.
- Sessionless request with matching policy captchaType passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)