### PR TITLE
fix(provider): send non-empty token sentinel on blocked sessions (hotfix)

### DIFF
--- a/.changeset/blocked-session-token-sentinel.md
+++ b/.changeset/blocked-session-token-sentinel.md
@@ -1,0 +1,10 @@
+---
+"@prosopo/provider": patch
+---
+
+blacklistRequestInspector: write `token: "blocked"` instead of `""` on blocked
+sessions so the mongoose `required: true` validator on `Session.token` stops
+rejecting the write. The empty-string sentinel was surfacing as
+"Validation failed: token: Path `token` is required" spam on every access-policy
+block and inflating API.PARSE_ERROR volume by ~3× on days with elevated block
+rules.

--- a/packages/provider/src/api/blacklistRequestInspector.ts
+++ b/packages/provider/src/api/blacklistRequestInspector.ts
@@ -647,8 +647,11 @@ export class BlacklistRequestInspector {
 			sessionId: `blocked-${randomUUID()}`,
 			createdAt: new Date(),
 			// Sentinel values for schema-required fields the blocked request
-			// never reached the point of populating.
-			token: "",
+			// never reached the point of populating. `token` must be non-empty:
+			// mongoose treats "" as missing on required String, and the
+			// resulting "Validation failed: token: Path `token` is required"
+			// spam floods the error stream and shows as API.PARSE_ERROR volume.
+			token: "blocked",
 			score: 1,
 			threshold: 0,
 			scoreComponents: { baseScore: 1 },


### PR DESCRIPTION
## Summary
- Blocked-session write path was setting `token: ""` on the synthetic Session record
- Mongoose treats empty string as missing on required String → threw \"Validation failed: token: Path \`token\` is required\" on every access-policy block
- Write is fire-and-forget so no user-visible failure, but log spam has been running at ~13k/day (3× baseline) and inflating API.PARSE_ERROR volume, masking real anomalies
- Fix: `token: "blocked"` sentinel — passes validation, disambiguated from real writes by `sessionId: blocked-<uuid>` prefix + `reason` / `ruleHash`

## Context
Diagnosed while investigating a Pimeyes referrer surge on prosopo.io — the widget converts frictionless 403s into a visible \"Cannot load CAPTCHA\" link to the FAQ, and the accompanying error-log spam was making it hard to isolate the actual cause.

## Test plan
- [x] Biome clean
- [ ] CI green
- [ ] After merge + release: verify pronodes' `production_provider_node` `err = *Validation failed: token*` count drops to zero within 15m of image roll
- [ ] Verify blocked-session rows still land in mongo with `token: "blocked"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)