### PR TITLE
fix(provider): surface requestId in 403 block response so widget renders it

### DIFF
--- a/.changeset/blocked-forbidden-requestid.md
+++ b/.changeset/blocked-forbidden-requestid.md
@@ -1,0 +1,12 @@
+---
+"@prosopo/provider": patch
+---
+
+blacklistRequestInspector: return structured `{ error: { message, code } }` on
+403 blocks with the requestId embedded (`Forbidden: <requestId>`), replacing
+the plain-string `{ error: "Forbidden" }`. The deployed widget's error
+extractor reads `result.error?.message` verbatim, so the FAQ-link banner now
+shows `Forbidden: <request-uuid>` instead of falling through to the generic
+"Cannot load CAPTCHA" — support can look up the blocking rule from the
+requestId a user quotes. Purely a backend response shape change; the widget
+already handles the structured object shape from the frictionless path.

--- a/demos/cypress-shared/cypress/e2e/accessPolicy.cy.ts
+++ b/demos/cypress-shared/cypress/e2e/accessPolicy.cy.ts
@@ -148,10 +148,19 @@ describe("User access policy Block rules", () => {
 					response?.statusCode,
 					"Access-policy block should return 403 at the middleware",
 				).to.equal(403);
+				// Structured `{ message, code }` so the widget's
+				// `result.error?.message` extractor renders
+				// `Forbidden: <requestId>` in the FAQ-link banner instead of
+				// falling through to "Cannot load CAPTCHA". requestId is
+				// generated per-request by requestLoggerMiddleware.
 				expect(
-					response?.body,
-					"403 body should carry the { error: 'Forbidden' } shape from blockMiddleware",
-				).to.deep.equal({ error: "Forbidden" });
+					response?.body?.error?.code,
+					"403 body error.code should be 403",
+				).to.equal(403);
+				expect(
+					response?.body?.error?.message,
+					"403 body error.message should be `Forbidden: <requestId>`",
+				).to.match(/^Forbidden: .+/);
 			});
 	});
 

--- a/packages/provider/src/api/blacklistRequestInspector.ts
+++ b/packages/provider/src/api/blacklistRequestInspector.ts
@@ -457,8 +457,17 @@ export class BlacklistRequestInspector {
 			// (blocked IP / JA4 / user / country / ASN), a request with no IP, or
 			// a fail-closed middleware error - is a 403 Forbidden, not a 401
 			// Unauthorized: the client isn't lacking credentials, it is denied
-			// access.
-			res.status(403).json({ error: "Forbidden" });
+			// access. Body must be a structured `{ message, code }` object
+			// (not a plain string) so the widget's `result.error?.message`
+			// extractor picks it up — a plain string falls through to the
+			// generic "Cannot load CAPTCHA" fallback. Surfacing the
+			// requestId lets support quote it back on tickets.
+			res.status(403).json({
+				error: {
+					message: `Forbidden: ${request.requestId ?? "unknown"}`,
+					code: 403,
+				},
+			});
 			return;
 		}
 

--- a/packages/provider/src/tests/unit/api/blacklistRequestInspector.unit.test.ts
+++ b/packages/provider/src/tests/unit/api/blacklistRequestInspector.unit.test.ts
@@ -813,6 +813,7 @@ describe("BlacklistRequestInspector.abortRequestForBlockedUsers", () => {
 			headers: {},
 			body: {},
 			logger: mockLogger,
+			requestId: "test-request-id",
 			...overrides,
 		}) as unknown as Request;
 
@@ -835,7 +836,13 @@ describe("BlacklistRequestInspector.abortRequestForBlockedUsers", () => {
 		);
 
 		expect(status).toHaveBeenCalledWith(403);
-		expect(json).toHaveBeenCalledWith({ error: "Forbidden" });
+		// Structured object so the widget's `result.error?.message` extractor
+		// renders `Forbidden: <requestId>` instead of falling through to
+		// "Cannot load CAPTCHA". requestId gives support a handle to trace
+		// the blocked session back to the matching rule.
+		expect(json).toHaveBeenCalledWith({
+			error: { message: "Forbidden: test-request-id", code: 403 },
+		});
 		expect(next).not.toHaveBeenCalled();
 	});
 


### PR DESCRIPTION
## Summary
- Block handler was returning plain-string `{ error: \"Forbidden\" }` on 403s
- Widget's error extractor reads `result.error?.message` — plain string has no `.message` so widget falls back to generic \"Cannot load CAPTCHA\"
- Return structured `{ error: { message: \"Forbidden: <requestId>\", code: 403 } }` — widget renders it verbatim inside the FAQ link, giving users a requestId to quote on support tickets
- Purely a backend shape change; deployed widget already handles the structured object shape used everywhere else

## Context
Follow-up to #3036 (which killed the mongoose validation spam on the block path). Same deploy investigation — Pimeyes referrer surge — surfaced this UX gap. Already shipped to prod as `prosopo/provider:3.7.5-hotfix3`; this PR folds it back onto mainline.

## Test plan
- [x] Biome clean
- [ ] CI green
- [ ] After merge + release + roll: hit a known blocked IP against `/prosopo/provider/client/frictionless` — response body should be `{\"error\":{\"message\":\"Forbidden: <uuid>\",\"code\":403}}`, and the widget banner should render `Forbidden: <uuid>` instead of \"Cannot load CAPTCHA\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)