### PR TITLE
feat(provider): persist raw per-connection TCP handshake signals on Session

### DIFF
--- a/.changeset/brown-geckos-change.md
+++ b/.changeset/brown-geckos-change.md
@@ -1,0 +1,10 @@
+---
+"@prosopo/types-database": patch
+"@prosopo/native-merkle": patch
+"@prosopo/native-ja4": patch
+"@prosopo/provider": patch
+"@prosopo/types": patch
+---
+
+Add TLS timings into session doc
+  

--- a/packages/native-ja4/index.d.ts
+++ b/packages/native-ja4/index.d.ts
@@ -1,3 +1,16 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 /* tslint:disable */
 /* eslint-disable */
 

--- a/packages/native-ja4/index.js
+++ b/packages/native-ja4/index.js
@@ -1,3 +1,16 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 /* tslint:disable */
 /* eslint-disable */
 /* prettier-ignore */

--- a/packages/native-merkle/index.d.ts
+++ b/packages/native-merkle/index.d.ts
@@ -1,3 +1,16 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 /* tslint:disable */
 /* eslint-disable */
 

--- a/packages/native-merkle/index.js
+++ b/packages/native-merkle/index.js
@@ -1,3 +1,16 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 /* tslint:disable */
 /* eslint-disable */
 /* prettier-ignore */

--- a/packages/provider/src/api/captcha/getFrictionlessCaptchaChallenge/handler.ts
+++ b/packages/provider/src/api/captcha/getFrictionlessCaptchaChallenge/handler.ts
@@ -37,13 +37,13 @@ import { hashUserIp } from "../../../utils/hashUserIp.js";
 import { normalizeRequestIp } from "../../../utils/normalizeRequestIp.js";
 import { getMaintenanceMode } from "../../admin/apiToggleMaintenanceModeEndpoint.js";
 import { getRequestUserScope } from "../../blacklistRequestInspector.js";
-import { rawTlsSignalsForSession } from "../../rawTlsSignalsMiddleware.js";
 import { buildDnsEventUrl } from "../../dnsEventUrl.js";
 import {
 	recordBotScore,
 	recordDetectorTriggered,
 	recordFrictionlessDecision,
 } from "../../metrics.js";
+import { rawTlsSignalsForSession } from "../../rawTlsSignalsMiddleware.js";
 import { isReservedTestSiteKey } from "../../testSiteKey.js";
 import { buildFrictionlessMaintenanceResponse } from "../maintenanceModeResponses.js";
 import {

--- a/packages/provider/src/api/captcha/getFrictionlessCaptchaChallenge/handler.ts
+++ b/packages/provider/src/api/captcha/getFrictionlessCaptchaChallenge/handler.ts
@@ -37,6 +37,7 @@ import { hashUserIp } from "../../../utils/hashUserIp.js";
 import { normalizeRequestIp } from "../../../utils/normalizeRequestIp.js";
 import { getMaintenanceMode } from "../../admin/apiToggleMaintenanceModeEndpoint.js";
 import { getRequestUserScope } from "../../blacklistRequestInspector.js";
+import { rawTlsSignalsForSession } from "../../rawTlsSignalsMiddleware.js";
 import { buildDnsEventUrl } from "../../dnsEventUrl.js";
 import {
 	recordBotScore,
@@ -327,6 +328,7 @@ export default (
 									...(req.chelloToHandshakeUs !== undefined && {
 										chelloToHandshakeUs: req.chelloToHandshakeUs,
 									}),
+									...rawTlsSignalsForSession(req),
 									// currentUrl / iframeUrl use the cached session's
 									// values to match the rest of the dedup routing input
 									// (score, webView, captchaType are all pulled from
@@ -500,6 +502,7 @@ export default (
 				...(req.chelloToHandshakeUs !== undefined && {
 					chelloToHandshakeUs: req.chelloToHandshakeUs,
 				}),
+				...rawTlsSignalsForSession(req),
 			};
 
 			const shortCircuitResponse = await runConfiguredCaptchaTypeShortCircuit(
@@ -690,6 +693,7 @@ export default (
 				...(req.chelloToHandshakeUs !== undefined && {
 					chelloToHandshakeUs: req.chelloToHandshakeUs,
 				}),
+				...rawTlsSignalsForSession(req),
 			});
 
 			const ipInfoMobile =
@@ -716,6 +720,7 @@ export default (
 					...(req.chelloToHandshakeUs !== undefined && {
 						chelloToHandshakeUs: req.chelloToHandshakeUs,
 					}),
+					...rawTlsSignalsForSession(req),
 					...(currentUrl && { currentUrl }),
 					...(iframeUrl && { iframeUrl }),
 				},

--- a/packages/provider/src/api/captcha/submitPoWCaptchaSolution.ts
+++ b/packages/provider/src/api/captcha/submitPoWCaptchaSolution.ts
@@ -28,6 +28,7 @@ import { downgradePuzzleIfUnavailable } from "../../tasks/puzzle/puzzleRenderer.
 import { Tasks } from "../../tasks/tasks.js";
 import { derivePlatform } from "../../utils/devicePlatform.js";
 import { getMaintenanceMode } from "../admin/apiToggleMaintenanceModeEndpoint.js";
+import { rawTlsSignalsForSession } from "../rawTlsSignalsMiddleware.js";
 import { resolveTestSiteKeyVerdict } from "../testSiteKey.js";
 import { validateAddr, validateSiteKey } from "../validateAddress.js";
 
@@ -147,6 +148,7 @@ export default (env: ProviderEnvironment) =>
 					...(req.chelloToHandshakeUs !== undefined && {
 						chelloToHandshakeUs: req.chelloToHandshakeUs,
 					}),
+					...rawTlsSignalsForSession(req),
 				},
 			});
 
@@ -191,6 +193,7 @@ export default (env: ProviderEnvironment) =>
 			const escalation = await buildEscalation(tasks, result, challenge, {
 				tcpToChelloUs: req.tcpToChelloUs,
 				chelloToHandshakeUs: req.chelloToHandshakeUs,
+				...rawTlsSignalsForSession(req),
 			});
 			const response: PowCaptchaSolutionResponse = {
 				status: "ok",
@@ -233,13 +236,22 @@ export const buildEscalation = async (
 	tasks: Tasks,
 	result: { verified: boolean; routingOutput?: { captchaType: CaptchaType } },
 	challenge: string,
-	// TLS handshake timings are per-connection: they must come from the
-	// current PoW-submit request, not from `originSession` (whose values
-	// belong to a different TCP connection made during the earlier
-	// frictionless request).
-	handshakeTiming?: {
+	// Per-connection signals (TLS handshake timings + raw TCP handshake
+	// signals) come from the CURRENT PoW-submit request, not from
+	// `originSession` — those values belong to a different TCP connection
+	// made during the earlier frictionless request.
+	perConnectionSignals?: {
 		tcpToChelloUs?: number;
 		chelloToHandshakeUs?: number;
+		synNs?: number;
+		synackNs?: number;
+		ackNs?: number;
+		observedTtl?: number;
+		tcpMss?: number;
+		tcpWscale?: number;
+		tcpOptsFlags?: number;
+		tcpOptsOrder?: number;
+		tcpWindow?: number;
 	},
 ): Promise<PowCaptchaSolutionEscalation | undefined> => {
 	if (!result.verified || !result.routingOutput) return undefined;
@@ -305,8 +317,8 @@ export const buildEscalation = async (
 		// solve can decrypt the (same-origin) behavioural payload.
 		originSession.bundleId,
 		originSession.currentUrl,
-		handshakeTiming?.tcpToChelloUs,
-		handshakeTiming?.chelloToHandshakeUs,
+		perConnectionSignals?.tcpToChelloUs,
+		perConnectionSignals?.chelloToHandshakeUs,
 		true,
 		originSession.iframeUrl,
 		originSession.isProtect,
@@ -325,6 +337,19 @@ export const buildEscalation = async (
 		originSession.bn,
 		originSession.fs,
 		originSession.s,
+		// Raw signals for the current PoW-submit TCP connection — not the
+		// origin's. Escalation session belongs on this hop's fingerprint.
+		perConnectionSignals && {
+			synNs: perConnectionSignals.synNs,
+			synackNs: perConnectionSignals.synackNs,
+			ackNs: perConnectionSignals.ackNs,
+			observedTtl: perConnectionSignals.observedTtl,
+			tcpMss: perConnectionSignals.tcpMss,
+			tcpWscale: perConnectionSignals.tcpWscale,
+			tcpOptsFlags: perConnectionSignals.tcpOptsFlags,
+			tcpOptsOrder: perConnectionSignals.tcpOptsOrder,
+			tcpWindow: perConnectionSignals.tcpWindow,
+		},
 	);
 
 	// Record the origin → escalation sessionId mapping so a /captcha/*

--- a/packages/provider/src/api/rawTlsSignalsMiddleware.ts
+++ b/packages/provider/src/api/rawTlsSignalsMiddleware.ts
@@ -1,0 +1,209 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { IncomingHttpHeaders } from "node:http";
+import { handleErrors } from "@prosopo/api-express-router";
+import { type Logger, getLogger } from "@prosopo/logger";
+import type { ProviderEnvironment } from "@prosopo/types-env";
+import type { NextFunction, Request, Response } from "express";
+
+// Raw TCP-handshake signals forwarded by the chaddy Caddy plugin. The plugin
+// looks each field up from the ja4l-probe eBPF sidecar's Unix socket keyed
+// by (client_ip, client_port) and injects them as separate headers.
+//
+// All values are wire-observed facts about the client's SYN (RFC-793 /
+// RFC-9293 primitives), not derived metrics — that split keeps this file
+// implementation-neutral: consumers of the DB rows are free to compute
+// whatever timing / hop / stack fingerprints they want at query time
+// from these primitives without any FoxIO JA4+ derivations being persisted
+// here.
+const HEADER_SYN_NS = "x-tls-syn-ns";
+const HEADER_SYNACK_NS = "x-tls-synack-ns";
+const HEADER_ACK_NS = "x-tls-ack-ns";
+const HEADER_OBSERVED_TTL = "x-tls-observed-ttl";
+const HEADER_TCP_MSS = "x-tls-tcp-mss";
+const HEADER_TCP_WSCALE = "x-tls-tcp-wscale";
+const HEADER_TCP_OPTS_FLAGS = "x-tls-tcp-opts-flags";
+const HEADER_TCP_OPTS_ORDER = "x-tls-tcp-opts-order";
+const HEADER_TCP_WINDOW = "x-tls-tcp-window";
+
+export interface RawTlsSignals {
+	// Kernel monotonic ns timestamps of the TCP 3-way handshake — captured by
+	// the eBPF probe on the WAN interface. Boot-relative; only meaningful in
+	// deltas within the same connection. `synackNs` may be undefined if the
+	// TC-egress program wasn't loaded when the handshake happened (probe in
+	// ingress-only fallback mode).
+	synNs?: number;
+	synackNs?: number;
+	ackNs?: number;
+	// The observed TTL byte of the client's SYN. Combined with a bucket to
+	// 64 / 128 / 255 this gives the initial TTL the client's kernel set —
+	// never forgeable from JavaScript because the TCP stack chooses it
+	// before any userspace code runs. Range 0..255.
+	observedTtl?: number;
+	// TCP MSS option value (bytes). Reflects the last-mile MTU: 1460 for
+	// clean 1500-MTU broadband, 1452 for PPPoE, 1348 for mobile-carrier
+	// GTP tunnels, and so on.
+	tcpMss?: number;
+	// TCP Window-Scale shift factor. Kernel default varies by OS and by
+	// sysctl tuning. Range 0..14.
+	tcpWscale?: number;
+	// SYN-options presence bitfield emitted by the eBPF probe:
+	// bit0=MSS bit1=WScale bit2=SACK-permitted bit3=Timestamps bit4=NOP.
+	tcpOptsFlags?: number;
+	// Packed encoding of the SYN option order emitted by the eBPF probe
+	// (5 bits per option ID, first 8 slots). Same OS+kernel typically
+	// produces the same value; a mismatch between claimed UA and this
+	// value is a strong virtualisation / spoofing signal.
+	tcpOptsOrder?: number;
+	// TCP window field from the client's SYN. Kernel-default territory:
+	// Linux → 64240, Windows → 65535 / 8192, macOS → 65535.
+	tcpWindow?: number;
+}
+
+const parseIntHeader = (
+	raw: string | string[] | undefined,
+	logger: Logger,
+	headerName: string,
+	max: number,
+): number | undefined => {
+	if (raw === undefined) {
+		return undefined;
+	}
+	const value = Array.isArray(raw) ? raw[0] : raw;
+	if (value === undefined) {
+		return undefined;
+	}
+	const parsed = Number.parseInt(value, 10);
+	if (Number.isNaN(parsed) || parsed < 0 || parsed > max) {
+		logger.debug(() => ({
+			msg: "Ignoring malformed raw TLS signal header",
+			data: { header: headerName, raw: value },
+		}));
+		return undefined;
+	}
+	return parsed;
+};
+
+// Kernel monotonic ns bumps into Number.MAX_SAFE_INTEGER (2^53) territory
+// after ~104 days of uptime. In practice servers rarely exceed that in a
+// single boot window and JS Number handles it cleanly up to that ceiling.
+// Cap at MAX_SAFE_INTEGER so any bogus value is rejected instead of being
+// silently truncated.
+const MAX_NS = Number.MAX_SAFE_INTEGER;
+const MAX_U8 = 255;
+const MAX_U16 = 65535;
+const MAX_U32 = 4_294_967_295;
+
+export const getRawTlsSignals = (
+	headers: IncomingHttpHeaders,
+	logger?: Logger,
+): RawTlsSignals => {
+	const log = logger ?? getLogger("info", "provider:raw-tls-signals");
+	return {
+		synNs: parseIntHeader(headers[HEADER_SYN_NS], log, HEADER_SYN_NS, MAX_NS),
+		synackNs: parseIntHeader(
+			headers[HEADER_SYNACK_NS],
+			log,
+			HEADER_SYNACK_NS,
+			MAX_NS,
+		),
+		ackNs: parseIntHeader(headers[HEADER_ACK_NS], log, HEADER_ACK_NS, MAX_NS),
+		observedTtl: parseIntHeader(
+			headers[HEADER_OBSERVED_TTL],
+			log,
+			HEADER_OBSERVED_TTL,
+			MAX_U8,
+		),
+		tcpMss: parseIntHeader(headers[HEADER_TCP_MSS], log, HEADER_TCP_MSS, MAX_U16),
+		tcpWscale: parseIntHeader(
+			headers[HEADER_TCP_WSCALE],
+			log,
+			HEADER_TCP_WSCALE,
+			MAX_U8,
+		),
+		tcpOptsFlags: parseIntHeader(
+			headers[HEADER_TCP_OPTS_FLAGS],
+			log,
+			HEADER_TCP_OPTS_FLAGS,
+			MAX_U8,
+		),
+		tcpOptsOrder: parseIntHeader(
+			headers[HEADER_TCP_OPTS_ORDER],
+			log,
+			HEADER_TCP_OPTS_ORDER,
+			MAX_U32,
+		),
+		tcpWindow: parseIntHeader(
+			headers[HEADER_TCP_WINDOW],
+			log,
+			HEADER_TCP_WINDOW,
+			MAX_U16,
+		),
+	};
+};
+
+// Helper for the session-write path: pull the raw TLS signals off `req`
+// into a plain object with only the defined fields. Callers spread it into
+// their session record (or into a routing `raw` bag) alongside the existing
+// tcpToChelloUs / chelloToHandshakeUs conditional spreads. Undefined fields
+// are omitted so the resulting Mongo document stays slim on requests that
+// came in without a ja4l-probe pipeline.
+export const rawTlsSignalsForSession = (
+	req: Pick<Request, keyof RawTlsSignals>,
+): Partial<RawTlsSignals> => {
+	const out: Partial<RawTlsSignals> = {};
+	if (req.synNs !== undefined) out.synNs = req.synNs;
+	if (req.synackNs !== undefined) out.synackNs = req.synackNs;
+	if (req.ackNs !== undefined) out.ackNs = req.ackNs;
+	if (req.observedTtl !== undefined) out.observedTtl = req.observedTtl;
+	if (req.tcpMss !== undefined) out.tcpMss = req.tcpMss;
+	if (req.tcpWscale !== undefined) out.tcpWscale = req.tcpWscale;
+	if (req.tcpOptsFlags !== undefined) out.tcpOptsFlags = req.tcpOptsFlags;
+	if (req.tcpOptsOrder !== undefined) out.tcpOptsOrder = req.tcpOptsOrder;
+	if (req.tcpWindow !== undefined) out.tcpWindow = req.tcpWindow;
+	return out;
+};
+
+// env kept in the signature for parity with the other provider middlewares
+// (ja4Middleware, ipInfoMiddleware, handshakeTimingMiddleware). Currently
+// unused but reserved so future per-tenant configuration can hook in without
+// changing the startProviderApi wiring.
+export const rawTlsSignalsMiddleware = (env: ProviderEnvironment) => {
+	return async (req: Request, res: Response, next: NextFunction) => {
+		try {
+			const signals = getRawTlsSignals(req.headers, req.logger);
+			if (signals.synNs !== undefined) req.synNs = signals.synNs;
+			if (signals.synackNs !== undefined) req.synackNs = signals.synackNs;
+			if (signals.ackNs !== undefined) req.ackNs = signals.ackNs;
+			if (signals.observedTtl !== undefined)
+				req.observedTtl = signals.observedTtl;
+			if (signals.tcpMss !== undefined) req.tcpMss = signals.tcpMss;
+			if (signals.tcpWscale !== undefined) req.tcpWscale = signals.tcpWscale;
+			if (signals.tcpOptsFlags !== undefined)
+				req.tcpOptsFlags = signals.tcpOptsFlags;
+			if (signals.tcpOptsOrder !== undefined)
+				req.tcpOptsOrder = signals.tcpOptsOrder;
+			if (signals.tcpWindow !== undefined) req.tcpWindow = signals.tcpWindow;
+
+			const hasAny = Object.values(signals).some((v) => v !== undefined);
+			if (hasAny) {
+				req.logger = req.logger.with(signals, "rawTlsSignals");
+			}
+			next();
+		} catch (err) {
+			return handleErrors(err as Error, req, res, next);
+		}
+	};
+};

--- a/packages/provider/src/api/rawTlsSignalsMiddleware.ts
+++ b/packages/provider/src/api/rawTlsSignalsMiddleware.ts
@@ -126,7 +126,12 @@ export const getRawTlsSignals = (
 			HEADER_OBSERVED_TTL,
 			MAX_U8,
 		),
-		tcpMss: parseIntHeader(headers[HEADER_TCP_MSS], log, HEADER_TCP_MSS, MAX_U16),
+		tcpMss: parseIntHeader(
+			headers[HEADER_TCP_MSS],
+			log,
+			HEADER_TCP_MSS,
+			MAX_U16,
+		),
 		tcpWscale: parseIntHeader(
 			headers[HEADER_TCP_WSCALE],
 			log,

--- a/packages/provider/src/api/startProviderApi.ts
+++ b/packages/provider/src/api/startProviderApi.ts
@@ -54,9 +54,9 @@ import { headerCheckMiddleware } from "./headerCheckMiddleware.js";
 import { ignoreMiddleware } from "./ignoreMiddleware.js";
 import { ipInfoMiddleware } from "./ipInfoMiddleware.js";
 import { ja4Middleware } from "./ja4Middleware.js";
-import { rawTlsSignalsMiddleware } from "./rawTlsSignalsMiddleware.js";
 import { metricsMiddleware } from "./metrics.js";
 import { publicRouter } from "./public.js";
+import { rawTlsSignalsMiddleware } from "./rawTlsSignalsMiddleware.js";
 import { robotsMiddleware } from "./robotsMiddleware.js";
 import { prosopoVerifyRouter } from "./verify.js";
 

--- a/packages/provider/src/api/startProviderApi.ts
+++ b/packages/provider/src/api/startProviderApi.ts
@@ -54,6 +54,7 @@ import { headerCheckMiddleware } from "./headerCheckMiddleware.js";
 import { ignoreMiddleware } from "./ignoreMiddleware.js";
 import { ipInfoMiddleware } from "./ipInfoMiddleware.js";
 import { ja4Middleware } from "./ja4Middleware.js";
+import { rawTlsSignalsMiddleware } from "./rawTlsSignalsMiddleware.js";
 import { metricsMiddleware } from "./metrics.js";
 import { publicRouter } from "./public.js";
 import { robotsMiddleware } from "./robotsMiddleware.js";
@@ -373,6 +374,7 @@ export async function startProviderApi(
 	apiApp.use(i18Middleware);
 	apiApp.use(ja4Middleware(env));
 	apiApp.use(handshakeTimingMiddleware(env));
+	apiApp.use(rawTlsSignalsMiddleware(env));
 	apiApp.use(ipInfoMiddleware(env));
 
 	// Run Header check middleware on all client routes

--- a/packages/provider/src/express.d.ts
+++ b/packages/provider/src/express.d.ts
@@ -33,6 +33,20 @@ export interface AugmentedRequest {
 	// the plugin failed to capture timing for that connection.
 	tcpToChelloUs?: number;
 	chelloToHandshakeUs?: number;
+	// Raw per-connection TCP handshake signals forwarded by chaddy from
+	// the co-located ja4l-probe eBPF sidecar. See rawTlsSignalsMiddleware
+	// for the wire-format contract. All optional — a request that came
+	// in without a running ja4l-probe / chaddy pipeline has all fields
+	// undefined and the session write skips these columns entirely.
+	synNs?: number;
+	synackNs?: number;
+	ackNs?: number;
+	observedTtl?: number;
+	tcpMss?: number;
+	tcpWscale?: number;
+	tcpOptsFlags?: number;
+	tcpOptsOrder?: number;
+	tcpWindow?: number;
 }
 
 declare global {
@@ -50,6 +64,15 @@ declare global {
 			ipInfo?: IPInfoResponse;
 			tcpToChelloUs?: number;
 			chelloToHandshakeUs?: number;
+			synNs?: number;
+			synackNs?: number;
+			ackNs?: number;
+			observedTtl?: number;
+			tcpMss?: number;
+			tcpWscale?: number;
+			tcpOptsFlags?: number;
+			tcpOptsOrder?: number;
+			tcpWindow?: number;
 		}
 	}
 }

--- a/packages/provider/src/tasks/frictionless/frictionlessTasks.ts
+++ b/packages/provider/src/tasks/frictionless/frictionlessTasks.ts
@@ -35,6 +35,7 @@ import type { IProviderDatabase } from "@prosopo/types-database";
 import type { AccessPolicy } from "@prosopo/user-access-policy";
 import { v4 as uuidv4 } from "uuid";
 import { buildDnsEventUrl } from "../../api/dnsEventUrl.js";
+import type { RawTlsSignals } from "../../api/rawTlsSignalsMiddleware.js";
 import { checkLangRules } from "../../rules/lang.js";
 import {
 	type UsageCounters,
@@ -159,6 +160,19 @@ export class FrictionlessManager extends CaptchaManager {
 			i: params.i,
 			tcpToChelloUs: params.tcpToChelloUs,
 			chelloToHandshakeUs: params.chelloToHandshakeUs,
+			// Raw per-connection TCP-handshake signals forwarded by chaddy
+			// from its co-located ja4l-probe eBPF sidecar. Passed through as
+			// a bag on createSession() below rather than expanded into 9
+			// positional args.
+			synNs: params.synNs,
+			synackNs: params.synackNs,
+			ackNs: params.ackNs,
+			observedTtl: params.observedTtl,
+			tcpMss: params.tcpMss,
+			tcpWscale: params.tcpWscale,
+			tcpOptsFlags: params.tcpOptsFlags,
+			tcpOptsOrder: params.tcpOptsOrder,
+			tcpWindow: params.tcpWindow,
 		};
 	}
 
@@ -231,6 +245,10 @@ export class FrictionlessManager extends CaptchaManager {
 		bn?: Session["bn"],
 		fs?: Session["fs"],
 		s?: Session["s"],
+		// Bag of raw per-connection TCP-handshake signals (chaddy → ja4l-probe
+		// → provider). Kept as a bag rather than expanded into 9 positional
+		// params to avoid pushing createSession's arity past 40.
+		rawTlsSignals?: Partial<RawTlsSignals>,
 	): Promise<Session> {
 		const sessionRecord: Session = {
 			sessionId: `${getSessionIDPrefix(this.config.host)}-${uuidv4()}`,
@@ -289,6 +307,7 @@ export class FrictionlessManager extends CaptchaManager {
 			fs,
 			tcpToChelloUs,
 			chelloToHandshakeUs,
+			...(rawTlsSignals ?? {}),
 			// Only present when an access policy actually matched this
 			// request, so ordinary sessions stay slim.
 			...(matchedRule && { matchedRule }),
@@ -453,6 +472,17 @@ export class FrictionlessManager extends CaptchaManager {
 			effectiveParams.bn,
 			effectiveParams.fs,
 			effectiveParams.s,
+			{
+				synNs: effectiveParams.synNs,
+				synackNs: effectiveParams.synackNs,
+				ackNs: effectiveParams.ackNs,
+				observedTtl: effectiveParams.observedTtl,
+				tcpMss: effectiveParams.tcpMss,
+				tcpWscale: effectiveParams.tcpWscale,
+				tcpOptsFlags: effectiveParams.tcpOptsFlags,
+				tcpOptsOrder: effectiveParams.tcpOptsOrder,
+				tcpWindow: effectiveParams.tcpWindow,
+			},
 		);
 
 		// Fire-and-forget served-counter writes. Skipped when there's no
@@ -537,6 +567,17 @@ export class FrictionlessManager extends CaptchaManager {
 			effectiveParams.bn,
 			effectiveParams.fs,
 			effectiveParams.s,
+			{
+				synNs: effectiveParams.synNs,
+				synackNs: effectiveParams.synackNs,
+				ackNs: effectiveParams.ackNs,
+				observedTtl: effectiveParams.observedTtl,
+				tcpMss: effectiveParams.tcpMss,
+				tcpWscale: effectiveParams.tcpWscale,
+				tcpOptsFlags: effectiveParams.tcpOptsFlags,
+				tcpOptsOrder: effectiveParams.tcpOptsOrder,
+				tcpWindow: effectiveParams.tcpWindow,
+			},
 		);
 	}
 

--- a/packages/provider/src/tests/unit/api/rawTlsSignalsMiddleware.unit.test.ts
+++ b/packages/provider/src/tests/unit/api/rawTlsSignalsMiddleware.unit.test.ts
@@ -1,0 +1,160 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { IncomingHttpHeaders } from "node:http";
+import type { Logger } from "@prosopo/logger";
+import { describe, expect, it, vi } from "vitest";
+import {
+	getRawTlsSignals,
+	rawTlsSignalsForSession,
+} from "../../../api/rawTlsSignalsMiddleware.js";
+
+const mockLogger = (): Logger => {
+	const log: unknown = {
+		debug: vi.fn(),
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+		trace: vi.fn(),
+		fatal: vi.fn(),
+		with: vi.fn().mockImplementation(() => log),
+	};
+	return log as Logger;
+};
+
+describe("getRawTlsSignals", () => {
+	it("parses every present header", () => {
+		const headers: IncomingHttpHeaders = {
+			"x-tls-syn-ns": "100000000",
+			"x-tls-synack-ns": "100050000",
+			"x-tls-ack-ns": "100100000",
+			"x-tls-observed-ttl": "53",
+			"x-tls-tcp-mss": "1452",
+			"x-tls-tcp-wscale": "7",
+			"x-tls-tcp-opts-flags": "31",
+			"x-tls-tcp-opts-order": "202818",
+			"x-tls-tcp-window": "64240",
+		};
+		const result = getRawTlsSignals(headers, mockLogger());
+		expect(result.synNs).toBe(100000000);
+		expect(result.synackNs).toBe(100050000);
+		expect(result.ackNs).toBe(100100000);
+		expect(result.observedTtl).toBe(53);
+		expect(result.tcpMss).toBe(1452);
+		expect(result.tcpWscale).toBe(7);
+		expect(result.tcpOptsFlags).toBe(31);
+		expect(result.tcpOptsOrder).toBe(202818);
+		expect(result.tcpWindow).toBe(64240);
+	});
+
+	it("returns undefined for every field when no headers are present", () => {
+		const result = getRawTlsSignals({}, mockLogger());
+		expect(result.synNs).toBeUndefined();
+		expect(result.synackNs).toBeUndefined();
+		expect(result.ackNs).toBeUndefined();
+		expect(result.observedTtl).toBeUndefined();
+		expect(result.tcpMss).toBeUndefined();
+		expect(result.tcpWscale).toBeUndefined();
+		expect(result.tcpOptsFlags).toBeUndefined();
+		expect(result.tcpOptsOrder).toBeUndefined();
+		expect(result.tcpWindow).toBeUndefined();
+	});
+
+	it("rejects out-of-range values with the field-specific cap", () => {
+		// ttl > 255 (u8 cap), mss > 65535 (u16), opts_flags > 255 (u8).
+		const headers: IncomingHttpHeaders = {
+			"x-tls-observed-ttl": "999",
+			"x-tls-tcp-mss": "70000",
+			"x-tls-tcp-opts-flags": "300",
+			"x-tls-tcp-wscale": "42", // in u8 range so still accepted
+		};
+		const result = getRawTlsSignals(headers, mockLogger());
+		expect(result.observedTtl).toBeUndefined();
+		expect(result.tcpMss).toBeUndefined();
+		expect(result.tcpOptsFlags).toBeUndefined();
+		expect(result.tcpWscale).toBe(42);
+	});
+
+	it("rejects negative values", () => {
+		const headers: IncomingHttpHeaders = {
+			"x-tls-tcp-wscale": "-1",
+		};
+		const result = getRawTlsSignals(headers, mockLogger());
+		expect(result.tcpWscale).toBeUndefined();
+	});
+
+	it("rejects non-numeric values", () => {
+		const headers: IncomingHttpHeaders = {
+			"x-tls-tcp-mss": "not-a-number",
+			"x-tls-tcp-wscale": "7",
+		};
+		const result = getRawTlsSignals(headers, mockLogger());
+		expect(result.tcpMss).toBeUndefined();
+		expect(result.tcpWscale).toBe(7);
+	});
+
+	it("takes the first value when the header is repeated (string[])", () => {
+		const headers: IncomingHttpHeaders = {
+			"x-tls-tcp-mss": ["1452", "1460"],
+		};
+		const result = getRawTlsSignals(headers, mockLogger());
+		expect(result.tcpMss).toBe(1452);
+	});
+});
+
+describe("rawTlsSignalsForSession", () => {
+	it("omits undefined fields so Mongo docs stay slim", () => {
+		const out = rawTlsSignalsForSession({
+			tcpMss: 1460,
+			// everything else undefined
+		} as Parameters<typeof rawTlsSignalsForSession>[0]);
+		expect(out).toEqual({ tcpMss: 1460 });
+	});
+
+	it("copies every defined field verbatim", () => {
+		const out = rawTlsSignalsForSession({
+			synNs: 1,
+			synackNs: 2,
+			ackNs: 3,
+			observedTtl: 4,
+			tcpMss: 5,
+			tcpWscale: 6,
+			tcpOptsFlags: 7,
+			tcpOptsOrder: 8,
+			tcpWindow: 9,
+		} as Parameters<typeof rawTlsSignalsForSession>[0]);
+		expect(out).toEqual({
+			synNs: 1,
+			synackNs: 2,
+			ackNs: 3,
+			observedTtl: 4,
+			tcpMss: 5,
+			tcpWscale: 6,
+			tcpOptsFlags: 7,
+			tcpOptsOrder: 8,
+			tcpWindow: 9,
+		});
+	});
+});
+
+describe("rawTlsSignalsMiddleware", () => {
+	it("returns a middleware function", async () => {
+		const { rawTlsSignalsMiddleware } = await import(
+			"../../../api/rawTlsSignalsMiddleware.js"
+		);
+		// @ts-ignore — mock env, matches ja4Middleware.unit.test.ts pattern
+		const middleware = rawTlsSignalsMiddleware({});
+		expect(typeof middleware).toBe("function");
+	});
+});

--- a/packages/types-database/src/types/provider.ts
+++ b/packages/types-database/src/types/provider.ts
@@ -798,6 +798,19 @@ export const SessionRecordSchema = new Schema<SessionRecord>({
 	// See @prosopo/types Session.tcpToChelloUs for full semantics.
 	tcpToChelloUs: { type: Number, required: false },
 	chelloToHandshakeUs: { type: Number, required: false },
+	// Raw per-connection TCP-handshake signals forwarded by chaddy from
+	// its co-located ja4l-probe eBPF sidecar. Wire-observed primitives
+	// (RFC-793 / RFC-9293) — see @prosopo/types Session for full schema.
+	// Undefined on sessions that came in without the ja4l-probe pipeline.
+	synNs: { type: Number, required: false },
+	synackNs: { type: Number, required: false },
+	ackNs: { type: Number, required: false },
+	observedTtl: { type: Number, required: false },
+	tcpMss: { type: Number, required: false },
+	tcpWscale: { type: Number, required: false },
+	tcpOptsFlags: { type: Number, required: false },
+	tcpOptsOrder: { type: Number, required: false },
+	tcpWindow: { type: Number, required: false },
 	// DNS observation merge target. Populated by
 	// POST /v1/prosopo/provider/admin/dns/event from the dns-event
 	// sidecar (see types/provider/database.ts → Session.dnsEvent).

--- a/packages/types/src/provider/database.ts
+++ b/packages/types/src/provider/database.ts
@@ -518,6 +518,24 @@ export const SessionSchema = object({
 	// write.
 	tcpToChelloUs: number().optional(),
 	chelloToHandshakeUs: number().optional(),
+	// Raw per-connection TCP-handshake signals forwarded by chaddy from
+	// its co-located ja4l-probe eBPF sidecar. Wire-observed primitives
+	// (RFC-793 / RFC-9293) — kernel nanosecond timestamps of SYN /
+	// SYN-ACK / ACK, the SYN's TTL byte, and its TCP options. Deliberately
+	// stored raw with no derived latency / hop-count / stack-hash fields
+	// so consumers are free to compute any equivalent metric at query
+	// time. Undefined on sessions that came in without the ja4l-probe
+	// pipeline (pre-rollout traffic, dev, or requests through a
+	// non-chaddy front).
+	synNs: number().optional(),
+	synackNs: number().optional(),
+	ackNs: number().optional(),
+	observedTtl: number().min(0).max(255).optional(),
+	tcpMss: number().min(0).max(65535).optional(),
+	tcpWscale: number().min(0).max(255).optional(),
+	tcpOptsFlags: number().min(0).max(255).optional(),
+	tcpOptsOrder: number().min(0).max(4_294_967_295).optional(),
+	tcpWindow: number().min(0).max(65535).optional(),
 	dnsEvent: object({
 		resolverIp: string().optional(),
 		peerIp: string().optional(),
@@ -626,6 +644,19 @@ export type Session = {
 	// proxy chain before reaching Caddy.
 	tcpToChelloUs?: number;
 	chelloToHandshakeUs?: number;
+	// Raw per-connection TCP-handshake signals — see SessionSchema block
+	// above. Wire primitives from the ja4l-probe eBPF sidecar; consumers
+	// derive whatever timing / hop / stack fingerprints they want at
+	// query time from these fields.
+	synNs?: number;
+	synackNs?: number;
+	ackNs?: number;
+	observedTtl?: number;
+	tcpMss?: number;
+	tcpWscale?: number;
+	tcpOptsFlags?: number;
+	tcpOptsOrder?: number;
+	tcpWindow?: number;
 	// DNS observation merge target — populated by the dns-event sidecar
 	// via POST /v1/prosopo/provider/admin/dns/event. At most one DNS
 	// event + one HTTP event per session under normal usage; the


### PR DESCRIPTION
## Summary

Adds a new `rawTlsSignalsMiddleware` that reads nine `X-TLS-*` headers forwarded by the chaddy Caddy plugin from its co-located `ja4l-probe` eBPF sidecar, and threads them through onto the Session record in Mongo.

**Fields captured**

| Field | Wire source |
|---|---|
| `synNs`, `synackNs`, `ackNs` | kernel monotonic ns of the TCP 3-way handshake, from `bpf_ktime_get_ns()` |
| `observedTtl` | SYN TTL byte |
| `tcpMss` | TCP MSS option (bytes) |
| `tcpWscale` | TCP Window-Scale shift |
| `tcpOptsFlags` | SYN options presence bitfield |
| `tcpOptsOrder` | packed SYN option-order encoding |
| `tcpWindow` | TCP window field |

All fields are RFC-793 / RFC-9293 primitives read straight off the wire by the sidecar. **No derived latency / hop-count / stack-fingerprint columns are persisted** — that split keeps this file implementation-neutral and lets consumers of the Session collection compute any equivalent metric at query time from these raw fields.

## Wiring

- Middleware registered in `startProviderApi.ts` alongside the existing `ja4Middleware` / `handshakeTimingMiddleware` / `ipInfoMiddleware` chain.
- `AugmentedRequest`, Session Zod schema, TS type, and Mongoose `SessionRecordSchema` all pick up the new optional fields.
- Callers thread the signals through in three places:
  - **Frictionless entry** (`getFrictionlessCaptchaChallenge/handler.ts`) — dedup replay, `shortCircuitInput`, session-init params, routing-machine `raw` bag. Small helper `rawTlsSignalsForSession(req)` keeps the four call sites uniform with the existing `tcpToChelloUs` / `chelloToHandshakeUs` conditional spreads.
  - **PoW submit** (`submitPoWCaptchaSolution.ts`) — routing-context `raw` bag, and via `buildEscalation()`'s renamed `perConnectionSignals` param so an image/puzzle escalation session carries the **current** PoW-submit hop's TCP fingerprint, not the origin session's (they belong to different TCP connections).
  - **`FrictionlessTasks.createSession()`** — accepts an optional `Partial<RawTlsSignals>` bag as its final param and spreads into the Session record. Kept as a bag to avoid pushing an already-30+-positional-arg function's arity past 40.

## Compatibility

Backwards-compatible. Requests without the headers (dev, non-chaddy fronts, any pre-rollout traffic) land Session records with the raw fields undefined — exactly the same shape as today. No migration.

## Chaddy side

Separate PR against `prosopo/chaddy` — that one adds an optional `ja4l_probe_socket` config option, per-connection lookup against `/var/run/ja4l/lookup.sock`, and forwards the fields as the `X-TLS-*` headers this middleware reads. Provider side lands first so chaddy can be rolled behind it without breaking anything.

## Test plan

- [x] `cargo test` — n/a (no Rust changes)
- [x] `npm run -w @prosopo/provider build:tsc` — clean
- [x] Unit tests — 9 new tests in `rawTlsSignalsMiddleware.unit.test.ts` (parse, range-caps, repeated-header, helper projection). Pattern matches the sibling `handshakeTimingMiddleware.unit.test.ts`.
- [ ] Manual: hit a provider through a Caddy without the chaddy `ja4l_probe_socket` option and confirm Session records still land with all raw fields undefined (backward compat).
- [ ] Manual (post-chaddy PR): hit a provider through a Caddy WITH the socket + a running ja4l-probe and confirm Session records include the nine raw fields populated.