### PR TITLE
feat(provider): record the matched access rule on the records it acts on

### DIFF
--- a/.changeset/audit-matched-access-rule.md
+++ b/.changeset/audit-matched-access-rule.md
@@ -1,0 +1,27 @@
+---
+"@prosopo/user-access-policy": patch
+"@prosopo/types-database": patch
+"@prosopo/provider": patch
+"@prosopo/types": patch
+---
+
+Record the access rule that actually fired on the record it acted on, so the
+audit page can name the exact policy behind a block rather than echoing its
+optional free-text description.
+
+Access rules are ephemeral — client rules carry a TTL and are reaped by
+Mongo's `expiry` index — so an audit row can't answer "which policy blocked
+me?" by joining to the live rules collection: by the time anyone looks, the
+rule is usually gone. `describeMatchedRule` snapshots the matched rule (policy
+type, captcha type, `deferToVerify`, description, rule group, and its scope
+conditions in record form) onto `Session.matchedRule` at enforcement time.
+
+Previously only the request-time block middleware recorded any rule identity,
+and only as a hash, a field-name list and a description. It is now written by
+every access-policy path: the block middleware, the frictionless entry (block,
+auto-ban, forced captcha type, and score-only restrict alike), and the
+verify-time hard-block check in the PoW / image / puzzle flows — which is where
+`deferToVerify` rules land, and where "why was I rejected?" was least obvious.
+
+`checkForHardBlock` now returns the whole `AccessRule` rather than just its
+policy half; the runtime value was always the full rule.

--- a/packages/provider/src/api/blacklistRequestInspector.ts
+++ b/packages/provider/src/api/blacklistRequestInspector.ts
@@ -33,6 +33,7 @@ import {
 	type UserScope,
 	type UserScopeRecord,
 	classifyOs,
+	describeMatchedRule,
 	makeAccessRuleHash,
 	userScopeInput,
 } from "@prosopo/user-access-policy";
@@ -678,10 +679,14 @@ export class BlacklistRequestInspector {
 				status: CaptchaStatus.disapproved,
 				reason: ResultReason.ACCESS_POLICY_BLOCK,
 			},
-			// Rule identity — the whole point of writing this record.
+			// Rule identity — the whole point of writing this record. The three
+			// flat fields drive the Traffic page's rule-type grouping;
+			// `matchedRule` carries the rule itself so the audit page can name
+			// the exact policy (and its conditions) long after the rule expires.
 			ruleHash,
 			ruleType,
 			ruleDescription,
+			matchedRule: describeMatchedRule(accessPolicy),
 			// blocked + deleted are stamped inside storeBlockedSession so
 			// the synthetic record is unmistakably a block-middleware
 			// artefact and can never be picked up by the captcha flow.

--- a/packages/provider/src/api/captcha/getFrictionlessCaptchaChallenge/accessPolicy.ts
+++ b/packages/provider/src/api/captcha/getFrictionlessCaptchaChallenge/accessPolicy.ts
@@ -20,7 +20,11 @@ import {
 	type ScoreComponents,
 } from "@prosopo/types";
 import type { ClientRecord } from "@prosopo/types-database";
-import type { AccessPolicy, UserScope } from "@prosopo/user-access-policy";
+import {
+	type AccessRule,
+	type UserScope,
+	describeMatchedRule,
+} from "@prosopo/user-access-policy";
 import type { Response } from "express";
 import { FrictionlessReason } from "../../../tasks/frictionless/frictionlessTasks.js";
 import type { Tasks } from "../../../tasks/index.js";
@@ -29,7 +33,10 @@ import { attachHoneypot } from "./honeypotResponse.js";
 export type AccessPolicyInput = {
 	tasks: Tasks;
 	clientRecord: ClientRecord;
-	userAccessPolicy: AccessPolicy | undefined;
+	// The full matched rule, not just its policy half: the user-scope fields
+	// are what `describeMatchedRule` turns into the audit page's "this is the
+	// condition that matched you" breakdown.
+	userAccessPolicy: AccessRule | undefined;
 	baseBotScore: number;
 	botScore: number;
 	scoreComponents: ScoreComponents;
@@ -64,6 +71,16 @@ export const handleAccessPolicy = async (
 	}
 
 	const { tasks, clientRecord, userAccessPolicy, logger } = input;
+
+	// Snapshot the rule onto the session bag so it lands on whichever record
+	// this request goes on to write — the 401'd block below, the auto-ban a
+	// score bump triggers, the captcha type a Restrict rule forces, or the
+	// plain decision-machine session left behind by a score-only Restrict.
+	// Without it those rows say only "ACCESS_POLICY_BLOCK" /
+	// "USER_ACCESS_POLICY", with no way to tell which of a site's rules did it.
+	tasks.frictionlessManager.setMatchedRule(
+		describeMatchedRule(userAccessPolicy),
+	);
 
 	logger.info(() => ({
 		msg: "User access policy matched",

--- a/packages/provider/src/tasks/captchaManager.ts
+++ b/packages/provider/src/tasks/captchaManager.ts
@@ -41,6 +41,7 @@ import type { ProviderEnvironment } from "@prosopo/types-env";
 import {
 	type AccessPolicy,
 	AccessPolicyType,
+	type AccessRule,
 	type AccessRulesStorage,
 	type UserScope,
 	type UserScopeRecord,
@@ -94,8 +95,8 @@ export interface PoolBundleDecrypt {
  * rules — they pick which challenge type to serve, not whether to reject.
  */
 const findHardBlockPolicy = (
-	accessPolicies: AccessPolicy[],
-): AccessPolicy | undefined => {
+	accessPolicies: AccessRule[],
+): AccessRule | undefined => {
 	return accessPolicies.find((policy) => {
 		if (policy.deferToVerify === true) {
 			return true;
@@ -842,7 +843,10 @@ export class CaptchaManager {
 		coords?: [number, number][][],
 		countryCode?: string,
 		asn?: number,
-	): Promise<AccessPolicy | undefined> {
+		// Returns the whole rule, not just its policy half: callers persist
+		// the matched rule (scope fields included) onto the record they
+		// disapprove, so the audit page can name the exact policy.
+	): Promise<AccessRule | undefined> {
 		// Get headHash from session record if available
 		let headHash: string | undefined;
 		if (challengeRecord.sessionId) {

--- a/packages/provider/src/tasks/frictionless/frictionlessTasks.ts
+++ b/packages/provider/src/tasks/frictionless/frictionlessTasks.ts
@@ -155,6 +155,23 @@ export class FrictionlessManager extends CaptchaManager {
 		};
 	}
 
+	/**
+	 * Record the access rule that matched this request, so every session this
+	 * request goes on to write carries it.
+	 *
+	 * Set separately from `setSessionParams` (which runs before rules are
+	 * evaluated) and applied at `createSession` time, so it reaches all the
+	 * outcomes a matched rule can lead to: the 401'd block, the auto-ban a
+	 * score bump triggered, the captcha type a Restrict rule forced, and the
+	 * ordinary decision-machine session a score-only Restrict leaves behind.
+	 * Mirrors `updateScore`'s after-the-fact mutation of the same bag.
+	 */
+	setMatchedRule(matchedRule: Session["matchedRule"]): void {
+		if (this.sessionParams) {
+			this.sessionParams.matchedRule = matchedRule;
+		}
+	}
+
 	updateScore(score: number, scoreComponents: ScoreComponents): void {
 		if (this.sessionParams) {
 			this.sessionParams.score = score;
@@ -200,6 +217,7 @@ export class FrictionlessManager extends CaptchaManager {
 		isProtect?: Session["isProtect"],
 		originSessionId?: Session["originSessionId"],
 		g?: Session["g"],
+		matchedRule?: Session["matchedRule"],
 	): Promise<Session> {
 		const sessionRecord: Session = {
 			sessionId: `${getSessionIDPrefix(this.config.host)}-${uuidv4()}`,
@@ -252,6 +270,9 @@ export class FrictionlessManager extends CaptchaManager {
 			g,
 			tcpToChelloUs,
 			chelloToHandshakeUs,
+			// Only present when an access policy actually matched this
+			// request, so ordinary sessions stay slim.
+			...(matchedRule && { matchedRule }),
 		};
 
 		await this.db.storeSessionRecord(sessionRecord);
@@ -398,6 +419,7 @@ export class FrictionlessManager extends CaptchaManager {
 			effectiveParams.isProtect,
 			undefined,
 			effectiveParams.g,
+			effectiveParams.matchedRule,
 		);
 
 		// Fire-and-forget served-counter writes. Skipped when there's no
@@ -475,6 +497,7 @@ export class FrictionlessManager extends CaptchaManager {
 			effectiveParams.isProtect,
 			undefined,
 			effectiveParams.g,
+			effectiveParams.matchedRule,
 		);
 	}
 

--- a/packages/provider/src/tasks/imgCaptcha/imgCaptchaTasks.ts
+++ b/packages/provider/src/tasks/imgCaptcha/imgCaptchaTasks.ts
@@ -45,13 +45,17 @@ import {
 	type ProsopoConfigOutput,
 	type RequestHeaders,
 	ResultReason,
+	type Session,
 	SimdReadingsStage,
 	type UserCommitment,
 	isBlockingCaptchaResult,
 } from "@prosopo/types";
 import type { ClientRecord, IProviderDatabase } from "@prosopo/types-database";
 import type { ProviderEnvironment } from "@prosopo/types-env";
-import type { AccessRulesStorage } from "@prosopo/user-access-policy";
+import {
+	type AccessRulesStorage,
+	describeMatchedRule,
+} from "@prosopo/user-access-policy";
 import { at, extractData } from "@prosopo/util";
 import { randomAsHex, signatureVerify } from "@prosopo/util-crypto";
 import {
@@ -738,6 +742,10 @@ export class ImgCaptchaManager extends CaptchaManager {
 		// perform a single batch write at the end.
 		const commitmentUpdates: Partial<UserCommitment> = {};
 		let failStatus: ResultReason | undefined;
+		// Set only by the access-policy branch below, and stamped onto the
+		// session at the end so the audit page can name the rule behind an
+		// ACCESS_POLICY_BLOCK.
+		let matchedRule: Session["matchedRule"];
 
 		// Check user access policies for hard blocks
 		if (userAccessRulesStorage) {
@@ -766,6 +774,7 @@ export class ImgCaptchaManager extends CaptchaManager {
 						reason: ResultReason.ACCESS_POLICY_BLOCK,
 					};
 					failStatus = ResultReason.ACCESS_POLICY_BLOCK;
+					matchedRule = describeMatchedRule(blockPolicy);
 				}
 			} catch (error) {
 				logger.warn(() => ({
@@ -1150,6 +1159,7 @@ export class ImgCaptchaManager extends CaptchaManager {
 						...(isBlockingCaptchaResult(CaptchaType.image, finalResult) && {
 							blocked: true,
 						}),
+						...(matchedRule && { matchedRule }),
 					},
 					true,
 				),

--- a/packages/provider/src/tasks/powCaptcha/powTasks.ts
+++ b/packages/provider/src/tasks/powCaptcha/powTasks.ts
@@ -42,6 +42,7 @@ import {
 	type RoutingMachineOutput,
 	type RoutingMachinePlatform,
 	type RoutingMachineRawSignals,
+	type Session,
 	SimdReadingsStage,
 	isBlockingCaptchaResult,
 } from "@prosopo/types";
@@ -50,7 +51,10 @@ import type {
 	PoWCaptchaRecord,
 } from "@prosopo/types-database";
 import type { ProviderEnvironment } from "@prosopo/types-env";
-import type { AccessRulesStorage } from "@prosopo/user-access-policy";
+import {
+	type AccessRulesStorage,
+	describeMatchedRule,
+} from "@prosopo/user-access-policy";
 import {
 	assertCoordsSafe,
 	at,
@@ -678,6 +682,11 @@ export class PowCaptchaManager extends CaptchaManager {
 		const powRecordUpdates: Partial<PoWCaptchaRecord> = {};
 		let failResult: CaptchaResult | undefined;
 		let failReason: string | undefined;
+		// Set only by the access-policy branch below, and stamped onto the
+		// session at the end so the audit page can name the rule behind an
+		// ACCESS_POLICY_BLOCK. This path is where `deferToVerify` rules land,
+		// which is precisely where "why was I rejected?" is least obvious.
+		let matchedRule: Session["matchedRule"];
 
 		const submittedAt = challengeRecord.submittedAtTimestamp;
 		const submitToVerifyMs =
@@ -722,6 +731,7 @@ export class PowCaptchaManager extends CaptchaManager {
 						reason: ResultReason.ACCESS_POLICY_BLOCK,
 					};
 					failReason = "API.ACCESS_POLICY_BLOCK";
+					matchedRule = describeMatchedRule(blockPolicy);
 				}
 			} catch (error) {
 				logger.warn(() => ({
@@ -1051,6 +1061,7 @@ export class PowCaptchaManager extends CaptchaManager {
 						...(isBlockingCaptchaResult(CaptchaType.pow, finalResult) && {
 							blocked: true,
 						}),
+						...(matchedRule && { matchedRule }),
 					},
 					true,
 				),

--- a/packages/provider/src/tasks/puzzleCaptcha/puzzleTasks.ts
+++ b/packages/provider/src/tasks/puzzleCaptcha/puzzleTasks.ts
@@ -41,7 +41,10 @@ import {
 } from "@prosopo/types";
 import type { IProviderDatabase } from "@prosopo/types-database";
 import type { ProviderEnvironment } from "@prosopo/types-env";
-import type { AccessRulesStorage } from "@prosopo/user-access-policy";
+import {
+	type AccessRulesStorage,
+	describeMatchedRule,
+} from "@prosopo/user-access-policy";
 import {
 	assertCoordsSafe,
 	at,
@@ -570,6 +573,11 @@ export class PuzzleCaptchaManager extends CaptchaManager {
 							serverChecked: true,
 							result: blockedResult,
 							...(isBlocked && { blocked: true }),
+							// Name the rule behind the ACCESS_POLICY_BLOCK on the
+							// audit row. This path is where `deferToVerify` rules
+							// land, which is precisely where "why was I rejected?"
+							// is least obvious.
+							matchedRule: describeMatchedRule(blockPolicy),
 						});
 					}
 					return notVerifiedResponse;

--- a/packages/provider/src/tests/unit/api/blacklistRequestInspector.unit.test.ts
+++ b/packages/provider/src/tests/unit/api/blacklistRequestInspector.unit.test.ts
@@ -548,6 +548,14 @@ describe("BlacklistRequestInspector blocked-session persistence", () => {
 		expect(written.ruleHash).toEqual(expect.any(String));
 		expect(written.ruleType).toEqual(["ja4Hash"]);
 		expect(written.ruleDescription).toBe("ja4 block — Solver");
+		// The rule itself, denormalised: the audit page names the exact
+		// policy from this, so it has to survive the rule's own expiry.
+		expect(written.matchedRule).toEqual({
+			ruleHash: written.ruleHash,
+			policyType: AccessPolicyType.Block,
+			description: "ja4 block — Solver",
+			conditions: [{ field: "ja4Hash", value: BOT_JA4 }],
+		});
 		const headers = written.headers as Record<string, unknown>;
 		expect(headers["user-agent"]).toBe(BOT_UA);
 		// Sentinel required-field values that the request never reached

--- a/packages/provider/src/tests/unit/api/captcha/getFrictionlessCaptchaChallenge/accessPolicy.unit.test.ts
+++ b/packages/provider/src/tests/unit/api/captcha/getFrictionlessCaptchaChallenge/accessPolicy.unit.test.ts
@@ -27,6 +27,7 @@ const buildInput = () => {
 				}),
 			),
 			updateScore: vi.fn(),
+			setMatchedRule: vi.fn(),
 			registerBlockedSession: vi.fn(),
 			sendImageCaptcha: vi.fn().mockResolvedValue({ kind: "image" }),
 			sendPowCaptcha: vi.fn().mockResolvedValue({ kind: "pow" }),
@@ -138,6 +139,79 @@ describe("handleAccessPolicy", () => {
 		const r = await handleAccessPolicy(input as never, res as never);
 		expect(r.handled).toBe(true);
 		expect(tasks.frictionlessManager.sendPuzzleCaptcha).toHaveBeenCalled();
+	});
+
+	// Every outcome below writes a session somewhere downstream, and each one
+	// used to land in the audit page as a bare "ACCESS_POLICY_BLOCK" /
+	// "USER_ACCESS_POLICY" with no way to tell which of a site's rules did it.
+	// The snapshot goes onto the session bag once, so it reaches all of them —
+	// including the score-only Restrict whose session runDecisionMachine
+	// writes after this function returns handled=false.
+	describe("matched-rule snapshot", () => {
+		it("records the rule and its conditions before blocking", async () => {
+			const { tasks, input } = buildInput();
+			input.userAccessPolicy = {
+				type: AccessPolicyType.Block,
+				ja4Hash: "t13d1516h2_8daaf6152771_b186095e22b6",
+				description: "known solver",
+			};
+			const res = buildRes();
+			await handleAccessPolicy(input as never, res as never);
+			expect(tasks.frictionlessManager.setMatchedRule).toHaveBeenCalledWith(
+				expect.objectContaining({
+					policyType: AccessPolicyType.Block,
+					description: "known solver",
+					conditions: [
+						{
+							field: "ja4Hash",
+							value: "t13d1516h2_8daaf6152771_b186095e22b6",
+						},
+					],
+				}),
+			);
+		});
+
+		it("records the rule that forced a captcha type", async () => {
+			const { tasks, input } = buildInput();
+			input.userAccessPolicy = {
+				type: AccessPolicyType.Restrict,
+				captchaType: CaptchaType.image,
+				countryCode: "CN",
+			};
+			const res = buildRes();
+			await handleAccessPolicy(input as never, res as never);
+			expect(tasks.frictionlessManager.setMatchedRule).toHaveBeenCalledWith(
+				expect.objectContaining({
+					policyType: AccessPolicyType.Restrict,
+					captchaType: CaptchaType.image,
+					conditions: [{ field: "countryCode", value: "CN" }],
+				}),
+			);
+		});
+
+		it("records a score-only restrict rule, which writes no session of its own", async () => {
+			const { tasks, input } = buildInput();
+			input.userAccessPolicy = {
+				type: AccessPolicyType.Restrict,
+				frictionlessScore: 0.2,
+				asn: 205016,
+			};
+			const res = buildRes();
+			const r = await handleAccessPolicy(input as never, res as never);
+			expect(r.handled).toBe(false);
+			expect(tasks.frictionlessManager.setMatchedRule).toHaveBeenCalledWith(
+				expect.objectContaining({
+					conditions: [{ field: "asn", value: "205016" }],
+				}),
+			);
+		});
+
+		it("does not record anything when no policy matched", async () => {
+			const { tasks, input } = buildInput();
+			const res = buildRes();
+			await handleAccessPolicy(input as never, res as never);
+			expect(tasks.frictionlessManager.setMatchedRule).not.toHaveBeenCalled();
+		});
 	});
 
 	describe("auto-ban threshold (post-policy bump)", () => {

--- a/packages/provider/src/tests/unit/api/getFrictionlessCaptchaChallenge.unit.test.ts
+++ b/packages/provider/src/tests/unit/api/getFrictionlessCaptchaChallenge.unit.test.ts
@@ -52,6 +52,7 @@ type MockTasks = {
 		scoreIncreaseWebView: MockFn;
 		scoreIncreaseTimestamp: MockFn;
 		updateScore: MockFn;
+		setMatchedRule: MockFn;
 	};
 	db: {
 		getSessionRecordByToken: MockFn;
@@ -201,6 +202,7 @@ vi.mock("../../../tasks/index.js", async () => {
 						}),
 					),
 					updateScore: vi.fn(),
+					setMatchedRule: vi.fn(),
 				},
 				db: {
 					getSessionRecordByToken: vi.fn().mockResolvedValue(null),
@@ -287,6 +289,7 @@ describe("getFrictionlessCaptchaChallenge - context selection", () => {
 				}),
 			),
 			updateScore: vi.fn(),
+			setMatchedRule: vi.fn(),
 		},
 		db: {
 			getSessionRecordByToken: vi.fn().mockResolvedValue(null),

--- a/packages/provider/src/tests/unit/tasks/imgCaptcha/imgCaptchaTasks.unit.test.ts
+++ b/packages/provider/src/tests/unit/tasks/imgCaptcha/imgCaptchaTasks.unit.test.ts
@@ -1176,6 +1176,82 @@ describe("ImgCaptchaManager", () => {
 			// biome-ignore lint/suspicious/noExplicitAny: tests
 			(imgCaptchaManager as any).decisionMachineRunner.decide = originalDecide;
 		});
+
+		it("stamps the matched rule onto the session so the audit row can name it", async () => {
+			const userAccount = "userAccount";
+			const dappAccount = "dappAccount";
+			const commitmentId = "commitmentId";
+
+			const commitment: Partial<UserCommitment> = {
+				id: commitmentId,
+				userAccount,
+				dappAccount,
+				result: { status: CaptchaStatus.approved },
+				userSubmitted: true,
+				serverChecked: false,
+				requestedAtTimestamp: new Date(),
+				submittedAtTimestamp: new Date(),
+				ipAddress: {
+					lower: ipAddress.bigInt(),
+					upper: 0n,
+					type: IpAddressType.v4,
+				},
+				headers,
+				ja4: "ja4",
+				lastUpdatedTimestamp: new Date(),
+				sessionId,
+			};
+
+			// biome-ignore lint/suspicious/noExplicitAny: tests
+			(db.getDappUserCommitmentById as any).mockResolvedValue(commitment);
+			// biome-ignore lint/suspicious/noExplicitAny: tests
+			(db.getSessionRecordBySessionId as any).mockResolvedValue(undefined);
+
+			// Stub the hard-block lookup rather than rebuilding the Redis
+			// fixture behind it — the assertion here is about what gets
+			// persisted, not about how the rule was found.
+			const originalCheckForHardBlock = imgCaptchaManager.checkForHardBlock;
+			imgCaptchaManager.checkForHardBlock = vi.fn().mockResolvedValue({
+				type: "block",
+				description: "deferred solver block",
+				deferToVerify: true,
+				asn: 205016,
+			});
+
+			try {
+				const result = await imgCaptchaManager.verifyImageCaptchaSolution(
+					userAccount,
+					dappAccount,
+					commitmentId,
+					mockEnv,
+					undefined, // maxVerifiedTime
+					undefined, // ip
+					undefined, // disallowWebView
+					false, // contextAwareEnabled
+					// Truthy storage triggers the checkForHardBlock branch;
+					// the stub above ignores whatever's passed here.
+					// biome-ignore lint/suspicious/noExplicitAny: test stub
+					{} as any,
+				);
+
+				expect(result.verified).toBe(false);
+				expect(db.updateSessionRecord).toHaveBeenCalledWith(
+					sessionId,
+					expect.objectContaining({
+						blocked: true,
+						matchedRule: expect.objectContaining({
+							policyType: "block",
+							description: "deferred solver block",
+							deferToVerify: true,
+							conditions: [{ field: "asn", value: "205016" }],
+						}),
+					}),
+					true,
+				);
+			} finally {
+				imgCaptchaManager.checkForHardBlock = originalCheckForHardBlock;
+			}
+		});
 	});
 
 	describe("verifyImageCaptchaSolution with spam email domain checking", () => {

--- a/packages/provider/src/tests/unit/tasks/powCaptcha/powTasks.unit.test.ts
+++ b/packages/provider/src/tests/unit/tasks/powCaptcha/powTasks.unit.test.ts
@@ -672,6 +672,21 @@ describe("PowCaptchaManager", () => {
 			);
 
 			expect(result.verified).toBe(false);
+			// The rule that did it is stamped onto the session, so the audit
+			// row for this verify-time block can name the policy rather than
+			// just showing ACCESS_POLICY_BLOCK. This is the `deferToVerify`
+			// landing site, where "why was I rejected?" is least obvious.
+			expect(db.updateSessionRecord).toHaveBeenCalledWith(
+				sessionId,
+				expect.objectContaining({
+					blocked: true,
+					matchedRule: expect.objectContaining({
+						policyType: AccessPolicyType.Block,
+						conditions: [{ field: "headHash", value: decryptedHeadHash }],
+					}),
+				}),
+				true,
+			);
 		});
 
 		it("should not block when access policy has captchaType (not a hard block)", async () => {

--- a/packages/provider/src/tests/unit/tasks/puzzleCaptcha/puzzleTasks.unit.test.ts
+++ b/packages/provider/src/tests/unit/tasks/puzzleCaptcha/puzzleTasks.unit.test.ts
@@ -788,6 +788,57 @@ describe("PuzzleCaptchaManager", () => {
 			}
 		});
 
+		it("stamps the matched rule onto the session so the audit row can name it", async () => {
+			const sessionId = "puzzle-blocked-session-id";
+			vi.mocked(db.getPuzzleCaptchaRecordByChallenge).mockResolvedValue(
+				asPuzzleRecord({
+					challenge,
+					dappAccount,
+					userAccount: "user",
+					result: { status: CaptchaStatus.approved },
+					serverChecked: false,
+					headers: { a: "1" },
+					sessionId,
+				}),
+			);
+			vi.mocked(verifyRecency).mockImplementation(() => true);
+
+			const originalCheckForHardBlock = puzzleCaptchaManager.checkForHardBlock;
+			puzzleCaptchaManager.checkForHardBlock = vi.fn().mockResolvedValue({
+				type: "block",
+				description: "deferred solver block",
+				deferToVerify: true,
+				countryCode: "CN",
+			});
+
+			try {
+				await puzzleCaptchaManager.serverVerifyPuzzleCaptchaSolution(
+					dappAccount,
+					challenge,
+					1000,
+					mockEnv,
+					undefined, // ip
+					// biome-ignore lint/suspicious/noExplicitAny: test stub
+					{} as any,
+				);
+
+				expect(db.updateSessionRecord).toHaveBeenCalledWith(
+					sessionId,
+					expect.objectContaining({
+						blocked: true,
+						matchedRule: expect.objectContaining({
+							policyType: "block",
+							description: "deferred solver block",
+							deferToVerify: true,
+							conditions: [{ field: "countryCode", value: "CN" }],
+						}),
+					}),
+				);
+			} finally {
+				puzzleCaptchaManager.checkForHardBlock = originalCheckForHardBlock;
+			}
+		});
+
 		it("forwards every session-derived field into the decide() input", async () => {
 			const sessionId = "puzzle-session-id";
 			vi.mocked(db.getPuzzleCaptchaRecordByChallenge).mockResolvedValue(

--- a/packages/types-database/src/types/provider.ts
+++ b/packages/types-database/src/types/provider.ts
@@ -740,6 +740,14 @@ export const SessionRecordSchema = new Schema<SessionRecord>({
 	ruleHash: { type: String, required: false },
 	ruleType: { type: [String], required: false },
 	ruleDescription: { type: String, required: false },
+	// The matched rule itself, denormalised at enforcement time. Written by
+	// every access-policy path (block middleware, frictionless entry, and the
+	// verify-time hard-block check) — not just the middleware — so the audit
+	// page can name the exact policy that acted on a request after the rule
+	// itself has expired. Mixed rather than a sub-schema: the shape is owned
+	// by MatchedAccessRuleSchema in @prosopo/types, which validates on the
+	// way in, and a second mongoose-side definition would only drift from it.
+	matchedRule: { type: Schema.Types.Mixed, required: false },
 	// Full ipinfo payload — replaces flat `countryCode` / `geolocation`
 	// fields. Mirrors the captcha record schemas (PoW / Puzzle /
 	// UserCommitment).

--- a/packages/types/src/provider/database.ts
+++ b/packages/types/src/provider/database.ts
@@ -50,6 +50,10 @@ import type {
 } from "../decisionMachine/index.js";
 import type { PuzzleEvent, RequestHeaders } from "./api.js";
 import type { SimdReadings } from "./detection.js";
+import {
+	type MatchedAccessRule,
+	MatchedAccessRuleSchema,
+} from "./matchedAccessRule.js";
 import type { FrictionlessReason, ResultReason } from "./reasons.js";
 
 export interface BrowserInfo {
@@ -458,6 +462,8 @@ export const SessionSchema = object({
 	ruleHash: string().optional(),
 	ruleType: string().array().optional(),
 	ruleDescription: string().optional(),
+	// See Session.matchedRule.
+	matchedRule: MatchedAccessRuleSchema.optional(),
 	// Full ipinfo payload from ipInfoMiddleware at session-creation
 	// time. Replaces the flat `countryCode` / `geolocation` fields —
 	// consumers narrow on `ipInfo.isValid` and read whichever sub-field
@@ -565,6 +571,13 @@ export type Session = {
 	ruleHash?: string; // == the redis-key suffix of the matched rule
 	ruleType?: string[]; // populated scope fields, e.g. ['ja4Hash'], ['ja4Hash','coords']
 	ruleDescription?: string; // operator-set description copied from the rule's AccessPolicy
+	// The full matched rule, denormalised at enforcement time. Unlike the three
+	// fields above it is written by EVERY access-policy path — the request-time
+	// block middleware, the frictionless entry (block and restrict alike), and
+	// the verify-time hard-block check — so the audit page can name the exact
+	// policy that acted on a request rather than just echoing its description.
+	// See MatchedAccessRule for why the rule is copied rather than joined.
+	matchedRule?: MatchedAccessRule;
 	// Full ipinfo payload from ipInfoMiddleware at session-creation
 	// time. Replaces the flat `countryCode` / `geolocation` fields.
 	ipInfo?: IPInfoResponse;

--- a/packages/types/src/provider/index.ts
+++ b/packages/types/src/provider/index.ts
@@ -16,5 +16,6 @@ export * from "./api.js";
 export * from "./scheduler.js";
 export * from "./detection.js";
 export * from "./database.js";
+export * from "./matchedAccessRule.js";
 export * from "./isBlockingCaptchaResult.js";
 export * from "./reasons.js";

--- a/packages/types/src/provider/matchedAccessRule.ts
+++ b/packages/types/src/provider/matchedAccessRule.ts
@@ -1,0 +1,74 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { array, boolean, literal, object, string, union } from "zod";
+import { type CaptchaType, CaptchaTypeSchema } from "../client/index.js";
+
+// Lives here rather than in @prosopo/user-access-policy because the Session
+// schema (below in database.ts) needs it, and user-access-policy already
+// depends on @prosopo/types — the reverse edge would be a package cycle.
+// `describeMatchedRule` in @prosopo/user-access-policy is the only producer.
+
+export const MatchedRuleConditionSchema = object({
+	// A `UserScopeRecordField` from @prosopo/user-access-policy — kept as a
+	// plain string here to avoid the package cycle. The producer only ever
+	// emits values from `userScopeRecordFields`, and every consumer treats an
+	// unrecognised field as a raw label, so nothing depends on the narrowing.
+	field: string(),
+	value: string(),
+	// Set when `value` was clipped (a `coords` polygon serialises unbounded),
+	// so the UI can say "truncated" rather than imply an exact match.
+	truncated: boolean().optional(),
+});
+
+export type MatchedRuleCondition = {
+	field: string;
+	value: string;
+	truncated?: boolean;
+};
+
+/**
+ * The access rule that actually fired, denormalised onto the record it acted
+ * on.
+ *
+ * Access rules are ephemeral — client rules carry a TTL (the anomaly jobs
+ * default to 24h) and are reaped by Mongo's `expiry` index — so an audit row
+ * cannot answer "which policy blocked me?" by joining to the live rules
+ * collection: by the time anyone looks, the rule is usually gone. Storing the
+ * matched rule's own content at enforcement time is what makes the answer
+ * survive. `ruleGroupId` is the join key back to the portal's Access Control
+ * page for the rules that DO still exist.
+ */
+export const MatchedAccessRuleSchema = object({
+	ruleHash: string(),
+	policyType: union([literal("block"), literal("restrict")]),
+	conditions: array(MatchedRuleConditionSchema),
+	description: string().optional(),
+	captchaType: CaptchaTypeSchema.optional(),
+	deferToVerify: boolean().optional(),
+	ruleGroupId: string().optional(),
+	// Absent for global (Prosopo-wide) rules; the siteKey for client rules.
+	clientId: string().optional(),
+});
+
+export type MatchedAccessRule = {
+	ruleHash: string;
+	policyType: "block" | "restrict";
+	conditions: MatchedRuleCondition[];
+	description?: string;
+	captchaType?: CaptchaType;
+	deferToVerify?: boolean;
+	ruleGroupId?: string;
+	clientId?: string;
+};

--- a/packages/user-access-policy/src/.export.ts
+++ b/packages/user-access-policy/src/.export.ts
@@ -28,6 +28,8 @@ export {
 	AccessPolicyType,
 } from "./rule.js";
 
+export { describeMatchedRule } from "./matchedRule.js";
+
 export { classifyOs, OS_NAMES, type OsName } from "./classifyOs.js";
 
 export {

--- a/packages/user-access-policy/src/matchedRule.ts
+++ b/packages/user-access-policy/src/matchedRule.ts
@@ -1,0 +1,99 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { MatchedAccessRule, MatchedRuleCondition } from "@prosopo/types";
+import type { AccessRule } from "#policy/rule.js";
+import {
+	type UserScopeRecordField,
+	getUserScopeRecordFromAccessRuleRecord,
+	userScopeRecordFields,
+} from "#policy/ruleRecord.js";
+import {
+	makeAccessRuleHash,
+	transformAccessRuleIntoRecord,
+} from "#policy/transformRule.js";
+
+// A `coords` polygon serialises to an unbounded JSON string. The audit UI only
+// needs enough to recognise the rule, and the snapshot is copied onto every
+// record the rule acts on, so cap it rather than dragging kilobytes through
+// Mongo on each blocked request.
+const MAX_CONDITION_VALUE_LENGTH = 256;
+
+const toCondition = (
+	field: UserScopeRecordField,
+	value: unknown,
+): MatchedRuleCondition | undefined => {
+	if (value === undefined || value === null) return undefined;
+	// `asn` is a number on the rule; every other scope field is a string.
+	const asString = typeof value === "string" ? value : String(value);
+	if (asString.length === 0) return undefined;
+	return asString.length > MAX_CONDITION_VALUE_LENGTH
+		? {
+				field,
+				value: `${asString.slice(0, MAX_CONDITION_VALUE_LENGTH)}…`,
+				truncated: true,
+			}
+		: { field, value: asString };
+};
+
+/**
+ * Derive the rule's populated scope fields in record form.
+ *
+ * Goes through `transformAccessRuleIntoRecord` so the IP triple collapses back
+ * to the human-readable `ip` / `ipMask` the operator originally typed, rather
+ * than the numeric range the matcher works in, and so the field names match
+ * the vocabulary the portal's Access Control page already labels conditions
+ * with (`ip`, `ipMask`, `userAgent`, `ja4Hash`, …).
+ */
+const deriveConditions = (rule: AccessRule): MatchedRuleCondition[] => {
+	let scope: Partial<Record<UserScopeRecordField, unknown>>;
+	try {
+		scope = getUserScopeRecordFromAccessRuleRecord(
+			transformAccessRuleIntoRecord(rule),
+		);
+	} catch {
+		// Never let audit bookkeeping break enforcement. A rule shape the
+		// record transform rejects (or an IP range cidr-calc can't express)
+		// still blocks — it just describes itself without conditions.
+		return [];
+	}
+
+	const conditions: MatchedRuleCondition[] = [];
+	for (const field of userScopeRecordFields) {
+		const condition = toCondition(field, scope[field]);
+		if (condition) {
+			conditions.push(condition);
+		}
+	}
+	return conditions;
+};
+
+/**
+ * Snapshot a matched rule for persistence alongside the request it acted on.
+ *
+ * Total function: every rule shape yields a value, so callers can inline it
+ * into a record literal without a try/catch of their own.
+ */
+export const describeMatchedRule = (rule: AccessRule): MatchedAccessRule => ({
+	ruleHash: makeAccessRuleHash(rule),
+	policyType: rule.type,
+	conditions: deriveConditions(rule),
+	...(rule.description !== undefined && { description: rule.description }),
+	...(rule.captchaType !== undefined && { captchaType: rule.captchaType }),
+	...(rule.deferToVerify !== undefined && {
+		deferToVerify: rule.deferToVerify,
+	}),
+	...(rule.groupId !== undefined && { ruleGroupId: rule.groupId }),
+	...(rule.clientId !== undefined && { clientId: rule.clientId }),
+});

--- a/packages/user-access-policy/src/tests/matchedRule.unit.test.ts
+++ b/packages/user-access-policy/src/tests/matchedRule.unit.test.ts
@@ -1,0 +1,184 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { CaptchaType, MatchedAccessRuleSchema } from "@prosopo/types";
+import { Address4 } from "ip-address";
+import { describe, expect, it } from "vitest";
+import { describeMatchedRule } from "#policy/matchedRule.js";
+import { AccessPolicyType, type AccessRule } from "#policy/rule.js";
+import { userScopeRecordFields } from "#policy/ruleRecord.js";
+import { makeAccessRuleHash } from "#policy/transformRule.js";
+
+describe("describeMatchedRule", () => {
+	it("carries the policy half of the rule", () => {
+		const rule: AccessRule = {
+			type: AccessPolicyType.Restrict,
+			captchaType: CaptchaType.image,
+			description: "6 rounds for this ASN",
+			deferToVerify: true,
+			clientId: "site-key",
+			groupId: "group-1",
+			ja4Hash: "t13d1516h2_8daaf6152771_b186095e22b6",
+		};
+
+		expect(describeMatchedRule(rule)).toEqual({
+			ruleHash: makeAccessRuleHash(rule),
+			policyType: AccessPolicyType.Restrict,
+			captchaType: CaptchaType.image,
+			description: "6 rounds for this ASN",
+			deferToVerify: true,
+			clientId: "site-key",
+			// `groupId` on the rule is `ruleGroupId` everywhere else — the
+			// portal joins the audit row back to its Access Control entry on
+			// this, so the rename has to happen here.
+			ruleGroupId: "group-1",
+			conditions: [
+				{
+					field: "ja4Hash",
+					value: "t13d1516h2_8daaf6152771_b186095e22b6",
+				},
+			],
+		});
+	});
+
+	it("omits policy fields the rule did not set rather than emitting undefined", () => {
+		const described = describeMatchedRule({ type: AccessPolicyType.Block });
+
+		expect(described).toEqual({
+			ruleHash: makeAccessRuleHash({ type: AccessPolicyType.Block }),
+			policyType: AccessPolicyType.Block,
+			conditions: [],
+		});
+		expect(Object.keys(described)).not.toContain("description");
+		expect(Object.keys(described)).not.toContain("ruleGroupId");
+	});
+
+	it("reports a single IP in the form the operator typed, not the numeric one", () => {
+		const { conditions } = describeMatchedRule({
+			type: AccessPolicyType.Block,
+			numericIp: new Address4("192.0.2.44").bigInt(),
+		});
+
+		expect(conditions).toEqual([{ field: "ip", value: "192.0.2.44" }]);
+	});
+
+	it("collapses an IP range back to its CIDR", () => {
+		const { conditions } = describeMatchedRule({
+			type: AccessPolicyType.Block,
+			numericIpMaskMin: new Address4("198.51.100.64").bigInt(),
+			numericIpMaskMax: new Address4("198.51.100.127").bigInt(),
+		});
+
+		expect(conditions).toEqual([
+			{ field: "ipMask", value: "198.51.100.64/26" },
+		]);
+	});
+
+	it("stringifies a numeric asn", () => {
+		const { conditions } = describeMatchedRule({
+			type: AccessPolicyType.Block,
+			asn: 205016,
+		});
+
+		expect(conditions).toEqual([{ field: "asn", value: "205016" }]);
+	});
+
+	it("reports every populated scope field, in record vocabulary", () => {
+		const { conditions } = describeMatchedRule({
+			type: AccessPolicyType.Block,
+			userId: "user",
+			ja4Hash: "ja4",
+			headersHash: "headers",
+			// Hashed on the rule, but surfaces under the record-side name the
+			// portal labels conditions with.
+			userAgentHash: "ua",
+			headHash: "head",
+			coords: "[[1,2]]",
+			countryCode: "GB",
+			asn: 1,
+			os: "macos",
+			numericIp: new Address4("203.0.113.5").bigInt(),
+		});
+
+		expect(conditions.map((condition) => condition.field)).toEqual([
+			"userId",
+			"ja4Hash",
+			"headersHash",
+			"userAgent",
+			"headHash",
+			"coords",
+			"countryCode",
+			"asn",
+			"os",
+			"ip",
+		]);
+		// Every emitted field is one the portal knows how to label.
+		for (const condition of conditions) {
+			expect(userScopeRecordFields).toContain(condition.field);
+		}
+	});
+
+	it("truncates an oversized coords polygon and flags it", () => {
+		const coords = JSON.stringify([Array.from({ length: 200 }, () => [1, 2])]);
+		const { conditions } = describeMatchedRule({
+			type: AccessPolicyType.Block,
+			coords,
+		});
+
+		const [condition] = conditions;
+		expect(condition?.truncated).toBe(true);
+		expect(condition?.value.length).toBe(257);
+		expect(coords.startsWith(condition?.value.slice(0, -1) ?? "")).toBe(true);
+	});
+
+	it("leaves a value at the cap untruncated", () => {
+		const coords = "x".repeat(256);
+		const { conditions } = describeMatchedRule({
+			type: AccessPolicyType.Block,
+			coords,
+		});
+
+		expect(conditions).toEqual([{ field: "coords", value: coords }]);
+	});
+
+	it("still describes a rule whose scope cannot be transformed", () => {
+		// An inverted mask range makes the record transform throw. Enforcement
+		// must not care: the block still happens, the snapshot just lacks
+		// conditions.
+		const rule: AccessRule = {
+			type: AccessPolicyType.Block,
+			description: "unrepresentable range",
+			numericIpMaskMin: new Address4("198.51.100.200").bigInt(),
+			numericIpMaskMax: new Address4("198.51.100.1").bigInt(),
+		};
+
+		expect(() => describeMatchedRule(rule)).not.toThrow();
+		expect(describeMatchedRule(rule)).toEqual({
+			ruleHash: makeAccessRuleHash(rule),
+			policyType: AccessPolicyType.Block,
+			description: "unrepresentable range",
+			conditions: [],
+		});
+	});
+
+	it("produces a value the persisted schema accepts", () => {
+		const described = describeMatchedRule({
+			type: AccessPolicyType.Restrict,
+			captchaType: CaptchaType.pow,
+			countryCode: "CN",
+		});
+
+		expect(MatchedAccessRuleSchema.safeParse(described).success).toBe(true);
+	});
+});


### PR DESCRIPTION
## Why

The portal's audit page can only tell a customer *which* policy blocked a request by echoing `ruleDescription` — an optional, non-unique free-text field that the anomaly jobs write identically across thousands of rules (`"ja4 block — Solver"`). Two different rules produce identical audit rows, and a rule with no description shows an em-dash.

Worse, only the request-time block middleware wrote even that much. The frictionless entry and the verify-time hard-block check recorded no rule identity at all, so an `ACCESS_POLICY_BLOCK` row from those paths named nothing.

A read-time join to the live rules collection isn't an option: access rules are ephemeral — client rules carry a TTL (the anomaly jobs default to 24h) and are reaped by Mongo's `expiry` index — so by the time anyone audits, the rule is usually gone. The rule has to be copied at enforcement time to survive.

## What

`describeMatchedRule` (new, in `@prosopo/user-access-policy`) snapshots a matched rule into `Session.matchedRule`: policy type, captcha type, `deferToVerify`, description, rule group, and its scope conditions.

Conditions are emitted in **record vocabulary** (`ip`, `ipMask`, `userAgent`, `ja4Hash`, …) so they match the labels the portal's Access Control page already uses, with the IP triple collapsed back to the address or CIDR the operator originally typed rather than the numeric range the matcher works in. The helper is total — a rule shape the record transform rejects still blocks, it just describes itself without conditions.

`matchedRule` is now written by **every** access-policy path:

| Path | Covers |
|---|---|
| `blacklistRequestInspector.recordBlockDecision` | request-time 401s, alongside the existing flat `ruleHash`/`ruleType`/`ruleDescription` the Traffic page groups on |
| `handleAccessPolicy` (frictionless entry) | the 401'd block, the auto-ban its score bump triggered, the captcha type a Restrict forced, **and** the ordinary decision-machine session a score-only Restrict leaves behind |
| `serverVerify*` in the PoW / image / puzzle flows | verify-time hard blocks — where `deferToVerify` rules land, and where "why was I rejected?" is least obvious |

The frictionless path sets it once on the session bag (`setMatchedRule`, mirroring `updateScore`'s after-the-fact mutation) rather than threading it through each call site, which is what lets it reach the score-only-Restrict case whose session is written after `handleAccessPolicy` returns.

`checkForHardBlock` / `findHardBlockPolicy` now return the whole `AccessRule` instead of just its policy half — the runtime value was always the full rule, only the type was narrowed, and the user-scope fields are exactly what the snapshot needs.

The canonical type lives in `@prosopo/types` rather than `@prosopo/user-access-policy` because the `Session` schema needs it and the reverse package edge would be a cycle.

## Notes

- Purely additive on the DB: existing rows have no `matchedRule` and consumers fall back to the flat fields. No backfill is possible — the rules those rows matched are gone.
- `coords` polygon values are capped at 256 chars (flagged `truncated`) so an unbounded polygon isn't copied onto every blocked request.
- The consuming audit-page UI is a separate PR in `captcha-private`; it reads this field over the wire and does not depend on any new export from this repo, so the submodule pin does not need to move for it.

## Testing

- New `matchedRule.unit.test.ts` (10 cases): record-vocabulary conditions, IP/CIDR collapse, numeric `asn`, truncation and its boundary, omitted-vs-undefined policy fields, the non-throwing fallback, and round-tripping through the persisted schema.
- Extended the existing test at each of the four enforcement points to assert the snapshot is persisted.
- `npm run build:tsc` clean across the workspace.
- Pre-existing unrelated failures on `main` (`assignDetectorBundle.test.ts`, plus the integration/benchmark suites needing live Mongo/Redis) are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HPV9HRXGCpZMc7Lhu3SizX