### PR TITLE
fix(procaptcha-common): make the error label selectable

### DIFF
--- a/.changeset/error-label-selectable.md
+++ b/.changeset/error-label-selectable.md
@@ -1,0 +1,9 @@
+---
+"@prosopo/procaptcha-common": patch
+---
+
+Checkbox: allow selecting the error-label text (and its inner link) so users
+can copy the `Forbidden: <requestId>` reference for support tickets. The
+label's `user-select: none` is a click-to-toggle hint that only makes sense
+when the checkbox is enabled; on the error branch the checkbox is disabled,
+so overriding to `user-select: text` (with a text cursor) is safe.

--- a/packages/procaptcha-common/src/reactComponents/Checkbox.tsx
+++ b/packages/procaptcha-common/src/reactComponents/Checkbox.tsx
@@ -229,10 +229,14 @@ export const Checkbox: FC<CheckboxProps> = ({
 				/>
 			)}
 			{error ? (
-				<ResponsiveLabel htmFor={id}>
+				<ResponsiveLabel
+					htmFor={id}
+					style={{ userSelect: "text", cursor: "text" }}
+				>
 					<a
 						css={{
 							color: theme.palette.error.main,
+							userSelect: "text",
 						}}
 						href={FAQ_LINK}
 					>


### PR DESCRIPTION
## Summary
- Overrides `user-select: none` on the checkbox error label (and its inner link) so users can copy the `Forbidden: <requestId>` reference for support tickets.
- Adds a text cursor on the error branch since it's no longer click-to-toggle.

Follow-up to #3037 which put the requestId into that string in the first place.

## Test plan
- [ ] Trigger a widget block → verify the reference is selectable/copyable
- [ ] Non-error state: label still shows the pointer cursor and doesn't select on drag

🤖 Generated with [Claude Code](https://claude.com/claude-code)