### PR TITLE
fix(provider): evict deduped session when incoming detector bundle differs

### DIFF
--- a/.changeset/frictionless-dedup-bundle-mismatch.md
+++ b/.changeset/frictionless-dedup-bundle-mismatch.md
@@ -1,0 +1,21 @@
+---
+"@prosopo/provider": patch
+---
+
+Evict the dedup'd session when the incoming request's
+`detectorSessionId` resolves to a different pool bundleId than the
+cached session's stored bundleId.
+
+`DetectorBundlePool.pickRandom` returns a uniform-random pick per
+`/detector/assign`, and the widget always fetches a fresh detector per
+page-load. If we hand back a dedup'd session whose bundleId doesn't
+match the fresh one, every later `/captcha/{type}` + solution hop
+encrypts with the new detector's public key while the provider tries
+to decrypt with the cached bundle's private key — yielding
+`ERR_OSSL_RSA_OAEP_DECODING_ERROR` on SIMD + behavioural, an empty BDP
+from the DM's point of view, and an R1-rule escalation to image on
+every submit. Extends the existing "evict on policy/routing conflict"
+branch to cover this case. Falls through to reuse when the incoming
+detectorSessionId binding cannot be resolved (Redis TTL expired), so
+we don't churn every returning user whose page has been open longer
+than the binding.

--- a/packages/provider/src/api/captcha/getFrictionlessCaptchaChallenge/handler.ts
+++ b/packages/provider/src/api/captcha/getFrictionlessCaptchaChallenge/handler.ts
@@ -344,7 +344,46 @@ export default (
 				const dedupConflictsWithRouting =
 					dedupRouted.captchaType !== cachedCaptchaType;
 
-				if (dedupConflictsWithPolicy || dedupConflictsWithRouting) {
+				// The reused session's `bundleId` is what the provider will
+				// use to decrypt every later behavioural / SIMD payload for
+				// this session (via resolveBundleBySessionId). But the client
+				// on this request just did a fresh /detector/assign that
+				// bound `detectorSessionId` to whichever bundle
+				// DetectorBundlePool.pickRandom returned — almost never the
+				// same one the cached session stored, because the pick is
+				// uniform-random across the pool. If we hand the client the
+				// cached sessionId, every later hop encrypts with the fresh
+				// detector's public key and the provider tries to decrypt
+				// with the cached bundle's private key, yielding
+				// ERR_OSSL_RSA_OAEP_DECODING_ERROR and an escalation via the
+				// DM's empty-BDP rule. Evict on mismatch so the fresh-session
+				// path below re-binds `bundleId` from the current
+				// detectorSessionId. When the incoming detectorSessionId
+				// binding has expired (Redis TTL) we cannot see the fresh
+				// bundleId; fall through to reuse rather than evict
+				// unconditionally — the widget will still be re-bootstrapped
+				// on the next retry.
+				let dedupConflictsWithBundle = false;
+				let dedupIncomingBundleId: string | undefined;
+				if (detectorSessionId && dedup.session.bundleId) {
+					const incoming =
+						await tasks.frictionlessManager.resolveBundleByDetectorSession(
+							detectorSessionId,
+						);
+					dedupIncomingBundleId = incoming?.bundleId;
+					if (
+						dedupIncomingBundleId !== undefined &&
+						dedupIncomingBundleId !== dedup.session.bundleId
+					) {
+						dedupConflictsWithBundle = true;
+					}
+				}
+
+				if (
+					dedupConflictsWithPolicy ||
+					dedupConflictsWithRouting ||
+					dedupConflictsWithBundle
+				) {
 					req.logger.info(() => ({
 						msg: "Evicting reused session: cached captchaType conflicts with access policy or routing machine",
 						data: {
@@ -357,6 +396,10 @@ export default (
 							}),
 							...(dedupConflictsWithRouting && {
 								routedCaptchaType: dedupRouted.captchaType,
+							}),
+							...(dedupConflictsWithBundle && {
+								cachedBundleId: dedup.session.bundleId,
+								incomingBundleId: dedupIncomingBundleId,
 							}),
 						},
 					}));

--- a/packages/provider/src/tests/unit/api/getFrictionlessCaptchaChallenge.unit.test.ts
+++ b/packages/provider/src/tests/unit/api/getFrictionlessCaptchaChallenge.unit.test.ts
@@ -53,6 +53,7 @@ type MockTasks = {
 		scoreIncreaseTimestamp: MockFn;
 		updateScore: MockFn;
 		setMatchedRule: MockFn;
+		resolveBundleByDetectorSession: MockFn;
 	};
 	db: {
 		getSessionRecordByToken: MockFn;
@@ -203,6 +204,7 @@ vi.mock("../../../tasks/index.js", async () => {
 					),
 					updateScore: vi.fn(),
 					setMatchedRule: vi.fn(),
+					resolveBundleByDetectorSession: vi.fn().mockResolvedValue(undefined),
 				},
 				db: {
 					getSessionRecordByToken: vi.fn().mockResolvedValue(null),
@@ -290,6 +292,7 @@ describe("getFrictionlessCaptchaChallenge - context selection", () => {
 			),
 			updateScore: vi.fn(),
 			setMatchedRule: vi.fn(),
+			resolveBundleByDetectorSession: vi.fn().mockResolvedValue(undefined),
 		},
 		db: {
 			getSessionRecordByToken: vi.fn().mockResolvedValue(null),
@@ -739,6 +742,189 @@ describe("getFrictionlessCaptchaChallenge - context selection", () => {
 		expect(res.json).toHaveBeenCalledWith(
 			expect.objectContaining({
 				sessionId: "live-pow-session-routing-agrees",
+			}),
+		);
+	});
+
+	// Regression: dedup returned a session bound to pool bundle A, but the
+	// client on this request just did a fresh /detector/assign that returned
+	// bundle B (uniform-random pick across the pool). Handing back the cached
+	// sessionId would leave every later SIMD / behavioural hop encrypted with
+	// bundle B's public key while the provider tries bundle A's private key —
+	// the OAEP-decode-error → empty-BDP → image-escalation cascade seen in
+	// prod after the 15:47 UTC 2026-08-13 restart wave. Evict on mismatch so
+	// the fresh-session path re-binds bundleId from the current
+	// detectorSessionId.
+	it("evicts the reused session when the incoming detectorSessionId bundle differs from the cached session's bundleId", async () => {
+		const clientRecord = {
+			account: "siteDedupBundleConflict",
+			settings: {
+				captchaType: CaptchaType.frictionless,
+				frictionlessThreshold: 0.5,
+				imageMaxRounds: 2,
+				disallowWebView: false,
+			},
+		};
+		tasksInstance.db.getClientRecord.mockResolvedValue(clientRecord);
+
+		// Cached session was minted with bundle-A.
+		tasksInstance.db.getSessionByuserSitekeyIpHash.mockResolvedValue({
+			sessionId: "stale-pow-session-bundle-conflict",
+			captchaType: CaptchaType.pow,
+			score: 0,
+			webView: false,
+			bundleId: "bundle-A",
+		});
+
+		// No policy conflict; routing agrees on captchaType.
+		tasksInstance.frictionlessManager.getPrioritisedAccessPolicies.mockResolvedValue(
+			[],
+		);
+		tasksInstance.frictionlessManager.applyRoutingMachine.mockResolvedValue({
+			captchaType: CaptchaType.pow,
+		});
+
+		// The fresh /detector/assign on this request resolved to bundle-B.
+		tasksInstance.frictionlessManager.resolveBundleByDetectorSession.mockResolvedValue(
+			{ bundleId: "bundle-B", key: "k", innerConfig: "c" },
+		);
+
+		tasksInstance.frictionlessManager.decryptPayload.mockResolvedValue({
+			baseBotScore: 0,
+			timestamp: Date.now(),
+			userId: "u",
+			userAgent: "844bc172f032bdd2d0baae3536c1d66c",
+			webView: false,
+			iFrame: false,
+			decryptedHeadHash: "abc",
+			decryptionFailed: false,
+		});
+
+		const body = {
+			token: "tBundleConflict",
+			headHash: "hhBundleConflict",
+			dapp: "siteDedupBundleConflict",
+			user: "u",
+			detectorSessionId: "det-fresh",
+		};
+		const { req, res, next } = buildReqRes(body);
+
+		// biome-ignore lint/suspicious/noExplicitAny: mock request
+		await handler(req as any, res as any, next);
+
+		expect(next).not.toHaveBeenCalled();
+		// Stale session is evicted so its bundleId can't cause OAEP failures
+		// on the client's subsequent /captcha/{type} + solution hops.
+		expect(tasksInstance.db.checkAndRemoveSession).toHaveBeenCalledWith(
+			"stale-pow-session-bundle-conflict",
+		);
+		// And the reuse response is not served.
+		expect(res.json).not.toHaveBeenCalledWith(
+			expect.objectContaining({
+				sessionId: "stale-pow-session-bundle-conflict",
+			}),
+		);
+	});
+
+	it("reuses the cached session when the incoming detectorSessionId bundle matches the cached session's bundleId", async () => {
+		const clientRecord = {
+			account: "siteDedupBundleAgrees",
+			settings: {
+				captchaType: CaptchaType.frictionless,
+				frictionlessThreshold: 0.5,
+				disallowWebView: false,
+			},
+		};
+		tasksInstance.db.getClientRecord.mockResolvedValue(clientRecord);
+
+		tasksInstance.db.getSessionByuserSitekeyIpHash.mockResolvedValue({
+			sessionId: "live-pow-session-bundle-agrees",
+			captchaType: CaptchaType.pow,
+			score: 0,
+			webView: false,
+			bundleId: "bundle-A",
+		});
+
+		tasksInstance.frictionlessManager.applyRoutingMachine.mockResolvedValue({
+			captchaType: CaptchaType.pow,
+		});
+
+		tasksInstance.frictionlessManager.resolveBundleByDetectorSession.mockResolvedValue(
+			{ bundleId: "bundle-A", key: "k", innerConfig: "c" },
+		);
+
+		const body = {
+			token: "tBundleAgrees",
+			headHash: "hhBundleAgrees",
+			dapp: "siteDedupBundleAgrees",
+			user: "u",
+			detectorSessionId: "det-fresh-agrees",
+		};
+		const { req, res, next } = buildReqRes(body);
+
+		// biome-ignore lint/suspicious/noExplicitAny: mock request
+		await handler(req as any, res as any, next);
+
+		expect(next).not.toHaveBeenCalled();
+		expect(tasksInstance.db.checkAndRemoveSession).not.toHaveBeenCalled();
+		expect(res.json).toHaveBeenCalledWith(
+			expect.objectContaining({
+				sessionId: "live-pow-session-bundle-agrees",
+			}),
+		);
+	});
+
+	// The fallback branch matters just as much as the conflict branch: when
+	// the incoming detectorSessionId's Redis binding has expired we cannot
+	// see the fresh bundleId, and evicting on that basis would churn every
+	// returning user whose page has been open longer than the binding TTL.
+	// So we must NOT evict — reuse and let the client's next retry
+	// re-bootstrap if the OAEP failure recurs.
+	it("reuses the cached session when the incoming detectorSessionId binding cannot be resolved", async () => {
+		const clientRecord = {
+			account: "siteDedupBundleUnresolved",
+			settings: {
+				captchaType: CaptchaType.frictionless,
+				frictionlessThreshold: 0.5,
+				disallowWebView: false,
+			},
+		};
+		tasksInstance.db.getClientRecord.mockResolvedValue(clientRecord);
+
+		tasksInstance.db.getSessionByuserSitekeyIpHash.mockResolvedValue({
+			sessionId: "live-pow-session-bundle-unresolved",
+			captchaType: CaptchaType.pow,
+			score: 0,
+			webView: false,
+			bundleId: "bundle-A",
+		});
+
+		tasksInstance.frictionlessManager.applyRoutingMachine.mockResolvedValue({
+			captchaType: CaptchaType.pow,
+		});
+
+		// Binding expired / never existed — resolve returns undefined.
+		tasksInstance.frictionlessManager.resolveBundleByDetectorSession.mockResolvedValue(
+			undefined,
+		);
+
+		const body = {
+			token: "tBundleUnresolved",
+			headHash: "hhBundleUnresolved",
+			dapp: "siteDedupBundleUnresolved",
+			user: "u",
+			detectorSessionId: "det-expired",
+		};
+		const { req, res, next } = buildReqRes(body);
+
+		// biome-ignore lint/suspicious/noExplicitAny: mock request
+		await handler(req as any, res as any, next);
+
+		expect(next).not.toHaveBeenCalled();
+		expect(tasksInstance.db.checkAndRemoveSession).not.toHaveBeenCalled();
+		expect(res.json).toHaveBeenCalledWith(
+			expect.objectContaining({
+				sessionId: "live-pow-session-bundle-unresolved",
 			}),
 		);
 	});

--- a/packages/provider/src/tests/unit/api/getFrictionlessCaptchaChallenge.unit.test.ts
+++ b/packages/provider/src/tests/unit/api/getFrictionlessCaptchaChallenge.unit.test.ts
@@ -818,12 +818,19 @@ describe("getFrictionlessCaptchaChallenge - context selection", () => {
 		expect(tasksInstance.db.checkAndRemoveSession).toHaveBeenCalledWith(
 			"stale-pow-session-bundle-conflict",
 		);
-		// And the reuse response is not served.
+		// The reuse response is not served ...
 		expect(res.json).not.toHaveBeenCalledWith(
 			expect.objectContaining({
 				sessionId: "stale-pow-session-bundle-conflict",
 			}),
 		);
+		// ... and the request falls through to the fresh-session path,
+		// which mints a new challenge (no policy or DM output forces
+		// image/puzzle in this test, so pow is picked). The important
+		// contract is "the client gets a new session", not an error.
+		expect(
+			tasksInstance.frictionlessManager.sendPowCaptcha,
+		).toHaveBeenCalled();
 	});
 
 	it("reuses the cached session when the incoming detectorSessionId bundle matches the cached session's bundleId", async () => {

--- a/packages/provider/src/tests/unit/api/getFrictionlessCaptchaChallenge.unit.test.ts
+++ b/packages/provider/src/tests/unit/api/getFrictionlessCaptchaChallenge.unit.test.ts
@@ -828,9 +828,7 @@ describe("getFrictionlessCaptchaChallenge - context selection", () => {
 		// which mints a new challenge (no policy or DM output forces
 		// image/puzzle in this test, so pow is picked). The important
 		// contract is "the client gets a new session", not an error.
-		expect(
-			tasksInstance.frictionlessManager.sendPowCaptcha,
-		).toHaveBeenCalled();
+		expect(tasksInstance.frictionlessManager.sendPowCaptcha).toHaveBeenCalled();
 	});
 
 	it("reuses the cached session when the incoming detectorSessionId bundle matches the cached session's bundleId", async () => {


### PR DESCRIPTION
## Summary
- Extends the existing dedup-eviction path in `getFrictionlessCaptchaChallenge/handler.ts` to also evict when the incoming request's `detectorSessionId` resolves to a different bundleId than the deduped session's stored bundleId.
- Without this, `DetectorBundlePool.pickRandom` almost never returns the same bundle across separate `/detector/assign` calls, so any dedup crossing means the client encrypts subsequent SIMD/behavioural with bundle B while the provider tries to decrypt with bundle A. Result: `ERR_OSSL_RSA_OAEP_DECODING_ERROR` on every submit and R1 "empty BDP" escalation to image.
- Fallback: when `resolveBundleByDetectorSession` returns undefined (Redis binding TTL expired) we reuse rather than evict — no churn for pages open longer than the binding.

## Test plan
- [x] Extended `getFrictionlessCaptchaChallenge.unit.test.ts` with three focused cases: mismatch evicts, match reuses, unresolvable-binding reuses.
- [x] `NODE_ENV=test TEST_TYPE=unit npx vitest run --config ./vite.test.config.ts src/tests/unit/api/getFrictionlessCaptchaChallenge.unit.test.ts src/tests/unit/api/captcha/getFrictionlessCaptchaChallenge` — 84/84 pass.
- [x] `npm run -w @prosopo/provider build:tsc` — clean.

## Production evidence
Observed on 2026-08-13 after the 15:47 UTC restart wave: ~180 OAEP decodes/min across the fleet, tracked to the frictionless dedup path returning sessions whose `bundleId` was assigned before the client's most recent `/detector/assign`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)