### PR TITLE
ci(demos): build the android and ios webview demos on every PR

### DIFF
--- a/.changeset/mobile-demo-ci.md
+++ b/.changeset/mobile-demo-ci.md
@@ -1,0 +1,4 @@
+---
+---
+
+ci: build the android and ios webview demos on every PR

--- a/.github/workflows/android-webview.yml
+++ b/.github/workflows/android-webview.yml
@@ -1,0 +1,46 @@
+name: android-webview
+
+on:
+  pull_request:
+    branches: [main]
+    types:
+      - opened
+      - synchronize
+      - reopened
+      # Not a type this workflow wants to run for -- the job below skips it. It
+      # exists so the run is created and cancels the in-flight one.
+      - converted_to_draft
+    paths:
+      - "demos/android-webview/**"
+      - ".github/workflows/android-webview.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    if: ${{ github.event.action != 'converted_to_draft' }}
+    # Hosted, deliberately, and not routed through `vars.GH_RUNNER` like the
+    # other repos: this repository is public, so a fork PR running on the
+    # self-hosted fleet would execute arbitrary code on it.
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: demos/android-webview
+    steps:
+      - uses: actions/checkout@v4
+
+      # 17, not the app's own jvmTarget: that is the bytecode level the app
+      # compiles *to*, while the Android Gradle Plugin itself needs a JDK 17.
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Gradle build + unit tests
+        run: ./gradlew --no-daemon --stacktrace testReleaseUnitTest assembleRelease

--- a/.github/workflows/android-webview.yml
+++ b/.github/workflows/android-webview.yml
@@ -14,6 +14,14 @@ on:
       - "demos/android-webview/**"
       - ".github/workflows/android-webview.yml"
 
+# Least privilege: both jobs only check out the repo and build it, so read
+# access to contents is the whole requirement. Without this the workflow
+# inherits the repository default, which is write on several scopes -- and this
+# repository is public, so a workflow that builds a fork's code is exactly
+# where a broad token should not be handed out.
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/ios-webview.yml
+++ b/.github/workflows/ios-webview.yml
@@ -14,6 +14,14 @@ on:
       - "demos/ios-webview/**"
       - ".github/workflows/ios-webview.yml"
 
+# Least privilege: both jobs only check out the repo and build it, so read
+# access to contents is the whole requirement. Without this the workflow
+# inherits the repository default, which is write on several scopes -- and this
+# repository is public, so a workflow that builds a fork's code is exactly
+# where a broad token should not be handed out.
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/ios-webview.yml
+++ b/.github/workflows/ios-webview.yml
@@ -1,0 +1,56 @@
+name: ios-webview
+
+on:
+  pull_request:
+    branches: [main]
+    types:
+      - opened
+      - synchronize
+      - reopened
+      # Not a type this workflow wants to run for -- the job below skips it. It
+      # exists so the run is created and cancels the in-flight one.
+      - converted_to_draft
+    paths:
+      - "demos/ios-webview/**"
+      - ".github/workflows/ios-webview.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    if: ${{ github.event.action != 'converted_to_draft' }}
+    # Hosted, deliberately: this repository is public, so a fork PR running on
+    # the self-hosted macOS runner would execute arbitrary code on it.
+    # macos-15 (Xcode 16) is enough here -- the app targets iOS 16.4.
+    runs-on: macos-15
+    defaults:
+      run:
+        working-directory: demos/ios-webview
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Toolchain versions
+        run: xcodebuild -version
+
+      # `-target`, not `-scheme`: the project ships no shared scheme
+      # (xcshareddata/xcschemes is absent) and Xcode only autocreates schemes
+      # when a human opens the project, so `-scheme procaptcha` fails on a
+      # clean machine.
+      #
+      # CODE_SIGNING_ALLOWED=NO and the simulator SDK: this is an app target,
+      # so it would otherwise fail looking for a signing identity and a
+      # provisioning profile that CI has no business holding.
+      - name: Build (iOS Simulator)
+        run: |
+          xcodebuild build \
+            -project procaptcha.xcodeproj \
+            -target procaptcha \
+            -configuration Release \
+            -sdk iphonesimulator \
+            CODE_SIGNING_ALLOWED=NO
+
+      # No test step: the project declares no test target, so there is nothing
+      # to run. Build-only is the honest answer -- it still catches the next
+      # change that breaks the native integration, which is the point.

--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,7 @@ issue-long-jwt.mjs
 # `docker compose up dns`. Pronodes come and go; the file is host
 # state, not source state.
 docker/dns-tenants.json
+
+# Android SDK location -- machine-specific, and if committed it overrides
+# ANDROID_HOME and breaks the build everywhere else, CI included.
+local.properties

--- a/demos/android-webview/local.properties
+++ b/demos/android-webview/local.properties
@@ -1,8 +1,0 @@
-## This file must *NOT* be checked into Version Control Systems,
-# as it contains information specific to your local configuration.
-#
-# Location of the SDK. This is only used by Gradle.
-# For customization when using a Version Control System, please read the
-# header note.
-#Thu Dec 12 13:58:37 GMT 2024
-sdk.dir=/home/chris/Android/Sdk


### PR DESCRIPTION
`demos/android-webview` and `demos/ios-webview` had no CI at all, so a change that breaks the native integration was only ever caught by whoever next opened the project.

- `android-webview.yml` — JDK 17 + `setup-android`, `testReleaseUnitTest assembleRelease`. The app does have a `src/test` source set, so the unit tests are real.
- `ios-webview.yml` — `xcodebuild build` against the simulator SDK with signing off. It uses `-target procaptcha` rather than `-scheme`: the project ships no shared scheme, and Xcode only autocreates schemes when a human opens the project. The project declares no test target, so this one is build-only and says so in a comment.

Both jobs stay on **hosted** runners rather than `vars.GH_RUNNER`. This repository is public, so a fork PR scheduled onto the self-hosted fleet would run arbitrary code on it. `macos-15` is sufficient — the app targets iOS 16.4.

Also drops `demos/android-webview/local.properties`, which was committed with `sdk.dir=/home/chris/Android/Sdk`. Gradle prefers `sdk.dir` over `ANDROID_HOME`, so with that file present the android build could not find the SDK on any machine but that one. Added to `.gitignore`.

Sibling change for the Protect mobile trees: https://github.com/prosopo/Protect/tree/ci/fickets-mobile-ci