### PR TITLE
chore(caddy-docker): bump image to 2.5.9

### DIFF
--- a/.changeset/caddy-2-5-9-tcp-probe.md
+++ b/.changeset/caddy-2-5-9-tcp-probe.md
@@ -1,0 +1,18 @@
+---
+"@prosopo/caddy-docker": patch
+---
+
+chore(caddy-docker): bump image to 2.5.9
+
+Rebuilds `prosopo/caddy` against the latest `github.com/prosopo/chaddy`,
+which now exposes a `tcp_probe_socket` global option. When set, chaddy
+performs a per-request lookup against a co-located eBPF probe's Unix
+socket and forwards the raw TCP handshake signals (`X-TLS-Syn-Ns`,
+`X-TLS-Synack-Ns`, `X-TLS-Ack-Ns`, `X-TLS-Observed-Ttl`, `X-TLS-Tcp-Mss`,
+`X-TLS-Tcp-Wscale`, `X-TLS-Tcp-Opts-Flags`, `X-TLS-Tcp-Opts-Order`,
+`X-TLS-Tcp-Window`) on the reverse-proxy request. Lookups are bounded at
+50 ms and drop cleanly on miss/timeout — the request continues without
+the extra headers. Unset by default: existing deploys are unaffected.
+
+Image published as `prosopo/caddy:2.5.9` and re-tagged `:latest` on
+Docker Hub.

--- a/docker/images/caddy/package.json
+++ b/docker/images/caddy/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@prosopo/caddy-docker",
-	"version": "2.5.8",
+	"version": "2.5.9",
 	"engines": {
 		"node": "^24",
 		"npm": "^11"


### PR DESCRIPTION
## Summary
- Version bump only in `docker/images/caddy/package.json` (`2.5.8` → `2.5.9`).
- Image already built + pushed as `prosopo/caddy:2.5.9` and `:latest` on Docker Hub (digest `sha256:5c68e7bbd7e76447178181d0ca5054bab2ccd4f5a34ec8e8812330112a0dbaa5`).
- Picks up `github.com/prosopo/chaddy`'s new `tcp_probe_socket` global option (forwards raw TCP handshake signals from a co-located eBPF probe as `X-TLS-Syn-Ns`, `X-TLS-Synack-Ns`, `X-TLS-Ack-Ns`, `X-TLS-Observed-Ttl`, `X-TLS-Tcp-Mss`, `X-TLS-Tcp-Wscale`, `X-TLS-Tcp-Opts-Flags`, `X-TLS-Tcp-Opts-Order`, `X-TLS-Tcp-Window`). Unset by default — existing deploys unaffected.

## Why
`npm run build:docker` derives the docker tag from `package.json.version`. Without the bump, a rebuild would re-use `2.5.8` and overwrite the existing tag. Bumping to `2.5.9` locks the tcp-probe build to a distinct tag while keeping `:latest` as the deploy target.

## Verification
- `strings /usr/bin/caddy` inside the built image contains `tcp_probe_socket`, `TcpProbeSocket`, `X-TLS-Syn-Ns`, `X-TLS-Ack-Ns`, `X-TLS-Tcp-Mss`, `X-TLS-Tcp-Wscale`, `X-TLS-Tcp-Window`.
- Consumer PR (provider-side persistence): #3086.

## Test plan
- [ ] Nothing to run here — version-string bump. CI green from that alone.
- [ ] After merge, next pronode deploy pulls `prosopo/caddy:latest` and picks up the new binary. The `tcp_probe_socket` global option remains unset until a Caddyfile change adds it, so behaviour is unchanged until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)