### PR TITLE
fix(provider): close caddy upstream keep-alive race causing intermittent 502s

### DIFF
--- a/docker/provider.Caddyfile
+++ b/docker/provider.Caddyfile
@@ -198,6 +198,21 @@ http://:9090 {
 			transport http {
 				# how long to wait for a connection to be established to backend
 				dial_timeout 1s
+
+				# Idle upstream keep-alive. Must stay strictly below the provider
+				# Node HTTP server's `keepAliveTimeout` (Node's default is 5s and
+				# startProviderApi.ts does not override it) so Caddy always
+				# closes a pooled connection before Node does. Without this,
+				# Caddy defaults to a 2-minute idle keep-alive on the upstream
+				# pool; Node closes those same connections after 5s, and any
+				# request Caddy sends on a pooled connection older than 5s
+				# races the peer FIN and comes back as
+				# `read: connection reset by peer` → 502 to the caller. POST
+				# request bodies are streamed, so Caddy can't safely replay
+				# them via lb_try_duration once the body has been forwarded,
+				# which is why the race surfaces as user-visible 502s on
+				# verify endpoints rather than a silent retry.
+				keepalive 3s
 			}
 
 			# how long to keep trying backends before giving up


### PR DESCRIPTION
## Summary
- Add `keepalive 3s` to the reverse_proxy `transport http` block in `docker/provider.Caddyfile` so Caddy's upstream idle keep-alive stays strictly below the provider Node HTTP server's `keepAliveTimeout` (Node default: 5 s).
- Node's default `keepAliveTimeout` is 5 s and `packages/provider/src/api/startProviderApi.ts` does not override it. Caddy's default upstream keep-alive is 2 minutes, so any request Caddy dispatches on a pooled connection older than 5 s races Node's peer-side FIN. Caddy sees `read: connection reset by peer` and returns 502. POST bodies are streamed, so `lb_try_duration` cannot safely retry them.

## Incident this fixes

Confirmed via cross-stream trace (lambda `verifyCaptcha` → provider caddy `/v1/prosopo/provider/client/image/dapp/verify`):

- Caddy returned **502** after ~29 ms with `read: connection reset by peer` on the upstream socket.
- The request never appeared in the provider-node stream (searched by caddy `request_id`, by the decoded user, and by all error/warn logs in the window). The node process was serving the same endpoint fine either side of the event (25–126 ms latencies on adjacent requests).
- Socket died before the handler dispatched — the fingerprint of a keep-alive close race.

## Why 3 s (not disable pool entirely)

- Must be `<` Node's `keepAliveTimeout` (5 s). 3 s gives a 2 s guard band.
- Still allows connection reuse for typical burst traffic (multi-request verify flows complete well under 3 s idle).
- Disabling the pool (`keepalive 0`) would force a TCP handshake per request — measurable latency + fd churn on providers under normal request volume.

## Test plan
- [ ] After merge + submodule bump + rolling deploy: watch provider caddy stream for `msg LIKE '%connection reset by peer%'` and `msg LIKE '%unexpected EOF%'` on the upstream Node port. Baseline ~1 event/min across the fleet; expect this to drop to ~0.
- [ ] Verify overall 502 rate at the provider caddy layer stays ≤ current baseline (~0.03 % of req volume) — no regression from more frequent connection churn.
- [ ] Sanity-check p50 / p95 latency on `/dapp/verify` and `/pow/verify` unchanged after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
