### PR TITLE
ci(lint): lint every language and file type, not just the ones present today

### DIFF
--- a/.changeset/polyglot-lint.md
+++ b/.changeset/polyglot-lint.md
@@ -1,0 +1,4 @@
+---
+---
+
+CI only: add a polyglot lint job. No package behaviour changes.

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -70,7 +70,13 @@ jobs:
         run: git fetch origin ${{ github.base_ref }} && git checkout ${{ github.base_ref }}
 
       - name: Checkout head ref
-        run: git fetch origin ${{ github.head_ref }} && git checkout ${{ github.head_ref }}
+        # Through env, not interpolated into the script. A branch name is
+        # attacker-controlled on a fork PR, and `${{ }}` is substituted into the
+        # shell source before the shell ever sees it, so a branch named with a
+        # `;` runs whatever follows.
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+        run: git fetch origin "$HEAD_REF" && git checkout "$HEAD_REF"
 
       # if this fails, you need to run `npm run changesets:add` (preferred!) or `npm run changesets:empty` for an empty changeset (avoid if possible)
       - name: check changesets

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -81,3 +81,181 @@ jobs:
 
       - run: npm run lint
 
+
+  # Every language and file type this repo could plausibly contain, not just the
+  # ones it contains today: a linter that runs and finds nothing because there is
+  # no such code is the point -- it is what stops new code of that kind arriving
+  # unlinted later. Each step therefore no-ops explicitly on an empty match set
+  # rather than being omitted.
+  #
+  # Deliberately the same linter set and invocation style as Protect and
+  # captcha-private, so a fix in one is a fix in all.
+  #
+  # No `paths:` filter on this job on purpose. A `paths:` list is an allowlist, so
+  # a newly added file type silently falls outside it; and a workflow that does
+  # not trigger reports no status at all, which deadlocks a required context.
+  # A job skipped by `if:` reports `skipped`, which branch protection accepts.
+  polyglot:
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false
+    # 2c/4g/20d: no compilation happens here, so this is sized for the tool
+    # downloads, not for a build. See `check` above for what the expression does.
+    runs-on: ${{ vars.GH_RUNNER && startsWith(vars.GH_RUNNER, '[') && fromJSON(format('["{0}","2c","4g","20d"]', join(fromJSON(vars.GH_RUNNER), '","'))) || fromJSON(vars.GH_RUNNER || '"ubuntu-latest"') }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          token: ${{ secrets.PROSOPONATOR_PAT }}
+          # No submodules: each one is linted by its own repo's lint workflow,
+          # and linting them here would report the same findings twice against a
+          # PR that cannot fix them.
+          submodules: false
+
+      # pipx is preinstalled on the hosted images but not in the self-hosted
+      # golden image, and its absence would fail every python-based linter below
+      # with a bare "command not found".
+      - name: python tooling
+        run: |
+          if ! command -v pipx >/dev/null; then
+            sudo apt-get update -qq
+            sudo apt-get install -y -qq pipx
+          fi
+          pipx ensurepath
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      # Roughly one connection in ten from the self-hosted fleet to github.com
+      # dies mid-transfer with `curl: (56) Connection died`. curl's own --retry
+      # does not help because the connection dies during a transfer it already
+      # started; `retry` re-runs the whole pipeline.
+      - name: retry helper
+        run: |
+          sudo tee /usr/local/bin/retry >/dev/null <<'EOF'
+          #!/bin/sh
+          for i in 1 2 3; do
+            "$@" && exit 0
+            [ "$i" = 3 ] && exit 1
+            sleep 15
+          done
+          EOF
+          sudo chmod +x /usr/local/bin/retry
+
+      - name: actionlint
+        run: |
+          # A pinned release tarball, not upstream's download-actionlint.bash:
+          # that script resolves "latest" through the unauthenticated GitHub API,
+          # which the self-hosted runners share an IP for, so it returns a
+          # rate-limit JSON body and dies in `gunzip` naming neither.
+          retry sh -c 'curl -fsSL https://github.com/rhysd/actionlint/releases/download/v1.7.7/actionlint_1.7.7_linux_amd64.tar.gz | tar xz actionlint'
+          # actionlint pipes every `run:` block through shellcheck, which is the
+          # only linting those blocks ever get. The suppressed codes are the ones
+          # that cannot mean a defect here:
+          #   SC2086  word splitting of `>> $GITHUB_ENV` and friends, a path
+          #           GitHub itself controls.
+          #   SC2209  false positive by construction: shellcheck reads the
+          #           `NODE_ENV=test npm run test` prefix as assigning the output
+          #           of the `test` builtin.
+          #   SC2129/SC2002/SC2012/SC2016  style and info only.
+          # Everything else, including the injection checks, still blocks.
+          ./actionlint -color -ignore 'SC(2086|2129|2002|2012|2016|2209)'
+
+      # Config in .yamllint, which already exists here and is unchanged by this
+      # job: the presentational rules are off, the ones where a finding means the
+      # file is wrong (duplicate keys, tabs) are on.
+      - name: yamllint
+        run: |
+          pipx install yamllint
+          yamllint --strict .
+
+      - name: taplo (toml)
+        run: |
+          # Pinned, and not the "-full" asset -- that variant is no longer
+          # published, so a `latest/download/taplo-full-...` URL 404s.
+          retry sh -c 'curl -fsSL https://github.com/tamasfe/taplo/releases/download/0.10.0/taplo-linux-x86_64.gz | gunzip | sudo tee /usr/local/bin/taplo >/dev/null'
+          sudo chmod +x /usr/local/bin/taplo
+          # `lint` only, no `fmt --check`: a misformatted toml is not a bug, a
+          # malformed one is. toml is not incidental here -- rust-toolchain.toml,
+          # Cargo.toml and pyproject.toml all drive builds, so a broken one fails
+          # late and confusingly.
+          taplo lint
+
+      - name: shellcheck
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq shellcheck
+          files=$(git ls-files '*.sh')
+          if [ -z "$files" ]; then echo 'no shell scripts'; exit 0; fi
+          echo "$files" | xargs shellcheck -S warning
+
+      - name: ruff (python)
+        run: |
+          pipx install ruff
+          if [ -z "$(git ls-files '*.py')" ]; then echo 'no python'; exit 0; fi
+          ruff check .
+          ruff format --check .
+
+      - name: hadolint (dockerfiles)
+        run: |
+          retry curl -fsSL -o /tmp/hadolint https://github.com/hadolint/hadolint/releases/download/v2.12.0/hadolint-Linux-x86_64
+          sudo install -m 0755 /tmp/hadolint /usr/local/bin/hadolint
+          files=$(git ls-files '*Dockerfile' '*.dockerfile' '*.Dockerfile' 'Dockerfile*')
+          if [ -z "$files" ]; then echo 'no dockerfiles'; exit 0; fi
+          # DL3008/DL3018 (pin apt/apk versions) are off: these images are
+          # rebuilt from scratch on every release, so a pinned distro package is
+          # a stale package rather than a reproducible one. DL3006 (tag the base
+          # image) is off because the distroless bases publish no versioned tags
+          # at all. --failure-threshold warning: info findings still print, but a
+          # blocking check that fails on style gets disabled rather than fixed.
+          echo "$files" | xargs hadolint --failure-threshold warning \
+            --ignore DL3008 --ignore DL3018 --ignore DL3006
+
+      - name: ansible-lint
+        run: |
+          if [ -z "$(git ls-files '*ansible*')" ]; then echo 'no ansible'; exit 0; fi
+          pipx install ansible-lint
+          ansible-lint --profile basic
+
+      - name: ktlint (kotlin)
+        run: |
+          if [ -z "$(git ls-files '*.kt' '*.kts')" ]; then echo 'no kotlin'; exit 0; fi
+          retry curl -fsSL -o /tmp/ktlint https://github.com/pinterest/ktlint/releases/download/1.5.0/ktlint
+          sudo install -m 0755 /tmp/ktlint /usr/local/bin/ktlint
+          ktlint --relative '**/*.kt' '**/*.kts'
+
+      - name: swiftlint
+        run: |
+          if [ -z "$(git ls-files '*.swift')" ]; then echo 'no swift'; exit 0; fi
+          # Through the official container rather than a native install:
+          # SwiftLint on Linux needs a full Swift toolchain, and the alternative
+          # -- running this step on a macOS runner -- would put a lint check in
+          # front of the single macOS guest the whole org shares.
+          docker run --rm -v "$PWD:/work" -w /work ghcr.io/realm/swiftlint:0.57.0 \
+            swiftlint lint --quiet
+
+      - name: sqlfluff
+        run: |
+          if [ -z "$(git ls-files '*.sql')" ]; then echo 'no sql'; exit 0; fi
+          pipx install sqlfluff
+          # Dialect is not optional and there is no sensible default. Rules are
+          # selected by group; the layout groups are deliberately absent because
+          # they only ever report indentation. NB the old L001-style codes
+          # silently select nothing in sqlfluff 2+ -- it warns and then lints
+          # with the full default set instead.
+          git ls-files -z '*.sql' | xargs -0 \
+            sqlfluff lint --dialect postgres \
+              --rules references,ambiguous,structure,convention
+
+      - name: htmlhint
+        run: |
+          if [ -z "$(git ls-files '*.html')" ]; then echo 'no html'; exit 0; fi
+          # --config is required: the repo's config is htmlhint.json, not the
+          # .htmlhintrc name htmlhint picks up on its own, so without this the
+          # svg plugin config is silently ignored and the defaults run instead.
+          git ls-files -z '*.html' | xargs -0 npx --yes htmlhint@1.1.4 --config htmlhint.json
+
+      - name: xmllint
+        run: |
+          if [ -z "$(git ls-files '*.xml')" ]; then echo 'no xml'; exit 0; fi
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq libxml2-utils
+          # Well-formedness only. Validating against a schema would need each
+          # file's DTD/XSD fetched at lint time, which makes the check depend on
+          # a third party being up.
+          git ls-files '*.xml' | xargs xmllint --noout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -291,7 +291,10 @@ jobs:
 #                done
 
       - name: publish to npm
-        if: ${{ env.affected != '[]' }} && ${{ env.prerelease == 'false' }}
+        # One expression, not two joined by a bare `&&`. Anything outside the
+        # `${{ }}` is literal text, so the original was a non-empty string and
+        # therefore always true -- this step ran on prereleases too.
+        if: ${{ env.affected != '[]' && env.prerelease == 'false' }}
         run: |
           # for each affected package
           for pkg in $(echo '${{ env.affected }}' | jq -r '.[] | .name'); do
@@ -369,7 +372,7 @@ jobs:
             result=0
             # if the package has a publish:docker script, run it
             # else it isn't a docker package
-            if cat $(npx -w "$pkg" node -p "process.cwd()+'/package.json'") | jq -r '.scripts["publish:docker"] or error("missing script")'; then
+            if cat "$(npx -w "$pkg" node -p "process.cwd()+'/package.json'")" | jq -r '.scripts["publish:docker"] or error("missing script")'; then
               echo "Package $pkg has a publish:docker script, publishing to Docker Hub"
             else
               echo "Package $pkg does not have a publish:docker script, skipping"

--- a/.github/workflows/stale-pr-to-draft.yml
+++ b/.github/workflows/stale-pr-to-draft.yml
@@ -97,7 +97,9 @@ jobs:
             exit 0
           fi
 
-          while IFS=$'\t' read -r number updated author title; do
+          # `_` soaks up the remaining author/title columns: naming them would
+          # be two variables nothing reads.
+          while IFS=$'\t' read -r number updated _; do
             [ -n "$number" ] || continue
             echo "Drafting #$number (last updated $updated)"
             # Comment first. A PR that goes draft with no explanation reads as a

--- a/.husky/check-branch.sh
+++ b/.husky/check-branch.sh
@@ -7,8 +7,11 @@ if [[ "$BRANCH_PROTECTION_DISABLED" != "true" ]]; then
 	# Get the current branch name
 	branch=$(git rev-parse --abbrev-ref HEAD)
 
-	# Check if the current branch is in the list of branches
-	if [[ " ${branches[@]} " =~ " ${branch} " ]]; then
+	# Check if the current branch is in the list of branches.
+	# Element-wise, not `[[ " ${branches[@]} " =~ " $branch " ]]`: that joins
+	# the array into one string and matches a quoted RHS literally, so it is a
+	# substring test -- a branch named "maintenance" would match "main".
+	if printf '%s\n' "${branches[@]}" | grep -qxF "$branch"; then
 		echo "Branch '$branch' is protected. Set BRANCH_PROTECTION_DISABLED=true to override."
 		exit 1  # Abort the commit if on restricted branches
 	fi

--- a/.yamllint
+++ b/.yamllint
@@ -1,9 +1,37 @@
+# yamllint's defaults are a house style, and most of what they flag here is
+# cosmetic. The rules kept below are the ones where a finding means the file is
+# wrong rather than merely unlike someone else's formatting: a duplicate key
+# silently discards a value, and a tab is a hard YAML syntax error.
+#
+# Everything switched off is presentational. Turning it on would mean reflowing
+# a few hundred lines across the ansible playbooks and the workflows for no
+# behavioural gain, and the churn would bury the findings that do matter.
+
 extends: default
 
 ignore-from-file: .gitignore
 
 rules:
+  # Workflows and ansible both run well past 80 columns, and a hard wrap in a
+  # `run:` block changes what the shell sees.
+  line-length: disable
+  # `---` is optional in YAML 1.2 and its absence never changes parsing.
   document-start: disable
-  line-length: disable  
+  # `[ main ]` vs `[main]`: pure style.
+  brackets: disable
+  braces: disable
+  indentation: disable
+  empty-lines: disable
   trailing-spaces: disable
+  comments-indentation: disable
+  comments:
+    require-starting-space: true
+    # The two-space-before rule is style; the starting space is not, since
+    # `#comment` directly after content is easy to misread.
+    min-spaces-from-content: 1
+  # Off, and it cannot usefully be on here. The two things it would flag are
+  # both required idiom: ansible's `yes`/`no` (used ~90 times across the
+  # playbooks, and the form ansible's own docs use), and GitHub Actions' `on:`
+  # key, which yamllint reads as the boolean `true`. With both excepted the
+  # rule has nothing left to catch in this repo.
   truthy: disable

--- a/demos/android-webview/app/build.gradle.kts
+++ b/demos/android-webview/app/build.gradle.kts
@@ -25,7 +25,7 @@ android {
             isMinifyEnabled = false
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
-                "proguard-rules.pro"
+                "proguard-rules.pro",
             )
         }
     }

--- a/demos/android-webview/app/src/androidTest/java/io/prosopo/procaptcha/ExampleInstrumentedTest.kt
+++ b/demos/android-webview/app/src/androidTest/java/io/prosopo/procaptcha/ExampleInstrumentedTest.kt
@@ -1,12 +1,10 @@
 package io.prosopo.procaptcha
 
-import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.ext.junit.runners.AndroidJUnit4
-
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
-
-import org.junit.Assert.*
 
 /**
  * Instrumented test, which will execute on an Android device.

--- a/demos/android-webview/app/src/main/java/io/prosopo/procaptcha/MainActivity.kt
+++ b/demos/android-webview/app/src/main/java/io/prosopo/procaptcha/MainActivity.kt
@@ -5,7 +5,6 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import android.os.Message
-import android.util.Base64
 import android.util.Log
 import android.webkit.ConsoleMessage
 import android.webkit.CookieManager
@@ -18,16 +17,23 @@ import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.appcompat.app.AppCompatActivity
 
-const val namespace = "procaptcha";
+const val NAMESPACE = "procaptcha"
 
 class MainActivity : AppCompatActivity() {
-
     private class ProcaptchaWebViewClient : WebViewClient() {
-        override fun doUpdateVisitedHistory(view: WebView?, url: String?, isReload: Boolean) {
+        override fun doUpdateVisitedHistory(
+            view: WebView?,
+            url: String?,
+            isReload: Boolean,
+        ) {
             // do nothing, don't worry about visited links
         }
 
-        override fun onFormResubmission(view: WebView, dontResend: Message, resend: Message) {
+        override fun onFormResubmission(
+            view: WebView,
+            dontResend: Message,
+            resend: Message,
+        ) {
             // just resend the message, don't bother the user
             resend.sendToTarget()
         }
@@ -35,7 +41,7 @@ class MainActivity : AppCompatActivity() {
         override fun onReceivedError(
             view: WebView?,
             request: WebResourceRequest?,
-            error: WebResourceError?
+            error: WebResourceError?,
         ) {
             // TODO this is triggered whenever a resource can't load, bundle/img/whatever etc. Handle the type and display corresponding error
             // handle http + ssl errors here to maintain compatibility with old android versions
@@ -44,19 +50,17 @@ class MainActivity : AppCompatActivity() {
 
         override fun shouldOverrideUrlLoading(
             view: WebView,
-            request: WebResourceRequest
+            request: WebResourceRequest,
         ): Boolean {
-            Log.i(namespace, "opening external url: ${request.url}")
+            Log.i(NAMESPACE, "opening external url: ${request.url}")
             // Open URLs in external browser
             val intent = Intent(Intent.ACTION_VIEW, Uri.parse(request.url.toString()))
             view.context.startActivity(intent)
             return true
         }
-
     }
 
     private class ProcaptchaWebChromeClient : WebChromeClient() {
-
         override fun getVisitedHistory(callback: ValueCallback<Array<String>>) {
             // call the callback with empty history, making all links appear unvisited
             callback.onReceiveValue(emptyArray())
@@ -69,19 +73,22 @@ class MainActivity : AppCompatActivity() {
         override fun onConsoleMessage(consoleMessage: ConsoleMessage): Boolean {
             val message = "File: ${consoleMessage.sourceId()}\nLine: ${consoleMessage.lineNumber()}\nMessage: ${consoleMessage.message()}"
             when (consoleMessage.messageLevel()) {
-                ConsoleMessage.MessageLevel.ERROR -> Log.e(
-                    namespace,
-                    message
-                )
-                ConsoleMessage.MessageLevel.WARNING -> Log.w(
-                    namespace,
-                    message
+                ConsoleMessage.MessageLevel.ERROR ->
+                    Log.e(
+                        NAMESPACE,
+                        message,
                     )
-                ConsoleMessage.MessageLevel.DEBUG -> Log.d(
-                    namespace,
-                    message
-                )
-                else -> Log.i(namespace, message)
+                ConsoleMessage.MessageLevel.WARNING ->
+                    Log.w(
+                        NAMESPACE,
+                        message,
+                    )
+                ConsoleMessage.MessageLevel.DEBUG ->
+                    Log.d(
+                        NAMESPACE,
+                        message,
+                    )
+                else -> Log.i(NAMESPACE, message)
             }
             return true; // suppress default logging
         }
@@ -90,11 +97,11 @@ class MainActivity : AppCompatActivity() {
             view: WebView?,
             isDialog: Boolean,
             isUserGesture: Boolean,
-            resultMsg: Message?
+            resultMsg: Message?,
         ): Boolean {
             val result = super.onCreateWindow(view, isDialog, isUserGesture, resultMsg)
-            if(!result) {
-                Log.e(namespace, "webview creation failed")
+            if (!result) {
+                Log.e(NAMESPACE, "webview creation failed")
             }
             return result
         }
@@ -125,6 +132,5 @@ class MainActivity : AppCompatActivity() {
         val cookieManager: CookieManager = CookieManager.getInstance()
         cookieManager.setAcceptCookie(true)
         webView.loadUrl("file:///android_asset/procaptcha.html")
-
     }
 }

--- a/demos/android-webview/app/src/test/java/io/prosopo/procaptcha/ExampleUnitTest.kt
+++ b/demos/android-webview/app/src/test/java/io/prosopo/procaptcha/ExampleUnitTest.kt
@@ -1,8 +1,7 @@
 package io.prosopo.procaptcha
 
+import org.junit.Assert.assertEquals
 import org.junit.Test
-
-import org.junit.Assert.*
 
 /**
  * Example local unit test, which will execute on the development machine (host).

--- a/demos/ios-webview/procaptcha/ContentView.swift
+++ b/demos/ios-webview/procaptcha/ContentView.swift
@@ -3,11 +3,11 @@ import WebKit
 
 struct WebView: UIViewRepresentable {
     let filePath: String
-    
+
     func makeCoordinator() -> Coordinator {
         return Coordinator(self)
     }
-    
+
     func makeUIView(context: Context) -> WKWebView {
         let webViewConfiguration = WKWebViewConfiguration()
         webViewConfiguration.preferences.javaScriptEnabled = true
@@ -37,47 +37,54 @@ struct WebView: UIViewRepresentable {
             console.debug = function() { sendMessage('DEBUG', arguments); oldDebug.apply(console, arguments); };
         })();
         """
-        
+
         let script = WKUserScript(source: scriptSource, injectionTime: .atDocumentStart, forMainFrameOnly: false)
         userContentController.addUserScript(script)
-        
+
         // Add the user content controller to the configuration
         webViewConfiguration.userContentController = userContentController
-        
+
         let webView = WKWebView(frame: .zero, configuration: webViewConfiguration)
         webView.navigationDelegate = context.coordinator
         webView.isInspectable = true
-        
-        //DispatchQueue.main.asyncAfter(deadline: .now() + 30) {
+
+        // DispatchQueue.main.asyncAfter(deadline: .now() + 30) {
         guard let fileUrl = Bundle.main.url(forResource: filePath, withExtension: nil) else {
             fatalError("html file \(filePath) not found")
         }
         webView.loadFileURL(fileUrl, allowingReadAccessTo: fileUrl.deletingLastPathComponent())
-        //}
-        
+        // }
+
         return webView
     }
-    
+
     func updateUIView(_ uiView: WKWebView, context: Context) {
         // Handle any updates if necessary
     }
-    
+
     class Coordinator: NSObject, WKNavigationDelegate, WKScriptMessageHandler {
         var parent: WebView
-        
+
         init(_ parent: WebView) {
             self.parent = parent
         }
-        
+
         // This is where JavaScript messages are received
-        func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+        func userContentController(
+            _ userContentController: WKUserContentController,
+            didReceive message: WKScriptMessage
+        ) {
             if message.name == "consoleLog", let messageBody = message.body as? String {
                 print("JavaScript Console: \(messageBody)") // Log to Xcode console
             }
         }
-        
+
         // Handle navigation actions
-        func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+        func webView(
+            _ webView: WKWebView,
+            decidePolicyFor navigationAction: WKNavigationAction,
+            decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
+        ) {
             if navigationAction.navigationType == .linkActivated {
                 decisionHandler(.cancel)
             } else {

--- a/demos/ios-webview/procaptcha/procaptchaApp.swift
+++ b/demos/ios-webview/procaptcha/procaptchaApp.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 @main
-struct procaptchaApp: App {
+struct ProcaptchaApp: App {
     var body: some Scene {
         WindowGroup {
             ContentView()

--- a/docker/images/caddy/src/Dockerfile
+++ b/docker/images/caddy/src/Dockerfile
@@ -9,7 +9,9 @@ FROM caddy:2
 RUN apk update && apk add libpcap
 RUN apk add --no-cache curl
 # Create a static directory for Caddy and write robots.txt inside the image
+# printf, not `echo -e`: the base image's /bin/sh is busybox ash, where echo's
+# flags are undefined behaviour, so `-e` can end up in the file itself.
 RUN mkdir -p /srv/static && \
-    echo -e "User-agent: *\nDisallow: /" > /srv/static/robots.txt
+    printf 'User-agent: *\nDisallow: /\n' > /srv/static/robots.txt
 COPY --from=builder /usr/bin/caddy /usr/bin/caddy
 

--- a/docker/images/vector/src/Dockerfile
+++ b/docker/images/vector/src/Dockerfile
@@ -15,6 +15,11 @@
 # refuse to start.
 FROM timberio/vector:0.55.0-debian
 
+# The apt setup below pipes curl into a file and into apt-key-style steps;
+# without pipefail a failed download is masked by the success of the last
+# command in the pipe and the image builds with a broken repo list.
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
 # Add Docker's official GPG key:
 RUN apt-get update \
     && apt-get install -y ca-certificates curl \

--- a/release.sh
+++ b/release.sh
@@ -1,3 +1,6 @@
+#!/bin/bash
+set -e
+
           npm i -g @changesets/cli
           npx @changesets/cli version --verbose
           git status


### PR DESCRIPTION
Adds a `polyglot` job to the lint workflow — the same linter set and invocation style already landed in [prosopo/Protect#461](https://github.com/prosopo/Protect/pull/461) and [prosopo/captcha-private#4141](https://github.com/prosopo/captcha-private/pull/4141), so a fix in one is a fix in all.

actionlint, yamllint, taplo (toml), shellcheck, ruff, hadolint, ansible-lint, ktlint, swiftlint, sqlfluff, htmlhint, xmllint. Every step no-ops explicitly on an empty match set, so a language this repo does not contain today still gets linted the day it arrives — that is the point, not an accident of scope.

No `paths:` filter on the job. A paths list is an allowlist, so a new file type silently falls outside it; and a workflow that does not trigger reports no status at all, which leaves a required context pending forever. A job skipped by `if:` reports `skipped`, which branch protection accepts.

### Findings fixed rather than suppressed

All linters were run locally against a clean checkout first, so this goes up green rather than red.

- **`changesets.yml`** interpolated `github.head_ref` directly into a `run:` script. A branch name is attacker-controlled on a fork PR and `\${{ }}` is substituted into the shell source before the shell sees it, so a branch named with a `;` ran whatever followed. Now passed through `env:`.
- **`release.yml`** publish-to-npm was gated on `\${{ env.affected != '[]' }} && \${{ env.prerelease == 'false' }}`. Anything outside the `\${{ }}` is literal text, so the condition was a non-empty string and always true — the step ran on prereleases too. Now one expression.
- **`.husky/check-branch.sh`** tested branch protection with `[[ \" \${branches[@]} \" =~ \" \$branch \" ]]`, which joins the array into one string and matches literally — a substring test, so a branch named `maintenance` matched `main`.
- **`docker/images/caddy/src/Dockerfile`** wrote robots.txt with `echo -e` under busybox ash, where echo's flags are undefined behaviour. **`vector`'s** Dockerfile piped curl without `pipefail`, so a failed download was masked.
- **kotlin/swift** demos: formatting brought to ktlint/swiftlint clean; `namespace` → `NAMESPACE`, wildcard junit imports made explicit, `procaptchaApp` → `ProcaptchaApp`.
- **`.yamllint`** now keeps only the rules where a finding means the file is wrong (duplicate keys, tabs) and drops the presentational ones, matching the sibling repos.

Suppressions that remain are per-code and justified in-file (actionlint's SC2086/SC2209 etc., hadolint's DL3008/DL3018/DL3006).