### PR TITLE
fix(provider): check in the decodePayload declaration

### DIFF
--- a/packages/provider/src/tasks/detection/decodePayload.d.ts
+++ b/packages/provider/src/tasks/detection/decodePayload.d.ts
@@ -1,0 +1,26 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { DetectorResult } from "@prosopo/types";
+
+// Hand-written to match decodeBehavior.d.ts and decodeSimd.d.ts, the other two
+// obfuscated .js modules in this directory. Without it tsc emits a declaration
+// for decodePayload.js into the source tree, and lint:license then trips on the
+// generated file because it carries no licence header.
+export default function getBotScoreFromPayload(
+	payload: string,
+	headHash: string,
+	privateKeyString?: string,
+	innerConfigEncoded?: string,
+): Promise<DetectorResult>;


### PR DESCRIPTION
`decodePayload.js` is an obfuscated module with no declaration of its own, so tsc emits one into the source tree during the build. The generated file carries no licence header, so `lint:license` fails whenever the build lands before it — intermittently, depending on turbo cache state. It has been blocking PRs in `prosopo/captcha-private`, which lints across the submodule.

Adds the declaration by hand, matching `decodeBehavior.d.ts` and `decodeSimd.d.ts` in the same directory. The signature is the one `getBotScore.ts` already assumes.