### PR TITLE
feat(provider): session chain — origin fallback for DM-input reads

### DIFF
--- a/.changeset/session-chain-origin-fallback.md
+++ b/.changeset/session-chain-origin-fallback.md
@@ -1,0 +1,16 @@
+---
+"@prosopo/provider": patch
+"@prosopo/database": patch
+"@prosopo/types-database": patch
+"@prosopo/types": patch
+---
+
+feat(provider,database,types): session chain — escalations reference origin, DM-input reads walk back for missing fields
+
+Adds `originSessionId` to the Session schema and populates it on escalation sessions in `submitPoWCaptchaSolution.buildEscalation`. Adds `CaptchaManager.getSessionRecordWithOriginFallback` — a session reader that, when the record is an escalation missing an inherently-origin-populated field (`simdReadings`, `dnsEvent`, `entropyMathRandom*`, `entropyCrypto*`, `entropyWallClockOffsetMs`), reads the origin session and fills the gap. Escalation-owned fields (`captchaType`, `sessionId`, `score`, `ipInfo`, `headers`, etc.) are never overridden.
+
+The three `serverVerify*CaptchaSolution` methods now use the walker instead of the raw `getSessionRecordBySessionId`, so decision-machine inputs on escalated puzzle / image sessions see the origin's SIMD readings and DNS event.
+
+Fixes the write-time race between (a) the origin's fire-and-forget SIMD attach via `scheduleMongoSimdReadingsUpdate` on pow-submit, and (b) `buildEscalation`'s immediate Mongo read — which left ~97% of escalation sessions with no `dnsEvent` and ~97% with no `simdReadings`, in turn tripping decide-machine deny rules (SIMD_ABSENT etc.) on legit escalation flows.
+
+Non-escalation sessions and older escalation records without `originSessionId` fall through as a no-op — no behavior change. Extra Mongo read only fires when the escalation is actually missing a fallback-eligible field.

--- a/packages/database/src/databases/provider.ts
+++ b/packages/database/src/databases/provider.ts
@@ -1718,6 +1718,7 @@ export class ProviderDatabase
 				simdReadings: 1,
 				bundleId: 1,
 				dnsEvent: 1,
+				originSessionId: 1,
 				currentUrl: 1,
 				iframeUrl: 1,
 				// captchaType is required by the peek-before-consume path

--- a/packages/database/src/tests/integration/sessionRecordProjection.integration.test.ts
+++ b/packages/database/src/tests/integration/sessionRecordProjection.integration.test.ts
@@ -247,6 +247,48 @@ describe("getSessionRecordBySessionId projection", () => {
 		expect(got?.bundleId).toBe("bundle-42");
 	});
 
+	// Regression guard for the session-chain walker
+	// (CaptchaManager.getSessionRecordWithOriginFallback). The walker needs
+	// `originSessionId` on the escalation session to know where to walk
+	// back to for missing simdReadings / dnsEvent / entropy fields. If the
+	// projection drops it, escalations look like non-escalations and the
+	// walker no-ops — puzzle / image escalations then hit the DM with
+	// undefined simdReadings and trip SIMD_ABSENT-style deny rules.
+	it("returns originSessionId so the escalation-fallback walker knows where to walk", async () => {
+		const originSessionId = "session-origin-for-chain";
+		const escalationSessionId = "session-escalation-with-origin";
+		await db.tables.session.create({
+			sessionId: originSessionId,
+			createdAt: new Date(),
+			token: "tok-origin",
+			score: 0.4,
+			threshold: 0.5,
+			scoreComponents: { baseScore: 0.4 },
+			ipAddress: ipv4Composite(16843009n),
+			captchaType: CaptchaType.pow,
+			webView: false,
+			iFrame: false,
+		});
+		await db.tables.session.create({
+			sessionId: escalationSessionId,
+			createdAt: new Date(),
+			token: "tok-escalation",
+			score: 0.4,
+			threshold: 0.5,
+			scoreComponents: { baseScore: 0.4 },
+			ipAddress: ipv4Composite(16843009n),
+			captchaType: CaptchaType.puzzle,
+			webView: false,
+			iFrame: false,
+			isEscalation: true,
+			originSessionId,
+		});
+
+		const got = await db.getSessionRecordBySessionId(escalationSessionId);
+		expect(got?.originSessionId).toBe(originSessionId);
+		expect(got?.isEscalation).toBe(true);
+	});
+
 	// Schema-contract guard: any field marked `required: true` on
 	// SessionRecordSchema must be present in the projection — otherwise
 	// callers like buildEscalation that forward the field into a new

--- a/packages/provider/src/api/captcha/submitPoWCaptchaSolution.ts
+++ b/packages/provider/src/api/captcha/submitPoWCaptchaSolution.ts
@@ -304,6 +304,13 @@ export const buildEscalation = async (
 		true,
 		originSession.iframeUrl,
 		originSession.isProtect,
+		// Record the origin sessionId on the escalation record. The
+		// DM-input read path (captchaManager.getSessionRecordWithOriginFallback)
+		// uses this to fall back to the origin session for fields that the
+		// escalation doesn't carry itself — simdReadings (attached by pow-
+		// submit fire-and-forget, races the escalation read), dnsEvent
+		// (set by the DNS sidecar on the origin's TLS connection only).
+		originSession.sessionId,
 	);
 
 	// Record the origin → escalation sessionId mapping so a /captcha/*

--- a/packages/provider/src/tasks/captchaManager.ts
+++ b/packages/provider/src/tasks/captchaManager.ts
@@ -173,6 +173,84 @@ export class CaptchaManager {
 	}
 
 	/**
+	 * Read a session and, if it's an escalation missing one of the
+	 * inherently-origin-populated fields, walk to `originSessionId` and fill
+	 * the gap. Intended for the decision-machine input read path only —
+	 * `simdReadings`, `dnsEvent`, `entropyMathRandomFingerprint` etc. are
+	 * populated on the origin session (SIMD via pow-submit's fire-and-forget
+	 * attach; DNS via the sidecar's origin-TLS-scoped patch) and don't
+	 * automatically end up on the escalation record because
+	 * `buildEscalation` reads the origin from Mongo before the async writes
+	 * settle. Rather than duplicating the origin's state onto every
+	 * escalation at write time, keep the origin as the source of truth and
+	 * fall back to it at read time.
+	 *
+	 * Fields intentionally NOT walked:
+	 *   - captchaType / sessionId / score / threshold / scoreComponents /
+	 *     ipAddress / ipInfo / headers — these describe the escalation
+	 *     itself and must never be overridden by the origin.
+	 *   - Anything already present on the escalation — first-write wins.
+	 *
+	 * Non-escalation sessions and escalations without `originSessionId`
+	 * (older records) fall through as no-op.
+	 */
+	public async getSessionRecordWithOriginFallback(
+		sessionId: string,
+	): Promise<Session | undefined> {
+		const session = await this.db.getSessionRecordBySessionId(sessionId);
+		if (!session) return undefined;
+		if (!session.originSessionId) return session;
+
+		const needsSimd =
+			session.simdReadings === undefined || session.simdReadings === null;
+		const needsDns =
+			session.dnsEvent === undefined || session.dnsEvent === null;
+		const needsEntropyMath =
+			session.entropyMathRandomFingerprint === undefined;
+		const needsEntropyCrypto = session.entropyCryptoFingerprint === undefined;
+		const needsEntropyWall = session.entropyWallClockOffsetMs === undefined;
+		const needsEntropyFirst = session.entropyMathRandomFirst === undefined;
+
+		if (
+			!needsSimd &&
+			!needsDns &&
+			!needsEntropyMath &&
+			!needsEntropyCrypto &&
+			!needsEntropyWall &&
+			!needsEntropyFirst
+		) {
+			return session;
+		}
+
+		const origin = await this.db.getSessionRecordBySessionId(
+			session.originSessionId,
+		);
+		if (!origin) return session;
+
+		return {
+			...session,
+			...(needsSimd && origin.simdReadings && { simdReadings: origin.simdReadings }),
+			...(needsDns && origin.dnsEvent && { dnsEvent: origin.dnsEvent }),
+			...(needsEntropyMath &&
+				origin.entropyMathRandomFingerprint !== undefined && {
+					entropyMathRandomFingerprint: origin.entropyMathRandomFingerprint,
+				}),
+			...(needsEntropyCrypto &&
+				origin.entropyCryptoFingerprint !== undefined && {
+					entropyCryptoFingerprint: origin.entropyCryptoFingerprint,
+				}),
+			...(needsEntropyWall &&
+				origin.entropyWallClockOffsetMs !== undefined && {
+					entropyWallClockOffsetMs: origin.entropyWallClockOffsetMs,
+				}),
+			...(needsEntropyFirst &&
+				origin.entropyMathRandomFirst !== undefined && {
+					entropyMathRandomFirst: origin.entropyMathRandomFirst,
+				}),
+		};
+	}
+
+	/**
 	 * Decrypt + first-hop-wins attach. Resolves the session's detector pool
 	 * bundle (promoted onto the session record at frictionless time) to decrypt.
 	 * No-op on decrypt failure / no bundle.

--- a/packages/provider/src/tasks/frictionless/frictionlessTasks.ts
+++ b/packages/provider/src/tasks/frictionless/frictionlessTasks.ts
@@ -197,6 +197,7 @@ export class FrictionlessManager extends CaptchaManager {
 		isEscalation?: Session["isEscalation"],
 		iframeUrl?: Session["iframeUrl"],
 		isProtect?: Session["isProtect"],
+		originSessionId?: Session["originSessionId"],
 	): Promise<Session> {
 		const sessionRecord: Session = {
 			sessionId: `${getSessionIDPrefix(this.config.host)}-${uuidv4()}`,
@@ -217,6 +218,10 @@ export class FrictionlessManager extends CaptchaManager {
 			// avoids polluting analytics with `false` on every plain
 			// frictionless session.
 			...(isEscalation && { isEscalation: true }),
+			// Origin sessionId is only meaningful for escalations. Persist
+			// alongside isEscalation so the DM-input read path can walk
+			// back for fallback fields (simdReadings, dnsEvent, etc.).
+			...(originSessionId && { originSessionId }),
 			decryptedHeadHash,
 			bundleId,
 			reason,

--- a/packages/provider/src/tasks/imgCaptcha/imgCaptchaTasks.ts
+++ b/packages/provider/src/tasks/imgCaptcha/imgCaptchaTasks.ts
@@ -862,8 +862,10 @@ export class ImgCaptchaManager extends CaptchaManager {
 			}
 		}
 
+		// Walker fills simdReadings / dnsEvent / entropy fields from the origin
+		// when this is an escalation record. See CaptchaManager.getSessionRecordWithOriginFallback.
 		const sessionRecord = solution.sessionId
-			? await this.db.getSessionRecordBySessionId(solution.sessionId)
+			? await this.getSessionRecordWithOriginFallback(solution.sessionId)
 			: undefined;
 
 		const enrichedDnsEvent = await enrichDnsEvent(

--- a/packages/provider/src/tasks/powCaptcha/powTasks.ts
+++ b/packages/provider/src/tasks/powCaptcha/powTasks.ts
@@ -804,8 +804,13 @@ export class PowCaptchaManager extends CaptchaManager {
 			}
 		}
 
+		// Walk to the origin session when this is an escalation record —
+		// simdReadings / dnsEvent / entropy fields are populated on the
+		// origin and don't automatically end up on the escalation. Non-
+		// escalations pass through unchanged (walker no-ops when there's
+		// no originSessionId).
 		const sessionRecord = challengeRecord.sessionId
-			? await this.db.getSessionRecordBySessionId(challengeRecord.sessionId)
+			? await this.getSessionRecordWithOriginFallback(challengeRecord.sessionId)
 			: undefined;
 
 		const enrichedDnsEvent = await enrichDnsEvent(

--- a/packages/provider/src/tasks/puzzleCaptcha/puzzleTasks.ts
+++ b/packages/provider/src/tasks/puzzleCaptcha/puzzleTasks.ts
@@ -622,7 +622,7 @@ export class PuzzleCaptchaManager extends CaptchaManager {
 		}
 
 		const sessionRecord = challengeRecord.sessionId
-			? await this.db.getSessionRecordBySessionId(challengeRecord.sessionId)
+			? await this.getSessionRecordWithOriginFallback(challengeRecord.sessionId)
 			: undefined;
 
 		const enrichedDnsEvent = await enrichDnsEvent(

--- a/packages/provider/src/tests/unit/tasks/captchaManager.unit.test.ts
+++ b/packages/provider/src/tests/unit/tasks/captchaManager.unit.test.ts
@@ -125,6 +125,145 @@ describe("CaptchaManager", () => {
 		vi.clearAllMocks();
 	});
 
+	// Session-chain walker. Escalation sessions (isEscalation=true) inherit
+	// their originSessionId from the pow-solve that spawned them. DM-input
+	// reads go through the walker so simdReadings / dnsEvent / entropy
+	// fields that live on the origin are surfaced on the escalation record
+	// without duplicating them at write time.
+	describe("getSessionRecordWithOriginFallback", () => {
+		const dbGet = () =>
+			db.getSessionRecordBySessionId as unknown as ReturnType<typeof vi.fn>;
+
+		it("returns the session as-is when there's no originSessionId (non-escalation)", async () => {
+			const session = {
+				sessionId: "sess",
+				captchaType: CaptchaType.pow,
+				simdReadings: undefined,
+			} as unknown as Session;
+			dbGet().mockResolvedValue(session);
+
+			const got = await captchaManager.getSessionRecordWithOriginFallback("sess");
+
+			expect(got).toBe(session);
+			expect(dbGet()).toHaveBeenCalledTimes(1);
+		});
+
+		it("returns undefined when the session isn't found", async () => {
+			dbGet().mockResolvedValue(null);
+			const got = await captchaManager.getSessionRecordWithOriginFallback("sess");
+			expect(got).toBeUndefined();
+		});
+
+		it("skips the origin walk when the escalation already carries every fallback-eligible field", async () => {
+			const session = {
+				sessionId: "esc",
+				originSessionId: "origin",
+				captchaType: CaptchaType.puzzle,
+				simdReadings: { supported: true, results: [] },
+				dnsEvent: { receivedAt: new Date() },
+				entropyMathRandomFingerprint: "a",
+				entropyCryptoFingerprint: "b",
+				entropyWallClockOffsetMs: 0,
+				entropyMathRandomFirst: 0.1,
+			} as unknown as Session;
+			dbGet().mockResolvedValue(session);
+
+			const got = await captchaManager.getSessionRecordWithOriginFallback("esc");
+
+			expect(got).toBe(session);
+			// Only one DB call — origin was never fetched.
+			expect(dbGet()).toHaveBeenCalledTimes(1);
+		});
+
+		it("fills simdReadings from origin when the escalation is missing it", async () => {
+			const origin = {
+				sessionId: "origin",
+				captchaType: CaptchaType.pow,
+				simdReadings: { supported: true, results: [1, 2, 3] },
+				dnsEvent: { receivedAt: new Date() },
+			} as unknown as Session;
+			const escalation = {
+				sessionId: "esc",
+				originSessionId: "origin",
+				captchaType: CaptchaType.puzzle,
+				// simdReadings and dnsEvent are undefined on the escalation
+				// (the exact production bug — origin's fire-and-forget writes
+				// raced buildEscalation's Mongo read).
+			} as unknown as Session;
+			dbGet().mockResolvedValueOnce(escalation).mockResolvedValueOnce(origin);
+
+			const got = await captchaManager.getSessionRecordWithOriginFallback("esc");
+
+			expect(got?.simdReadings).toEqual({
+				supported: true,
+				results: [1, 2, 3],
+			});
+			expect(got?.dnsEvent).toBeDefined();
+			// The escalation's own identity is preserved — origin fields
+			// don't overwrite escalation-owned fields.
+			expect(got?.sessionId).toBe("esc");
+			expect(got?.captchaType).toBe(CaptchaType.puzzle);
+		});
+
+		it("does not fill anything when origin also lacks the fields", async () => {
+			const origin = {
+				sessionId: "origin",
+				captchaType: CaptchaType.pow,
+				simdReadings: undefined,
+				dnsEvent: undefined,
+			} as unknown as Session;
+			const escalation = {
+				sessionId: "esc",
+				originSessionId: "origin",
+				captchaType: CaptchaType.puzzle,
+			} as unknown as Session;
+			dbGet().mockResolvedValueOnce(escalation).mockResolvedValueOnce(origin);
+
+			const got = await captchaManager.getSessionRecordWithOriginFallback("esc");
+
+			expect(got?.simdReadings).toBeUndefined();
+			expect(got?.dnsEvent).toBeUndefined();
+		});
+
+		it("returns the escalation unchanged when the origin session has been deleted", async () => {
+			const escalation = {
+				sessionId: "esc",
+				originSessionId: "origin-gone",
+				captchaType: CaptchaType.puzzle,
+			} as unknown as Session;
+			dbGet().mockResolvedValueOnce(escalation).mockResolvedValueOnce(null);
+
+			const got = await captchaManager.getSessionRecordWithOriginFallback("esc");
+
+			expect(got).toBe(escalation);
+		});
+
+		it("preserves escalation-owned fields — origin captchaType / sessionId / score never leak through", async () => {
+			const origin = {
+				sessionId: "origin",
+				captchaType: CaptchaType.pow,
+				score: 0.1,
+				simdReadings: { supported: true },
+			} as unknown as Session;
+			const escalation = {
+				sessionId: "esc",
+				originSessionId: "origin",
+				captchaType: CaptchaType.puzzle,
+				score: 0.5,
+			} as unknown as Session;
+			dbGet().mockResolvedValueOnce(escalation).mockResolvedValueOnce(origin);
+
+			const got = await captchaManager.getSessionRecordWithOriginFallback("esc");
+
+			// simd was filled from origin
+			expect(got?.simdReadings).toEqual({ supported: true });
+			// escalation-owned fields untouched
+			expect(got?.sessionId).toBe("esc");
+			expect(got?.captchaType).toBe(CaptchaType.puzzle);
+			expect(got?.score).toBe(0.5);
+		});
+	});
+
 	describe("isValidRequest", () => {
 		it("should validate a request for an image captcha when the client settings are set to image and no session ID is passed", async () => {
 			const result = await captchaManager.isValidRequest(

--- a/packages/types-database/src/types/provider.ts
+++ b/packages/types-database/src/types/provider.ts
@@ -676,6 +676,15 @@ export const SessionRecordSchema = new Schema<SessionRecord>({
 	// an escalation of an earlier session. Optional so ordinary
 	// frictionless-created sessions can omit it and stay slim.
 	isEscalation: { type: Boolean, required: false },
+	// SessionId of the session this one escalated from, when isEscalation is
+	// true. Read-time fallback source for fields that are inherently populated
+	// on the origin (simdReadings, dnsEvent, etc.) but not on the escalation
+	// itself — avoids the write-time race between the origin's fire-and-forget
+	// SIMD-attach / DNS-event patches and buildEscalation's Mongo read. The
+	// walker in captchaManager.getSessionRecordWithOriginFallback fills the
+	// gap only for fields that are inherently origin-populated; escalation-
+	// owned fields (captchaType, sessionId, score, etc.) are never overridden.
+	originSessionId: { type: String, required: false },
 	decryptedHeadHash: { type: String, required: false, default: "" },
 	bundleId: { type: String, required: false },
 	siteKey: { type: String, required: false },

--- a/packages/types/src/provider/database.ts
+++ b/packages/types/src/provider/database.ts
@@ -414,6 +414,11 @@ export const SessionSchema = object({
 	// "user hit the widget cold" from "user got escalated into a
 	// stronger captcha after a low-confidence PoW".
 	isEscalation: boolean().optional(),
+	// SessionId of the session this one escalated from. Populated when
+	// isEscalation is true; used by the DM-input read path to fall back
+	// to the origin for fields the escalation doesn't carry itself
+	// (simdReadings, dnsEvent, etc.). Absent on non-escalation sessions.
+	originSessionId: string().optional(),
 	decryptedHeadHash: string(),
 	siteKey: string().optional(),
 	// Full page URL the widget was rendered on (origin + path only — query
@@ -515,6 +520,9 @@ export type Session = {
 	// True when this session was minted by the post-PoW routing machine
 	// as an escalation. Undefined / false on ordinary frictionless sessions.
 	isEscalation?: boolean;
+	// SessionId of the origin session this one escalated from. Populated
+	// alongside isEscalation; consumed by the DM-input read path.
+	originSessionId?: string;
 	decryptedHeadHash: string;
 	// The provider-assigned detector pool bundle this session's detector ran
 	// from, promoted off the short-lived detectorSessionId→bundleId Redis


### PR DESCRIPTION
## Summary

Escalation sessions inherit an `originSessionId` back to the pow-solve that spawned them. A new `CaptchaManager.getSessionRecordWithOriginFallback` walker fills in fields that are inherently populated on the origin — `simdReadings` (attached fire-and-forget on pow-submit) and `dnsEvent` (set by the DNS sidecar on the origin's TLS connection) — when the escalation record lacks them. The three `serverVerify*CaptchaSolution` methods use the walker so decision-machine inputs on escalated puzzle / image sessions see the origin's SIMD readings and DNS event instead of `undefined`.

## Observed impact (before fix)

Field-presence on `sessions.createdAt > now-60m`, representative pronode:

| field | non-escalation | escalation |
|---|---|---|
| `simdReadings` | 53 % | **3 %** |
| `dnsEvent` | 99 % | **2 %** |
| `bundleId` | 95 % | 98 % |
| `decryptedHeadHash` | 95 % | 100 % |

Split by escalation captchaType (last 60m, pronode10): `puzzle` (n=25) had 2 with simd / 1 with dns. `image` (n=32) had 0 / 0. This was tripping decide-machine deny rules (`SIMD_ABSENT` etc.) on legit escalation flows.

Root cause: `verifyPowCaptchaSolution` awaits Redis for the SIMD attach but fires the Mongo update through `scheduleMongoSimdReadingsUpdate` (fire-and-forget). `buildEscalation` then reads the origin from Mongo — the async write hasn't landed. `dnsEvent` is worse: the sidecar patches it onto the origin session directly and `buildEscalation`'s `createSession` call never forwarded it.

## Change

- Add `originSessionId: string` to `SessionRecordSchema` and the projection in `getSessionRecordBySessionId`.
- `buildEscalation` in `submitPoWCaptchaSolution.ts` sets `originSessionId: originSession.sessionId` on the new session.
- New `CaptchaManager.getSessionRecordWithOriginFallback(sessionId)`: reads the session, and if it's an escalation with `originSessionId` AND any fallback-eligible field is missing, walks to the origin and fills the gap. Escalation-owned fields (`captchaType`, `sessionId`, `score`, `ipInfo`, `headers`) are never overridden.
- `PowCaptchaManager.serverVerifyPowCaptchaSolution`, `PuzzleCaptchaManager.serverVerifyPuzzleCaptchaSolution`, `ImgCaptchaManager.serverVerifyImgCaptchaSolution` all switch their DM-input session read to the walker.

## Non-goals

- No change to write paths for `simdReadings` / `dnsEvent` — origin remains the single source of truth, escalation just references it.
- Non-escalations and legacy escalations without `originSessionId` are pass-through no-ops.
- Extra Mongo read only fires when the escalation is actually missing a fallback-eligible field.

## Test plan
- [x] `npm run -w @prosopo/provider test:unit` — `captchaManager.unit.test.ts` passes 55/55 (48 pre-existing + 7 new walker tests).
- [x] Type-check clean: `types`, `types-database`, `database`, `provider`.
- [ ] Post-deploy: `session.simdReadings` / `session.dnsEvent` presence rate on escalation sessions climbs from ~3 % / ~2 % to match the non-escalation baseline (~53 % / ~99 %). Decide-machine `SIMD_ABSENT`-style deny counts on escalated puzzle / image sessions falls to near-zero.

## Regression guards

- Integration: `sessionRecordProjection.integration.test.ts` — asserts `originSessionId` round-trips through the projection.
- Unit (7 cases in `captchaManager.unit.test.ts`):
  - non-escalation session: pass-through, no origin lookup
  - session not found: undefined
  - all fallback fields present on escalation: no origin lookup fires
  - missing `simdReadings`: filled from origin
  - origin also lacks the fields: no fill
  - origin session deleted: pass-through escalation unchanged
  - escalation-owned fields (`captchaType`, `sessionId`, `score`) preserved even when origin has different values

🤖 Generated with [Claude Code](https://claude.com/claude-code)
