### PR TITLE
feat(puzzle): randomise piece size, shape family and decoy depth

### DIFF
--- a/.changeset/puzzle-piece-randomisation.md
+++ b/.changeset/puzzle-piece-randomisation.md
@@ -1,0 +1,6 @@
+---
+"@prosopo/types": patch
+"@prosopo/provider": patch
+---
+
+Randomise puzzle piece size, silhouette family, and decoy depth. New per-client `puzzle.pieceScale.{min,max}` and `puzzle.decoyHoleDarken` settings on `ClientSettingsSchema`; defaults preserve behaviour where possible.

--- a/packages/provider/src/api/captcha/getPuzzleCaptchaChallenge.ts
+++ b/packages/provider/src/api/captcha/getPuzzleCaptchaChallenge.ts
@@ -29,6 +29,7 @@ import type { AugmentedRequest } from "../../express.js";
 import { Tasks } from "../../tasks/index.js";
 import {
 	renderPuzzleImages,
+	resolvePuzzlePieceSize,
 	resolvePuzzleRenderSettings,
 } from "../../tasks/puzzle/puzzleRenderer.js";
 import { normalizeRequestIp } from "../../utils/normalizeRequestIp.js";
@@ -211,6 +212,14 @@ export default (
 				clientSettings?.settings?.puzzle,
 				trafficPuzzleSettings,
 			);
+			// Piece size is drawn per-challenge from the effective scale
+			// range so a solver can't hard-code the expected silhouette
+			// scale. Uses the same layered client / traffic-filter override
+			// order as the render settings above.
+			const effectivePieceSize = resolvePuzzlePieceSize(
+				clientSettings?.settings?.puzzle,
+				trafficPuzzleSettings,
+			);
 			const challenge =
 				await tasks.puzzleCaptchaManager.getPuzzleCaptchaChallenge(
 					user,
@@ -267,6 +276,7 @@ export default (
 					targetY: challenge.targetY,
 				},
 				effectivePuzzleSettings,
+				effectivePieceSize,
 			);
 
 			const getPuzzleCaptchaResponse: GetPuzzleCaptchaResponse = {

--- a/packages/provider/src/tasks/puzzle/puzzleRenderer.ts
+++ b/packages/provider/src/tasks/puzzle/puzzleRenderer.ts
@@ -21,7 +21,12 @@ import {
 	renderPuzzle,
 	toDataUri,
 } from "@prosopo/puzzle-assets";
-import { CaptchaType, type IPuzzleSettings } from "@prosopo/types";
+import {
+	CaptchaType,
+	type IPuzzleSettings,
+	puzzlePieceScaleMaxDefault,
+	puzzlePieceScaleMinDefault,
+} from "@prosopo/types";
 import {
 	getPuzzleBackgroundBuffer,
 	initPuzzleBackgroundBuffer,
@@ -60,8 +65,91 @@ export const resolvePuzzleRenderSettings = (
 		if (override.holeDarken !== undefined) {
 			resolved = { ...resolved, holeDarken: override.holeDarken };
 		}
+		if (override.decoyHoleDarken !== undefined) {
+			resolved = { ...resolved, decoyHoleDarken: override.decoyHoleDarken };
+		}
 	}
 	return resolved;
+};
+
+/**
+ * Number of size buckets used for stratified sampling. The scale range is
+ * split into this many equal windows; every window is visited once per
+ * cycle before the sequence repeats, so a short run of challenges is
+ * guaranteed to span the full range rather than clustering by chance.
+ */
+const PIECE_SIZE_BUCKETS = 8;
+
+// In-process interleaved order the buckets are visited in. Rebuilt at each
+// cycle so consecutive requests strictly alternate between the small half
+// (buckets 0..N/2−1) and the large half (buckets N/2..N−1). Pure shuffle
+// still permits runs of adjacent buckets ("three large in a row" by
+// chance); interleaving forbids that by construction.
+let pieceSizeBucketOrder: number[] = [];
+let pieceSizeBucketCursor = 0;
+
+const shuffleArray = <T>(input: T[]): T[] => {
+	const out = [...input];
+	for (let i = out.length - 1; i > 0; i--) {
+		const j = Math.floor(Math.random() * (i + 1));
+		const tmp = out[i] as T;
+		out[i] = out[j] as T;
+		out[j] = tmp;
+	}
+	return out;
+};
+
+const buildBucketOrder = (): number[] => {
+	const half = PIECE_SIZE_BUCKETS >> 1;
+	const smallHalf = shuffleArray(Array.from({ length: half }, (_, i) => i));
+	const largeHalf = shuffleArray(
+		Array.from({ length: half }, (_, i) => i + half),
+	);
+	// Randomise which half opens the cycle so the pattern is not always
+	// small-then-large across cycle boundaries.
+	const [first, second] =
+		Math.random() < 0.5 ? [smallHalf, largeHalf] : [largeHalf, smallHalf];
+	const order: number[] = [];
+	for (let i = 0; i < half; i++) {
+		order.push(first[i] as number);
+		order.push(second[i] as number);
+	}
+	return order;
+};
+
+/**
+ * Resolve the effective piece scale range from the same layered
+ * client-settings / traffic-filter overrides used for render settings, and
+ * draw a per-challenge piece size in pixels. Stratified over
+ * `PIECE_SIZE_BUCKETS` windows so the distribution is evenly spread across
+ * the range even for short bursts of requests. Rounded to an integer
+ * because the pixel buffer is allocated as `size * size * 4`.
+ */
+export const resolvePuzzlePieceSize = (
+	...overrides: (IPuzzleSettings | undefined)[]
+): number => {
+	let min = puzzlePieceScaleMinDefault;
+	let max = puzzlePieceScaleMaxDefault;
+	for (const override of overrides) {
+		if (!override?.pieceScale) continue;
+		if (override.pieceScale.min !== undefined) min = override.pieceScale.min;
+		if (override.pieceScale.max !== undefined) max = override.pieceScale.max;
+	}
+	// Defend against a partial override that inverts the range (e.g. only
+	// `min` set, above the default `max`).
+	if (min > max) min = max;
+	if (pieceSizeBucketCursor >= pieceSizeBucketOrder.length) {
+		pieceSizeBucketOrder = buildBucketOrder();
+		pieceSizeBucketCursor = 0;
+	}
+	const bucket = pieceSizeBucketOrder[pieceSizeBucketCursor] as number;
+	pieceSizeBucketCursor++;
+	// Uniform sample within the bucket → uniform overall across the range,
+	// with a guaranteed spread across any N consecutive samples where
+	// N ≥ PIECE_SIZE_BUCKETS and no monotonic runs of large or small sizes.
+	const u = (bucket + Math.random()) / PIECE_SIZE_BUCKETS;
+	const scale = min + u * (max - min);
+	return Math.max(1, Math.round(DEFAULT_GEOMETRY.width * scale));
 };
 
 /**
@@ -105,6 +193,7 @@ export const downgradePuzzleIfUnavailable = <T extends CaptchaType>(
 export const renderPuzzleImages = async (
 	placement: NotchPlacement,
 	settings: PuzzleRenderSettings = DEFAULT_RENDER_SETTINGS,
+	pieceSize?: number,
 ): Promise<RenderedPuzzleImages> => {
 	const buffer = getPuzzleBackgroundBuffer() ?? initPuzzleBackgroundBuffer();
 	const background = buffer.take();
@@ -115,7 +204,9 @@ export const renderPuzzleImages = async (
 	const rendered = await renderPuzzle(
 		background,
 		placement,
-		DEFAULT_GEOMETRY,
+		pieceSize !== undefined
+			? { ...DEFAULT_GEOMETRY, pieceSize }
+			: DEFAULT_GEOMETRY,
 		settings,
 	);
 

--- a/packages/puzzle-assets/src/compose.ts
+++ b/packages/puzzle-assets/src/compose.ts
@@ -61,14 +61,21 @@ const PIECE_EDGE_LIGHT = 8;
 
 const clamp255 = (v: number): number => (v < 0 ? 0 : v > 255 ? 255 : v);
 
-const sampleClamped = (
+/**
+ * Sample the background at `(x, y)`. Returns `null` when the coordinate
+ * sits outside the frame — the piece is clipped at the boundary rather
+ * than filled from a clamped edge pixel, so a piece whose placement
+ * overhangs the frame simply loses those pixels.
+ */
+const sampleBackground = (
 	image: RgbaImage,
 	x: number,
 	y: number,
-): [number, number, number] => {
-	const cx = x < 0 ? 0 : x >= image.width ? image.width - 1 : x;
-	const cy = y < 0 ? 0 : y >= image.height ? image.height - 1 : y;
-	const i = (cy * image.width + cx) * 4;
+): [number, number, number] | null => {
+	if (x < 0 || y < 0 || x >= image.width || y >= image.height) {
+		return null;
+	}
+	const i = (y * image.width + x) * 4;
 	return [image.data[i] ?? 0, image.data[i + 1] ?? 0, image.data[i + 2] ?? 0];
 };
 
@@ -115,7 +122,14 @@ export const cutNotch = (
 				continue;
 			}
 
-			const [r, g, b] = sampleClamped(background, left + lx, top + ly);
+			const sample = sampleBackground(background, left + lx, top + ly);
+			if (sample === null) {
+				// Piece extends past the frame — leave this pixel transparent
+				// so the overhang doesn't smear the edge colour outward.
+				pieceData[pi + 3] = 0;
+				continue;
+			}
+			const [r, g, b] = sample;
 
 			// A bright rim just inside the edge makes the piece read as a
 			// raised object rather than a flat sticker.

--- a/packages/puzzle-assets/src/decoys.ts
+++ b/packages/puzzle-assets/src/decoys.ts
@@ -52,6 +52,12 @@ const distanceSquared = (
 };
 
 /**
+ * Depth cue on decoys, mirroring `HOLE_INNER_SHADOW` in `compose.ts`.
+ * Smaller so decoys read as shallower cuts than the real hole.
+ */
+const DECOY_INNER_SHADOW = 0.35;
+
+/**
  * Composite a jigsaw-shaped decoration onto `background`, centred on
  * `(cx, cy)`. Mutates `background`. Runs the same signed-distance sampling
  * as the real cut, so the silhouette reads as the same family of shapes.
@@ -64,6 +70,7 @@ export const paintDecoyPiece = (
 	cy: number,
 	edgeDarkness: number,
 	bodyBrightness: number,
+	holeDarken: number,
 ): void => {
 	const shape = createNotchShape(prng, size);
 	const half = size / 2;
@@ -88,16 +95,29 @@ export const paintDecoyPiece = (
 			const g = background.data[bi + 1] ?? 0;
 			const b = background.data[bi + 2] ?? 0;
 
-			// Dark rim just inside the silhouette, matching the direction of
-			// the real cutout's inner shadow so decoys can't be visually
-			// dismissed as "obviously raised". Ramps from zero at 3px inside
-			// up to full amplitude at the edge.
+			// Multiplicative darken with an inner shadow, matching the real
+			// cut's structure. Without this, decoys were just faint edge
+			// tints and the real hole stood out as the only deep region on
+			// the frame — trivially findable by eye or by luminance.
+			const edge = d > -3 ? DECOY_INNER_SHADOW * (1 + d / 3) : 0;
+			const factor = holeDarken * (1 - edge);
+			const dr = r * factor;
+			const dg = g * factor;
+			const db = b * factor;
+
+			// Existing additive tweak stays on top, so operators keep the
+			// same rim / body knobs — they now fine-tune the multiplicative
+			// base rather than being the sole depth cue.
 			const edgeDark = d > -3 ? edgeDarkness * (1 + d / 3) : 0;
 			const delta = bodyBrightness - edgeDark;
 
-			background.data[bi] = clamp255(Math.round(r + delta * coverage));
-			background.data[bi + 1] = clamp255(Math.round(g + delta * coverage));
-			background.data[bi + 2] = clamp255(Math.round(b + delta * coverage));
+			const mixR = r * (1 - coverage) + dr * coverage;
+			const mixG = g * (1 - coverage) + dg * coverage;
+			const mixB = b * (1 - coverage) + db * coverage;
+
+			background.data[bi] = clamp255(Math.round(mixR + delta * coverage));
+			background.data[bi + 1] = clamp255(Math.round(mixG + delta * coverage));
+			background.data[bi + 2] = clamp255(Math.round(mixB + delta * coverage));
 		}
 	}
 };
@@ -126,6 +146,7 @@ export const paintDecoys = (
 	notch: NotchPlacement,
 	edgeDarkness: number,
 	bodyBrightness: number,
+	holeDarken: number,
 ): void => {
 	if (targetCount <= 0) return;
 
@@ -135,13 +156,14 @@ export const paintDecoys = (
 	if (count === 0) return;
 
 	const notchClearanceSq = (notchSize * NOTCH_CLEARANCE) ** 2;
-	const half = notchSize / 2;
-	// Keep the whole bounding box inside the frame so decoys never clip.
-	const minX = half;
-	const maxX = background.width - half;
-	const minY = half;
-	const maxY = background.height - half;
-	if (maxX <= minX || maxY <= minY) return;
+	// Centre may sit anywhere on the frame; a decoy that overhangs the edge
+	// is clipped by `paintDecoyPiece`, matching the real piece's overhang
+	// behaviour. Without this, large pieces would render zero decoys because
+	// `notchSize/2` exceeds the frame dimensions.
+	const minX = 0;
+	const maxX = background.width;
+	const minY = 0;
+	const maxY = background.height;
 
 	for (let i = 0; i < count; i++) {
 		for (let attempt = 0; attempt < PLACEMENT_ATTEMPTS; attempt++) {
@@ -161,6 +183,7 @@ export const paintDecoys = (
 				cy,
 				edgeDarkness,
 				bodyBrightness,
+				holeDarken,
 			);
 			break;
 		}

--- a/packages/puzzle-assets/src/index.ts
+++ b/packages/puzzle-assets/src/index.ts
@@ -65,6 +65,7 @@ export const DEFAULT_RENDER_SETTINGS: PuzzleRenderSettings = {
 	decoyEdgeDarkness: 20,
 	decoyBodyBrightness: 4,
 	holeDarken: 0.55,
+	decoyHoleDarken: 0.7,
 };
 
 /**
@@ -90,23 +91,27 @@ export const renderPuzzle = async (
 	settings: PuzzleRenderSettings = DEFAULT_RENDER_SETTINGS,
 ): Promise<RenderedPuzzle> => {
 	const prng = createPrng(createSeed());
+	const pieceSize = geometry.pieceSize ?? geometry.notchSize;
 	// Decoys go on first so the real cut sits on top of any overlap and
-	// always reads as the deepest, darkest region on the board.
+	// always reads as the deepest, darkest region on the board. Decoys use
+	// the same size as the real piece so a solver can't key on scale to
+	// disambiguate the target.
 	paintDecoys(
 		background,
 		prng,
 		settings.decoyCount,
-		geometry.notchSize,
+		pieceSize,
 		placement,
 		settings.decoyEdgeDarkness,
 		settings.decoyBodyBrightness,
+		settings.decoyHoleDarken,
 	);
-	const shape = createNotchShape(prng, geometry.notchSize);
+	const shape = createNotchShape(prng, pieceSize);
 	const { background: cut, piece } = cutNotch(
 		prng,
 		background,
 		shape,
-		geometry.notchSize,
+		pieceSize,
 		placement,
 		settings.holeDarken,
 	);
@@ -119,7 +124,7 @@ export const renderPuzzle = async (
 	return {
 		background: backgroundWebp,
 		piece: pieceWebp,
-		pieceSize: geometry.notchSize,
+		pieceSize,
 	};
 };
 

--- a/packages/puzzle-assets/src/notch.ts
+++ b/packages/puzzle-assets/src/notch.ts
@@ -60,7 +60,7 @@ const roundedBoxDistance = (
 	return outside + inside - radius;
 };
 
-export const createNotchShape = (prng: Prng, size: number): NotchShape => {
+const createJigsawShape = (prng: Prng, size: number): NotchShape => {
 	// The body is inset so the knob can protrude without leaving the bounding
 	// box — the caller places the box, not the body.
 	const knobRadius = size * prng.range(0.15, 0.19);
@@ -96,6 +96,118 @@ export const createNotchShape = (prng: Prng, size: number): NotchShape => {
 			return d;
 		},
 	};
+};
+
+const createCircleShape = (prng: Prng, size: number): NotchShape => {
+	const radius = (size / 2) * prng.range(0.85, 0.98);
+	const cx = size / 2;
+	const cy = size / 2;
+	return {
+		distance(lx: number, ly: number): number {
+			return Math.hypot(lx - cx, ly - cy) - radius;
+		},
+	};
+};
+
+const createRoundedRectShape = (prng: Prng, size: number): NotchShape => {
+	// One axis fills the box; the other is squashed by a random aspect ratio.
+	// Randomising which axis gets squashed avoids a landscape-only bias.
+	const aspect = prng.range(0.5, 1.0);
+	const halfMax = (size / 2) * prng.range(0.82, 0.98);
+	const [halfW, halfH] =
+		prng.next() < 0.5
+			? [halfMax, halfMax * aspect]
+			: [halfMax * aspect, halfMax];
+	const cornerRadius = Math.min(halfW, halfH) * prng.range(0.08, 0.5);
+	const cx = size / 2;
+	const cy = size / 2;
+	return {
+		distance(lx: number, ly: number): number {
+			const px = lx - cx;
+			const py = ly - cy;
+			const qx = Math.abs(px) - halfW + cornerRadius;
+			const qy = Math.abs(py) - halfH + cornerRadius;
+			const outside = Math.hypot(Math.max(qx, 0), Math.max(qy, 0));
+			const inside = Math.min(Math.max(qx, qy), 0);
+			return outside + inside - cornerRadius;
+		},
+	};
+};
+
+const createPolygonShape = (prng: Prng, size: number): NotchShape => {
+	// Random regular polygon (triangle through octagon), rotated arbitrarily.
+	// SDF is max-of-halfplanes: exact at the boundary and inside, slightly
+	// approximate for far-outside points — fine for the 1-pixel anti-aliased
+	// coverage band. Edge normals are precomputed so the per-pixel loop is a
+	// tight sum-and-max over a handful of values.
+	const n = prng.int(3, 8);
+	const radius = (size / 2) * prng.range(0.85, 0.98);
+	const inradius = radius * Math.cos(Math.PI / n);
+	const rotation = prng.next() * Math.PI * 2;
+	const normals: [number, number][] = [];
+	for (let i = 0; i < n; i++) {
+		// Start at the top and go around; edge i's outward normal points at
+		// angle (2πi/n − π/2) from the +x axis, rotated by `rotation`.
+		const angle = (2 * Math.PI * i) / n - Math.PI / 2 + rotation;
+		normals.push([Math.cos(angle), Math.sin(angle)]);
+	}
+	const cx = size / 2;
+	const cy = size / 2;
+	return {
+		distance(lx: number, ly: number): number {
+			const px = lx - cx;
+			const py = ly - cy;
+			let maxD = Number.NEGATIVE_INFINITY;
+			for (const [nx, ny] of normals) {
+				const d = px * nx + py * ny - inradius;
+				if (d > maxD) maxD = d;
+			}
+			return maxD;
+		},
+	};
+};
+
+const createFlowerShape = (prng: Prng, size: number): NotchShape => {
+	// Sinusoidal boundary: r(θ) = rAvg + rAmp·cos(nθ + φ). Reads as a soft
+	// flower / gear silhouette. Kept smooth (no sharp inner points) so the
+	// coverage sampler doesn't misread narrow petals.
+	const petals = prng.int(4, 8);
+	const rAvg = (size / 2) * prng.range(0.72, 0.88);
+	const rAmp = rAvg * prng.range(0.1, 0.22);
+	const phase = prng.next() * Math.PI * 2;
+	const cx = size / 2;
+	const cy = size / 2;
+	return {
+		distance(lx: number, ly: number): number {
+			const px = lx - cx;
+			const py = ly - cy;
+			const len = Math.hypot(px, py);
+			const angle = Math.atan2(py, px);
+			const r = rAvg + rAmp * Math.cos(petals * angle + phase);
+			return len - r;
+		},
+	};
+};
+
+/**
+ * Pick a random shape family per call. The real piece and its hole are cut
+ * from the same call so they match; decoys each call independently so they
+ * form a mixed field of silhouettes on the frame.
+ */
+export const createNotchShape = (prng: Prng, size: number): NotchShape => {
+	const family = prng.int(0, 4);
+	switch (family) {
+		case 0:
+			return createJigsawShape(prng, size);
+		case 1:
+			return createCircleShape(prng, size);
+		case 2:
+			return createRoundedRectShape(prng, size);
+		case 3:
+			return createPolygonShape(prng, size);
+		default:
+			return createFlowerShape(prng, size);
+	}
 };
 
 /**

--- a/packages/puzzle-assets/src/tests/puzzleAssets.unit.test.ts
+++ b/packages/puzzle-assets/src/tests/puzzleAssets.unit.test.ts
@@ -15,7 +15,7 @@
 import { describe, expect, it } from "vitest";
 import { generateBackground } from "../background.js";
 import { cutNotch } from "../compose.js";
-import { paintDecoys } from "../decoys.js";
+import { paintDecoyPiece, paintDecoys } from "../decoys.js";
 import {
 	DEFAULT_GEOMETRY,
 	DEFAULT_RENDER_SETTINGS,
@@ -182,6 +182,45 @@ describe("cutNotch", () => {
 		expect(piece.data[3] ?? 255).toBeLessThan(128);
 	});
 
+	it("clips the piece to transparent where the placement overhangs the frame", () => {
+		// Place the notch centred on the top-right corner: roughly a
+		// quarter of the bounding box sits inside the frame; the rest
+		// hangs off. Every piece pixel outside the frame must be
+		// transparent — the sampler no longer clamps to the edge.
+		const prng = createPrng(SEED_A);
+		const bg = createBackground(geometry);
+		const shape = createNotchShape(prng, geometry.notchSize);
+		const overhangPlacement = {
+			targetX: geometry.width,
+			targetY: 0,
+		};
+		const { piece } = cutNotch(
+			prng,
+			bg,
+			shape,
+			geometry.notchSize,
+			overhangPlacement,
+			DEFAULT_RENDER_SETTINGS.holeDarken,
+		);
+
+		const half = geometry.notchSize / 2;
+		const left = Math.round(overhangPlacement.targetX - half);
+		const top = Math.round(overhangPlacement.targetY - half);
+		let outOfFrameOpaque = 0;
+		for (let ly = 0; ly < geometry.notchSize; ly++) {
+			for (let lx = 0; lx < geometry.notchSize; lx++) {
+				const bx = left + lx;
+				const by = top + ly;
+				const inFrame =
+					bx >= 0 && by >= 0 && bx < geometry.width && by < geometry.height;
+				if (inFrame) continue;
+				const alpha = piece.data[(ly * geometry.notchSize + lx) * 4 + 3] ?? 0;
+				if (alpha !== 0) outOfFrameOpaque++;
+			}
+		}
+		expect(outOfFrameOpaque).toBe(0);
+	});
+
 	it("does not reproduce the background pixel-exactly in the piece", () => {
 		// The anti-correlation defence: an exact copy would let an attacker
 		// locate the target by sliding the piece over the background.
@@ -238,6 +277,16 @@ describe("renderPuzzle", () => {
 		expect(rendered.pieceSize).toBe(DEFAULT_GEOMETRY.notchSize);
 	});
 
+	it("honors a `pieceSize` override independently of `notchSize`", async () => {
+		const overrideSize = 180;
+		const rendered = await renderPuzzle(
+			createBackground(),
+			{ targetX: 150, targetY: 100 },
+			{ ...DEFAULT_GEOMETRY, pieceSize: overrideSize },
+		);
+		expect(rendered.pieceSize).toBe(overrideSize);
+	});
+
 	it("stays small enough to inline as a data uri", async () => {
 		const rendered = await renderPuzzle(createBackground(), {
 			targetX: 200,
@@ -272,7 +321,8 @@ describe("background brightness", () => {
 
 describe("paintDecoys", () => {
 	const notch = { targetX: 220, targetY: 140 };
-	const { decoyEdgeDarkness, decoyBodyBrightness } = DEFAULT_RENDER_SETTINGS;
+	const { decoyEdgeDarkness, decoyBodyBrightness, decoyHoleDarken } =
+		DEFAULT_RENDER_SETTINGS;
 
 	it("is a no-op for count <= 0", () => {
 		const bg = generateBackground(createPrng(SEED_A), 300, 200);
@@ -285,6 +335,7 @@ describe("paintDecoys", () => {
 			notch,
 			decoyEdgeDarkness,
 			decoyBodyBrightness,
+			decoyHoleDarken,
 		);
 		expect(bg.data.equals(before)).toBe(true);
 	});
@@ -300,6 +351,7 @@ describe("paintDecoys", () => {
 			notch,
 			decoyEdgeDarkness,
 			decoyBodyBrightness,
+			decoyHoleDarken,
 		);
 		expect(bg.data.equals(before)).toBe(false);
 	});
@@ -315,6 +367,7 @@ describe("paintDecoys", () => {
 			notch,
 			decoyEdgeDarkness,
 			decoyBodyBrightness,
+			decoyHoleDarken,
 		);
 		paintDecoys(
 			bg2,
@@ -324,23 +377,37 @@ describe("paintDecoys", () => {
 			notch,
 			decoyEdgeDarkness,
 			decoyBodyBrightness,
+			decoyHoleDarken,
 		);
 		expect(bg1.data.equals(bg2.data)).toBe(true);
 	});
 
-	it("respects edgeDarkness — zero leaves the background unchanged if body is zero too", () => {
+	// holeDarken == 0 collapses every decoy body to full black in the
+	// interior. Guards the multiplicative path — a regression that reverts
+	// decoys to the pre-hole-darken additive shift only would still tint the
+	// pixels but never reach zero. Uses `paintDecoyPiece` directly so the
+	// centre pixel is deterministic (`paintDecoys` scatters randomly).
+	it("blackens the decoy interior when holeDarken is zero", () => {
 		const bg = generateBackground(createPrng(SEED_A), 300, 200);
-		const before = Buffer.from(bg.data);
-		paintDecoys(
+		const cx = 150;
+		const cy = 100;
+		// Additive rim/body knobs at 0 too so only the multiplicative path
+		// contributes; otherwise `bodyBrightness` adds back a few units and
+		// the pixels never reach exactly zero.
+		paintDecoyPiece(
 			bg,
 			createPrng(SEED_B),
-			5,
 			DEFAULT_GEOMETRY.notchSize,
-			notch,
+			cx,
+			cy,
+			0,
 			0,
 			0,
 		);
-		expect(bg.data.equals(before)).toBe(true);
+		const i = (cy * bg.width + cx) * 4;
+		expect(bg.data[i]).toBe(0);
+		expect(bg.data[i + 1]).toBe(0);
+		expect(bg.data[i + 2]).toBe(0);
 	});
 });
 

--- a/packages/puzzle-assets/src/types.ts
+++ b/packages/puzzle-assets/src/types.ts
@@ -37,8 +37,19 @@ export interface RenderedPuzzle {
 export interface PuzzleGeometry {
 	width: number;
 	height: number;
-	/** Bounding box of the notch/piece, in px. */
+	/**
+	 * Bounding box of the decoy notches, in px. Kept fixed so decoys read as
+	 * a consistent field of small distractions even when the real piece is
+	 * randomised to a large size.
+	 */
 	notchSize: number;
+	/**
+	 * Bounding box of the real piece, in px. Defaults to `notchSize` when
+	 * unset; the provider randomises this per challenge within a scale
+	 * range configured on the client's puzzle settings. May exceed the
+	 * background dimensions — the cut is clipped at the edge.
+	 */
+	pieceSize?: number;
 }
 
 /**
@@ -72,4 +83,11 @@ export interface PuzzleRenderSettings {
 	 * blend closer to the decoys. Bounded 0..1 by the schema.
 	 */
 	holeDarken: number;
+	/**
+	 * Multiplier applied to decoy pixels, mirroring `holeDarken`. Kept
+	 * looser than `holeDarken` so the real hole is still the deepest
+	 * region on the frame — otherwise humans can't tell target from decoy.
+	 * Bounded 0..1 by the schema.
+	 */
+	decoyHoleDarken: number;
 }

--- a/packages/types/src/client/settings.ts
+++ b/packages/types/src/client/settings.ts
@@ -36,6 +36,18 @@ export const puzzleDecoyCountDefault = 5;
 export const puzzleDecoyEdgeDarknessDefault = 20;
 export const puzzleDecoyBodyBrightnessDefault = 4;
 export const puzzleHoleDarkenDefault = 0.55;
+// Multiplier on decoy pixels, mirroring `holeDarken` for the real cut.
+// Lower = darker decoys. Kept looser than `holeDarken` so the real hole is
+// still the deepest region on the frame; too close and humans can't tell,
+// too far and a solver keys on brightness alone.
+export const puzzleDecoyHoleDarkenDefault = 0.7;
+// Piece size as a fraction of the background width. The provider draws a
+// fresh value from [min, max] per challenge so a solver can't hard-code
+// the expected silhouette scale. Defaults preserve the historical 44px
+// minimum (44/300 ≈ 0.147) and open the top end to 90% of the frame; a
+// piece is allowed to overhang the background — the cut is clipped.
+export const puzzlePieceScaleMinDefault = 0.15;
+export const puzzlePieceScaleMaxDefault = 0.45;
 
 // Field-level schemas hoisted so `TrafficFilterSchema` per-category
 // challenge policies validate captcha parameters with the same bounds as
@@ -52,6 +64,21 @@ export const puzzleDecoyBodyBrightnessFieldSchema = number()
 	.min(-20)
 	.max(20);
 export const puzzleHoleDarkenFieldSchema = number().min(0).max(1);
+export const puzzleDecoyHoleDarkenFieldSchema = number().min(0).max(1);
+// Bounds are wider than the defaults so operators can pin the piece to a
+// fixed size (min == max) or explore the full frame. Cross-field
+// `min <= max` is enforced on the containing object schema.
+export const puzzlePieceScaleFieldSchema = number().min(0.05).max(0.95);
+export const PuzzlePieceScaleSchema = object({
+	min: puzzlePieceScaleFieldSchema
+		.optional()
+		.default(puzzlePieceScaleMinDefault),
+	max: puzzlePieceScaleFieldSchema
+		.optional()
+		.default(puzzlePieceScaleMaxDefault),
+}).refine((v) => v.min <= v.max, {
+	message: "puzzle piece scale min must be <= max",
+});
 
 /**
  * Per-render tunables for the puzzle captcha. Every field is optional so
@@ -63,7 +90,9 @@ export const PuzzleSettingsSchema = object({
 	decoyCount: puzzleDecoyCountFieldSchema.optional(),
 	decoyEdgeDarkness: puzzleDecoyEdgeDarknessFieldSchema.optional(),
 	decoyBodyBrightness: puzzleDecoyBodyBrightnessFieldSchema.optional(),
+	decoyHoleDarken: puzzleDecoyHoleDarkenFieldSchema.optional(),
 	holeDarken: puzzleHoleDarkenFieldSchema.optional(),
+	pieceScale: PuzzlePieceScaleSchema.optional(),
 });
 
 export type IPuzzleSettings = output<typeof PuzzleSettingsSchema>;


### PR DESCRIPTION
## Summary
- Piece size varies per challenge from a client-tunable `pieceScale.{min,max}` range (defaults 0.15 → 0.45 of bg width). Stratified over 8 buckets with interleaved small/large ordering so consecutive challenges alternate.
- Shape family picked per silhouette: jigsaw, circle, rounded rectangle, regular polygon (3–8 sides), sinusoidal flower. Real cut and its piece always match; decoys pick independently.
- Decoys now darken pixels multiplicatively (new `decoyHoleDarken`, default 0.7) so they read as plausible false targets. Real cut stays deepest at 0.55.
- Piece may overhang the background — cut is clipped rather than clamped.

## Test plan
- [x] `@prosopo/puzzle-assets` unit tests (24/24)
- [x] `@prosopo/provider` unit tests (1117/1117 excluding integration; integration failures pre-existing / infra-only)
- [x] `@prosopo/types` schema tests (338/338)
- [x] Biome lint clean (`npm run lint:js -- --changed`)
- [x] Local demo (`client-bundle-example`): 16 consecutive `/captcha/puzzle` samples span the range evenly with strict small/large alternation

🤖 Generated with [Claude Code](https://claude.com/claude-code)