### PR TITLE
fix(provider): persist puzzleEvents even when behavioural decryption fails

### DIFF
--- a/.changeset/persist-puzzle-events-on-decrypt-failure.md
+++ b/.changeset/persist-puzzle-events-on-decrypt-failure.md
@@ -1,0 +1,20 @@
+---
+"@prosopo/provider": patch
+---
+
+Fix a data-loss bug where puzzle captcha submissions could drop their raw
+mouse-trail (`puzzleEvents`) and get wrongly denied for it. When a solve
+carried an encrypted behavioural payload but the provider couldn't decrypt
+it — most commonly because the session's detector-pool bundle wasn't
+resolvable (Redis binding expired, `bundleId` never promoted onto the session
+record, or the bundle rotated out of the process) — the entire persistence
+block was skipped. The record kept its default empty `puzzleEvents` array and
+no `behavioralDataPacked`, and the global `checkNoCacheNoBehavioural` rule
+then denied the submission with "no-cache request with no behavioural data"
+against otherwise legitimate desktop browsers that send `cache-control:
+no-cache` on hard reloads or with devtools cache disabled.
+
+`puzzleEvents` are now persisted unconditionally up front, so the raw event
+trail survives independently of whether the behavioural blob can be decrypted.
+The decrypt attempt still runs and its output is still written when it
+succeeds; its failure no longer takes the event trail with it.

--- a/packages/provider/src/tasks/puzzleCaptcha/puzzleTasks.ts
+++ b/packages/provider/src/tasks/puzzleCaptcha/puzzleTasks.ts
@@ -322,6 +322,16 @@ export class PuzzleCaptchaManager extends CaptchaManager {
 			);
 		}
 
+		// Persist puzzleEvents unconditionally so the raw event trail survives
+		// even when the behavioural payload is absent or its decryption fails
+		// (missing bundle, ciphertext / key mismatch, etc.). Previously the
+		// puzzleEvents write was gated on decryption succeeding, so legitimate
+		// solves whose bundle couldn't be resolved lost the event trail AND
+		// tripped the "no-cache request with no behavioural data" DM rule.
+		await this.db.updatePuzzleCaptchaRecord(challenge, {
+			puzzleEvents,
+		});
+
 		// Process behavioral data if provided
 		if (behavioralData) {
 			try {
@@ -364,11 +374,9 @@ export class PuzzleCaptchaManager extends CaptchaManager {
 						d: decryptedData.deviceCapability,
 					};
 
-					// Store the packed data to database
 					await this.db.updatePuzzleCaptchaRecord(challenge, {
 						behavioralDataPacked: packedData,
 						deviceCapability: decryptedData.deviceCapability,
-						puzzleEvents,
 					});
 				}
 			} catch (error) {
@@ -378,11 +386,6 @@ export class PuzzleCaptchaManager extends CaptchaManager {
 				}));
 				// Don't fail the captcha if behavioral analysis fails
 			}
-		} else {
-			// Store puzzle events even without behavioral data
-			await this.db.updatePuzzleCaptchaRecord(challenge, {
-				puzzleEvents,
-			});
 		}
 
 		if (clientMetaData?.hp) {

--- a/packages/provider/src/tests/unit/tasks/puzzleCaptcha/puzzleTasks.unit.test.ts
+++ b/packages/provider/src/tests/unit/tasks/puzzleCaptcha/puzzleTasks.unit.test.ts
@@ -407,6 +407,128 @@ describe("PuzzleCaptchaManager", () => {
 			);
 		});
 
+		// Regression: puzzleEvents must persist even when a behavioural payload
+		// was sent but decryption returns null (e.g. resolveBundleBySessionId
+		// can't find the bundleId promoted onto the session record). The old
+		// code path gated the puzzleEvents write on the successful-decrypt
+		// branch, so a bundle-lookup miss dropped the raw event trail AND left
+		// the DM to fire "no-cache request with no behavioural data" on an
+		// otherwise legitimate submission.
+		it("persists puzzleEvents even when behavioural decryption returns null", async () => {
+			const a = buildArgs();
+			const challengeRecord: Partial<PuzzleCaptchaStored> = {
+				challenge: a.challenge,
+				dappAccount: a.dappAccount,
+				userAccount: a.userAccount,
+				targetX: 100,
+				targetY: 100,
+				tolerance: 15,
+				ipAddress: getCompositeIpAddress(a.ipAddress),
+				result: { status: CaptchaStatus.pending },
+				sessionId: "session-1",
+			};
+
+			vi.mocked(db.getPuzzleCaptchaRecordByChallenge).mockResolvedValue(
+				asPuzzleRecord(challengeRecord),
+			);
+			vi.mocked(verifyRecency).mockImplementation(() => true);
+			vi.mocked(validatePuzzleSolution).mockReturnValue(true);
+
+			// Stub the inherited bundle lookup + decrypt so the failure branch
+			// is deterministic without needing a real detector bundle wired up.
+			vi.spyOn(
+				puzzleCaptchaManager,
+				"resolveBundleBySessionId",
+			).mockResolvedValue(undefined);
+			vi.spyOn(
+				puzzleCaptchaManager,
+				"decryptBehavioralData",
+			).mockResolvedValue(null);
+
+			const trail = [
+				{ x: 1, y: 1, t: 1 },
+				{ x: 2, y: 1, t: 2 },
+			];
+
+			const result = await puzzleCaptchaManager.verifyPuzzleCaptchaSolution(
+				a.challenge,
+				a.providerSignature,
+				102,
+				101,
+				trail,
+				1000,
+				a.userSignature,
+				a.ipAddress,
+				a.headers,
+				"encrypted-blob",
+			);
+
+			expect(result).toBe(true);
+			expect(db.updatePuzzleCaptchaRecord).toHaveBeenCalledWith(
+				a.challenge,
+				expect.objectContaining({ puzzleEvents: trail }),
+			);
+			// And no behavioralDataPacked write happened — decryption failed,
+			// so there was nothing to persist there.
+			const calls = vi.mocked(db.updatePuzzleCaptchaRecord).mock.calls;
+			expect(
+				calls.some(([, patch]) => "behavioralDataPacked" in patch),
+			).toBe(false);
+		});
+
+		// Regression: same guarantee when decryptBehavioralData throws (bad
+		// ciphertext, key mismatch, etc.) rather than returning null.
+		it("persists puzzleEvents even when behavioural decryption throws", async () => {
+			const a = buildArgs();
+			const challengeRecord: Partial<PuzzleCaptchaStored> = {
+				challenge: a.challenge,
+				dappAccount: a.dappAccount,
+				userAccount: a.userAccount,
+				targetX: 100,
+				targetY: 100,
+				tolerance: 15,
+				ipAddress: getCompositeIpAddress(a.ipAddress),
+				result: { status: CaptchaStatus.pending },
+				sessionId: "session-1",
+			};
+
+			vi.mocked(db.getPuzzleCaptchaRecordByChallenge).mockResolvedValue(
+				asPuzzleRecord(challengeRecord),
+			);
+			vi.mocked(verifyRecency).mockImplementation(() => true);
+			vi.mocked(validatePuzzleSolution).mockReturnValue(true);
+
+			vi.spyOn(
+				puzzleCaptchaManager,
+				"resolveBundleBySessionId",
+			).mockResolvedValue(undefined);
+			vi.spyOn(
+				puzzleCaptchaManager,
+				"decryptBehavioralData",
+			).mockRejectedValue(new Error("bad ciphertext"));
+
+			const trail = [{ x: 3, y: 3, t: 3 }];
+
+			const result = await puzzleCaptchaManager.verifyPuzzleCaptchaSolution(
+				a.challenge,
+				a.providerSignature,
+				102,
+				101,
+				trail,
+				1000,
+				a.userSignature,
+				a.ipAddress,
+				a.headers,
+				"encrypted-blob",
+			);
+
+			expect(result).toBe(true);
+			expect(db.updatePuzzleCaptchaRecord).toHaveBeenCalledWith(
+				a.challenge,
+				expect.objectContaining({ puzzleEvents: trail }),
+			);
+		});
+
 		// Locks in the contract added by the puzzle DM threading PR (#2873):
 		// the widget encodes the trusted checkbox click into the salt as
 		// [x, y]; the provider decodes and persists them as coords[0][0].

--- a/packages/provider/src/tests/unit/tasks/puzzleCaptcha/puzzleTasks.unit.test.ts
+++ b/packages/provider/src/tests/unit/tasks/puzzleCaptcha/puzzleTasks.unit.test.ts
@@ -407,6 +407,109 @@ describe("PuzzleCaptchaManager", () => {
 			);
 		});
 
+		// Happy path with a valid decrypt: both puzzleEvents AND
+		// behavioralDataPacked (+ deviceCapability) must land on the record.
+		// The current implementation writes these in two separate
+		// updatePuzzleCaptchaRecord calls (puzzleEvents up front, then the
+		// packed payload after decrypt succeeds); this test asserts on the
+		// combined mock-call history so a regression that drops either write
+		// — or accidentally re-gates puzzleEvents behind the decrypt branch —
+		// surfaces immediately.
+		it("persists both puzzleEvents and behavioralDataPacked on a successful decrypt", async () => {
+			const a = buildArgs();
+			const challengeRecord: Partial<PuzzleCaptchaStored> = {
+				challenge: a.challenge,
+				dappAccount: a.dappAccount,
+				userAccount: a.userAccount,
+				targetX: 100,
+				targetY: 100,
+				tolerance: 15,
+				ipAddress: getCompositeIpAddress(a.ipAddress),
+				result: { status: CaptchaStatus.pending },
+				sessionId: "session-1",
+			};
+
+			vi.mocked(db.getPuzzleCaptchaRecordByChallenge).mockResolvedValue(
+				asPuzzleRecord(challengeRecord),
+			);
+			vi.mocked(verifyRecency).mockImplementation(() => true);
+			vi.mocked(validatePuzzleSolution).mockReturnValue(true);
+
+			// Bundle resolves and decrypt returns unpacked collectors.
+			// The exact PoolBundleDecrypt shape isn't relevant to the assertion;
+			// only that resolve returns *something* truthy so decryptBehavioralData
+			// isn't short-circuited on the missing-bundle branch.
+			vi.spyOn(
+				puzzleCaptchaManager,
+				"resolveBundleBySessionId",
+			).mockResolvedValue({
+				key: "test-key",
+				innerConfig: {},
+			} as unknown as Awaited<
+				ReturnType<typeof puzzleCaptchaManager.resolveBundleBySessionId>
+			>);
+			vi.spyOn(puzzleCaptchaManager, "decryptBehavioralData").mockResolvedValue(
+				{
+					collector1: [{ x: 10, y: 20, timestamp: 100 }],
+					collector2: [],
+					collector3: [{ x: 15, y: 25, timestamp: 200 }],
+					deviceCapability: "desktop",
+				} as unknown as Awaited<
+					ReturnType<typeof puzzleCaptchaManager.decryptBehavioralData>
+				>,
+			);
+
+			const trail = [
+				{ x: 5, y: 5, t: 5 },
+				{ x: 6, y: 5, t: 6 },
+			];
+
+			const result = await puzzleCaptchaManager.verifyPuzzleCaptchaSolution(
+				a.challenge,
+				a.providerSignature,
+				102,
+				101,
+				trail,
+				1000,
+				a.userSignature,
+				a.ipAddress,
+				a.headers,
+				"encrypted-blob",
+			);
+
+			expect(result).toBe(true);
+
+			const calls = vi.mocked(db.updatePuzzleCaptchaRecord).mock.calls;
+
+			// puzzleEvents landed on some call. Guards against a regression that
+			// re-gates the raw-trail write behind the decrypt-success branch.
+			expect(
+				calls.some(
+					([challenge, patch]) =>
+						challenge === a.challenge &&
+						Array.isArray(patch.puzzleEvents) &&
+						patch.puzzleEvents.length === trail.length,
+				),
+				"puzzleEvents must be written on a successful decrypt",
+			).toBe(true);
+
+			// behavioralDataPacked (+ deviceCapability) landed on some call.
+			// Also verifies the c1/c2/c3 shape survived the pack transform.
+			expect(
+				calls.some(
+					([challenge, patch]) =>
+						challenge === a.challenge &&
+						patch.behavioralDataPacked !== undefined &&
+						patch.behavioralDataPacked.c1.length === 1 &&
+						patch.behavioralDataPacked.c2.length === 0 &&
+						patch.behavioralDataPacked.c3.length === 1 &&
+						patch.behavioralDataPacked.d === "desktop" &&
+						patch.deviceCapability === "desktop",
+				),
+				"behavioralDataPacked must be written on a successful decrypt",
+			).toBe(true);
+		});
+
 		// Regression: puzzleEvents must persist even when a behavioural payload
 		// was sent but decryption returns null (e.g. resolveBundleBySessionId
 		// can't find the bundleId promoted onto the session record). The old
@@ -440,10 +543,9 @@ describe("PuzzleCaptchaManager", () => {
 				puzzleCaptchaManager,
 				"resolveBundleBySessionId",
 			).mockResolvedValue(undefined);
-			vi.spyOn(
-				puzzleCaptchaManager,
-				"decryptBehavioralData",
-			).mockResolvedValue(null);
+			vi.spyOn(puzzleCaptchaManager, "decryptBehavioralData").mockResolvedValue(
+				null,
+			);
 
 			const trail = [
 				{ x: 1, y: 1, t: 1 },
@@ -471,9 +573,9 @@ describe("PuzzleCaptchaManager", () => {
 			// And no behavioralDataPacked write happened — decryption failed,
 			// so there was nothing to persist there.
 			const calls = vi.mocked(db.updatePuzzleCaptchaRecord).mock.calls;
-			expect(
-				calls.some(([, patch]) => "behavioralDataPacked" in patch),
-			).toBe(false);
+			expect(calls.some(([, patch]) => "behavioralDataPacked" in patch)).toBe(
+				false,
+			);
 		});
 
 		// Regression: same guarantee when decryptBehavioralData throws (bad
@@ -502,10 +604,9 @@ describe("PuzzleCaptchaManager", () => {
 				puzzleCaptchaManager,
 				"resolveBundleBySessionId",
 			).mockResolvedValue(undefined);
-			vi.spyOn(
-				puzzleCaptchaManager,
-				"decryptBehavioralData",
-			).mockRejectedValue(new Error("bad ciphertext"));
+			vi.spyOn(puzzleCaptchaManager, "decryptBehavioralData").mockRejectedValue(
+				new Error("bad ciphertext"),
+			);
 
 			const trail = [{ x: 3, y: 3, t: 3 }];
 


### PR DESCRIPTION
## Summary

- Puzzle solves lost their raw `puzzleEvents` trail — and got wrongly denied — whenever the provider couldn't decrypt the accompanying behavioural payload.
- Root cause: in `puzzleTasks.verifyPuzzleCaptchaSolution`, the write for `puzzleEvents` was gated on the successful-decrypt branch. If `resolveBundleBySessionId` returned `undefined` (Redis binding expired, `bundleId` not promoted onto the session, bundle rotated out) or `decryptBehavioralData` threw/returned null, the try-block bailed and no persistence happened. The record kept its default empty `puzzleEvents` array with no `behavioralDataPacked`.
- Fix: write `puzzleEvents` unconditionally up front. The decrypt attempt still runs and its output is still persisted when it succeeds; its failure no longer takes the event trail with it.

## Test plan

- [x] Two new unit tests in `puzzleTasks.unit.test.ts` covering the two failure branches (decrypt returns `null`; decrypt throws) — both assert `puzzleEvents` land on the record.
- [x] Existing "puzzleEvents stored when no behavioral data" test still passes (the unconditional write subsumes the old `else` branch).
- [x] `npm run -w @prosopo/provider build:tsc` clean.
- [x] `npx vitest run packages/provider/src/tests/unit` — 71 files, 1022 tests, all passing.

## Follow-up

The underlying "why couldn't the bundle be resolved?" question is orthogonal to this data-loss fix and worth chasing separately — likely session bundleId promotion never fired for some sessions, or the Redis binding is expiring before the puzzle solve arrives. Repro record: pronode16, sessionId `pronode16-4735f75e-1c10-4e20-8e27-01fadec2cf8d` at `2026-08-12T14:21:35Z`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)