### PR TITLE
fix(provider,types,types-database): drop `s` field from Session

### DIFF
--- a/.changeset/drop-s-field-from-session.md
+++ b/.changeset/drop-s-field-from-session.md
@@ -1,0 +1,19 @@
+---
+"@prosopo/provider": patch
+"@prosopo/types": patch
+"@prosopo/types-database": patch
+---
+
+fix(provider,types,types-database): drop the `s` field from `Session`,
+`DetectorResult`, and the mongoose `SessionRecordSchema`. The client
+no longer emits it, so the server-side wiring is redundant.
+
+Stop reading position 18 out of the decrypted client payload in
+`getBotScore`. Prune every `s`/`ss`/`sv` local, log field, and
+`createSession` argument in `frictionlessTasks.ts`, the origin-fallback
+merger in `captchaManager.ts`, the frictionless handler, and
+`submitPoWCaptchaSolution.ts`. Two `s`-focused unit tests removed.
+
+Backward-compatible: older clients still send position 18, the new
+server just ignores it. Existing Mongo docs keep their `s` values;
+mongoose stops projecting or writing the field. No migration needed.

--- a/packages/provider/src/api/captcha/getFrictionlessCaptchaChallenge/handler.ts
+++ b/packages/provider/src/api/captcha/getFrictionlessCaptchaChallenge/handler.ts
@@ -585,7 +585,6 @@ export default (
 				md,
 				bn,
 				fs,
-				s,
 				bundleId,
 			} = decryptedPayload;
 
@@ -694,7 +693,6 @@ export default (
 				...(md !== undefined && { md }),
 				...(bn !== undefined && { bn }),
 				...(fs !== undefined && { fs }),
-				...(s !== undefined && { s }),
 				...(req.tcpToChelloUs !== undefined && {
 					tcpToChelloUs: req.tcpToChelloUs,
 				}),

--- a/packages/provider/src/api/captcha/submitPoWCaptchaSolution.ts
+++ b/packages/provider/src/api/captcha/submitPoWCaptchaSolution.ts
@@ -336,7 +336,6 @@ export const buildEscalation = async (
 		originSession.md,
 		originSession.bn,
 		originSession.fs,
-		originSession.s,
 		// Raw signals for the current PoW-submit TCP connection — not the
 		// origin's. Escalation session belongs on this hop's fingerprint.
 		perConnectionSignals && {

--- a/packages/provider/src/tasks/captchaManager.ts
+++ b/packages/provider/src/tasks/captchaManager.ts
@@ -217,7 +217,6 @@ export class CaptchaManager {
 		const needsMd = session.md === undefined;
 		const needsBn = session.bn === undefined;
 		const needsFs = session.fs === undefined;
-		const needsS = session.s === undefined;
 
 		if (
 			!needsSimd &&
@@ -231,8 +230,7 @@ export class CaptchaManager {
 			!needsSw &&
 			!needsMd &&
 			!needsBn &&
-			!needsFs &&
-			!needsS
+			!needsFs
 		) {
 			return session;
 		}
@@ -269,7 +267,6 @@ export class CaptchaManager {
 			...(needsMd && origin.md !== undefined && { md: origin.md }),
 			...(needsBn && origin.bn !== undefined && { bn: origin.bn }),
 			...(needsFs && origin.fs !== undefined && { fs: origin.fs }),
-			...(needsS && origin.s !== undefined && { s: origin.s }),
 		};
 	}
 

--- a/packages/provider/src/tasks/detection/getBotScore.ts
+++ b/packages/provider/src/tasks/detection/getBotScore.ts
@@ -45,7 +45,6 @@ export const getBotScore = async (
 	const entropyMathRandomFirst: number | undefined =
 		result.entropyMathRandomFirst;
 	const g: string | undefined = result.g;
-	const s: string | undefined = result.s;
 	const i: boolean | undefined = result.i;
 	const sw: boolean | undefined = result.sw;
 	const md: boolean | undefined = result.md;
@@ -74,7 +73,6 @@ export const getBotScore = async (
 		entropyWallClockOffsetMs,
 		entropyMathRandomFirst,
 		g,
-		s,
 		i,
 		sw,
 		md,

--- a/packages/provider/src/tasks/frictionless/frictionlessTasks.ts
+++ b/packages/provider/src/tasks/frictionless/frictionlessTasks.ts
@@ -156,7 +156,6 @@ export class FrictionlessManager extends CaptchaManager {
 			fs: params.fs,
 			entropyMathRandomFirst: params.entropyMathRandomFirst,
 			g: params.g,
-			s: params.s,
 			i: params.i,
 			tcpToChelloUs: params.tcpToChelloUs,
 			chelloToHandshakeUs: params.chelloToHandshakeUs,
@@ -244,7 +243,6 @@ export class FrictionlessManager extends CaptchaManager {
 		md?: Session["md"],
 		bn?: Session["bn"],
 		fs?: Session["fs"],
-		s?: Session["s"],
 		// Bag of raw per-connection TCP-handshake signals (chaddy → ja4l-probe
 		// → provider). Kept as a bag rather than expanded into 9 positional
 		// params to avoid pushing createSession's arity past 40.
@@ -299,7 +297,6 @@ export class FrictionlessManager extends CaptchaManager {
 			entropyWallClockOffsetMs,
 			entropyMathRandomFirst,
 			g,
-			s,
 			i,
 			sw,
 			md,
@@ -471,7 +468,6 @@ export class FrictionlessManager extends CaptchaManager {
 			effectiveParams.md,
 			effectiveParams.bn,
 			effectiveParams.fs,
-			effectiveParams.s,
 			{
 				synNs: effectiveParams.synNs,
 				synackNs: effectiveParams.synackNs,
@@ -566,7 +562,6 @@ export class FrictionlessManager extends CaptchaManager {
 			effectiveParams.md,
 			effectiveParams.bn,
 			effectiveParams.fs,
-			effectiveParams.s,
 			{
 				synNs: effectiveParams.synNs,
 				synackNs: effectiveParams.synackNs,
@@ -726,7 +721,6 @@ export class FrictionlessManager extends CaptchaManager {
 		let md: boolean | undefined;
 		let bn: boolean | undefined;
 		let fs: boolean | undefined;
-		let ss: string | undefined;
 		for (const [keyIndex, attempt] of decryptKeys.entries()) {
 			try {
 				this.logger.info(() => ({
@@ -760,7 +754,6 @@ export class FrictionlessManager extends CaptchaManager {
 				const mdv = decrypted.md;
 				const bnv = decrypted.bn;
 				const fsv = decrypted.fs;
-				const sv = decrypted.s;
 				this.logger.debug(() => ({
 					msg: "Successfully decrypted score",
 					data: {
@@ -781,7 +774,6 @@ export class FrictionlessManager extends CaptchaManager {
 						md: mdv,
 						bn: bnv,
 						fs: fsv,
-						s: sv,
 					},
 				}));
 				baseBotScore = s;
@@ -802,7 +794,6 @@ export class FrictionlessManager extends CaptchaManager {
 				md = mdv;
 				bn = bnv;
 				fs = fsv;
-				ss = sv;
 				break;
 			} catch (err) {
 				// check if the next index exists, if not, log an error
@@ -849,7 +840,6 @@ export class FrictionlessManager extends CaptchaManager {
 				md,
 				bn,
 				fs,
-				s: ss,
 			},
 		}));
 
@@ -875,7 +865,6 @@ export class FrictionlessManager extends CaptchaManager {
 			md,
 			bn,
 			fs,
-			s: ss,
 			// The pool bundle used (if any) — promoted onto the session so the
 			// later behavioural-data hop can resolve the same keypair/inner cfg.
 			bundleId,

--- a/packages/provider/src/tests/unit/tasks/captchaManager.unit.test.ts
+++ b/packages/provider/src/tests/unit/tasks/captchaManager.unit.test.ts
@@ -174,7 +174,6 @@ describe("CaptchaManager", () => {
 				md: true,
 				bn: false,
 				fs: true,
-				s: "d",
 			} as unknown as Session;
 			dbGet().mockResolvedValue(session);
 
@@ -316,46 +315,6 @@ describe("CaptchaManager", () => {
 				await captchaManager.getSessionRecordWithOriginFallback("esc");
 
 			expect(got?.i).toBe(true);
-		});
-
-		it("fills s from origin when the escalation is missing it", async () => {
-			const origin = {
-				sessionId: "origin",
-				captchaType: CaptchaType.pow,
-				s: "A1B2C3D4",
-			} as unknown as Session;
-			const escalation = {
-				sessionId: "esc",
-				originSessionId: "origin",
-				captchaType: CaptchaType.puzzle,
-			} as unknown as Session;
-			dbGet().mockResolvedValueOnce(escalation).mockResolvedValueOnce(origin);
-
-			const got =
-				await captchaManager.getSessionRecordWithOriginFallback("esc");
-
-			expect(got?.s).toBe("A1B2C3D4");
-			expect(got?.sessionId).toBe("esc");
-		});
-
-		it("keeps the escalation's own s rather than the origin's", async () => {
-			const origin = {
-				sessionId: "origin",
-				captchaType: CaptchaType.pow,
-				s: "origin-s",
-			} as unknown as Session;
-			const escalation = {
-				sessionId: "esc",
-				originSessionId: "origin",
-				captchaType: CaptchaType.puzzle,
-				s: "escalation-s",
-			} as unknown as Session;
-			dbGet().mockResolvedValueOnce(escalation).mockResolvedValueOnce(origin);
-
-			const got =
-				await captchaManager.getSessionRecordWithOriginFallback("esc");
-
-			expect(got?.s).toBe("escalation-s");
 		});
 
 		it("does not fill anything when origin also lacks the fields", async () => {

--- a/packages/provider/src/tests/unit/tasks/detection/getBotScore.unit.test.ts
+++ b/packages/provider/src/tests/unit/tasks/detection/getBotScore.unit.test.ts
@@ -165,33 +165,6 @@ describe("getBotScore", () => {
 		expect(result.i).toBeUndefined();
 	});
 
-	it("passes s through", async () => {
-		const mockResult: DetectorResult = {
-			score: 0.5,
-			timestamp: 1234567890,
-			s: "A1B2C3D4",
-		} as unknown as DetectorResult;
-
-		vi.mocked(decodePayloadModule.default).mockResolvedValue(mockResult);
-
-		const result = await getBotScore("payload", "headHash");
-
-		expect(result.s).toBe("A1B2C3D4");
-	});
-
-	it("leaves s undefined when the client predates the field", async () => {
-		const mockResult: DetectorResult = {
-			score: 0.5,
-			timestamp: 1234567890,
-		} as unknown as DetectorResult;
-
-		vi.mocked(decodePayloadModule.default).mockResolvedValue(mockResult);
-
-		const result = await getBotScore("payload", "headHash");
-
-		expect(result.s).toBeUndefined();
-	});
-
 	it("handles isWebView as undefined", async () => {
 		const mockResult: DetectorResult = {
 			score: 0.5,

--- a/packages/types-database/src/types/provider.ts
+++ b/packages/types-database/src/types/provider.ts
@@ -792,7 +792,6 @@ export const SessionRecordSchema = new Schema<SessionRecord>({
 	entropyWallClockOffsetMs: { type: Number, required: false },
 	entropyMathRandomFirst: { type: Number, required: false },
 	g: { type: String, required: false },
-	s: { type: String, required: false },
 	i: { type: Boolean, required: false },
 	// Raw iOS WKWebView-vs-Safari DOM signals that the client-side
 	// classifier folds into `webView` (see @prosopo/types Session for

--- a/packages/types/src/provider/database.ts
+++ b/packages/types/src/provider/database.ts
@@ -494,7 +494,6 @@ export const SessionSchema = object({
 	entropyWallClockOffsetMs: number().optional(),
 	entropyMathRandomFirst: number().optional(),
 	g: string().optional(),
-	s: string().optional(),
 	i: boolean().optional(),
 	// Raw iOS WKWebView-vs-Safari DOM signals that the client-side
 	// classifier folds into `webView`. Persisted per session so
@@ -631,7 +630,6 @@ export type Session = {
 	entropyWallClockOffsetMs?: number;
 	entropyMathRandomFirst?: number;
 	g?: string;
-	s?: string;
 	i?: boolean;
 	// Raw iOS WKWebView-vs-Safari DOM signals — see SessionSchema above.
 	sw?: boolean;

--- a/packages/types/src/provider/detection.ts
+++ b/packages/types/src/provider/detection.ts
@@ -56,7 +56,6 @@ export type DetectorResult = {
 	entropyWallClockOffsetMs?: number;
 	entropyMathRandomFirst?: number;
 	g?: string;
-	s?: string;
 	i?: boolean;
 	// Raw iOS WKWebView-vs-Safari DOM signals (positions 14-17 in the client
 	// payload). Undefined for clients that predate the fields, or on non-iOS


### PR DESCRIPTION
## Summary
- Drop `s?: string` from `Session` (both zod `SessionSchema` + `Session` interface), `DetectorResult`, and the mongoose `SessionRecordSchema`.
- Stop reading `payloadParts[18]` in `getBotScore`.
- Prune every `s`/`ss`/`sv` local, log field, and `createSession` argument in `frictionlessTasks.ts`, the origin-fallback merger in `captchaManager.ts`, the frictionless handler, and `submitPoWCaptchaSolution.ts`.
- Delete two `s`-focused unit tests (in `getBotScore.unit.test.ts` and `captchaManager.unit.test.ts`).

## Why
The client no longer emits `s` on the frictionless payload (paired change: prosopo/captcha-private#4194), so the server-side wiring is redundant.

## Compatibility
Backward-compatible with older widgets in the wild: they still send position 18 on the wire, the new server just ignores it. Existing Mongo docs keep any `s` values they had; mongoose stops projecting or writing the field going forward. No migration required.

## Test plan
- [x] `npm run -w @prosopo/provider build:tsc` — clean
- [x] `npm run -w @prosopo/provider test:unit` — 75/75 files, 1101/1101 tests pass
- [x] `npm run -w @prosopo/types test`, `-w @prosopo/types-database test` — pass
- Integration test failures (`25 failed / 46 passed`) are pre-existing (`fetch failed` on ephemeral ports without full infra) — confirmed by stash-and-rerun baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)