### PR TITLE
feat(health): add consistent /health and /auth/health endpoints to provider API

### DIFF
--- a/packages/provider/src/api/authHealth.ts
+++ b/packages/provider/src/api/authHealth.ts
@@ -1,0 +1,38 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { handleErrors } from "@prosopo/api-express-router";
+import type { ProviderEnvironment } from "@prosopo/env";
+import { type AuthHealthResponse, HealthApiPaths } from "@prosopo/types";
+import { version } from "@prosopo/util";
+import express, { type Router } from "express";
+
+export function authHealthRouter(env: ProviderEnvironment): Router {
+	const router = express.Router();
+
+	router.get(HealthApiPaths.AuthHealth, (req, res) => {
+		const response: AuthHealthResponse = {
+			alive: true,
+			timestamp: new Date().toISOString(),
+			version,
+			uptimeSeconds: process.uptime(),
+			name: "provider",
+		};
+		res.json(response);
+	});
+
+	router.use(handleErrors);
+
+	return router;
+}

--- a/packages/provider/src/api/authHealth.ts
+++ b/packages/provider/src/api/authHealth.ts
@@ -21,7 +21,12 @@ import express, { type Router } from "express";
 export function authHealthRouter(env: ProviderEnvironment): Router {
 	const router = express.Router();
 
-	router.get(HealthApiPaths.AuthHealth, (req, res) => {
+	// Declared as the bare "/health": startProviderApi mounts this router under
+	// "/auth", immediately after the auth middleware for that prefix, so the
+	// effective path is still HealthApiPaths.AuthHealth. Spelling the prefix out
+	// here as well would let a later route be added to this router that resolves
+	// outside "/auth" and so outside the middleware.
+	router.get(HealthApiPaths.Health, (req, res) => {
 		const response: AuthHealthResponse = {
 			alive: true,
 			timestamp: new Date().toISOString(),

--- a/packages/provider/src/api/public.ts
+++ b/packages/provider/src/api/public.ts
@@ -15,7 +15,12 @@
 import { handleErrors } from "@prosopo/api-express-router";
 import { ProsopoApiError } from "@prosopo/common";
 import type { ProviderEnvironment } from "@prosopo/env";
-import { type ProviderDetails, PublicApiPaths } from "@prosopo/types";
+import {
+	HealthApiPaths,
+	type HealthResponse,
+	type ProviderDetails,
+	PublicApiPaths,
+} from "@prosopo/types";
 import { version } from "@prosopo/util";
 import express, { type Router } from "express";
 import { metricsEnabled, metricsHandler } from "./metrics.js";
@@ -48,6 +53,14 @@ export function publicRouter(env: ProviderEnvironment): Router {
 	if (metricsEnabled()) {
 		router.get(PublicApiPaths.Metrics, metricsHandler(env));
 	}
+
+	router.get(HealthApiPaths.Health, (req, res) => {
+		const response: HealthResponse = {
+			alive: true,
+			timestamp: new Date().toISOString(),
+		};
+		res.json(response);
+	});
 
 	/**
 	 * Gets public details of the provider

--- a/packages/provider/src/api/startProviderApi.ts
+++ b/packages/provider/src/api/startProviderApi.ts
@@ -45,6 +45,7 @@ import {
 	initDetectorBundlePool,
 } from "../tasks/detection/bundlePool.js";
 import { createApiAdminRoutesProvider } from "./admin/createApiAdminRoutesProvider.js";
+import { authHealthRouter } from "./authHealth.js";
 import { getVerdictCache } from "./blacklistRequestInspector.js";
 import { blockMiddleware } from "./block.js";
 import { prosopoRouter } from "./captcha.js";
@@ -55,8 +56,6 @@ import { ignoreMiddleware } from "./ignoreMiddleware.js";
 import { ipInfoMiddleware } from "./ipInfoMiddleware.js";
 import { ja4Middleware } from "./ja4Middleware.js";
 import { metricsMiddleware } from "./metrics.js";
-
-import { authHealthRouter } from "./authHealth.js";
 import { publicRouter } from "./public.js";
 import { robotsMiddleware } from "./robotsMiddleware.js";
 import { prosopoVerifyRouter } from "./verify.js";
@@ -392,7 +391,7 @@ export async function startProviderApi(
 
 	// Authenticated health endpoint
 	apiApp.use("/auth", authMiddleware(env.pair, env.authAccount));
-	apiApp.use(authHealthRouter(env));
+	apiApp.use("/auth", authHealthRouter(env));
 	if (apiRuleRoutesProvider) {
 		const userAccessRuleRoutes = apiRuleRoutesProvider.getRoutes();
 		for (const userAccessRuleRoute in userAccessRuleRoutes) {

--- a/packages/provider/src/api/startProviderApi.ts
+++ b/packages/provider/src/api/startProviderApi.ts
@@ -55,6 +55,8 @@ import { ignoreMiddleware } from "./ignoreMiddleware.js";
 import { ipInfoMiddleware } from "./ipInfoMiddleware.js";
 import { ja4Middleware } from "./ja4Middleware.js";
 import { metricsMiddleware } from "./metrics.js";
+
+import { authHealthRouter } from "./authHealth.js";
 import { publicRouter } from "./public.js";
 import { robotsMiddleware } from "./robotsMiddleware.js";
 import { prosopoVerifyRouter } from "./verify.js";
@@ -387,6 +389,10 @@ export async function startProviderApi(
 		"/v1/prosopo/provider/admin",
 		authMiddleware(env.pair, env.authAccount),
 	);
+
+	// Authenticated health endpoint
+	apiApp.use("/auth", authMiddleware(env.pair, env.authAccount));
+	apiApp.use(authHealthRouter(env));
 	if (apiRuleRoutesProvider) {
 		const userAccessRuleRoutes = apiRuleRoutesProvider.getRoutes();
 		for (const userAccessRuleRoute in userAccessRuleRoutes) {

--- a/packages/provider/src/tests/unit/api/health.unit.test.ts
+++ b/packages/provider/src/tests/unit/api/health.unit.test.ts
@@ -1,0 +1,122 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { ProviderEnvironment } from "@prosopo/env";
+import { HealthApiPaths } from "@prosopo/types";
+import type { Request, RequestHandler, Response, Router } from "express";
+import { describe, expect, it, vi } from "vitest";
+import { authHealthRouter } from "../../../api/authHealth.js";
+import { publicRouter } from "../../../api/public.js";
+
+vi.mock("@prosopo/api-express-router", () => ({
+	handleErrors: vi.fn(),
+}));
+
+vi.mock("@prosopo/util", () => ({
+	version: "1.0.0-test",
+}));
+
+/**
+ * The router's registered layers, as express actually stores them.
+ *
+ * Reached into rather than mocked so the tests exercise the paths the routers
+ * really register: asserting against a hand-rolled copy of the handler, as the
+ * older tests in this directory do, passes whatever the router does.
+ */
+interface RouterLayer {
+	route?: { path: string; stack: Array<{ handle: RequestHandler }> };
+}
+
+const handlerFor = (router: Router, path: string): RequestHandler => {
+	const layers = (router as unknown as { stack: RouterLayer[] }).stack;
+	const handler = layers.find((layer) => layer.route?.path === path)?.route
+		?.stack[0]?.handle;
+	if (handler === undefined) {
+		throw new Error(`no route registered at ${path}`);
+	}
+	return handler;
+};
+
+const providerEnv = (): ProviderEnvironment =>
+	({
+		getDb: vi.fn(),
+		logger: { error: vi.fn(), info: vi.fn() },
+	}) as unknown as ProviderEnvironment;
+
+const responseSpy = (): { res: Response; json: ReturnType<typeof vi.fn> } => {
+	const json = vi.fn();
+	return {
+		res: {
+			status: vi.fn().mockReturnThis(),
+			send: vi.fn(),
+			json,
+		} as unknown as Response,
+		json,
+	};
+};
+
+const isoTimestamp = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+
+describe("health endpoints", () => {
+	it("answers the public health route with alive and a timestamp", () => {
+		const { res, json } = responseSpy();
+
+		handlerFor(publicRouter(providerEnv()), HealthApiPaths.Health)(
+			{} as Request,
+			res,
+			vi.fn(),
+		);
+
+		const body: unknown = json.mock.calls[0]?.[0];
+		expect(body).toEqual({
+			alive: true,
+			timestamp: expect.stringMatching(isoTimestamp),
+		});
+	});
+
+	it("answers the authenticated health route with the full provider detail", () => {
+		const { res, json } = responseSpy();
+
+		handlerFor(authHealthRouter(providerEnv()), HealthApiPaths.Health)(
+			{} as Request,
+			res,
+			vi.fn(),
+		);
+
+		const body: unknown = json.mock.calls[0]?.[0];
+		expect(body).toEqual({
+			alive: true,
+			timestamp: expect.stringMatching(isoTimestamp),
+			version: "1.0.0-test",
+			uptimeSeconds: expect.any(Number),
+			name: "provider",
+		});
+	});
+
+	it("registers the authenticated route relative to its mount point", () => {
+		// startProviderApi mounts this router at "/auth" behind the auth
+		// middleware. If the router spelled the prefix out itself the effective
+		// path would be /auth/auth/health; if it were mounted at the root
+		// instead, the route would answer unauthenticated.
+		const layers = (
+			authHealthRouter(providerEnv()) as unknown as { stack: RouterLayer[] }
+		).stack;
+		const paths = layers
+			.map((layer) => layer.route?.path)
+			.filter((path): path is string => path !== undefined);
+
+		expect(paths).toEqual([HealthApiPaths.Health]);
+		expect(paths).not.toContain(HealthApiPaths.AuthHealth);
+	});
+});

--- a/packages/types/src/provider/api.ts
+++ b/packages/types/src/provider/api.ts
@@ -22,6 +22,7 @@ import {
 	boolean,
 	coerce,
 	type input,
+	literal,
 	nativeEnum,
 	number,
 	object,
@@ -103,6 +104,26 @@ export enum PublicApiPaths {
 	GetProviderDetails = "/v1/prosopo/provider/public/details",
 	Metrics = "/metrics",
 }
+
+export enum HealthApiPaths {
+	Health = "/health",
+	AuthHealth = "/auth/health",
+}
+
+export const healthResponseSchema = object({
+	alive: literal(true),
+	timestamp: string(),
+});
+
+export type HealthResponse = output<typeof healthResponseSchema>;
+
+export const authHealthResponseSchema = healthResponseSchema.extend({
+	version: string(),
+	uptimeSeconds: number(),
+	name: string(),
+});
+
+export type AuthHealthResponse = output<typeof authHealthResponseSchema>;
 
 export const providerDetailsSchema = object({
 	version: string(),


### PR DESCRIPTION
Re-opens the work from https://github.com/prosopo/captcha/pull/2579, which was merged and then backed out of `main` by https://github.com/prosopo/captcha/pull/3018 so it could go back through review. Same branch, same commits.