### PR TITLE
chore(compose,caddyfile): wire tcp-probe sidecar into the provider stack

### DIFF
--- a/docker/docker-compose.provider.yml
+++ b/docker/docker-compose.provider.yml
@@ -144,6 +144,14 @@ services:
       - ./provider.Caddyfile:/etc/caddy/Caddyfile
       - caddy_data:/data
       - caddy_config:/config
+      # Shared with the tcp-probe sidecar (`tcp-probe` profile). Chaddy's
+      # `tcp_probe_socket` directive dials the sidecar's Unix socket
+      # here to look up raw TCP handshake signals for the current
+      # request and forward them as `X-TLS-*` headers. If the socket
+      # isn't there (sidecar not enabled) chaddy debug-logs and drops
+      # the extra headers per-request — Caddy startup is unaffected.
+      # `ro`: only the sidecar creates / writes the socket.
+      - /var/run/tcp-probe:/var/run/tcp-probe:ro
       # PEM for the load-balanced pronode.prosopo.io hostname. The cert
       # getter (pronode4) obtains it via certbot DNS-01 against Bunny,
       # then provider.yml's distribute step rsyncs it to every pronode
@@ -173,6 +181,62 @@ services:
       - 8.8.8.8
       - 1.1.1.1
       - 208.67.222.222
+  # eBPF sidecar that captures raw TCP handshake data (SYN / SYN-ACK / ACK)
+  # off the WAN interface and serves per-request lookups over a Unix socket.
+  # Chaddy (adjacent `caddy` service) reads that socket at accept() time and
+  # forwards the raw fields (`X-TLS-Syn-Ns`, `X-TLS-Observed-Ttl`, `X-TLS-Tcp-*`)
+  # onto the reverse-proxy request; the provider persists them onto the Session
+  # record. Nothing here is on by default: this service sits behind the
+  # `tcp-probe` profile so `docker compose --profile production` (which is
+  # what ansible sets today) does not pull or start it. Enable per host by
+  # appending `--profile tcp-probe` to the compose command AND publishing
+  # `prosopo/tcp-probe:${TCP_PROBE_IMAGE}` to Docker Hub — currently only
+  # built locally under `protect/tcp-probe`. See `deploy/DEPLOY.md` there
+  # for the bumblebee-side reference deployment; the same wire protocol
+  # (12-byte req, 80-byte reply) and image are reused here.
+  #
+  # `network_mode: host` is mandatory: XDP/TC hooks attach to real host
+  # interfaces, and the container-network veth wouldn't see the outside
+  # traffic. Caps are the minimum needed to load BPF programs and attach
+  # them; the probe never modifies traffic (XDP_PASS / TC_ACT_PIPE) so a
+  # crash cannot black-hole requests — worst case is the socket disappears
+  # and chaddy silently degrades to the pre-sidecar header set.
+  tcp-probe:
+    container_name: tcp-probe
+    profiles:
+      - tcp-probe
+    image: prosopo/tcp-probe:${TCP_PROBE_IMAGE:-latest}
+    network_mode: host
+    cap_add:
+      - BPF
+      - NET_ADMIN
+      - SYS_RESOURCE
+      - PERFMON
+    labels:
+      - "vector.tcp-probe=true"
+      - "vector.docker=true"
+    volumes:
+      # Host-side socket dir; caddy mounts the same path read-only so both
+      # containers see the same inode. Docker will create the dir if it
+      # doesn't exist yet.
+      - /var/run/tcp-probe:/var/run/tcp-probe
+    command:
+      - "--iface"
+      # Each pronode's WAN NIC name is different (contabo/hetzner/etc.);
+      # ansible sets TCP_PROBE_IFACE per-host in .env.1.$NODE_ENV.
+      - "${TCP_PROBE_IFACE}"
+      - "--port"
+      - "443"
+      - "--format"
+      - "jsonl"
+      - "--lookup-socket"
+      - "/var/run/tcp-probe/lookup.sock"
+    restart: unless-stopped
+    logging:
+      driver: 'json-file'
+      options:
+        max-size: '100m'
+        max-file: '1'
   redis-stack:
     container_name: redis-stack
     # unlike "redis/redis-stack-server" this image includes Insights

--- a/docker/provider.Caddyfile
+++ b/docker/provider.Caddyfile
@@ -62,6 +62,23 @@
 		max_client_hello_size 16384
 	}
 
+	# Per-request lookup against the tcp-probe eBPF sidecar's Unix socket.
+	# When the socket is present chaddy dials it at accept() time keyed on
+	# the client-side 4-tuple and forwards the raw handshake fields
+	# (`X-TLS-Syn-Ns` / `X-TLS-Synack-Ns` / `X-TLS-Ack-Ns` /
+	# `X-TLS-Observed-Ttl` / `X-TLS-Tcp-{Mss,Wscale,Opts-Flags,Opts-Order,
+	# Window}`) on the reverse-proxied request. The provider persists them
+	# onto Session records; downstream detection derives whatever timing /
+	# stack fingerprints it wants from these primitives at query time.
+	#
+	# The path is bind-mounted onto the caddy container from the host at
+	# the same location (see docker-compose.provider.yml). When the
+	# sidecar isn't running the file is simply absent; chaddy debug-logs
+	# the dial error per-request and drops the extra headers — Caddy
+	# startup is unaffected, so this directive is safe to leave in
+	# unconditionally on hosts without the sidecar.
+	tcp_probe_socket /var/run/tcp-probe/lookup.sock
+
 	servers {
 		protocols h1 h2
 		# Order matters: proxy_protocol must run before tls so the


### PR DESCRIPTION
## Summary

Adds the compose + Caddyfile scaffolding for the `tcp-probe` eBPF sidecar (paired with chaddy's `tcp_probe_socket` global option shipped in `prosopo/caddy:2.5.9`). Zero runtime impact on existing hosts — behind a new `tcp-probe` docker-compose profile.

## Changes

- `docker/docker-compose.provider.yml`
  - New `tcp-probe` service: `profiles: [tcp-probe]`, `network_mode: host`, caps `BPF / NET_ADMIN / SYS_RESOURCE / PERFMON`, reads `TCP_PROBE_IFACE` per-host, serves `/var/run/tcp-probe/lookup.sock`.
  - `caddy` service gets a read-only bind mount of `/var/run/tcp-probe:/var/run/tcp-probe:ro` so chaddy can dial the socket.
- `docker/provider.Caddyfile`
  - Global `tcp_probe_socket /var/run/tcp-probe/lookup.sock` directive. Chaddy dials it per-request; when the sidecar isn't running chaddy debug-logs and drops the extra `X-TLS-*` headers — Caddy startup is unaffected.

## No-op today

- `docker compose --profile production` (what ansible sets) does **not** include the `tcp-probe` service — verified locally (`config --services` returns the same 8 services as main). No pull of `prosopo/tcp-probe` will be attempted on next deploy.
- Caddy always gets the bind mount; if the host dir doesn't exist Docker creates it empty.
- Caddy always gets the `tcp_probe_socket` directive; if the socket file doesn't exist, per-request dial fails and headers are dropped.

## Opting in on a host

1. Ansible appends `--profile tcp-probe` to `docker compose pull|up` commands (separate PR against captcha-private).
2. `prosopo/tcp-probe:${TCP_PROBE_IMAGE:-latest}` must be published to Docker Hub before enabling — currently only builds locally under `protect/tcp-probe`.
3. Per-host `TCP_PROBE_IFACE` set to the WAN NIC name.

## Test plan

- [ ] Not testable in CI — needs live TLS traffic on a WAN NIC with the eBPF probe attached to observe the forwarded headers. Verify in staging after the ansible-side toggle lands and the image is published.

Merging without tests per repo owner's direction: no runtime impact until the profile is enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)