### PR TITLE
ci: cancel in-flight runs when a PR is converted to draft

### DIFF
--- a/.changeset/cancel-on-draft.md
+++ b/.changeset/cancel-on-draft.md
@@ -1,0 +1,4 @@
+---
+---
+
+ci: cancel in-flight runs when a PR is converted to draft

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -12,6 +12,7 @@ on:
       - synchronize # when a PR is pushed to
       - reopened # when a PR is reopened
       - ready_for_review # when a PR is marked as ready for review (e.g. taken off draft mode)
+      - converted_to_draft # so the concurrency group cancels the in-flight run
   workflow_dispatch:
 
 permissions:
@@ -36,7 +37,7 @@ jobs:
     # given, which is how a repo opts back out to a hosted runner.
     runs-on: ${{ vars.GH_RUNNER && startsWith(vars.GH_RUNNER, '[') && fromJSON(format('["{0}","2c","4g","20d"]', join(fromJSON(vars.GH_RUNNER), '","'))) || fromJSON(vars.GH_RUNNER || '"ubuntu-latest"') }}
     # Skip if PR title starts with "Release v"
-    if: ${{ !startsWith(github.event.pull_request.title, 'Release v') }}
+    if: ${{ !startsWith(github.event.pull_request.title, 'Release v') && github.event.action != 'converted_to_draft' }}
     steps:
       - name: Print contexts
         uses: prosopo/github_actions/.github/actions/print_contexts@a8f2d18145fedb774d5aacbde7b617c6c8852475 # main

--- a/.github/workflows/cypress-firefox.yml
+++ b/.github/workflows/cypress-firefox.yml
@@ -25,6 +25,7 @@ on:
       - synchronize # when a PR is pushed to
       - reopened # when a PR is reopened
       - ready_for_review # when a PR is marked as ready for review (e.g. taken off draft mode)
+      - converted_to_draft # so the concurrency group cancels the in-flight run
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -10,6 +10,7 @@ on:
       - synchronize # when a PR is pushed to
       - reopened # when a PR is reopened
       - ready_for_review # when a PR is marked as ready for review (e.g. taken off draft mode)
+      - converted_to_draft # so the concurrency group cancels the in-flight run
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/dependabot-changeset.yml
+++ b/.github/workflows/dependabot-changeset.yml
@@ -24,6 +24,7 @@ on:
       - opened
       - synchronize
       - reopened
+      - converted_to_draft # so the concurrency group cancels the in-flight run
 
 permissions:
   contents: read
@@ -46,7 +47,7 @@ jobs:
     # only lands on a host big enough for it. Set to a JSON string -> used as
     # given, which is how a repo opts back out to a hosted runner.
     runs-on: ${{ vars.GH_RUNNER && startsWith(vars.GH_RUNNER, '[') && fromJSON(format('["{0}","2c","4g","20d"]', join(fromJSON(vars.GH_RUNNER), '","'))) || fromJSON(vars.GH_RUNNER || '"ubuntu-latest"') }}
-    if: ${{ github.actor == 'dependabot[bot]' }}
+    if: ${{ github.actor == 'dependabot[bot]' && github.event.action != 'converted_to_draft' }}
     env:
       BASE_REF: ${{ github.event.pull_request.base.ref }}
       HEAD_REF: ${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,6 +10,7 @@ on:
       - synchronize # when a PR is pushed to
       - reopened # when a PR is reopened
       - ready_for_review # when a PR is marked as ready for review (e.g. taken off draft mode)
+      - converted_to_draft # so the concurrency group cancels the in-flight run
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/pinned-versions.yml
+++ b/.github/workflows/pinned-versions.yml
@@ -16,6 +16,7 @@ on:
       - synchronize # when a PR is pushed to
       - reopened # when a PR is reopened
       - ready_for_review # when a PR is marked as ready for review (e.g. taken off draft mode)
+      - converted_to_draft # so the concurrency group cancels the in-flight run
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/provider_image.yml
+++ b/.github/workflows/provider_image.yml
@@ -10,6 +10,7 @@ on:
       - synchronize # when a PR is pushed to
       - reopened # when a PR is reopened
       - ready_for_review # when a PR is marked as ready for review (e.g. taken off draft mode)
+      - converted_to_draft # so the concurrency group cancels the in-flight run
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,7 @@ on:
       - synchronize # when a PR is pushed to
       - reopened # when a PR is reopened
       - ready_for_review # when a PR is marked as ready for review (e.g. taken off draft mode)
+      - converted_to_draft # so the concurrency group cancels the in-flight run
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -10,6 +10,7 @@ on:
       - synchronize # when a PR is pushed to
       - reopened # when a PR is reopened
       - ready_for_review # when a PR is marked as ready for review (e.g. taken off draft mode)
+      - converted_to_draft # so the concurrency group cancels the in-flight run
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Same change as https://github.com/prosopo/captcha-private/pull/4113, applied here.

Adds `converted_to_draft` to the `pull_request` types of the nine PR-triggered workflows. Every one of them already has `concurrency: cancel-in-progress: true`, and that is what does the cancelling — a job-level `if` cannot stop a run that is already going. Adding the trigger type means a new run is created, claims the group, and evicts the in-flight one; the jobs then skip, so the new run costs nothing.

Seven of the nine need no new condition: they already gate on `github.event.pull_request.draft == false`, and on a `converted_to_draft` event the PR *is* draft, so they skip on their own. Two gate on something else and got an explicit `github.event.action != 'converted_to_draft'`:
- `changesets.yml` (gates on the PR title)
- `dependabot-changeset.yml` (gates on the actor)

Out of scope: `tag_release.yml` (`closed` only) and `release.yml`.

Not verifiable from a draft PR — to prove it, convert a throwaway non-draft PR to draft while a run is in flight and watch the run get cancelled.