### PR TITLE
fix(provider): rebind deduped session bundleId in-place instead of evicting

### DIFF
--- a/.changeset/rebind-dedup-session-bundle.md
+++ b/.changeset/rebind-dedup-session-bundle.md
@@ -1,0 +1,17 @@
+---
+"@prosopo/provider": patch
+---
+
+Fix regression from previous release where a bundleId mismatch on a
+deduped session was resolved by evicting the session. If the widget
+already had a `/captcha/{type}` or solution call in flight for that
+sessionId, the session lookup mid-request returned `No session found`,
+the handler returned `INCORRECT_CAPTCHA_TYPE` (400), and the client
+saw a broken challenge. Observed at ~21% of pimeyes `/captcha/pow`
+post-hotfix (baseline 0.3%).
+
+Rebind the reused session's `bundleId` in place with cache-first
+write-behind semantics instead. Only the `bundleId` field is updated
+— `captchaType`, score, threshold and every other field stay put, so
+in-flight `/captcha/{type}` calls keep working with the same sessionId
+and future SIMD / behavioural decrypts use the fresh key.

--- a/packages/provider/src/api/captcha/getFrictionlessCaptchaChallenge/handler.ts
+++ b/packages/provider/src/api/captcha/getFrictionlessCaptchaChallenge/handler.ts
@@ -379,11 +379,7 @@ export default (
 					}
 				}
 
-				if (
-					dedupConflictsWithPolicy ||
-					dedupConflictsWithRouting ||
-					dedupConflictsWithBundle
-				) {
+				if (dedupConflictsWithPolicy || dedupConflictsWithRouting) {
 					req.logger.info(() => ({
 						msg: "Evicting reused session: cached captchaType conflicts with access policy or routing machine",
 						data: {
@@ -396,10 +392,6 @@ export default (
 							}),
 							...(dedupConflictsWithRouting && {
 								routedCaptchaType: dedupRouted.captchaType,
-							}),
-							...(dedupConflictsWithBundle && {
-								cachedBundleId: dedup.session.bundleId,
-								incomingBundleId: dedupIncomingBundleId,
 							}),
 						},
 					}));
@@ -415,6 +407,34 @@ export default (
 						) ?? Promise.resolve(),
 					]);
 				} else {
+					// Bundle-only mismatch: rebind the cached session's `bundleId`
+					// in-place rather than evicting and minting fresh. Evicting
+					// races concurrent /captcha/{type} + solution calls the widget
+					// already has in flight for `dedup.sessionId` — those calls
+					// look the session up mid-request and get `No session found`
+					// → `INCORRECT_CAPTCHA_TYPE` → 400. Observed in prod at ~21%
+					// of pimeyes /captcha/pow post-hotfix (baseline 0.3%) until
+					// this branch was added. captchaType, score, threshold etc.
+					// are untouched — only the bundleId flips to the fresh
+					// detector's key so future SIMD / behavioural decrypts on
+					// this session work. Cache-first write-behind so the reuse
+					// response below already reflects the update for any
+					// same-request read.
+					if (dedupConflictsWithBundle && dedupIncomingBundleId) {
+						req.logger.info(() => ({
+							msg: "Rebinding reused session bundleId to match incoming detector",
+							data: {
+								userSitekeyIpHash,
+								sessionId: dedup.sessionId,
+								cachedBundleId: dedup.session.bundleId,
+								incomingBundleId: dedupIncomingBundleId,
+							},
+						}));
+						await tasks.frictionlessManager.updateSessionRecordWithCache(
+							dedup.sessionId,
+							{ bundleId: dedupIncomingBundleId },
+						);
+					}
 					req.logger.info(() => ({
 						msg: "Reusing existing session for user-IP-sitekey combination",
 						data: {

--- a/packages/provider/src/tests/unit/api/getFrictionlessCaptchaChallenge.unit.test.ts
+++ b/packages/provider/src/tests/unit/api/getFrictionlessCaptchaChallenge.unit.test.ts
@@ -54,6 +54,7 @@ type MockTasks = {
 		updateScore: MockFn;
 		setMatchedRule: MockFn;
 		resolveBundleByDetectorSession: MockFn;
+		updateSessionRecordWithCache: MockFn;
 	};
 	db: {
 		getSessionRecordByToken: MockFn;
@@ -205,6 +206,7 @@ vi.mock("../../../tasks/index.js", async () => {
 					updateScore: vi.fn(),
 					setMatchedRule: vi.fn(),
 					resolveBundleByDetectorSession: vi.fn().mockResolvedValue(undefined),
+					updateSessionRecordWithCache: vi.fn().mockResolvedValue(undefined),
 				},
 				db: {
 					getSessionRecordByToken: vi.fn().mockResolvedValue(null),
@@ -293,6 +295,7 @@ describe("getFrictionlessCaptchaChallenge - context selection", () => {
 			updateScore: vi.fn(),
 			setMatchedRule: vi.fn(),
 			resolveBundleByDetectorSession: vi.fn().mockResolvedValue(undefined),
+			updateSessionRecordWithCache: vi.fn().mockResolvedValue(undefined),
 		},
 		db: {
 			getSessionRecordByToken: vi.fn().mockResolvedValue(null),
@@ -748,14 +751,17 @@ describe("getFrictionlessCaptchaChallenge - context selection", () => {
 
 	// Regression: dedup returned a session bound to pool bundle A, but the
 	// client on this request just did a fresh /detector/assign that returned
-	// bundle B (uniform-random pick across the pool). Handing back the cached
-	// sessionId would leave every later SIMD / behavioural hop encrypted with
-	// bundle B's public key while the provider tries bundle A's private key —
-	// the OAEP-decode-error → empty-BDP → image-escalation cascade seen in
-	// prod after the 15:47 UTC 2026-08-13 restart wave. Evict on mismatch so
-	// the fresh-session path re-binds bundleId from the current
-	// detectorSessionId.
-	it("evicts the reused session when the incoming detectorSessionId bundle differs from the cached session's bundleId", async () => {
+	// bundle B (uniform-random pick across the pool). If we evict the cached
+	// session and mint a fresh one, any concurrent /captcha/{type} or
+	// solution call the client already has in flight for the cached sessionId
+	// hits `No session found` → `INCORRECT_CAPTCHA_TYPE` → 400 (observed in
+	// prod at ~21% of pimeyes /captcha/pow post-hotfix, up from 0.3%
+	// baseline). Instead, rebind the cached session's `bundleId` in-place
+	// with cache-first write-behind semantics — future decrypts for this
+	// sessionId use the fresh key, and the in-flight calls with the same
+	// sessionId keep working. Only the bundleId changes; captchaType,
+	// score, threshold etc. stay put.
+	it("rebinds the reused session's bundleId in-place when the incoming detectorSessionId bundle differs from the cached one (does NOT evict)", async () => {
 		const clientRecord = {
 			account: "siteDedupBundleConflict",
 			settings: {
@@ -769,7 +775,7 @@ describe("getFrictionlessCaptchaChallenge - context selection", () => {
 
 		// Cached session was minted with bundle-A.
 		tasksInstance.db.getSessionByuserSitekeyIpHash.mockResolvedValue({
-			sessionId: "stale-pow-session-bundle-conflict",
+			sessionId: "live-pow-session-bundle-conflict",
 			captchaType: CaptchaType.pow,
 			score: 0,
 			webView: false,
@@ -813,22 +819,28 @@ describe("getFrictionlessCaptchaChallenge - context selection", () => {
 		await handler(req as any, res as any, next);
 
 		expect(next).not.toHaveBeenCalled();
-		// Stale session is evicted so its bundleId can't cause OAEP failures
-		// on the client's subsequent /captcha/{type} + solution hops.
-		expect(tasksInstance.db.checkAndRemoveSession).toHaveBeenCalledWith(
-			"stale-pow-session-bundle-conflict",
+		// The session is NOT evicted — that was the pre-fix behaviour that
+		// caused NO_SESSION_FOUND on concurrent /captcha/{type} calls.
+		expect(tasksInstance.db.checkAndRemoveSession).not.toHaveBeenCalled();
+		// The bundleId is rebound in-place via the cache-first write-behind
+		// path so the same sessionId keeps working with the new key.
+		expect(
+			tasksInstance.frictionlessManager.updateSessionRecordWithCache,
+		).toHaveBeenCalledWith(
+			"live-pow-session-bundle-conflict",
+			expect.objectContaining({ bundleId: "bundle-B" }),
 		);
-		// The reuse response is not served ...
-		expect(res.json).not.toHaveBeenCalledWith(
+		// And the client gets the SAME sessionId back — no fresh mint, no
+		// in-flight-call disruption.
+		expect(res.json).toHaveBeenCalledWith(
 			expect.objectContaining({
-				sessionId: "stale-pow-session-bundle-conflict",
+				sessionId: "live-pow-session-bundle-conflict",
+				captchaType: CaptchaType.pow,
 			}),
 		);
-		// ... and the request falls through to the fresh-session path,
-		// which mints a new challenge (no policy or DM output forces
-		// image/puzzle in this test, so pow is picked). The important
-		// contract is "the client gets a new session", not an error.
-		expect(tasksInstance.frictionlessManager.sendPowCaptcha).toHaveBeenCalled();
+		expect(
+			tasksInstance.frictionlessManager.sendPowCaptcha,
+		).not.toHaveBeenCalled();
 	});
 
 	it("reuses the cached session when the incoming detectorSessionId bundle matches the cached session's bundleId", async () => {


### PR DESCRIPTION
## Summary
Hotfix on top of v3.7.9. The previous release's fix ([#3058](https://github.com/prosopo/captcha/pull/3058)) evicted the deduped session on bundleId mismatch. But the widget frequently has a `/captcha/{type}` or `/pow/solution` call in flight for the deduped sessionId when the next `/captcha/frictionless` fires — those in-flight calls then look up the just-evicted session mid-request and get `No session found` → `INCORRECT_CAPTCHA_TYPE` → 400.

Rebind the reused session's `bundleId` in place with cache-first write-behind semantics instead. Only `bundleId` changes; `captchaType`, score, threshold etc. are untouched, so in-flight calls with the same sessionId keep working.

## Prod evidence
Pimeyes `/captcha/pow` INCORRECT_CAPTCHA_TYPE rate:
- Baseline (pre-incident): 0.3% (~2-20 400s/hour)
- Post-#3058 hotfix: **~21% (1,200-2,000 400s/hour)**, sustained 12+ hours
- Trace of one failing session (`pronode13-52aad245`) confirmed: "Evicting reused session" logged at 07:57:37.489, `/captcha/pow` for the same sessionId arrived 07:57:38.213, `No session found` 07:57:38.236.

## Test plan
- [x] Wrote failing test FIRST (TDD): `"rebinds the reused session's bundleId in-place when the incoming detectorSessionId bundle differs from the cached one (does NOT evict)"` — asserts `checkAndRemoveSession` NOT called, `updateSessionRecordWithCache` called with `{ bundleId }`, response returns cached sessionId. Ran against unfixed code → failed on the eviction assertion.
- [x] Applied fix → 84/84 tests pass across the frictionless test suites.
- [x] `npm run -w @prosopo/provider build:tsc` — clean.
- [x] `biome check` on changed files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)