### PR TITLE
fix(tests): replace non-null assertions with runtime guards

### DIFF
--- a/packages/provider/src/tests/unit/api/captcha/submitPoWCaptchaSolution.escalation.unit.test.ts
+++ b/packages/provider/src/tests/unit/api/captcha/submitPoWCaptchaSolution.escalation.unit.test.ts
@@ -250,7 +250,8 @@ describe("submitPoWCaptchaSolution.buildEscalation", () => {
 		);
 
 		expect(env.spies.createSession).toHaveBeenCalledTimes(1);
-		const args = env.spies.createSession.mock.calls[0]!;
+		const args = env.spies.createSession.mock.calls[0];
+		if (!args) throw new Error("expected createSession to be called");
 		expect(args[CAPTCHA_TYPE_IDX]).toBe(CaptchaType.image);
 		expect(args[ORIGIN_SESSION_ID_IDX]).toBe("origin-id");
 		// siteKey resolves from the origin session, not from the pow record's
@@ -274,7 +275,8 @@ describe("submitPoWCaptchaSolution.buildEscalation", () => {
 		);
 
 		expect(env.spies.createSession).toHaveBeenCalledTimes(1);
-		const args = env.spies.createSession.mock.calls[0]!;
+		const args = env.spies.createSession.mock.calls[0];
+		if (!args) throw new Error("expected createSession to be called");
 		expect(args[CAPTCHA_TYPE_IDX]).toBe(CaptchaType.puzzle);
 		expect(args[ORIGIN_SESSION_ID_IDX]).toBe("origin-id");
 	});
@@ -286,7 +288,16 @@ describe("submitPoWCaptchaSolution.buildEscalation", () => {
 			timerResolutionMs: 0.005,
 			runsPerOp: 500,
 			durationMs: 42,
-			ops: [{ name: "f32x4_add", category: "arith", bestNs: 1.1, medianNs: 1.2, iters: 100, resultLane: 0 }],
+			ops: [
+				{
+					name: "f32x4_add",
+					category: "arith",
+					bestNs: 1.1,
+					medianNs: 1.2,
+					iters: 100,
+					resultLane: 0,
+				},
+			],
 		};
 		const origin = {
 			...makeOriginSession(),
@@ -304,7 +315,8 @@ describe("submitPoWCaptchaSolution.buildEscalation", () => {
 			"challenge",
 		);
 
-		const args = env.spies.createSession.mock.calls[0]!;
+		const args = env.spies.createSession.mock.calls[0];
+		if (!args) throw new Error("expected createSession to be called");
 		expect(args[SIMD_READINGS_IDX]).toBe(originSimd);
 	});
 
@@ -315,7 +327,16 @@ describe("submitPoWCaptchaSolution.buildEscalation", () => {
 			timerResolutionMs: 0.005,
 			runsPerOp: 500,
 			durationMs: 42,
-			ops: [{ name: "i32x4_add", category: "arith", bestNs: 0.9, medianNs: 1.0, iters: 100, resultLane: 0 }],
+			ops: [
+				{
+					name: "i32x4_add",
+					category: "arith",
+					bestNs: 0.9,
+					medianNs: 1.0,
+					iters: 100,
+					resultLane: 0,
+				},
+			],
 		};
 		const origin = {
 			...makeOriginSession(),
@@ -333,7 +354,8 @@ describe("submitPoWCaptchaSolution.buildEscalation", () => {
 			"challenge",
 		);
 
-		const args = env.spies.createSession.mock.calls[0]!;
+		const args = env.spies.createSession.mock.calls[0];
+		if (!args) throw new Error("expected createSession to be called");
 		expect(args[SIMD_READINGS_IDX]).toBe(originSimd);
 	});
 
@@ -354,7 +376,8 @@ describe("submitPoWCaptchaSolution.buildEscalation", () => {
 			"challenge",
 		);
 
-		const args = env.spies.createSession.mock.calls[0]!;
+		const args = env.spies.createSession.mock.calls[0];
+		if (!args) throw new Error("expected createSession to be called");
 		expect(args[BUNDLE_ID_IDX]).toBe("bundle-42");
 	});
 
@@ -375,7 +398,8 @@ describe("submitPoWCaptchaSolution.buildEscalation", () => {
 			"challenge",
 		);
 
-		const args = env.spies.createSession.mock.calls[0]!;
+		const args = env.spies.createSession.mock.calls[0];
+		if (!args) throw new Error("expected createSession to be called");
 		expect(args[BUNDLE_ID_IDX]).toBe("bundle-17");
 	});
 
@@ -407,7 +431,8 @@ describe("submitPoWCaptchaSolution.buildEscalation", () => {
 			"challenge",
 		);
 
-		const args = env.spies.createSession.mock.calls[0]!;
+		const args = env.spies.createSession.mock.calls[0];
+		if (!args) throw new Error("expected createSession to be called");
 		// No positional arg equals the origin's BDP — nothing was copied.
 		expect(
 			args.some(

--- a/packages/provider/src/tests/unit/tasks/frictionless/routingMachine.unit.test.ts
+++ b/packages/provider/src/tests/unit/tasks/frictionless/routingMachine.unit.test.ts
@@ -144,7 +144,8 @@ describe("applyRouter", () => {
 		// version — this is what per-DM artifacts rely on.
 		// The routing runner receives the full userAgent verbatim in the
 		// input's `raw` — per-DM artifacts rely on that.
-		const call = runner.route.mock.calls[0]!;
+		const call = runner.route.mock.calls[0];
+		if (!call) throw new Error("expected runner.route to be called");
 		expect(call[0]).toEqual(
 			expect.objectContaining({
 				raw: expect.objectContaining({ userAgent: headlessUa }),
@@ -174,7 +175,8 @@ describe("applyRouter", () => {
 		const result = await run(ctx);
 
 		expect(result).toEqual({ captchaType: CaptchaType.puzzle });
-		const call = runner.route.mock.calls[0]!;
+		const call = runner.route.mock.calls[0];
+		if (!call) throw new Error("expected runner.route to be called");
 		expect(call[0]).toEqual(
 			expect.objectContaining({
 				raw: expect.objectContaining({ userAgent: webviewUa }),


### PR DESCRIPTION
## Summary
Fixup on #3063. The test batch used `mock.calls[0]!` non-null assertions to satisfy strict TypeScript, but biome's linter disallows the `!` operator. The tests still all passed locally (180/180) but `npm run lint` errors on those lines.

The full `lint` / `tests` / `typecheck` / `cypress` workflows didn't run on #3063's branch (only `pinned-versions`, `CodeQL`, `dependabot-changeset` fired) so this landed on main without being caught by CI. This PR replaces the 9 non-null assertions with equivalent runtime guards.

## Test plan
- [x] `npx biome check <changed>` — clean.
- [x] `NODE_ENV=test TEST_TYPE=unit npx vitest run` on affected files — 27/27 pass.
- [x] `npm run -w @prosopo/provider build:tsc` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)