### PR TITLE
fix(provider): promote bundleId onto bypass-path sessions

### DIFF
--- a/.changeset/bypass-session-bundleid.md
+++ b/.changeset/bypass-session-bundleid.md
@@ -1,0 +1,17 @@
+---
+"@prosopo/provider": patch
+---
+
+fix(provider): promote bundleId onto bypass-path sessions so SIMD / BDP attach can decrypt
+
+Sitekeys configured with a fixed `captchaType` (`pow` / `image` / `puzzle`) short-circuit
+the frictionless bot-detection path via `runConfiguredCaptchaTypeShortCircuit` and build
+their session via `buildBypassSessionParams`. Before this fix, that helper never wrote a
+`bundleId` onto the session, so every subsequent `decryptAndAttachSimdReadingsIfAbsent`
+call at `/captcha/{type}` and solution-submit resolved `bundle=undefined` and silently
+dropped the ciphertext — SIMD readings and behavioural data never landed on the session
+or the powcaptcha record for these sitekeys.
+
+The fix resolves the widget's `detectorSessionId` → `bundleId` via the existing Redis
+binding and promotes it onto the bypass session so the attach path finds the correct
+keypair. Empty-pool PoW fallback continues to no-op (no detector was assigned).

--- a/.changeset/session-chain-origin-fallback.md
+++ b/.changeset/session-chain-origin-fallback.md
@@ -1,0 +1,16 @@
+---
+"@prosopo/provider": patch
+"@prosopo/database": patch
+"@prosopo/types-database": patch
+"@prosopo/types": patch
+---
+
+feat(provider,database,types): session chain — escalations reference origin, DM-input reads walk back for missing fields
+
+Adds `originSessionId` to the Session schema and populates it on escalation sessions in `submitPoWCaptchaSolution.buildEscalation`. Adds `CaptchaManager.getSessionRecordWithOriginFallback` — a session reader that, when the record is an escalation missing an inherently-origin-populated field (`simdReadings`, `dnsEvent`, `entropyMathRandom*`, `entropyCrypto*`, `entropyWallClockOffsetMs`), reads the origin session and fills the gap. Escalation-owned fields (`captchaType`, `sessionId`, `score`, `ipInfo`, `headers`, etc.) are never overridden.
+
+The three `serverVerify*CaptchaSolution` methods now use the walker instead of the raw `getSessionRecordBySessionId`, so decision-machine inputs on escalated puzzle / image sessions see the origin's SIMD readings and DNS event.
+
+Fixes the write-time race between (a) the origin's fire-and-forget SIMD attach via `scheduleMongoSimdReadingsUpdate` on pow-submit, and (b) `buildEscalation`'s immediate Mongo read — which left ~97% of escalation sessions with no `dnsEvent` and ~97% with no `simdReadings`, in turn tripping decide-machine deny rules (SIMD_ABSENT etc.) on legit escalation flows.
+
+Non-escalation sessions and older escalation records without `originSessionId` fall through as a no-op — no behavior change. Extra Mongo read only fires when the escalation is actually missing a fallback-eligible field.

--- a/demos/cypress-shared/cypress/e2e/accessPolicyRestrict.cy.ts
+++ b/demos/cypress-shared/cypress/e2e/accessPolicyRestrict.cy.ts
@@ -24,12 +24,11 @@
 //      the captchaType-equality check accidentally rejecting matching
 //      Restricts (the same check that had the sanitiser bug for Block).
 //   2. Restrict with `captchaType: pow` on an image request →
-//      isValidRequest returns INCORRECT_CAPTCHA_TYPE with 400. This IS
-//      the intended behaviour for Restrict — an operator saying "you may
-//      only complete pow" and the widget asking for image.
-//
-// Unlike Block, Restrict has no `deferToVerify` semantics that matter at
-// request time — the pin-mismatch check fires unconditionally.
+//      session captchaType wins over the restrict pin (PR #3010): when a
+//      valid session exists, its captchaType is authoritative at the
+//      /captcha/{type} gate; the policy still fires at verify time via
+//      the decision machine. So the /captcha/image call returns 200 even
+//      though the policy pins pow.
 
 import "@cypress/xpath";
 import { CaptchaType } from "@prosopo/types";
@@ -129,17 +128,19 @@ describe("User access policy Restrict rules", () => {
 			});
 	});
 
-	it("Restrict pinning a different captchaType returns 400 INCORRECT_CAPTCHA_TYPE", () => {
-		// Restrict says "you must do pow" but the image sitekey is
-		// serving image. isValidRequest's captchaType-equality check
-		// fires (this is the intended behaviour for Restrict — it's what
-		// makes the captchaType pin do useful work).
+	it("Restrict pinning a different captchaType is overridden by the session's captchaType (200)", () => {
+		// Restrict says "you must do pow" but the widget already minted a
+		// session for the image sitekey. PR #3010 made the session
+		// captchaType authoritative at /captcha/{type} — the /captcha/image
+		// call therefore returns 200 despite the mismatched pin. The
+		// restrict policy still fires at verify time via the decision
+		// machine's hard-block path; that half is covered by the verify-
+		// time restrict tests.
 		//
 		// Intercept /captcha/image specifically (not /captcha/**) — the
-		// widget hits /captcha/frictionless FIRST which returns 200 (the
-		// pin-mismatch check only fires on the specific-type endpoint),
-		// and matching /captcha/** would catch the frictionless response
-		// before the image one and hide the real behaviour.
+		// widget hits /captcha/frictionless FIRST which returns 200, and
+		// matching /captcha/** would catch that response before the image
+		// one and hide the real behaviour.
 		cy.addAccessRules(buildRestrictRule({ captchaType: "pow" })).then(
 			(response) => {
 				expect(response.status).to.equal(200);
@@ -165,8 +166,8 @@ describe("User access policy Restrict rules", () => {
 			.then((response) => {
 				expect(
 					response?.statusCode,
-					"Restrict pinning a different captchaType should 400",
-				).to.equal(400);
+					"session captchaType wins over restrict pin at /captcha/{type}",
+				).to.equal(200);
 			});
 	});
 

--- a/packages/database/src/databases/provider.ts
+++ b/packages/database/src/databases/provider.ts
@@ -1718,6 +1718,7 @@ export class ProviderDatabase
 				simdReadings: 1,
 				bundleId: 1,
 				dnsEvent: 1,
+				originSessionId: 1,
 				currentUrl: 1,
 				iframeUrl: 1,
 				// captchaType is required by the peek-before-consume path

--- a/packages/database/src/tests/integration/sessionRecordProjection.integration.test.ts
+++ b/packages/database/src/tests/integration/sessionRecordProjection.integration.test.ts
@@ -247,6 +247,48 @@ describe("getSessionRecordBySessionId projection", () => {
 		expect(got?.bundleId).toBe("bundle-42");
 	});
 
+	// Regression guard for the session-chain walker
+	// (CaptchaManager.getSessionRecordWithOriginFallback). The walker needs
+	// `originSessionId` on the escalation session to know where to walk
+	// back to for missing simdReadings / dnsEvent / entropy fields. If the
+	// projection drops it, escalations look like non-escalations and the
+	// walker no-ops — puzzle / image escalations then hit the DM with
+	// undefined simdReadings and trip SIMD_ABSENT-style deny rules.
+	it("returns originSessionId so the escalation-fallback walker knows where to walk", async () => {
+		const originSessionId = "session-origin-for-chain";
+		const escalationSessionId = "session-escalation-with-origin";
+		await db.tables.session.create({
+			sessionId: originSessionId,
+			createdAt: new Date(),
+			token: "tok-origin",
+			score: 0.4,
+			threshold: 0.5,
+			scoreComponents: { baseScore: 0.4 },
+			ipAddress: ipv4Composite(16843009n),
+			captchaType: CaptchaType.pow,
+			webView: false,
+			iFrame: false,
+		});
+		await db.tables.session.create({
+			sessionId: escalationSessionId,
+			createdAt: new Date(),
+			token: "tok-escalation",
+			score: 0.4,
+			threshold: 0.5,
+			scoreComponents: { baseScore: 0.4 },
+			ipAddress: ipv4Composite(16843009n),
+			captchaType: CaptchaType.puzzle,
+			webView: false,
+			iFrame: false,
+			isEscalation: true,
+			originSessionId,
+		});
+
+		const got = await db.getSessionRecordBySessionId(escalationSessionId);
+		expect(got?.originSessionId).toBe(originSessionId);
+		expect(got?.isEscalation).toBe(true);
+	});
+
 	// Schema-contract guard: any field marked `required: true` on
 	// SessionRecordSchema must be present in the projection — otherwise
 	// callers like buildEscalation that forward the field into a new

--- a/packages/provider/src/api/captcha/getFrictionlessCaptchaChallenge/handler.ts
+++ b/packages/provider/src/api/captcha/getFrictionlessCaptchaChallenge/handler.ts
@@ -422,6 +422,11 @@ export default (
 				userSitekeyIpHash,
 				requestId: req.requestId,
 				logger: req.logger,
+				// Thread the client's detector session id through so the
+				// bypass paths (configured-captchaType + empty-pool pow
+				// fallback) can promote the resolved bundleId onto the
+				// session and enable later SIMD / BDP attach to decrypt.
+				...(detectorSessionId && { detectorSessionId }),
 				...(req.tcpToChelloUs !== undefined && {
 					tcpToChelloUs: req.tcpToChelloUs,
 				}),

--- a/packages/provider/src/api/captcha/getFrictionlessCaptchaChallenge/shortCircuit.ts
+++ b/packages/provider/src/api/captcha/getFrictionlessCaptchaChallenge/shortCircuit.ts
@@ -66,9 +66,11 @@ export type ShortCircuitInput = {
 // so bundleId stays undefined and the attach path continues to no-op.
 const buildBypassSessionParams = async (input: ShortCircuitInput) => {
 	const bundleId = input.detectorSessionId
-		? (await input.tasks.frictionlessManager.resolveBundleByDetectorSession(
-				input.detectorSessionId,
-			))?.bundleId
+		? (
+				await input.tasks.frictionlessManager.resolveBundleByDetectorSession(
+					input.detectorSessionId,
+				)
+			)?.bundleId
 		: undefined;
 	return {
 		// `sendCaptcha` requires a truthy token and dedup needs a unique value, so

--- a/packages/provider/src/api/captcha/getFrictionlessCaptchaChallenge/shortCircuit.ts
+++ b/packages/provider/src/api/captcha/getFrictionlessCaptchaChallenge/shortCircuit.ts
@@ -43,6 +43,13 @@ export type ShortCircuitInput = {
 	userSitekeyIpHash: string;
 	requestId: string | undefined;
 	logger: Logger;
+	// Client's detector-session id from the request body. When present, the
+	// bypass paths resolve the assigned bundleId via Redis and promote it
+	// onto the session so SIMD / BDP attach at later hops (challenge GET,
+	// solution submit) can find the right keypair. Without this, sessions on
+	// configured-captchaType sitekeys (pow / image / puzzle) had no bundleId
+	// and every attach silently dropped the payload.
+	detectorSessionId?: string;
 	tcpToChelloUs?: number;
 	chelloToHandshakeUs?: number;
 };
@@ -50,31 +57,46 @@ export type ShortCircuitInput = {
 // Builds the session params used by the bypass paths (configured captcha type
 // and empty-pool fallback). Score 0 — these paths do not run bot detection, so
 // the session is created as a plain challenge rather than a scored one.
-const buildBypassSessionParams = (input: ShortCircuitInput) => ({
-	// `sendCaptcha` requires a truthy token and dedup needs a unique value, so
-	// synthesise one when the client had no detector to produce it.
-	token: input.token || `nodetector-${uuidv4()}`,
-	score: 0,
-	threshold:
-		input.clientRecord.settings?.frictionlessThreshold ??
-		DEFAULT_FRICTIONLESS_THRESHOLD,
-	scoreComponents: { baseScore: 0 } as ScoreComponents,
-	ipAddress: input.ipAddress,
-	webView: false,
-	iFrame: false,
-	decryptedHeadHash: "",
-	siteKey: input.dapp,
-	ipInfo: input.ipInfo,
-	headers: input.flatHeaders,
-	mode: input.sessionMode,
-	userSitekeyIpHash: input.userSitekeyIpHash,
-	...(input.tcpToChelloUs !== undefined && {
-		tcpToChelloUs: input.tcpToChelloUs,
-	}),
-	...(input.chelloToHandshakeUs !== undefined && {
-		chelloToHandshakeUs: input.chelloToHandshakeUs,
-	}),
-});
+//
+// `bundleId` is resolved from the client's detectorSessionId (Redis binding
+// short-TTL) when the client actually ran a detector. Configured-captchaType
+// sitekeys still get a detector assigned by /detector/assign because the
+// widget doesn't know upstream that the sitekey is short-circuited — so the
+// binding is usually there. Empty-pool fallback has no binding to resolve,
+// so bundleId stays undefined and the attach path continues to no-op.
+const buildBypassSessionParams = async (input: ShortCircuitInput) => {
+	const bundleId = input.detectorSessionId
+		? (await input.tasks.frictionlessManager.resolveBundleByDetectorSession(
+				input.detectorSessionId,
+			))?.bundleId
+		: undefined;
+	return {
+		// `sendCaptcha` requires a truthy token and dedup needs a unique value, so
+		// synthesise one when the client had no detector to produce it.
+		token: input.token || `nodetector-${uuidv4()}`,
+		score: 0,
+		threshold:
+			input.clientRecord.settings?.frictionlessThreshold ??
+			DEFAULT_FRICTIONLESS_THRESHOLD,
+		scoreComponents: { baseScore: 0 } as ScoreComponents,
+		ipAddress: input.ipAddress,
+		webView: false,
+		iFrame: false,
+		decryptedHeadHash: "",
+		siteKey: input.dapp,
+		ipInfo: input.ipInfo,
+		headers: input.flatHeaders,
+		mode: input.sessionMode,
+		userSitekeyIpHash: input.userSitekeyIpHash,
+		...(bundleId && { bundleId }),
+		...(input.tcpToChelloUs !== undefined && {
+			tcpToChelloUs: input.tcpToChelloUs,
+		}),
+		...(input.chelloToHandshakeUs !== undefined && {
+			chelloToHandshakeUs: input.chelloToHandshakeUs,
+		}),
+	};
+};
 
 /**
  * Empty-pool PoW fallback. The detector lives only in the provider-served pool
@@ -107,7 +129,7 @@ export const runEmptyDetectorPoolPowFallback = async (
 	attachHoneypot(res, input.clientRecord);
 	return res.json(
 		await input.tasks.frictionlessManager.sendPowCaptcha(
-			buildBypassSessionParams(input),
+			await buildBypassSessionParams(input),
 		),
 	);
 };
@@ -123,7 +145,7 @@ export const runConfiguredCaptchaTypeShortCircuit = async (
 		return null;
 	}
 
-	const sessionParams = buildBypassSessionParams(input);
+	const sessionParams = await buildBypassSessionParams(input);
 
 	input.logger.info(() => ({
 		msg: "Frictionless decision",

--- a/packages/provider/src/api/captcha/submitPoWCaptchaSolution.ts
+++ b/packages/provider/src/api/captcha/submitPoWCaptchaSolution.ts
@@ -304,6 +304,13 @@ export const buildEscalation = async (
 		true,
 		originSession.iframeUrl,
 		originSession.isProtect,
+		// Record the origin sessionId on the escalation record. The
+		// DM-input read path (captchaManager.getSessionRecordWithOriginFallback)
+		// uses this to fall back to the origin session for fields that the
+		// escalation doesn't carry itself — simdReadings (attached by pow-
+		// submit fire-and-forget, races the escalation read), dnsEvent
+		// (set by the DNS sidecar on the origin's TLS connection only).
+		originSession.sessionId,
 	);
 
 	// Record the origin → escalation sessionId mapping so a /captcha/*

--- a/packages/provider/src/tasks/captchaManager.ts
+++ b/packages/provider/src/tasks/captchaManager.ts
@@ -173,6 +173,84 @@ export class CaptchaManager {
 	}
 
 	/**
+	 * Read a session and, if it's an escalation missing one of the
+	 * inherently-origin-populated fields, walk to `originSessionId` and fill
+	 * the gap. Intended for the decision-machine input read path only —
+	 * `simdReadings`, `dnsEvent`, `entropyMathRandomFingerprint` etc. are
+	 * populated on the origin session (SIMD via pow-submit's fire-and-forget
+	 * attach; DNS via the sidecar's origin-TLS-scoped patch) and don't
+	 * automatically end up on the escalation record because
+	 * `buildEscalation` reads the origin from Mongo before the async writes
+	 * settle. Rather than duplicating the origin's state onto every
+	 * escalation at write time, keep the origin as the source of truth and
+	 * fall back to it at read time.
+	 *
+	 * Fields intentionally NOT walked:
+	 *   - captchaType / sessionId / score / threshold / scoreComponents /
+	 *     ipAddress / ipInfo / headers — these describe the escalation
+	 *     itself and must never be overridden by the origin.
+	 *   - Anything already present on the escalation — first-write wins.
+	 *
+	 * Non-escalation sessions and escalations without `originSessionId`
+	 * (older records) fall through as no-op.
+	 */
+	public async getSessionRecordWithOriginFallback(
+		sessionId: string,
+	): Promise<Session | undefined> {
+		const session = await this.db.getSessionRecordBySessionId(sessionId);
+		if (!session) return undefined;
+		if (!session.originSessionId) return session;
+
+		const needsSimd =
+			session.simdReadings === undefined || session.simdReadings === null;
+		const needsDns =
+			session.dnsEvent === undefined || session.dnsEvent === null;
+		const needsEntropyMath =
+			session.entropyMathRandomFingerprint === undefined;
+		const needsEntropyCrypto = session.entropyCryptoFingerprint === undefined;
+		const needsEntropyWall = session.entropyWallClockOffsetMs === undefined;
+		const needsEntropyFirst = session.entropyMathRandomFirst === undefined;
+
+		if (
+			!needsSimd &&
+			!needsDns &&
+			!needsEntropyMath &&
+			!needsEntropyCrypto &&
+			!needsEntropyWall &&
+			!needsEntropyFirst
+		) {
+			return session;
+		}
+
+		const origin = await this.db.getSessionRecordBySessionId(
+			session.originSessionId,
+		);
+		if (!origin) return session;
+
+		return {
+			...session,
+			...(needsSimd && origin.simdReadings && { simdReadings: origin.simdReadings }),
+			...(needsDns && origin.dnsEvent && { dnsEvent: origin.dnsEvent }),
+			...(needsEntropyMath &&
+				origin.entropyMathRandomFingerprint !== undefined && {
+					entropyMathRandomFingerprint: origin.entropyMathRandomFingerprint,
+				}),
+			...(needsEntropyCrypto &&
+				origin.entropyCryptoFingerprint !== undefined && {
+					entropyCryptoFingerprint: origin.entropyCryptoFingerprint,
+				}),
+			...(needsEntropyWall &&
+				origin.entropyWallClockOffsetMs !== undefined && {
+					entropyWallClockOffsetMs: origin.entropyWallClockOffsetMs,
+				}),
+			...(needsEntropyFirst &&
+				origin.entropyMathRandomFirst !== undefined && {
+					entropyMathRandomFirst: origin.entropyMathRandomFirst,
+				}),
+		};
+	}
+
+	/**
 	 * Decrypt + first-hop-wins attach. Resolves the session's detector pool
 	 * bundle (promoted onto the session record at frictionless time) to decrypt.
 	 * No-op on decrypt failure / no bundle.

--- a/packages/provider/src/tasks/captchaManager.ts
+++ b/packages/provider/src/tasks/captchaManager.ts
@@ -205,8 +205,7 @@ export class CaptchaManager {
 			session.simdReadings === undefined || session.simdReadings === null;
 		const needsDns =
 			session.dnsEvent === undefined || session.dnsEvent === null;
-		const needsEntropyMath =
-			session.entropyMathRandomFingerprint === undefined;
+		const needsEntropyMath = session.entropyMathRandomFingerprint === undefined;
 		const needsEntropyCrypto = session.entropyCryptoFingerprint === undefined;
 		const needsEntropyWall = session.entropyWallClockOffsetMs === undefined;
 		const needsEntropyFirst = session.entropyMathRandomFirst === undefined;
@@ -229,7 +228,8 @@ export class CaptchaManager {
 
 		return {
 			...session,
-			...(needsSimd && origin.simdReadings && { simdReadings: origin.simdReadings }),
+			...(needsSimd &&
+				origin.simdReadings && { simdReadings: origin.simdReadings }),
 			...(needsDns && origin.dnsEvent && { dnsEvent: origin.dnsEvent }),
 			...(needsEntropyMath &&
 				origin.entropyMathRandomFingerprint !== undefined && {

--- a/packages/provider/src/tasks/frictionless/frictionlessTasks.ts
+++ b/packages/provider/src/tasks/frictionless/frictionlessTasks.ts
@@ -197,6 +197,7 @@ export class FrictionlessManager extends CaptchaManager {
 		isEscalation?: Session["isEscalation"],
 		iframeUrl?: Session["iframeUrl"],
 		isProtect?: Session["isProtect"],
+		originSessionId?: Session["originSessionId"],
 	): Promise<Session> {
 		const sessionRecord: Session = {
 			sessionId: `${getSessionIDPrefix(this.config.host)}-${uuidv4()}`,
@@ -217,6 +218,10 @@ export class FrictionlessManager extends CaptchaManager {
 			// avoids polluting analytics with `false` on every plain
 			// frictionless session.
 			...(isEscalation && { isEscalation: true }),
+			// Origin sessionId is only meaningful for escalations. Persist
+			// alongside isEscalation so the DM-input read path can walk
+			// back for fallback fields (simdReadings, dnsEvent, etc.).
+			...(originSessionId && { originSessionId }),
 			decryptedHeadHash,
 			bundleId,
 			reason,

--- a/packages/provider/src/tasks/imgCaptcha/imgCaptchaTasks.ts
+++ b/packages/provider/src/tasks/imgCaptcha/imgCaptchaTasks.ts
@@ -862,8 +862,10 @@ export class ImgCaptchaManager extends CaptchaManager {
 			}
 		}
 
+		// Walker fills simdReadings / dnsEvent / entropy fields from the origin
+		// when this is an escalation record. See CaptchaManager.getSessionRecordWithOriginFallback.
 		const sessionRecord = solution.sessionId
-			? await this.db.getSessionRecordBySessionId(solution.sessionId)
+			? await this.getSessionRecordWithOriginFallback(solution.sessionId)
 			: undefined;
 
 		const enrichedDnsEvent = await enrichDnsEvent(

--- a/packages/provider/src/tasks/powCaptcha/powTasks.ts
+++ b/packages/provider/src/tasks/powCaptcha/powTasks.ts
@@ -804,8 +804,13 @@ export class PowCaptchaManager extends CaptchaManager {
 			}
 		}
 
+		// Walk to the origin session when this is an escalation record —
+		// simdReadings / dnsEvent / entropy fields are populated on the
+		// origin and don't automatically end up on the escalation. Non-
+		// escalations pass through unchanged (walker no-ops when there's
+		// no originSessionId).
 		const sessionRecord = challengeRecord.sessionId
-			? await this.db.getSessionRecordBySessionId(challengeRecord.sessionId)
+			? await this.getSessionRecordWithOriginFallback(challengeRecord.sessionId)
 			: undefined;
 
 		const enrichedDnsEvent = await enrichDnsEvent(

--- a/packages/provider/src/tasks/puzzleCaptcha/puzzleTasks.ts
+++ b/packages/provider/src/tasks/puzzleCaptcha/puzzleTasks.ts
@@ -622,7 +622,7 @@ export class PuzzleCaptchaManager extends CaptchaManager {
 		}
 
 		const sessionRecord = challengeRecord.sessionId
-			? await this.db.getSessionRecordBySessionId(challengeRecord.sessionId)
+			? await this.getSessionRecordWithOriginFallback(challengeRecord.sessionId)
 			: undefined;
 
 		const enrichedDnsEvent = await enrichDnsEvent(

--- a/packages/provider/src/tests/unit/api/captcha/getFrictionlessCaptchaChallenge/shortCircuit.unit.test.ts
+++ b/packages/provider/src/tests/unit/api/captcha/getFrictionlessCaptchaChallenge/shortCircuit.unit.test.ts
@@ -16,12 +16,24 @@ import { CaptchaType } from "@prosopo/types";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { runConfiguredCaptchaTypeShortCircuit } from "../../../../../api/captcha/getFrictionlessCaptchaChallenge/shortCircuit.js";
 
-const buildInput = (overrides: Partial<Record<string, unknown>> = {}) => {
+const buildInput = (
+	overrides: Partial<Record<string, unknown>> = {},
+	{
+		resolvedBundleId,
+	}: { resolvedBundleId?: string } = {},
+) => {
 	const tasks = {
 		frictionlessManager: {
 			sendImageCaptcha: vi.fn().mockResolvedValue({ kind: "image" }),
 			sendPowCaptcha: vi.fn().mockResolvedValue({ kind: "pow" }),
 			sendPuzzleCaptcha: vi.fn().mockResolvedValue({ kind: "puzzle" }),
+			resolveBundleByDetectorSession: vi
+				.fn()
+				.mockResolvedValue(
+					resolvedBundleId
+						? { bundleId: resolvedBundleId, key: "k", innerConfig: "c" }
+						: undefined,
+				),
 		},
 	};
 	const env = {
@@ -124,5 +136,74 @@ describe("runConfiguredCaptchaTypeShortCircuit", () => {
 		await expect(
 			runConfiguredCaptchaTypeShortCircuit(input as never, res as never),
 		).rejects.toThrow(/Unhandled configured captchaType/);
+	});
+
+	describe("bundleId promotion (regression)", () => {
+		it("promotes bundleId onto pow bypass session when client sent a detectorSessionId", async () => {
+			const { tasks, input } = buildInput(
+				{ detectorSessionId: "det-abc" },
+				{ resolvedBundleId: "bundle-7" },
+			);
+			const res = buildRes();
+			await runConfiguredCaptchaTypeShortCircuit(input as never, res as never);
+			expect(
+				tasks.frictionlessManager.resolveBundleByDetectorSession,
+			).toHaveBeenCalledWith("det-abc");
+			const args = tasks.frictionlessManager.sendPowCaptcha.mock.calls[0]?.[0];
+			expect(args.bundleId).toBe("bundle-7");
+		});
+
+		it("promotes bundleId onto image bypass session", async () => {
+			const { tasks, input } = buildInput(
+				{ detectorSessionId: "det-img" },
+				{ resolvedBundleId: "bundle-3" },
+			);
+			input.clientRecord = {
+				settings: { imageMaxRounds: 3, captchaType: CaptchaType.image },
+			};
+			const res = buildRes();
+			await runConfiguredCaptchaTypeShortCircuit(input as never, res as never);
+			const args =
+				tasks.frictionlessManager.sendImageCaptcha.mock.calls[0]?.[0];
+			expect(args.bundleId).toBe("bundle-3");
+		});
+
+		it("promotes bundleId onto puzzle bypass session", async () => {
+			const { tasks, input } = buildInput(
+				{ detectorSessionId: "det-puz" },
+				{ resolvedBundleId: "bundle-99" },
+			);
+			input.clientRecord = {
+				settings: { imageMaxRounds: 10, captchaType: CaptchaType.puzzle },
+			};
+			const res = buildRes();
+			await runConfiguredCaptchaTypeShortCircuit(input as never, res as never);
+			const args =
+				tasks.frictionlessManager.sendPuzzleCaptcha.mock.calls[0]?.[0];
+			expect(args.bundleId).toBe("bundle-99");
+		});
+
+		it("omits bundleId when detectorSessionId is absent (empty-pool fallback)", async () => {
+			const { tasks, input } = buildInput({}, { resolvedBundleId: "bundle-1" });
+			// no detectorSessionId set
+			const res = buildRes();
+			await runConfiguredCaptchaTypeShortCircuit(input as never, res as never);
+			expect(
+				tasks.frictionlessManager.resolveBundleByDetectorSession,
+			).not.toHaveBeenCalled();
+			const args = tasks.frictionlessManager.sendPowCaptcha.mock.calls[0]?.[0];
+			expect(args.bundleId).toBeUndefined();
+		});
+
+		it("omits bundleId when Redis binding has expired", async () => {
+			// resolveBundleByDetectorSession returns undefined (no binding)
+			const { tasks, input } = buildInput({
+				detectorSessionId: "det-expired",
+			});
+			const res = buildRes();
+			await runConfiguredCaptchaTypeShortCircuit(input as never, res as never);
+			const args = tasks.frictionlessManager.sendPowCaptcha.mock.calls[0]?.[0];
+			expect(args.bundleId).toBeUndefined();
+		});
 	});
 });

--- a/packages/provider/src/tests/unit/api/captcha/getFrictionlessCaptchaChallenge/shortCircuit.unit.test.ts
+++ b/packages/provider/src/tests/unit/api/captcha/getFrictionlessCaptchaChallenge/shortCircuit.unit.test.ts
@@ -18,9 +18,7 @@ import { runConfiguredCaptchaTypeShortCircuit } from "../../../../../api/captcha
 
 const buildInput = (
 	overrides: Partial<Record<string, unknown>> = {},
-	{
-		resolvedBundleId,
-	}: { resolvedBundleId?: string } = {},
+	{ resolvedBundleId }: { resolvedBundleId?: string } = {},
 ) => {
 	const tasks = {
 		frictionlessManager: {

--- a/packages/provider/src/tests/unit/tasks/captchaManager.unit.test.ts
+++ b/packages/provider/src/tests/unit/tasks/captchaManager.unit.test.ts
@@ -142,7 +142,8 @@ describe("CaptchaManager", () => {
 			} as unknown as Session;
 			dbGet().mockResolvedValue(session);
 
-			const got = await captchaManager.getSessionRecordWithOriginFallback("sess");
+			const got =
+				await captchaManager.getSessionRecordWithOriginFallback("sess");
 
 			expect(got).toBe(session);
 			expect(dbGet()).toHaveBeenCalledTimes(1);
@@ -150,7 +151,8 @@ describe("CaptchaManager", () => {
 
 		it("returns undefined when the session isn't found", async () => {
 			dbGet().mockResolvedValue(null);
-			const got = await captchaManager.getSessionRecordWithOriginFallback("sess");
+			const got =
+				await captchaManager.getSessionRecordWithOriginFallback("sess");
 			expect(got).toBeUndefined();
 		});
 
@@ -168,7 +170,8 @@ describe("CaptchaManager", () => {
 			} as unknown as Session;
 			dbGet().mockResolvedValue(session);
 
-			const got = await captchaManager.getSessionRecordWithOriginFallback("esc");
+			const got =
+				await captchaManager.getSessionRecordWithOriginFallback("esc");
 
 			expect(got).toBe(session);
 			// Only one DB call — origin was never fetched.
@@ -192,7 +195,8 @@ describe("CaptchaManager", () => {
 			} as unknown as Session;
 			dbGet().mockResolvedValueOnce(escalation).mockResolvedValueOnce(origin);
 
-			const got = await captchaManager.getSessionRecordWithOriginFallback("esc");
+			const got =
+				await captchaManager.getSessionRecordWithOriginFallback("esc");
 
 			expect(got?.simdReadings).toEqual({
 				supported: true,
@@ -219,7 +223,8 @@ describe("CaptchaManager", () => {
 			} as unknown as Session;
 			dbGet().mockResolvedValueOnce(escalation).mockResolvedValueOnce(origin);
 
-			const got = await captchaManager.getSessionRecordWithOriginFallback("esc");
+			const got =
+				await captchaManager.getSessionRecordWithOriginFallback("esc");
 
 			expect(got?.simdReadings).toBeUndefined();
 			expect(got?.dnsEvent).toBeUndefined();
@@ -233,7 +238,8 @@ describe("CaptchaManager", () => {
 			} as unknown as Session;
 			dbGet().mockResolvedValueOnce(escalation).mockResolvedValueOnce(null);
 
-			const got = await captchaManager.getSessionRecordWithOriginFallback("esc");
+			const got =
+				await captchaManager.getSessionRecordWithOriginFallback("esc");
 
 			expect(got).toBe(escalation);
 		});
@@ -253,7 +259,8 @@ describe("CaptchaManager", () => {
 			} as unknown as Session;
 			dbGet().mockResolvedValueOnce(escalation).mockResolvedValueOnce(origin);
 
-			const got = await captchaManager.getSessionRecordWithOriginFallback("esc");
+			const got =
+				await captchaManager.getSessionRecordWithOriginFallback("esc");
 
 			// simd was filled from origin
 			expect(got?.simdReadings).toEqual({ supported: true });

--- a/packages/provider/src/tests/unit/tasks/captchaManager.unit.test.ts
+++ b/packages/provider/src/tests/unit/tasks/captchaManager.unit.test.ts
@@ -125,6 +125,145 @@ describe("CaptchaManager", () => {
 		vi.clearAllMocks();
 	});
 
+	// Session-chain walker. Escalation sessions (isEscalation=true) inherit
+	// their originSessionId from the pow-solve that spawned them. DM-input
+	// reads go through the walker so simdReadings / dnsEvent / entropy
+	// fields that live on the origin are surfaced on the escalation record
+	// without duplicating them at write time.
+	describe("getSessionRecordWithOriginFallback", () => {
+		const dbGet = () =>
+			db.getSessionRecordBySessionId as unknown as ReturnType<typeof vi.fn>;
+
+		it("returns the session as-is when there's no originSessionId (non-escalation)", async () => {
+			const session = {
+				sessionId: "sess",
+				captchaType: CaptchaType.pow,
+				simdReadings: undefined,
+			} as unknown as Session;
+			dbGet().mockResolvedValue(session);
+
+			const got = await captchaManager.getSessionRecordWithOriginFallback("sess");
+
+			expect(got).toBe(session);
+			expect(dbGet()).toHaveBeenCalledTimes(1);
+		});
+
+		it("returns undefined when the session isn't found", async () => {
+			dbGet().mockResolvedValue(null);
+			const got = await captchaManager.getSessionRecordWithOriginFallback("sess");
+			expect(got).toBeUndefined();
+		});
+
+		it("skips the origin walk when the escalation already carries every fallback-eligible field", async () => {
+			const session = {
+				sessionId: "esc",
+				originSessionId: "origin",
+				captchaType: CaptchaType.puzzle,
+				simdReadings: { supported: true, results: [] },
+				dnsEvent: { receivedAt: new Date() },
+				entropyMathRandomFingerprint: "a",
+				entropyCryptoFingerprint: "b",
+				entropyWallClockOffsetMs: 0,
+				entropyMathRandomFirst: 0.1,
+			} as unknown as Session;
+			dbGet().mockResolvedValue(session);
+
+			const got = await captchaManager.getSessionRecordWithOriginFallback("esc");
+
+			expect(got).toBe(session);
+			// Only one DB call — origin was never fetched.
+			expect(dbGet()).toHaveBeenCalledTimes(1);
+		});
+
+		it("fills simdReadings from origin when the escalation is missing it", async () => {
+			const origin = {
+				sessionId: "origin",
+				captchaType: CaptchaType.pow,
+				simdReadings: { supported: true, results: [1, 2, 3] },
+				dnsEvent: { receivedAt: new Date() },
+			} as unknown as Session;
+			const escalation = {
+				sessionId: "esc",
+				originSessionId: "origin",
+				captchaType: CaptchaType.puzzle,
+				// simdReadings and dnsEvent are undefined on the escalation
+				// (the exact production bug — origin's fire-and-forget writes
+				// raced buildEscalation's Mongo read).
+			} as unknown as Session;
+			dbGet().mockResolvedValueOnce(escalation).mockResolvedValueOnce(origin);
+
+			const got = await captchaManager.getSessionRecordWithOriginFallback("esc");
+
+			expect(got?.simdReadings).toEqual({
+				supported: true,
+				results: [1, 2, 3],
+			});
+			expect(got?.dnsEvent).toBeDefined();
+			// The escalation's own identity is preserved — origin fields
+			// don't overwrite escalation-owned fields.
+			expect(got?.sessionId).toBe("esc");
+			expect(got?.captchaType).toBe(CaptchaType.puzzle);
+		});
+
+		it("does not fill anything when origin also lacks the fields", async () => {
+			const origin = {
+				sessionId: "origin",
+				captchaType: CaptchaType.pow,
+				simdReadings: undefined,
+				dnsEvent: undefined,
+			} as unknown as Session;
+			const escalation = {
+				sessionId: "esc",
+				originSessionId: "origin",
+				captchaType: CaptchaType.puzzle,
+			} as unknown as Session;
+			dbGet().mockResolvedValueOnce(escalation).mockResolvedValueOnce(origin);
+
+			const got = await captchaManager.getSessionRecordWithOriginFallback("esc");
+
+			expect(got?.simdReadings).toBeUndefined();
+			expect(got?.dnsEvent).toBeUndefined();
+		});
+
+		it("returns the escalation unchanged when the origin session has been deleted", async () => {
+			const escalation = {
+				sessionId: "esc",
+				originSessionId: "origin-gone",
+				captchaType: CaptchaType.puzzle,
+			} as unknown as Session;
+			dbGet().mockResolvedValueOnce(escalation).mockResolvedValueOnce(null);
+
+			const got = await captchaManager.getSessionRecordWithOriginFallback("esc");
+
+			expect(got).toBe(escalation);
+		});
+
+		it("preserves escalation-owned fields — origin captchaType / sessionId / score never leak through", async () => {
+			const origin = {
+				sessionId: "origin",
+				captchaType: CaptchaType.pow,
+				score: 0.1,
+				simdReadings: { supported: true },
+			} as unknown as Session;
+			const escalation = {
+				sessionId: "esc",
+				originSessionId: "origin",
+				captchaType: CaptchaType.puzzle,
+				score: 0.5,
+			} as unknown as Session;
+			dbGet().mockResolvedValueOnce(escalation).mockResolvedValueOnce(origin);
+
+			const got = await captchaManager.getSessionRecordWithOriginFallback("esc");
+
+			// simd was filled from origin
+			expect(got?.simdReadings).toEqual({ supported: true });
+			// escalation-owned fields untouched
+			expect(got?.sessionId).toBe("esc");
+			expect(got?.captchaType).toBe(CaptchaType.puzzle);
+			expect(got?.score).toBe(0.5);
+		});
+	});
+
 	describe("isValidRequest", () => {
 		it("should validate a request for an image captcha when the client settings are set to image and no session ID is passed", async () => {
 			const result = await captchaManager.isValidRequest(

--- a/packages/types-database/src/types/provider.ts
+++ b/packages/types-database/src/types/provider.ts
@@ -676,6 +676,15 @@ export const SessionRecordSchema = new Schema<SessionRecord>({
 	// an escalation of an earlier session. Optional so ordinary
 	// frictionless-created sessions can omit it and stay slim.
 	isEscalation: { type: Boolean, required: false },
+	// SessionId of the session this one escalated from, when isEscalation is
+	// true. Read-time fallback source for fields that are inherently populated
+	// on the origin (simdReadings, dnsEvent, etc.) but not on the escalation
+	// itself — avoids the write-time race between the origin's fire-and-forget
+	// SIMD-attach / DNS-event patches and buildEscalation's Mongo read. The
+	// walker in captchaManager.getSessionRecordWithOriginFallback fills the
+	// gap only for fields that are inherently origin-populated; escalation-
+	// owned fields (captchaType, sessionId, score, etc.) are never overridden.
+	originSessionId: { type: String, required: false },
 	decryptedHeadHash: { type: String, required: false, default: "" },
 	bundleId: { type: String, required: false },
 	siteKey: { type: String, required: false },

--- a/packages/types/src/provider/database.ts
+++ b/packages/types/src/provider/database.ts
@@ -414,6 +414,11 @@ export const SessionSchema = object({
 	// "user hit the widget cold" from "user got escalated into a
 	// stronger captcha after a low-confidence PoW".
 	isEscalation: boolean().optional(),
+	// SessionId of the session this one escalated from. Populated when
+	// isEscalation is true; used by the DM-input read path to fall back
+	// to the origin for fields the escalation doesn't carry itself
+	// (simdReadings, dnsEvent, etc.). Absent on non-escalation sessions.
+	originSessionId: string().optional(),
 	decryptedHeadHash: string(),
 	siteKey: string().optional(),
 	// Full page URL the widget was rendered on (origin + path only — query
@@ -515,6 +520,9 @@ export type Session = {
 	// True when this session was minted by the post-PoW routing machine
 	// as an escalation. Undefined / false on ordinary frictionless sessions.
 	isEscalation?: boolean;
+	// SessionId of the origin session this one escalated from. Populated
+	// alongside isEscalation; consumed by the DM-input read path.
+	originSessionId?: string;
 	decryptedHeadHash: string;
 	// The provider-assigned detector pool bundle this session's detector ran
 	// from, promoted off the short-lived detectorSessionId→bundleId Redis


### PR DESCRIPTION
## Summary

Sitekeys with a configured `captchaType` (`pow` / `image` / `puzzle`) short-circuit the frictionless bot-detection path and build their session via `buildBypassSessionParams`. That helper never wrote `bundleId` onto the session, so every later `decryptAndAttachSimdReadingsIfAbsent` call at `/captcha/{type}` and solution-submit resolved `bundle=undefined` and silently dropped the SIMD / BDP ciphertext.

Resolve the widget's `detectorSessionId` → `bundleId` via the existing Redis binding and promote it onto the bypass session so attach finds the correct keypair. Empty-pool PoW fallback continues to no-op (no detector was assigned).

Reproduced locally via headless Chrome + CDP against the full stack: pow-configured sitekeys sent SIMD ciphertext at both `/captcha/pow` and `/pow/solution` but the session persisted with `bundleId=null` and `simdReadings=absent`. After the fix, session has `bundleId` set and SIMD lands.

## Test plan

- [x] `npm run build:tsc` — clean
- [x] `npm run test:unit` — 1006 passing (5 new regression tests in `shortCircuit.unit.test.ts` cover bundleId promotion on pow / image / puzzle paths + absent-detectorSessionId + expired-Redis-binding fallthroughs)
- [ ] e2e green
- [ ] confirm in prod: `bundleId` presence rate should tick from ~96% → ~100% on the sessions collection for the ~160 sitekeys with configured captchaType

🤖 Generated with [Claude Code](https://claude.com/claude-code)