### PR TITLE
feat(catcher,provider,types): ship raw iOS WKWebView DOM signals as sw/md/bn/fs

### DIFF
--- a/.changeset/ios-webview-signals-sw-md-bn-fs.md
+++ b/.changeset/ios-webview-signals-sw-md-bn-fs.md
@@ -1,0 +1,12 @@
+---
+"@prosopo/types": minor
+"@prosopo/provider": minor
+---
+
+Ship raw iOS WKWebView DOM signals (`sw`, `md`, `bn`, `fs`) alongside the classifier verdict `isWebView`.
+
+The four booleans that `classifyIosWebViewFromSignals` folds into `isWebView` are now decrypted off the client payload (positions 14-17) and surfaced individually on `DetectorResult` and in the "decryptPayload result" info log. Short-acronym keys match the existing `g`/`i` wire convention. Backwards-compatible: `isWebView` at position 4 is untouched; older catcher clients that don't emit positions 14-17 log the fields as `undefined`.
+
+Motivation: real iOS 17.7.x devices appear to expose one or more of these APIs even on stock WKWebView (unlike the iOS 18 Simulator the classifier was audited against), collapsing iOS Twickets `webView:true` from 97.6% to 0.2% post-v3.7.8. Shipping the raw signals lets server-side rules retune the aggregation from live traffic in OpenObserve without a catcher release.
+
+Note: `decodePayload.js` (obfuscated production build) still needs to be rebuilt to parse positions 14-17 out of the delimited payload and expose them as `result.sw`/`result.md`/`result.bn`/`result.fs`. Until that ships, the fields log as `undefined`.

--- a/packages/provider/src/api/captcha/getFrictionlessCaptchaChallenge/handler.ts
+++ b/packages/provider/src/api/captcha/getFrictionlessCaptchaChallenge/handler.ts
@@ -570,6 +570,10 @@ export default (
 				entropyWallClockOffsetMs,
 				entropyMathRandomFirst,
 				g,
+				sw,
+				md,
+				bn,
+				fs,
 				bundleId,
 			} = decryptedPayload;
 
@@ -674,6 +678,10 @@ export default (
 					entropyMathRandomFirst,
 				}),
 				...(g !== undefined && { g }),
+				...(sw !== undefined && { sw }),
+				...(md !== undefined && { md }),
+				...(bn !== undefined && { bn }),
+				...(fs !== undefined && { fs }),
 				...(req.tcpToChelloUs !== undefined && {
 					tcpToChelloUs: req.tcpToChelloUs,
 				}),

--- a/packages/provider/src/api/captcha/submitPoWCaptchaSolution.ts
+++ b/packages/provider/src/api/captcha/submitPoWCaptchaSolution.ts
@@ -314,6 +314,10 @@ export const buildEscalation = async (
 		originSession.g,
 		undefined,
 		originSession.i,
+		originSession.sw,
+		originSession.md,
+		originSession.bn,
+		originSession.fs,
 	);
 
 	// Record the origin → escalation sessionId mapping so a /captcha/*

--- a/packages/provider/src/tasks/captchaManager.ts
+++ b/packages/provider/src/tasks/captchaManager.ts
@@ -213,6 +213,10 @@ export class CaptchaManager {
 		const needsEntropyFirst = session.entropyMathRandomFirst === undefined;
 		const needsG = session.g === undefined;
 		const needsI = session.i === undefined;
+		const needsSw = session.sw === undefined;
+		const needsMd = session.md === undefined;
+		const needsBn = session.bn === undefined;
+		const needsFs = session.fs === undefined;
 
 		if (
 			!needsSimd &&
@@ -222,7 +226,11 @@ export class CaptchaManager {
 			!needsEntropyWall &&
 			!needsEntropyFirst &&
 			!needsG &&
-			!needsI
+			!needsI &&
+			!needsSw &&
+			!needsMd &&
+			!needsBn &&
+			!needsFs
 		) {
 			return session;
 		}
@@ -255,6 +263,10 @@ export class CaptchaManager {
 				}),
 			...(needsG && origin.g !== undefined && { g: origin.g }),
 			...(needsI && origin.i !== undefined && { i: origin.i }),
+			...(needsSw && origin.sw !== undefined && { sw: origin.sw }),
+			...(needsMd && origin.md !== undefined && { md: origin.md }),
+			...(needsBn && origin.bn !== undefined && { bn: origin.bn }),
+			...(needsFs && origin.fs !== undefined && { fs: origin.fs }),
 		};
 	}
 

--- a/packages/provider/src/tasks/detection/getBotScore.ts
+++ b/packages/provider/src/tasks/detection/getBotScore.ts
@@ -46,6 +46,10 @@ export const getBotScore = async (
 		result.entropyMathRandomFirst;
 	const g: string | undefined = result.g;
 	const i: boolean | undefined = result.i;
+	const sw: boolean | undefined = result.sw;
+	const md: boolean | undefined = result.md;
+	const bn: boolean | undefined = result.bn;
+	const fs: boolean | undefined = result.fs;
 
 	if (baseBotScore === undefined || Number.isNaN(baseBotScore)) {
 		return {
@@ -70,5 +74,9 @@ export const getBotScore = async (
 		entropyMathRandomFirst,
 		g,
 		i,
+		sw,
+		md,
+		bn,
+		fs,
 	};
 };

--- a/packages/provider/src/tasks/frictionless/frictionlessTasks.ts
+++ b/packages/provider/src/tasks/frictionless/frictionlessTasks.ts
@@ -647,6 +647,10 @@ export class FrictionlessManager extends CaptchaManager {
 		let entropyMathRandomFirst: number | undefined;
 		let g: string | undefined;
 		let ii: boolean | undefined;
+		let sw: boolean | undefined;
+		let md: boolean | undefined;
+		let bn: boolean | undefined;
+		let fs: boolean | undefined;
 		for (const [keyIndex, attempt] of decryptKeys.entries()) {
 			try {
 				this.logger.info(() => ({
@@ -676,6 +680,10 @@ export class FrictionlessManager extends CaptchaManager {
 				const em = decrypted.entropyMathRandomFirst;
 				const gv = decrypted.g;
 				const iv = decrypted.i;
+				const swv = decrypted.sw;
+				const mdv = decrypted.md;
+				const bnv = decrypted.bn;
+				const fsv = decrypted.fs;
 				this.logger.debug(() => ({
 					msg: "Successfully decrypted score",
 					data: {
@@ -692,6 +700,10 @@ export class FrictionlessManager extends CaptchaManager {
 						entropyCryptoFingerprint: ec,
 						entropyWallClockOffsetMs: eo,
 						entropyMathRandomFirst: em,
+						sw: swv,
+						md: mdv,
+						bn: bnv,
+						fs: fsv,
 					},
 				}));
 				baseBotScore = s;
@@ -708,6 +720,10 @@ export class FrictionlessManager extends CaptchaManager {
 				entropyMathRandomFirst = em;
 				g = gv;
 				ii = iv;
+				sw = swv;
+				md = mdv;
+				bn = bnv;
+				fs = fsv;
 				break;
 			} catch (err) {
 				// check if the next index exists, if not, log an error
@@ -750,6 +766,10 @@ export class FrictionlessManager extends CaptchaManager {
 				decryptedHeadHash,
 				decryptionFailed,
 				shadowDomPenalty,
+				sw,
+				md,
+				bn,
+				fs,
 			},
 		}));
 
@@ -771,6 +791,10 @@ export class FrictionlessManager extends CaptchaManager {
 			entropyMathRandomFirst,
 			g,
 			i: ii,
+			sw,
+			md,
+			bn,
+			fs,
 			// The pool bundle used (if any) — promoted onto the session so the
 			// later behavioural-data hop can resolve the same keypair/inner cfg.
 			bundleId,

--- a/packages/provider/src/tasks/frictionless/frictionlessTasks.ts
+++ b/packages/provider/src/tasks/frictionless/frictionlessTasks.ts
@@ -148,6 +148,10 @@ export class FrictionlessManager extends CaptchaManager {
 			entropyMathRandomFingerprint: params.entropyMathRandomFingerprint,
 			entropyCryptoFingerprint: params.entropyCryptoFingerprint,
 			entropyWallClockOffsetMs: params.entropyWallClockOffsetMs,
+			sw: params.sw,
+			md: params.md,
+			bn: params.bn,
+			fs: params.fs,
 			entropyMathRandomFirst: params.entropyMathRandomFirst,
 			g: params.g,
 			i: params.i,
@@ -220,6 +224,10 @@ export class FrictionlessManager extends CaptchaManager {
 		g?: Session["g"],
 		matchedRule?: Session["matchedRule"],
 		i?: Session["i"],
+		sw?: Session["sw"],
+		md?: Session["md"],
+		bn?: Session["bn"],
+		fs?: Session["fs"],
 	): Promise<Session> {
 		const sessionRecord: Session = {
 			sessionId: `${getSessionIDPrefix(this.config.host)}-${uuidv4()}`,
@@ -271,6 +279,10 @@ export class FrictionlessManager extends CaptchaManager {
 			entropyMathRandomFirst,
 			g,
 			i,
+			sw,
+			md,
+			bn,
+			fs,
 			tcpToChelloUs,
 			chelloToHandshakeUs,
 			// Only present when an access policy actually matched this
@@ -424,6 +436,10 @@ export class FrictionlessManager extends CaptchaManager {
 			effectiveParams.g,
 			effectiveParams.matchedRule,
 			effectiveParams.i,
+			effectiveParams.sw,
+			effectiveParams.md,
+			effectiveParams.bn,
+			effectiveParams.fs,
 		);
 
 		// Fire-and-forget served-counter writes. Skipped when there's no
@@ -503,6 +519,10 @@ export class FrictionlessManager extends CaptchaManager {
 			effectiveParams.g,
 			effectiveParams.matchedRule,
 			effectiveParams.i,
+			effectiveParams.sw,
+			effectiveParams.md,
+			effectiveParams.bn,
+			effectiveParams.fs,
 		);
 	}
 

--- a/packages/provider/src/tests/unit/tasks/captchaManager.unit.test.ts
+++ b/packages/provider/src/tests/unit/tasks/captchaManager.unit.test.ts
@@ -170,6 +170,10 @@ describe("CaptchaManager", () => {
 				entropyMathRandomFirst: 0.1,
 				g: "c",
 				i: false,
+				sw: true,
+				md: true,
+				bn: false,
+				fs: true,
 			} as unknown as Session;
 			dbGet().mockResolvedValue(session);
 

--- a/packages/types-database/src/types/provider.ts
+++ b/packages/types-database/src/types/provider.ts
@@ -784,6 +784,14 @@ export const SessionRecordSchema = new Schema<SessionRecord>({
 	entropyMathRandomFirst: { type: Number, required: false },
 	g: { type: String, required: false },
 	i: { type: Boolean, required: false },
+	// Raw iOS WKWebView-vs-Safari DOM signals that the client-side
+	// classifier folds into `webView` (see @prosopo/types Session for
+	// per-key semantics). Persisted so server-side rules can retune
+	// the aggregation from live traffic without a catcher release.
+	sw: { type: Boolean, required: false },
+	md: { type: Boolean, required: false },
+	bn: { type: Boolean, required: false },
+	fs: { type: Boolean, required: false },
 	// Per-TLS-connection handshake timings forwarded by the chaddy Caddy
 	// plugin (X-TLS-TCP-To-Chello-Us / X-TLS-Chello-To-Handshake-Us).
 	// See @prosopo/types Session.tcpToChelloUs for full semantics.

--- a/packages/types/src/provider/database.ts
+++ b/packages/types/src/provider/database.ts
@@ -495,6 +495,19 @@ export const SessionSchema = object({
 	entropyMathRandomFirst: number().optional(),
 	g: string().optional(),
 	i: boolean().optional(),
+	// Raw iOS WKWebView-vs-Safari DOM signals that the client-side
+	// classifier folds into `webView`. Persisted per session so
+	// decision-machine rules can key off the individual signals
+	// without a catcher release. Undefined on non-iOS / non-WebKit
+	// clients and on catcher versions predating the fields.
+	//   sw = navigator.serviceWorker present
+	//   md = navigator.mediaDevices present
+	//   bn = window.browser namespace present (WebExtensions)
+	//   fs = document.fullscreenEnabled present
+	sw: boolean().optional(),
+	md: boolean().optional(),
+	bn: boolean().optional(),
+	fs: boolean().optional(),
 	// Per-TLS-connection handshake timings forwarded by the chaddy Caddy
 	// plugin (X-TLS-TCP-To-Chello-Us / X-TLS-Chello-To-Handshake-Us).
 	// Server-observed microsecond deltas across the TLS handshake
@@ -600,6 +613,11 @@ export type Session = {
 	entropyMathRandomFirst?: number;
 	g?: string;
 	i?: boolean;
+	// Raw iOS WKWebView-vs-Safari DOM signals — see SessionSchema above.
+	sw?: boolean;
+	md?: boolean;
+	bn?: boolean;
+	fs?: boolean;
 	// Per-TLS-connection handshake timings forwarded by the chaddy Caddy
 	// plugin. See the SessionSchema block above for full semantics —
 	// elevated values indicate the client's ClientHello traversed a

--- a/packages/types/src/provider/detection.ts
+++ b/packages/types/src/provider/detection.ts
@@ -57,4 +57,18 @@ export type DetectorResult = {
 	entropyMathRandomFirst?: number;
 	g?: string;
 	i?: boolean;
+	// Raw iOS WKWebView-vs-Safari DOM signals (positions 14-17 in the client
+	// payload). Undefined for clients that predate the fields, or on non-iOS
+	// / non-WebKit engines where the classifier gate returns early. Shipped
+	// unconditionally alongside `isWebView` so server-side rules can retune
+	// without a catcher release. Short names match the acronym convention
+	// established by `g` (gpu signature) and `i`.
+	//   sw = navigator.serviceWorker present
+	//   md = navigator.mediaDevices present
+	//   bn = window.browser namespace present (WebExtensions)
+	//   fs = document.fullscreenEnabled present
+	sw?: boolean;
+	md?: boolean;
+	bn?: boolean;
+	fs?: boolean;
 };


### PR DESCRIPTION
## Summary
Ship the four raw DOM signals (`sw`, `md`, `bn`, `fs`) that `classifyIosWebViewFromSignals` folds into `isWebView`, so server-side rules can retune the classifier from live iOS traffic without needing a catcher release.

- `sw` = `navigator.serviceWorker` present
- `md` = `navigator.mediaDevices` present
- `bn` = `window.browser` namespace present (WebExtensions)
- `fs` = `document.fullscreenEnabled` present

Short-acronym keys match the existing wire convention (`g`, `i`).

## Motivation
Post-v3.7.8 the DOM-signal classifier requires all four signals absent to flag a WebView. Real iOS 17.7.x devices appear to expose one or more of these APIs by default even on stock WKWebView (unlike the iOS 18 Simulator the classifier was audited against), collapsing iOS Twickets traffic from 97.6% to 0.2% `webView:true`. Shipping the raw signals lets us see which signal Apple has flipped on and retune the aggregation from live traffic in OpenObserve without guessing.

## Changes
- `packages/types/src/provider/detection.ts` — `DetectorResult` gains optional `sw`/`md`/`bn`/`fs` booleans.
- `packages/provider/src/tasks/detection/getBotScore.ts` — extract the four fields off `DetectorResult` and pass them through.
- `packages/provider/src/tasks/frictionless/frictionlessTasks.ts` — destructure from `getBotScore`, include in the "Successfully decrypted score" debug log and the "decryptPayload result" info log (surfaces as `data_sw`/`data_md`/`data_bn`/`data_fs` in OpenObserve), and include in the returned session shape.

`isWebView` at position 4 is untouched — backwards compatible with older clients and older decision-machine rules.

## Notes / follow-ups
- `decodePayload.js` (obfuscated production build) needs to be rebuilt to parse positions 14-17 out of the delimited payload and expose them as `result.sw`/`result.md`/`result.bn`/`result.fs`. Until that rebuild lands, the fields log as `undefined` — harmless, but no data flows.
- Client-side (catcher) half is in the outer repo: prosopo/captcha-private#... (paired branch `feat/catcher-ios-webview-signals`).

## Test plan
- [ ] tsc build passes on `@prosopo/types`, `@prosopo/provider`
- [ ] Existing provider unit tests unchanged and green
- [ ] After decodePayload rebuild + prod deploy: check OpenObserve for `data_sw` / `data_md` / `data_bn` / `data_fs` on iOS Twickets traffic (site key `5EZVvsHMrKCFKp5NYNoTyDjTjetoVo1Z4UNNbTwJf1GfN6Xm`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)