### PR TITLE
fix(procaptcha-bundle): make reset() remount the widget

### DIFF
--- a/.changeset/procaptcha-reset-remount.md
+++ b/.changeset/procaptcha-reset-remount.md
@@ -1,0 +1,20 @@
+---
+"@prosopo/procaptcha-bundle": patch
+---
+
+Make `reset()` remount the widget instead of only tearing it down.
+
+`reset()` unmounted every React root and then called `start()`, which
+re-renders only when the page uses implicit rendering. On an explicitly
+rendered page nothing came back: the widget skeleton is plain DOM created
+outside React, so it stayed on screen with no checkbox inside it, and no fresh
+captcha request was ever made. Callers had to follow every `reset()` with their
+own `render()` to recover.
+
+Widgets are now tracked with the element and render options that produced them,
+so `reset()` can rebuild in place. `render()` returns a widget id, and both
+`reset(widgetId)` and the new `remove(widgetId)` accept one to target a single
+widget; omitting it applies to every widget on the page. `remove()` preserves
+the old teardown-without-remount behaviour for callers that want the widget
+gone. `reset()` no longer calls `start()`, which would have double-rendered
+implicit widgets and attached another `load` listener on every call.

--- a/packages/procaptcha-bundle/src/index.ts
+++ b/packages/procaptcha-bundle/src/index.ts
@@ -21,7 +21,49 @@ import { WidgetFactory } from "./util/widgetFactory.js";
 import { WidgetThemeResolver } from "./util/widgetThemeResolver.js";
 
 const BUNDLE_NAMES = ["procaptcha.bundle.iife.js", "procaptcha.bundle.js"];
-let procaptchaRoots: Root[] = [];
+
+/**
+ * Everything needed to rebuild a widget in place.
+ *
+ * Previously only the React `Root` was retained, which made `reset()` a
+ * one-way operation: unmounting tore out the React tree but the widget
+ * skeleton (created imperatively by `createWidgetSkeleton`, not by React)
+ * stayed in the DOM, leaving a container with a logo and no checkbox. There
+ * was no record of which element or render options produced it, so nothing
+ * could put it back. Keeping the descriptor alongside the root is what lets
+ * `reset()` remount rather than just destroy.
+ */
+interface WidgetEntry {
+	root: Root;
+	element: Element;
+	renderOptions: ProcaptchaRenderOptions;
+	isWeb2: boolean;
+	invisible: boolean;
+}
+
+const procaptchaWidgets = new Map<string, WidgetEntry>();
+
+let widgetIdCounter = 0;
+const nextWidgetId = (): string => `procaptcha-widget-${widgetIdCounter++}`;
+
+const registerWidgets = (
+	roots: Root[],
+	elements: Element[],
+	renderOptions: ProcaptchaRenderOptions,
+	isWeb2: boolean,
+	invisible: boolean,
+): string[] =>
+	roots.map((root, index) => {
+		const id = nextWidgetId();
+		procaptchaWidgets.set(id, {
+			root,
+			element: at(elements, index),
+			renderOptions,
+			isWeb2,
+			invisible,
+		});
+		return id;
+	});
 
 const widgetFactory = new WidgetFactory(new WidgetThemeResolver());
 
@@ -87,17 +129,25 @@ const implicitRender = async () => {
 		// `customDetectBot` claims the in-flight promise when it eventually runs.
 		startDetectorPrefetch(siteKey, { ipv4, ipv6 });
 
+		const implicitRenderOptions: ProcaptchaRenderOptions = {
+			siteKey: siteKey,
+			ipv4,
+			ipv6,
+		};
+
 		const root = await widgetFactory.createWidgets(
 			elements,
-			{
-				siteKey: siteKey,
-				ipv4,
-				ipv6,
-			},
+			implicitRenderOptions,
 			!(web3 === "true"),
 		);
 
-		procaptchaRoots.push(...root);
+		registerWidgets(
+			root,
+			elements,
+			implicitRenderOptions,
+			!(web3 === "true"),
+			false,
+		);
 	}
 
 	// Check for invisible mode indicators (procaptcha class on buttons)
@@ -114,19 +164,21 @@ const implicitRender = async () => {
 
 			startDetectorPrefetch(siteKey, { ipv4, ipv6 });
 
+			const buttonRenderOptions: ProcaptchaRenderOptions = {
+				siteKey: siteKey,
+				callback: callback,
+				ipv4,
+				ipv6,
+			};
+
 			const root = await widgetFactory.createWidgets(
 				[button],
-				{
-					siteKey: siteKey,
-					callback: callback,
-					ipv4,
-					ipv6,
-				},
+				buttonRenderOptions,
 				true,
 				true,
 			);
 
-			procaptchaRoots.push(...root);
+			registerWidgets(root, [button], buttonRenderOptions, true, true);
 
 			// Add click event listener to the button
 			button.addEventListener("click", async (event) => {
@@ -138,10 +190,19 @@ const implicitRender = async () => {
 };
 
 // Explicit render for targeting specific elements
+/**
+ * Renders a widget into `element` and returns its id, which `reset()` and
+ * `remove()` accept to target this widget alone. Previously this returned
+ * nothing, so callers had no handle on an individual widget and the only
+ * available reset was all-or-nothing.
+ *
+ * Returns undefined when no widget was created, rather than throwing — the
+ * factory legitimately yields nothing for an element it cannot mount into.
+ */
 export const render = async (
 	element: Element,
 	renderOptions: ProcaptchaRenderOptions,
-) => {
+): Promise<string | undefined> => {
 	startDetectorPrefetch(renderOptions.siteKey, renderOptions);
 
 	const hasInvisibleSize =
@@ -149,26 +210,27 @@ export const render = async (
 		renderOptions.size === "invisible";
 
 	const isWeb2 = !renderOptions.web3;
-
-	if (hasInvisibleSize || element.tagName.toLowerCase() === "button") {
-		const roots = await widgetFactory.createWidgets(
-			[element],
-			renderOptions,
-			isWeb2,
-			true,
-		);
-		procaptchaRoots.push(...roots);
-		return;
-	}
+	const invisible =
+		hasInvisibleSize || element.tagName.toLowerCase() === "button";
 
 	const roots = await widgetFactory.createWidgets(
 		[element],
 		renderOptions,
 		isWeb2,
-		false,
+		invisible,
 	);
 
-	procaptchaRoots.push(...roots);
+	const ids = registerWidgets(
+		roots,
+		[element],
+		renderOptions,
+		isWeb2,
+		invisible,
+	);
+
+	// Deliberately not `at()`: it throws on an empty array before it consults
+	// `optional`, and zero roots is a legitimate outcome here.
+	return ids[0];
 };
 
 export default function ready(fn: () => void) {
@@ -246,6 +308,7 @@ declare global {
 			ready: typeof ready;
 			render: typeof render;
 			reset: typeof reset;
+			remove: typeof remove;
 			execute: typeof execute;
 		};
 	}
@@ -284,17 +347,69 @@ const start = () => {
 	}
 };
 
-export const reset = () => {
-	for (const root of procaptchaRoots) {
-		root.unmount();
-	}
-	procaptchaRoots = [];
+/**
+ * Returns a widget to its unsolved state, ready to be solved again. Pass a
+ * widget id to reset one widget, or omit it to reset every widget on the page.
+ *
+ * This remounts rather than merely unmounting. The previous implementation
+ * unmounted every root and then called `start()`, which only re-renders when
+ * the page uses implicit rendering — and even then only via the
+ * `document.readyState` fallback, because the script's `load` event has long
+ * since fired. On an explicitly-rendered page nothing came back at all: the
+ * skeleton stayed in the DOM with no checkbox inside it, and no fresh captcha
+ * request was ever made. Rebuilding from the stored descriptor makes reset
+ * behave the same way on both paths.
+ *
+ * `start()` is deliberately not called here any more. It re-renders implicit
+ * widgets, which would double up with the remount below, and it attaches
+ * another `load` listener to the script tag on every call.
+ */
+export const reset = async (widgetId?: string): Promise<void> => {
+	const ids: string[] =
+		undefined === widgetId ? Array.from(procaptchaWidgets.keys()) : [widgetId];
 
-	start();
+	for (const id of ids) {
+		const current = procaptchaWidgets.get(id);
+		if (!current) continue;
+
+		current.root.unmount();
+
+		const [root] = await widgetFactory.createWidgets(
+			[current.element],
+			current.renderOptions,
+			current.isWeb2,
+			current.invisible,
+		);
+
+		if (root) {
+			procaptchaWidgets.set(id, { ...current, root });
+		} else {
+			procaptchaWidgets.delete(id);
+		}
+	}
+};
+
+/**
+ * Tears a widget down without putting it back — the behaviour `reset()` used
+ * to have by accident on explicitly-rendered pages, kept as an explicit
+ * operation for callers that genuinely want the widget gone (a closing modal,
+ * an SPA route change).
+ */
+export const remove = (widgetId?: string): void => {
+	const ids =
+		undefined === widgetId ? Array.from(procaptchaWidgets.keys()) : [widgetId];
+
+	for (const id of ids) {
+		const entry = procaptchaWidgets.get(id);
+		if (!entry) continue;
+		entry.root.unmount();
+		entry.element.innerHTML = "";
+		procaptchaWidgets.delete(id);
+	}
 };
 
 // set the procaptcha attribute on the window
-window.procaptcha = { ready, render, reset, execute };
+window.procaptcha = { ready, render, reset, remove, execute };
 
 // Dispatch a custom event to notify that window.procaptcha is ready
 const procaptchaReadyEvent = new CustomEvent(PROCAPTCHA_READY_EVENT, {

--- a/packages/procaptcha-bundle/src/tests/reset.unit.test.ts
+++ b/packages/procaptcha-bundle/src/tests/reset.unit.test.ts
@@ -1,0 +1,204 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * `reset()` used to unmount every React root and then call `start()`, which
+ * re-renders only on implicitly-rendered pages. An explicitly-rendered widget
+ * was therefore destroyed and never rebuilt: the skeleton stayed in the DOM
+ * with no checkbox inside it and no fresh captcha request was made. These
+ * tests pin the remount so that regression cannot return.
+ */
+
+import type { Root } from "react-dom/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+	prefetchDetector: vi.fn(),
+	createWidgets: vi.fn(),
+}));
+
+vi.mock("@prosopo/procaptcha-frictionless", () => ({
+	prefetchDetector: mocks.prefetchDetector,
+}));
+
+vi.mock("@prosopo/procaptcha-common", () => ({
+	getWindowCallback: vi.fn(),
+	pickIpMode: vi.fn(() => undefined),
+}));
+
+vi.mock("../util/widgetFactory.js", () => ({
+	WidgetFactory: vi.fn(function () {
+		return { createWidgets: mocks.createWidgets };
+	}),
+}));
+
+const { render, reset, remove } = await import("../index.js");
+
+const SITE_KEY = "5CcNvLUdiXFpzKDMjThGLSK9rhWHA1H4EF3zrgkpkjAdqmuP";
+
+const makeRoot = (): Root =>
+	({ unmount: vi.fn(), render: vi.fn() }) as unknown as Root;
+
+/** Each createWidgets call yields a distinct root, as the real factory does. */
+const queueRoots = (...roots: Root[]): void => {
+	for (const root of roots) {
+		mocks.createWidgets.mockResolvedValueOnce([root]);
+	}
+};
+
+beforeEach(async () => {
+	vi.clearAllMocks();
+	// Drop any widgets registered by a previous test — module state persists
+	// across tests in the same file.
+	await remove();
+	mocks.createWidgets.mockResolvedValue([makeRoot()]);
+});
+
+describe("render", () => {
+	it("returns a widget id", async () => {
+		queueRoots(makeRoot());
+
+		const widgetId = await render(document.createElement("div"), {
+			siteKey: SITE_KEY,
+		});
+
+		expect(typeof widgetId).toBe("string");
+		expect(widgetId).toBeTruthy();
+	});
+
+	it("returns undefined when the factory creates no widget", async () => {
+		mocks.createWidgets.mockResolvedValueOnce([] as Root[]);
+
+		const widgetId = await render(document.createElement("div"), {
+			siteKey: SITE_KEY,
+		});
+
+		expect(widgetId).toBeUndefined();
+	});
+});
+
+describe("reset", () => {
+	it("unmounts the old root and mounts a replacement", async () => {
+		const first = makeRoot();
+		const second = makeRoot();
+		queueRoots(first, second);
+
+		const element = document.createElement("div");
+		await render(element, { siteKey: SITE_KEY });
+		expect(mocks.createWidgets).toHaveBeenCalledTimes(1);
+
+		await reset();
+
+		expect(first.unmount).toHaveBeenCalledTimes(1);
+		expect(mocks.createWidgets).toHaveBeenCalledTimes(2);
+		// Rebuilt into the same element, with the options it was rendered with.
+		expect(mocks.createWidgets).toHaveBeenLastCalledWith(
+			[element],
+			expect.objectContaining({ siteKey: SITE_KEY }),
+			true,
+			false,
+		);
+		expect(second.unmount).not.toHaveBeenCalled();
+	});
+
+	it("resets only the widget whose id is given", async () => {
+		const firstA = makeRoot();
+		const firstB = makeRoot();
+		const replacementA = makeRoot();
+		queueRoots(firstA, firstB, replacementA);
+
+		const elementA = document.createElement("div");
+		const elementB = document.createElement("div");
+		const idA = await render(elementA, { siteKey: SITE_KEY });
+		await render(elementB, { siteKey: SITE_KEY });
+
+		await reset(idA);
+
+		expect(firstA.unmount).toHaveBeenCalledTimes(1);
+		expect(firstB.unmount).not.toHaveBeenCalled();
+		expect(mocks.createWidgets).toHaveBeenLastCalledWith(
+			[elementA],
+			expect.anything(),
+			true,
+			false,
+		);
+	});
+
+	it("keeps the widget resettable more than once", async () => {
+		const roots = [makeRoot(), makeRoot(), makeRoot()];
+		queueRoots(...roots);
+
+		await render(document.createElement("div"), { siteKey: SITE_KEY });
+		await reset();
+		await reset();
+
+		expect(roots[0]?.unmount).toHaveBeenCalledTimes(1);
+		expect(roots[1]?.unmount).toHaveBeenCalledTimes(1);
+		expect(mocks.createWidgets).toHaveBeenCalledTimes(3);
+	});
+
+	it("preserves the invisible flag when rebuilding", async () => {
+		queueRoots(makeRoot(), makeRoot());
+
+		const button = document.createElement("button");
+		await render(button, { siteKey: SITE_KEY });
+
+		await reset();
+
+		expect(mocks.createWidgets).toHaveBeenLastCalledWith(
+			[button],
+			expect.anything(),
+			true,
+			true,
+		);
+	});
+
+	it("does nothing for an unknown widget id", async () => {
+		queueRoots(makeRoot());
+		await render(document.createElement("div"), { siteKey: SITE_KEY });
+
+		await reset("procaptcha-widget-does-not-exist");
+
+		expect(mocks.createWidgets).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe("remove", () => {
+	it("unmounts without mounting a replacement", async () => {
+		const root = makeRoot();
+		queueRoots(root);
+
+		const element = document.createElement("div");
+		element.innerHTML = "<span>skeleton</span>";
+		await render(element, { siteKey: SITE_KEY });
+
+		await remove();
+
+		expect(root.unmount).toHaveBeenCalledTimes(1);
+		expect(mocks.createWidgets).toHaveBeenCalledTimes(1);
+		// The skeleton is plain DOM, so unmounting React alone would leave it
+		// behind — remove() is responsible for clearing the container too.
+		expect(element.innerHTML).toBe("");
+	});
+
+	it("makes a subsequent reset a no-op", async () => {
+		queueRoots(makeRoot());
+		await render(document.createElement("div"), { siteKey: SITE_KEY });
+
+		await remove();
+		await reset();
+
+		expect(mocks.createWidgets).toHaveBeenCalledTimes(1);
+	});
+});


### PR DESCRIPTION
## Problem

`reset()` destroys the widget and never puts it back on explicitly-rendered pages.

```js
export const reset = () => {
  for (const root of procaptchaRoots) root.unmount();
  procaptchaRoots = [];
  start();
};
```

`start()` re-renders only when the page uses **implicit** rendering, and even then only via its `document.readyState === "complete"` fallback — the script's `load` event fired long ago. Explicit pages get nothing back.

The visible result is a half-rendered widget: `createWidgetSkeleton` builds the outer box and logo as plain DOM and React renders only *into* `widgetInteractiveArea` inside it, so `root.unmount()` strips the checkbox and "I am human" while the shell stays on screen. No new `/captcha/*` request is made, so the widget is inert — the user cannot re-solve, and the only recovery is for the integrator to call `render()` themselves after every `reset()`.

Reproduced from a customer HAR: solve succeeds, `/pow/solution` returns `verified: true`, the site's backend rejects the token at siteverify, and after that there is zero network activity from the widget.

## Change

- Track widgets in a `Map<string, WidgetEntry>` holding the `element`, `renderOptions`, `isWeb2` and `invisible` flags alongside the root, so a widget can be rebuilt in place. Previously only the `Root` was kept and everything needed to rebuild was discarded.
- `render()` returns a widget id (it returned nothing before, so there was no handle on an individual widget).
- `reset(widgetId?)` unmounts and remounts — one widget with an id, all of them without.
- New `remove(widgetId?)` keeps teardown-without-remount for callers that genuinely want the widget gone (closing modal, SPA route change), which is what `reset()` did by accident on explicit pages.
- `reset()` no longer calls `start()`. That would double-render implicit widgets alongside the remount, and it attached another `load` listener to the script tag on every call.
- `render()` returns `undefined` when the factory creates no widget rather than throwing: `at()` rejects an empty array before consulting its `optional` flag, and zero roots is legitimate.

## Notes for review

- **`reset()` is now async.** Existing `window.procaptcha.reset()` call sites keep working as fire-and-forget; `await` it if you need the remount to have completed.
- **Behaviour change for teardown users.** Anyone relying on `reset()` leaving nothing behind on an explicit page should move to `remove()`.
- Skeleton stacking is not a risk — `createWidgetSkeleton` does `container.innerHTML = ""` before appending, so repeated resets don't accumulate DOM.
- The `invisible` flag is carried through the rebuild so a widget bound to a button doesn't come back as a visible one.

## Testing

New `reset.unit.test.ts` covers: `render()` returning an id and returning `undefined` on zero roots; `reset()` unmounting then remounting with the original element and options; `reset(widgetId)` targeting a single widget; repeated resets; the `invisible` flag surviving a rebuild; unknown ids being a no-op; and `remove()` unmounting without a replacement, clearing the container, and making a later `reset()` inert.

`@prosopo/procaptcha-bundle`: 22 tests pass, typecheck clean, biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017hPGTJ23KyDz2WuUgzz2pi