### PR TITLE
fix(provider): raise MAX_NS cap in rawTlsSignalsMiddleware

### DIFF
--- a/.changeset/caddyfile-tcp-probe-socket-inside-client-hello.md
+++ b/.changeset/caddyfile-tcp-probe-socket-inside-client-hello.md
@@ -1,0 +1,13 @@
+---
+"@prosopo/caddy-docker": patch
+---
+
+fix(caddyfile): move `tcp_probe_socket` inside the `client_hello` block
+
+Chaddy's caddyfile parser registers `client_hello` as the caddyfile
+global option and reads `tcp_probe_socket` as a sub-key inside that
+block. v3.7.17 placed the directive at top-level global scope, which
+caddy's config-adapter rejects with `unrecognized global option:
+tcp_probe_socket` — caddy exits 1 at startup and the container
+restart-loops. Move the directive into `client_hello { … }` so it is
+parsed by the plugin instead of the caddy core.

--- a/.changeset/raw-tls-ns-cap-too-small.md
+++ b/.changeset/raw-tls-ns-cap-too-small.md
@@ -1,0 +1,18 @@
+---
+"@prosopo/provider": patch
+---
+
+fix(provider): raise MAX_NS cap in rawTlsSignalsMiddleware so long-uptime
+hosts don't lose the kernel monotonic timestamps
+
+Kernel `bpf_ktime_get_ns()` crosses `Number.MAX_SAFE_INTEGER` (2^53)
+after ~104 days of uptime. The v3.7.17 middleware capped at that
+ceiling, so on any pronode with a longer uptime every `synNs` /
+`synackNs` / `ackNs` header was rejected as malformed and the raw
+timings never reached the Session record. Confirmed on staging where
+the first pronode had ~119 days of uptime — every incoming request
+logged `Ignoring malformed raw TLS signal header` for the three ns
+fields while the TTL / MSS / wscale / opts / window fields landed
+fine. Cap at 2^63 so real timestamps get through; downstream
+consumers subtract before use, so the ns-level precision loss above
+2^53 is a non-issue.

--- a/docker/provider.Caddyfile
+++ b/docker/provider.Caddyfile
@@ -60,24 +60,32 @@
 	client_hello {
 		# Configure the maximum allowed ClientHello packet size in bytes (1-16384)
 		max_client_hello_size 16384
+		# Per-request lookup against the tcp-probe eBPF sidecar's Unix
+		# socket. When the socket is present chaddy dials it at accept()
+		# time keyed on the client-side 4-tuple and forwards the raw
+		# handshake fields (`X-TLS-Syn-Ns` / `X-TLS-Synack-Ns` /
+		# `X-TLS-Ack-Ns` / `X-TLS-Observed-Ttl` /
+		# `X-TLS-Tcp-{Mss,Wscale,Opts-Flags,Opts-Order,Window}`) on the
+		# reverse-proxied request. The provider persists them onto Session
+		# records; downstream detection derives whatever timing / stack
+		# fingerprints it wants from these primitives at query time.
+		#
+		# Chaddy registers `client_hello` as the caddyfile global option
+		# (`httpcaddyfile.RegisterGlobalOption("client_hello", ...)`),
+		# and `tcp_probe_socket` is parsed as a sub-key of that block —
+		# NOT as its own top-level global. Putting it at global scope
+		# fails config-adapt with `unrecognized global option:
+		# tcp_probe_socket` and caddy crash-loops. Confirmed the hard way
+		# on staging after v3.7.17 — do not move it back out.
+		#
+		# The path is bind-mounted onto the caddy container from the host
+		# (see docker-compose.provider.yml). When the sidecar isn't
+		# running the file is simply absent; chaddy debug-logs the dial
+		# error per-request and drops the extra headers — Caddy startup
+		# is unaffected, so this directive is safe to leave in
+		# unconditionally on hosts without the sidecar.
+		tcp_probe_socket /var/run/tcp-probe/lookup.sock
 	}
-
-	# Per-request lookup against the tcp-probe eBPF sidecar's Unix socket.
-	# When the socket is present chaddy dials it at accept() time keyed on
-	# the client-side 4-tuple and forwards the raw handshake fields
-	# (`X-TLS-Syn-Ns` / `X-TLS-Synack-Ns` / `X-TLS-Ack-Ns` /
-	# `X-TLS-Observed-Ttl` / `X-TLS-Tcp-{Mss,Wscale,Opts-Flags,Opts-Order,
-	# Window}`) on the reverse-proxied request. The provider persists them
-	# onto Session records; downstream detection derives whatever timing /
-	# stack fingerprints it wants from these primitives at query time.
-	#
-	# The path is bind-mounted onto the caddy container from the host at
-	# the same location (see docker-compose.provider.yml). When the
-	# sidecar isn't running the file is simply absent; chaddy debug-logs
-	# the dial error per-request and drops the extra headers — Caddy
-	# startup is unaffected, so this directive is safe to leave in
-	# unconditionally on hosts without the sidecar.
-	tcp_probe_socket /var/run/tcp-probe/lookup.sock
 
 	servers {
 		protocols h1 h2

--- a/packages/provider/src/api/rawTlsSignalsMiddleware.ts
+++ b/packages/provider/src/api/rawTlsSignalsMiddleware.ts
@@ -97,11 +97,16 @@ const parseIntHeader = (
 };
 
 // Kernel monotonic ns bumps into Number.MAX_SAFE_INTEGER (2^53) territory
-// after ~104 days of uptime. In practice servers rarely exceed that in a
-// single boot window and JS Number handles it cleanly up to that ceiling.
-// Cap at MAX_SAFE_INTEGER so any bogus value is rejected instead of being
-// silently truncated.
-const MAX_NS = Number.MAX_SAFE_INTEGER;
+// after ~104 days of uptime and hosts stay up longer than that (staging
+// caught the bug immediately — first pronode had ~119-day uptime and
+// every syn_ns / synack_ns / ack_ns was rejected as malformed, wiping
+// the raw timings from every Session record). Cap at 2^63 so bogus
+// values (negatives, non-numeric text) are still rejected but real
+// long-uptime timestamps land. Values above 2^53 lose ~ns precision on
+// storage (Mongo Double follows IEEE-754 like Number), which is fine
+// since every consumer subtracts them before use — a delta of two
+// low-nanosecond noise floors carries no useful information anyway.
+const MAX_NS = 2 ** 63;
 const MAX_U8 = 255;
 const MAX_U16 = 65535;
 const MAX_U32 = 4_294_967_295;


### PR DESCRIPTION
Kernel bpf_ktime_get_ns crosses 2^53 after ~104 days uptime; middleware was rejecting every synNs/synackNs/ackNs on staging pronode2 (119-day uptime). Raise cap to 2^63.