### PR TITLE
fix(provider): always persist `mode` on the frictionless session

### DIFF
--- a/.changeset/session-mode-always-persist.md
+++ b/.changeset/session-mode-always-persist.md
@@ -1,0 +1,22 @@
+---
+"@prosopo/provider": patch
+---
+
+fix(provider): always persist `mode` on the frictionless session
+
+`getFrictionlessCaptchaChallenge` was collapsing anything that wasn't
+`ModeEnum.invisible` to `undefined` before it reached the session
+record. Mongoose then dropped the field on write, so today's DB carries
+zero sessions with any `mode` value set — invisible or visible.
+
+That makes it impossible to distinguish invisible from visible traffic
+in analytics, and it blocks the follow-up on empty-`coords` records
+(the checkbox-click coord is empty by design in invisible mode; we
+need `Session.mode` to tell whether an empty-coords record came from a
+legit invisible integration or from a widget-bypass bot).
+
+Change: default `sessionMode` to `ModeEnum.visible` when the client
+doesn't opt into invisible. Every session now carries an explicit
+`mode` value. The `ShortCircuitInput.sessionMode` type tightens from
+`ModeEnum | undefined` to `ModeEnum` to reflect that; two unit tests
+updated to pass `ModeEnum.visible` instead of `undefined`.

--- a/packages/provider/src/api/captcha/getFrictionlessCaptchaChallenge/handler.ts
+++ b/packages/provider/src/api/captcha/getFrictionlessCaptchaChallenge/handler.ts
@@ -118,8 +118,16 @@ export default (
 			const sessionToken = token || `notoken-${uuidv4()}`;
 
 			const normalizedIp = normalizeRequestIp(req.ip, req.logger);
-			const sessionMode =
-				mode === ModeEnum.invisible ? ModeEnum.invisible : undefined;
+			// Always persist a concrete mode on the session — the client only
+			// sends `mode` when it wants to opt into invisible; visible is the
+			// implicit default. Previously the visible path collapsed to
+			// `undefined` and never reached the record, so the DB had zero
+			// sessions with `mode` set, making it impossible to distinguish
+			// visible from invisible traffic in analytics or to correlate
+			// widget-bypass symptoms (empty checkbox coords, missing
+			// behaviouralData) with invisible-mode deployments.
+			const sessionMode: ModeEnum =
+				mode === ModeEnum.invisible ? ModeEnum.invisible : ModeEnum.visible;
 
 			req.logger.info(() => ({
 				msg: "Frictionless handler entry",
@@ -131,7 +139,7 @@ export default (
 					ja4: req.ja4,
 					path: req.path,
 					method: req.method,
-					...(sessionMode && { mode: sessionMode }),
+					mode: sessionMode,
 				},
 			}));
 

--- a/packages/provider/src/api/captcha/getFrictionlessCaptchaChallenge/shortCircuit.powFallback.test.ts
+++ b/packages/provider/src/api/captcha/getFrictionlessCaptchaChallenge/shortCircuit.powFallback.test.ts
@@ -15,6 +15,7 @@
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { ModeEnum } from "@prosopo/types";
 import type { Response } from "express";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { initDetectorBundlePool } from "../../../tasks/detection/bundlePool.js";
@@ -36,7 +37,7 @@ const makeInput = (
 		ipAddress: { ip: "1.2.3.4" },
 		ipInfo: undefined,
 		flatHeaders: {},
-		sessionMode: undefined,
+		sessionMode: ModeEnum.visible,
 		userSitekeyIpHash: "hash",
 		requestId: "req-1",
 		logger: { warn: vi.fn(), info: vi.fn() },

--- a/packages/provider/src/api/captcha/getFrictionlessCaptchaChallenge/shortCircuit.ts
+++ b/packages/provider/src/api/captcha/getFrictionlessCaptchaChallenge/shortCircuit.ts
@@ -39,7 +39,7 @@ export type ShortCircuitInput = {
 	ipAddress: ReturnType<typeof getCompositeIpAddress>;
 	ipInfo: IPInfoResponse | undefined;
 	flatHeaders: RequestHeaders;
-	sessionMode: ModeEnum | undefined;
+	sessionMode: ModeEnum;
 	userSitekeyIpHash: string;
 	requestId: string | undefined;
 	logger: Logger;

--- a/packages/provider/src/tests/unit/api/captcha/getFrictionlessCaptchaChallenge/shortCircuit.unit.test.ts
+++ b/packages/provider/src/tests/unit/api/captcha/getFrictionlessCaptchaChallenge/shortCircuit.unit.test.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { CaptchaType } from "@prosopo/types";
+import { CaptchaType, ModeEnum } from "@prosopo/types";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { runConfiguredCaptchaTypeShortCircuit } from "../../../../../api/captcha/getFrictionlessCaptchaChallenge/shortCircuit.js";
 
@@ -54,7 +54,7 @@ const buildInput = (
 			ipAddress: { lower: 0n, type: "v4" } as never,
 			ipInfo: undefined,
 			flatHeaders: {},
-			sessionMode: undefined,
+			sessionMode: ModeEnum.visible,
 			userSitekeyIpHash: "hash",
 			logger: { info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
 			...overrides,


### PR DESCRIPTION
## Summary
`getFrictionlessCaptchaChallenge/handler.ts` collapsed anything that wasn't `ModeEnum.invisible` to `undefined` before it reached the session record. Mongoose then dropped the field on write, so today's production DB carries **0 sessions with any `mode` value set** — invisible or visible.

That leaves us unable to distinguish visible from invisible traffic in analytics, and blocks the empty-\`coords\` follow-up (invisible mode legitimately produces empty checkbox coords; without `Session.mode` we can't tell those apart from widget-bypass bots).

## Changes
- `handler.ts`: default `sessionMode` to `ModeEnum.visible` when the client doesn't opt into invisible; every session now carries an explicit `mode`.
- `shortCircuit.ts`: tighten `ShortCircuitInput.sessionMode` from `ModeEnum | undefined` to `ModeEnum` to reflect the invariant.
- `handler.ts`: drop the now-redundant `...(sessionMode && { mode })` spread in the log record.
- Two unit tests updated to pass `ModeEnum.visible` instead of `undefined`.

## Test plan
- [x] `npm run -w @prosopo/provider build:tsc` — no type errors
- [x] Touched test files (`shortCircuit.unit.test.ts`, `shortCircuit.powFallback.test.ts`) — 14/14 pass
- [x] `biome check` clean
- [ ] After merge + deploy: verify `db.sessions.countDocuments({mode:"visible"})` and `db.sessions.countDocuments({mode:"invisible"})` both climb, and the empty-coords follow-up can attribute records to one or the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)