### PR TITLE
ci: skip lint, typecheck, tests and cypress for changeset-only changes

### DIFF
--- a/.changeset/skip-changeset-only-runs.md
+++ b/.changeset/skip-changeset-only-runs.md
@@ -1,0 +1,4 @@
+---
+---
+
+ci: skip lint, typecheck, tests and cypress for changeset-only changes

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -5,6 +5,20 @@ name: cypress
 on:
   pull_request:
     branches: [main, dev, staging, release/*]
+    # Ignore-based, never inclusion-based: an allowlist silently stops testing
+    # any newly added directory, whereas anything unrecognised here still runs
+    # CI. Only paths that cannot possibly affect this workflow belong below.
+    #
+    # Safe against the "required check never reports" trap: the one required
+    # context on main is `check`, and changesets.yml publishes a job named
+    # `check` with no path filter at all, so a PR touching only ignored paths
+    # still gets a `check` and does not sit pending forever.
+    paths-ignore:
+      - '.changeset/**' # release metadata; nothing here reads it
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/PULL_REQUEST_TEMPLATE*'
+      - 'docs/**'
+      - '**.md'
     types:
       - opened # when a PR is opened
       - synchronize # when a PR is pushed to

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,18 @@ name: lint
 on:
   pull_request:
     branches: [main, dev, staging, release/*]
+    # Ignore-based, never inclusion-based: an allowlist silently stops testing
+    # any newly added directory, whereas anything unrecognised here still runs
+    # CI. Only paths that cannot possibly affect this workflow belong below.
+    #
+    # Safe against the "required check never reports" trap: the one required
+    # context on main is `check`, and changesets.yml publishes a job named
+    # `check` with no path filter at all, so a PR touching only ignored paths
+    # still gets a `check` and does not sit pending forever.
+    paths-ignore:
+      - '.changeset/**' # release metadata; nothing here reads it
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/PULL_REQUEST_TEMPLATE*'
     types:
       - opened # when a PR is opened
       - synchronize # when a PR is pushed to

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,20 @@ name: tests
 on:
   pull_request:
     branches: [main, dev, staging, release/*]
+    # Ignore-based, never inclusion-based: an allowlist silently stops testing
+    # any newly added directory, whereas anything unrecognised here still runs
+    # CI. Only paths that cannot possibly affect this workflow belong below.
+    #
+    # Safe against the "required check never reports" trap: the one required
+    # context on main is `check`, and changesets.yml publishes a job named
+    # `check` with no path filter at all, so a PR touching only ignored paths
+    # still gets a `check` and does not sit pending forever.
+    paths-ignore:
+      - '.changeset/**' # release metadata; nothing here reads it
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/PULL_REQUEST_TEMPLATE*'
+      - 'docs/**'
+      - '**.md'
     types:
       - opened # when a PR is opened
       - synchronize # when a PR is pushed to

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -5,6 +5,20 @@ name: typecheck
 on:
   pull_request:
     branches: [main, dev, staging, release/*]
+    # Ignore-based, never inclusion-based: an allowlist silently stops testing
+    # any newly added directory, whereas anything unrecognised here still runs
+    # CI. Only paths that cannot possibly affect this workflow belong below.
+    #
+    # Safe against the "required check never reports" trap: the one required
+    # context on main is `check`, and changesets.yml publishes a job named
+    # `check` with no path filter at all, so a PR touching only ignored paths
+    # still gets a `check` and does not sit pending forever.
+    paths-ignore:
+      - '.changeset/**' # release metadata; nothing here reads it
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/PULL_REQUEST_TEMPLATE*'
+      - 'docs/**'
+      - '**.md'
     types:
       - opened # when a PR is opened
       - synchronize # when a PR is pushed to


### PR DESCRIPTION
Adds `paths-ignore` to lint, typecheck, tests, cypress and cypress-firefox so a PR touching only release metadata or issue/PR templates (plus docs/markdown for the non-lint ones) doesn't burn a full CI run on the self-hosted fleet.

Ignore-based, never inclusion-based: an allowlist silently stops testing any newly added directory.

Safe against the required-check deadlock: the only required context on `main` is `check`, and `changesets.yml` publishes a job named `check` with no path filter at all, so a PR touching only ignored paths still reports `check` rather than sitting pending forever.

Mirrors https://github.com/prosopo/captcha-private/pull/4116.