### PR TITLE
perf(types-database): compound {dappAccount, requestedAtTimestamp} on UserCommitmentRecordSchema

### DIFF
--- a/.changeset/usercommitments-dapp-timestamp-index.md
+++ b/.changeset/usercommitments-dapp-timestamp-index.md
@@ -1,0 +1,11 @@
+---
+"@prosopo/types-database": patch
+---
+
+perf(types-database): add `{dappAccount, requestedAtTimestamp}` compound index to `UserCommitmentRecordSchema`
+
+The anomaly-detector top-level pipeline runs the same `{dappAccount: {$in: [...]}, requestedAtTimestamp: {$gte, $lt}}` match plus `{$sort: {requestedAtTimestamp: -1}}` against all three captcha collections. Pow and puzzle already carry the matching compound index; usercommitments only had `{requestedAtTimestamp: -1}` and `{dappAccount: 1}` separately, so mongo range-scanned by timestamp and FETCH-filtered every doc by dappAccount.
+
+Measured on the live detector query for a 1h Pimeyes window: `nReturned: 9149`, `totalDocsExamined: 24930` — 2.7× wasted docs. Scales linearly with window length and inversely with tenant share, so a small-share account on a 24h window would fetch millions of unrelated docs.
+
+Adding the compound brings image detector queries to parity with pow/puzzle. Mongo builds the index in the background so no downtime; on a hot 1M+ doc collection expect the index to be online within minutes to hours depending on size.

--- a/packages/types-database/src/types/provider.ts
+++ b/packages/types-database/src/types/provider.ts
@@ -558,6 +558,15 @@ UserCommitmentRecordSchema.index({
 	lastUpdatedTimestamp: 1,
 });
 UserCommitmentRecordSchema.index({ userAccount: 1, dappAccount: 1 });
+// Compound for the anomaly-detector top-level match
+// (`{dappAccount: {$in: [...]}, requestedAtTimestamp: {$gte, $lt}}` followed
+// by `{$sort: {requestedAtTimestamp: -1}}`). Mirrors the equivalent index on
+// `PoWCaptchaRecordSchema` / `PuzzleCaptchaRecordSchema`; without it, the
+// query planner falls back to a range scan on `{requestedAtTimestamp}` and
+// FETCH-filters every doc by `dappAccount` — measured 2.7× wasted docs on a
+// 1h window for a single high-share tenant, degrades linearly with window
+// length and inversely with tenant share.
+UserCommitmentRecordSchema.index({ dappAccount: 1, requestedAtTimestamp: 1 });
 UserCommitmentRecordSchema.index({ "ipAddress.lower": 1 });
 UserCommitmentRecordSchema.index({ "ipAddress.upper": 1 });
 UserCommitmentRecordSchema.index({ "result.reason": 1 });


### PR DESCRIPTION
## Summary
The anomaly-detector top-level pipeline runs the same \`{dappAccount: {$in: [...]}, requestedAtTimestamp: {$gte, $lt}}\` match + \`{$sort: {requestedAtTimestamp: -1}}\` against all three captcha collections. Pow and puzzle carry the matching compound index; usercommitments only had \`{requestedAtTimestamp: -1}\` and \`{dappAccount: 1}\` separately, so mongo range-scans by timestamp and FETCH-filters every doc by \`dappAccount\`.

## Live evidence (before)
Explained a 1h Pimeyes-window detector query against prod:
\`\`\`
winning plan: IXSCAN {requestedAtTimestamp: -1} backward → FETCH filter
executionTimeMillis: 260
totalKeysExamined: 24,930
totalDocsExamined: 24,930
nReturned:          9,149     ← 2.7× wasted docs
\`\`\`
Scales linearly with window length and inversely with tenant share — a small-share account on a 24h window would fetch millions of unrelated docs.

## Change
- Add \`UserCommitmentRecordSchema.index({ dappAccount: 1, requestedAtTimestamp: 1 })\` in \`packages/types-database/src/types/provider.ts\`, mirroring the equivalent index on \`PoWCaptchaRecordSchema\` / \`PuzzleCaptchaRecordSchema\`.

## Rollout
Mongoose creates the index in the background at provider startup (\`{ background: true }\` is the mongo default in modern versions). No downtime; on a hot 1M+ doc collection expect the index to be online within minutes to hours depending on collection size. Detector queries stay served by the existing plan until the new index is ready, then flip automatically.

## Related
Follows on from captcha-private #4180 (widened detector dataSources to include puzzlecaptchas + usercommitments) which made this the new hot query.

🤖 Generated with [Claude Code](https://claude.com/claude-code)