### PR TITLE
chore(ci): bump the pinned github_actions SHA to main

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ${{ vars.GH_RUNNER && startsWith(vars.GH_RUNNER, '[') && fromJSON(format('["{0}","4c","8g","40d"]', join(fromJSON(vars.GH_RUNNER), '","'))) || fromJSON(vars.GH_RUNNER || '"ubuntu-latest"') }}
     steps:
       - name: Print contexts
-        uses: prosopo/github_actions/.github/actions/print_contexts@a8f2d18145fedb774d5aacbde7b617c6c8852475 # main
+        uses: prosopo/github_actions/.github/actions/print_contexts@7c4a3922c80bd2b7ca90cdedebd226bd0439467e # main
         with:
           INPUTS_CONTEXT: ${{ toJson(inputs) }}
           NEEDS_CONTEXT: ${{ toJson(needs) }}
@@ -58,7 +58,7 @@ jobs:
       # don't restore the cache, otherwise we get artifacts left over from the previous run sit in the cache for eternity. Do a clean build every time.
       - run: npm cache clean --force
 
-      - uses: prosopo/github_actions/.github/actions/npm@a8f2d18145fedb774d5aacbde7b617c6c8852475 # main
+      - uses: prosopo/github_actions/.github/actions/npm@7c4a3922c80bd2b7ca90cdedebd226bd0439467e # main
         with:
           npm_ci_args: '--include=dev --no-audit --no-fund --prefer-offline'
 
@@ -77,5 +77,5 @@ jobs:
       - run: NODE_ENV=development npx turbo run bundle:webpack
 
       - name: Save npm cache
-        uses: prosopo/github_actions/.github/actions/save_npm_cache@a8f2d18145fedb774d5aacbde7b617c6c8852475 # main
+        uses: prosopo/github_actions/.github/actions/save_npm_cache@7c4a3922c80bd2b7ca90cdedebd226bd0439467e # main
 

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -39,7 +39,7 @@ jobs:
     if: ${{ !startsWith(github.event.pull_request.title, 'Release v') }}
     steps:
       - name: Print contexts
-        uses: prosopo/github_actions/.github/actions/print_contexts@a8f2d18145fedb774d5aacbde7b617c6c8852475 # main
+        uses: prosopo/github_actions/.github/actions/print_contexts@7c4a3922c80bd2b7ca90cdedebd226bd0439467e # main
         with:
           INPUTS_CONTEXT: ${{ toJson(inputs) }}
           NEEDS_CONTEXT: ${{ toJson(needs) }}
@@ -60,7 +60,7 @@ jobs:
           node-version: '24'
           cache: 'npm'
 
-      - uses: prosopo/github_actions/.github/actions/npm@a8f2d18145fedb774d5aacbde7b617c6c8852475 # main
+      - uses: prosopo/github_actions/.github/actions/npm@7c4a3922c80bd2b7ca90cdedebd226bd0439467e # main
         with:
           npm_ci_args: '--include=dev --no-audit --no-fund --prefer-offline'
 

--- a/.github/workflows/cypress-baselines.yml
+++ b/.github/workflows/cypress-baselines.yml
@@ -56,7 +56,7 @@ jobs:
           node-version: '24'
           cache: 'npm'
 
-      - uses: prosopo/github_actions/.github/actions/npm@a8f2d18145fedb774d5aacbde7b617c6c8852475 # main
+      - uses: prosopo/github_actions/.github/actions/npm@7c4a3922c80bd2b7ca90cdedebd226bd0439467e # main
         with:
           npm_ci_args: '--include=dev --no-audit --no-fund --prefer-offline'
 

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -58,7 +58,7 @@ jobs:
     if: github.event.pull_request.draft == false
     steps:
       - name: Print contexts
-        uses: prosopo/github_actions/.github/actions/print_contexts@a8f2d18145fedb774d5aacbde7b617c6c8852475 # main
+        uses: prosopo/github_actions/.github/actions/print_contexts@7c4a3922c80bd2b7ca90cdedebd226bd0439467e # main
         with:
           INPUTS_CONTEXT: ${{ toJson(inputs) }}
           NEEDS_CONTEXT: ${{ toJson(needs) }}
@@ -78,7 +78,7 @@ jobs:
           node-version: '24'
           cache: 'npm'
 
-      - uses: prosopo/github_actions/.github/actions/npm@a8f2d18145fedb774d5aacbde7b617c6c8852475 # main
+      - uses: prosopo/github_actions/.github/actions/npm@7c4a3922c80bd2b7ca90cdedebd226bd0439467e # main
         with:
           npm_ci_args: '--include=dev --no-audit --no-fund --prefer-offline'
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -53,7 +53,7 @@ jobs:
     if: github.event.pull_request.draft == false
     steps:
       - name: Print contexts
-        uses: prosopo/github_actions/.github/actions/print_contexts@a8f2d18145fedb774d5aacbde7b617c6c8852475 # main
+        uses: prosopo/github_actions/.github/actions/print_contexts@7c4a3922c80bd2b7ca90cdedebd226bd0439467e # main
         with:
           INPUTS_CONTEXT: ${{ toJson(inputs) }}
           NEEDS_CONTEXT: ${{ toJson(needs) }}
@@ -73,7 +73,7 @@ jobs:
           node-version: '24'
           cache: 'npm'
 
-      - uses: prosopo/github_actions/.github/actions/npm@a8f2d18145fedb774d5aacbde7b617c6c8852475 # main
+      - uses: prosopo/github_actions/.github/actions/npm@7c4a3922c80bd2b7ca90cdedebd226bd0439467e # main
         with:
           npm_ci_args: '--include=dev --no-audit --no-fund --prefer-offline'
 

--- a/.github/workflows/provider_image.yml
+++ b/.github/workflows/provider_image.yml
@@ -42,7 +42,7 @@ jobs:
     if: github.event.pull_request.draft == false
     steps:
       - name: Print contexts
-        uses: prosopo/github_actions/.github/actions/print_contexts@a8f2d18145fedb774d5aacbde7b617c6c8852475 # main
+        uses: prosopo/github_actions/.github/actions/print_contexts@7c4a3922c80bd2b7ca90cdedebd226bd0439467e # main
         with:
           INPUTS_CONTEXT: ${{ toJson(inputs) }}
           NEEDS_CONTEXT: ${{ toJson(needs) }}
@@ -57,7 +57,7 @@ jobs:
           token: ${{ secrets.PROSOPONATOR_PAT }}
           submodules: "recursive"
 
-      - uses: prosopo/github_actions/.github/actions/npm@a8f2d18145fedb774d5aacbde7b617c6c8852475 # main
+      - uses: prosopo/github_actions/.github/actions/npm@7c4a3922c80bd2b7ca90cdedebd226bd0439467e # main
         with:
           npm_ci_args: '--include=dev --no-audit --no-fund --prefer-offline'
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,7 +57,7 @@ jobs:
     if: github.event.pull_request.draft == false
     steps:
       - name: Print contexts
-        uses: prosopo/github_actions/.github/actions/print_contexts@a8f2d18145fedb774d5aacbde7b617c6c8852475 # main
+        uses: prosopo/github_actions/.github/actions/print_contexts@7c4a3922c80bd2b7ca90cdedebd226bd0439467e # main
         with:
           INPUTS_CONTEXT: ${{ toJson(inputs) }}
           NEEDS_CONTEXT: ${{ toJson(needs) }}
@@ -77,7 +77,7 @@ jobs:
           node-version: '24'
           cache: 'npm'
 
-      - uses: prosopo/github_actions/.github/actions/npm@a8f2d18145fedb774d5aacbde7b617c6c8852475 # main
+      - uses: prosopo/github_actions/.github/actions/npm@7c4a3922c80bd2b7ca90cdedebd226bd0439467e # main
         with:
           npm_ci_args: '--include=dev --no-audit --no-fund --prefer-offline'
 

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -56,7 +56,7 @@ jobs:
     if: github.event.pull_request.draft == false
     steps:
       - name: Print contexts
-        uses: prosopo/github_actions/.github/actions/print_contexts@a8f2d18145fedb774d5aacbde7b617c6c8852475 # main
+        uses: prosopo/github_actions/.github/actions/print_contexts@7c4a3922c80bd2b7ca90cdedebd226bd0439467e # main
         with:
           INPUTS_CONTEXT: ${{ toJson(inputs) }}
           NEEDS_CONTEXT: ${{ toJson(needs) }}
@@ -76,7 +76,7 @@ jobs:
           node-version: '24'
           cache: 'npm'
 
-      - uses: prosopo/github_actions/.github/actions/npm@a8f2d18145fedb774d5aacbde7b617c6c8852475 # main
+      - uses: prosopo/github_actions/.github/actions/npm@7c4a3922c80bd2b7ca90cdedebd226bd0439467e # main
         with:
           npm_ci_args: '--include=dev --no-audit --no-fund --prefer-offline'
 


### PR DESCRIPTION
The pin sat 8 commits behind:

- a lint workflow with a working `check` context (prosopo/github_actions#3)
- the taplo download fix
- per-ecosystem free-disk-space actions for hosted runners (prosopo/github_actions#4)
- cargo cache pruning before save (prosopo/github_actions#5)
- skip cache save on self-hosted runners (prosopo/github_actions#2)

That last one makes `save_npm_cache`/`save_cargo_cache` skip the save on self-hosted runners unless passed `save-on-self-hosted: "true"`. It has no effect here: this repo sets no `GH_RUNNER` variable, so every job is GitHub-hosted.

That is deliberate and should stay so — this repository is public, and a self-hosted runner would let a fork PR execute arbitrary code on the fleet.