### PR TITLE
chore(docker): cap container log size across compose files

### DIFF
--- a/docker/docker-compose.demo.yml
+++ b/docker/docker-compose.demo.yml
@@ -8,6 +8,12 @@ services:
             - MONGO_INITDB_ROOT_USERNAME=root
             - MONGO_INITDB_ROOT_PASSWORD=$MONGO_INITDB_ROOT_PASSWORD
             - MONGO_INITDB_DATABASE=prosopo
+        # Cap the json log file so a chatty container can't fill the host disk.
+        logging:
+            driver: 'json-file'
+            options:
+                max-size: '100m'
+                max-file: '1'
     provider:
         # TODO update provider image
         image: prosopo/provider:v1.0.5
@@ -19,6 +25,12 @@ services:
             - '3000:3000'
         depends_on:
             - database
+        # Cap the json log file so a chatty container can't fill the host disk.
+        logging:
+            driver: 'json-file'
+            options:
+                max-size: '100m'
+                max-file: '1'
 
 # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specifying-sensitive-data-secrets.html
 # secrets:

--- a/docker/docker-compose.development.yml
+++ b/docker/docker-compose.development.yml
@@ -9,6 +9,12 @@ services:
       - MONGO_INITDB_ROOT_USERNAME=root
       - MONGO_INITDB_ROOT_PASSWORD=root
       - MONGO_INITDB_DATABASE=prosopo
+    # Cap the json log file so a chatty container can't fill the host disk.
+    logging:
+      driver: 'json-file'
+      options:
+        max-size: '100m'
+        max-file: '1'
   redis-stack:
     container_name: redis-stack
     # unlike "redis/redis-stack-server" this image includes Insights
@@ -21,3 +27,9 @@ services:
       - '8001:8001' # Insight tool
     environment:
       - REDIS_ARGS=--requirepass root
+    # Cap the json log file so a chatty container can't fill the host disk.
+    logging:
+      driver: 'json-file'
+      options:
+        max-size: '100m'
+        max-file: '1'

--- a/docker/docker-compose.flux-provider.yml
+++ b/docker/docker-compose.flux-provider.yml
@@ -12,6 +12,12 @@ services:
         networks:
             - internal
             - external
+        # Cap the json log file so a chatty container can't fill the host disk.
+        logging:
+            driver: 'json-file'
+            options:
+                max-size: '100m'
+                max-file: '1'
 networks:
     internal:
         name: internal

--- a/docker/docker-compose.js_server.yml
+++ b/docker/docker-compose.js_server.yml
@@ -13,6 +13,12 @@ services:
             # STAGE: 'production' # Don't use production until staging works
         volumes:
             - https-portal-data:/var/lib/https-portal
+        # Cap the json log file so a chatty container can't fill the host disk.
+        logging:
+            driver: 'json-file'
+            options:
+                max-size: '100m'
+                max-file: '1'
 
 volumes:
     # Recommended, to avoid re-signing when upgrading HTTPS-PORTAL

--- a/docker/docker-compose.provider.yml
+++ b/docker/docker-compose.provider.yml
@@ -189,6 +189,12 @@ services:
       internal:
         ipv4_address: 172.18.0.8
         ipv6_address: fd00:aaaa::8
+    # Cap the json log file so a chatty container can't fill the host disk.
+    logging:
+      driver: 'json-file'
+      options:
+        max-size: '100m'
+        max-file: '1'
   vector:
     container_name: vector
     profiles:
@@ -247,6 +253,12 @@ services:
       - ./ipinfo/ipapi_database_ram:/usr/src/app/ipapi_database_ram:ro
       # Config override
       - ./ipinfo/config:/usr/src/app/config:ro
+    # Cap the json log file so a chatty container can't fill the host disk.
+    logging:
+      driver: 'json-file'
+      options:
+        max-size: '100m'
+        max-file: '1'
   dns:
     # DNS observation sidecar. Caddy fronts TLS for *.t.{CADDY_DOMAIN}
     # and reverse-proxies HTTP to this container — see provider.Caddyfile.
@@ -302,6 +314,12 @@ services:
         ipv4_address: 172.18.0.10
         ipv6_address: fd00:aaaa::a
     restart: unless-stopped
+    # Cap the json log file so a chatty container can't fill the host disk.
+    logging:
+      driver: 'json-file'
+      options:
+        max-size: '100m'
+        max-file: '1'
 networks:
   internal:
     enable_ipv6: true

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -9,6 +9,12 @@ services:
             - MONGO_INITDB_ROOT_USERNAME=root
             - MONGO_INITDB_ROOT_PASSWORD=root
             - MONGO_INITDB_DATABASE=prosopo
+        # Cap the json log file so a chatty container can't fill the host disk.
+        logging:
+            driver: 'json-file'
+            options:
+                max-size: '100m'
+                max-file: '1'
     redis-stack:
         container_name: redis-stack
         # unlike "redis/redis-stack-server" this image includes Insights
@@ -21,3 +27,9 @@ services:
             - '8001:8001' # Insight tool
         environment:
             - REDIS_ARGS=--requirepass root
+        # Cap the json log file so a chatty container can't fill the host disk.
+        logging:
+            driver: 'json-file'
+            options:
+                max-size: '100m'
+                max-file: '1'

--- a/docker/redis/redis-stack-server.docker-compose.yml
+++ b/docker/redis/redis-stack-server.docker-compose.yml
@@ -10,3 +10,9 @@ services:
       - '6379:6379'
     env_file:
       - ../.env.${NODE_ENV}
+    # Cap the json log file so a chatty container can't fill the host disk.
+    logging:
+      driver: 'json-file'
+      options:
+        max-size: '100m'
+        max-file: '1'

--- a/docker/redis/redis-stack.docker-compose.yml
+++ b/docker/redis/redis-stack.docker-compose.yml
@@ -11,3 +11,9 @@ services:
       - '8001:8001' # Insight tool
     environment:
       - REDIS_ARGS=--requirepass root
+    # Cap the json log file so a chatty container can't fill the host disk.
+    logging:
+      driver: 'json-file'
+      options:
+        max-size: '100m'
+        max-file: '1'


### PR DESCRIPTION
Docker's default `json-file` driver keeps logs unbounded, so a chatty container can fill the host disk. These services had **no rotation at all**:

| File | Services |
|---|---|
| `docker-compose.provider.yml` | `redis-stack`, `ipinfo`, `dns` |
| `docker-compose.demo.yml` | `database`, `provider` |
| `docker-compose.development.yml` | `database`, `redis-stack` |
| `docker-compose.test.yml` | `database`, `redis-stack` |
| `docker-compose.flux-provider.yml` | `provider` |
| `docker-compose.js_server.yml` | `https-portal` |
| `redis/redis-stack.docker-compose.yml` | `redis-stack` |
| `redis/redis-stack-server.docker-compose.yml` | `redis-stack-server` |

`docker-compose.provider.yml` is the notable one — it's the production provider compose file, and three of its sidecars were uncapped.

Ceiling is `max-size: 100m` x `max-file: 1`, matching the files in this repo that were already configured (`client-example-server`, `mongo`, `oo1`, `oo2`, `provider-mock`) — those are untouched.

The `logging:` snippet is repeated per service rather than hoisted into a YAML anchor, so each service's config is readable in place.

Pure additions — no existing value changed. Verified by parsing every compose file and asserting each service's resolved `logging` map: all 29 services across 13 files now match.

Dockerfiles are untouched: log rotation is a runtime/daemon concern and cannot be expressed in an image. A daemon-wide default is being added in the parent repo's ansible playbook as a backstop for anything started without an explicit block.