### PR TITLE
feat(provider,types): surface tcp-probe + ipInfo on routing raw

### DIFF
--- a/.changeset/dm-raw-tcp-probe-and-ipinfo.md
+++ b/.changeset/dm-raw-tcp-probe-and-ipinfo.md
@@ -1,0 +1,22 @@
+---
+"@prosopo/provider": patch
+"@prosopo/types": patch
+---
+
+feat(provider,types): surface tcp-probe + ipInfo on routing raw
+
+`RoutingMachineRawSignals` gains the 9 raw TCP-handshake fields
+(`synNs / synackNs / ackNs / observedTtl / tcpMss / tcpWscale /
+tcpOptsFlags / tcpOptsOrder / tcpWindow`) and the per-request
+`ipInfo` payload. Callsites that build a routing raw — the
+frictionless entry, its dedup replay branch, and the PoW submit
+post-pow hop — spread `req.ipInfo` alongside the existing
+`rawTlsSignalsForSession(req)`, gated on the discriminated-union
+success branch so the routing machine never sees an
+`isValid:false` error payload.
+
+Route-time `ipInfo` is separate from the existing decide-kind
+`input.ipInfo` (persisted on the Session record at verify time).
+The DM helper is being updated in the captcha-private
+decision-machines package to resolve both channels through one
+matcher surface.

--- a/packages/provider/src/api/captcha/getFrictionlessCaptchaChallenge/handler.ts
+++ b/packages/provider/src/api/captcha/getFrictionlessCaptchaChallenge/handler.ts
@@ -337,6 +337,16 @@ export default (
 										chelloToHandshakeUs: req.chelloToHandshakeUs,
 									}),
 									...rawTlsSignalsForSession(req),
+									// req.ipInfo is the per-request ipapi lookup. Only
+									// surface it into `raw` when the lookup succeeded —
+									// an `isValid:false` payload just means the middleware
+									// errored and none of the threat flags are populated,
+									// so pushing it in would give the routing machine
+									// nothing to reason on and waste bytes across the
+									// wire.
+									...(req.ipInfo &&
+										"isValid" in req.ipInfo &&
+										req.ipInfo.isValid && { ipInfo: req.ipInfo }),
 									// currentUrl / iframeUrl use the cached session's
 									// values to match the rest of the dedup routing input
 									// (score, webView, captchaType are all pulled from
@@ -727,6 +737,12 @@ export default (
 						chelloToHandshakeUs: req.chelloToHandshakeUs,
 					}),
 					...rawTlsSignalsForSession(req),
+					// req.ipInfo is the per-request ipapi lookup; only surface
+					// on the successful branch of the discriminated union.
+					// See the dedup replay path above for the full comment.
+					...(req.ipInfo &&
+						"isValid" in req.ipInfo &&
+						req.ipInfo.isValid && { ipInfo: req.ipInfo }),
 					...(currentUrl && { currentUrl }),
 					...(iframeUrl && { iframeUrl }),
 				},

--- a/packages/provider/src/api/captcha/submitPoWCaptchaSolution.ts
+++ b/packages/provider/src/api/captcha/submitPoWCaptchaSolution.ts
@@ -149,6 +149,13 @@ export default (env: ProviderEnvironment) =>
 						chelloToHandshakeUs: req.chelloToHandshakeUs,
 					}),
 					...rawTlsSignalsForSession(req),
+					// PoW-submit's ipInfo is looked up fresh on this request
+					// (per-connection, so it's the PoW submit hop's IP not
+					// the frictionless entry hop's). Only surface on the
+					// isValid:true branch of the discriminated union.
+					...(req.ipInfo &&
+						"isValid" in req.ipInfo &&
+						req.ipInfo.isValid && { ipInfo: req.ipInfo }),
 				},
 			});
 

--- a/packages/types/src/decisionMachine/index.ts
+++ b/packages/types/src/decisionMachine/index.ts
@@ -245,6 +245,40 @@ export interface RoutingMachineRawSignals {
 	// traverse a chaddy-enabled ingress (e.g. dev requests, HTTP/3).
 	tcpToChelloUs?: number;
 	chelloToHandshakeUs?: number;
+	// Raw per-connection TCP-handshake signals forwarded by chaddy from
+	// its co-located tcp-probe eBPF sidecar. Wire-observed primitives
+	// (RFC-793 / RFC-9293) captured off the WAN NIC before caddy sees the
+	// TLS bytes. All optional — a request that came in through an ingress
+	// without a running tcp-probe pipeline has all fields undefined.
+	//
+	// Fields decoded from the sidecar's `X-TLS-*` headers by
+	// `rawTlsSignalsMiddleware`. See @prosopo/types Session for full
+	// per-field semantics (kernel monotonic ns for the syn/synack/ack
+	// timestamps, TTL byte for observedTtl, MSS / window-scale / options
+	// bitfield / packed options order / window from the client's SYN).
+	synNs?: number;
+	synackNs?: number;
+	ackNs?: number;
+	observedTtl?: number;
+	tcpMss?: number;
+	tcpWscale?: number;
+	tcpOptsFlags?: number;
+	tcpOptsOrder?: number;
+	tcpWindow?: number;
+	// IP metadata as looked up by `ipInfoMiddleware` from the provider's
+	// ipapi/isp mirror at request time. Undefined when the lookup failed
+	// or the middleware wasn't reached (dev requests bypassing the
+	// standard chain). Undefined-check any field before use — an IPInfo
+	// with `isValid:false` means the lookup errored and no threat
+	// indicators are populated.
+	//
+	// Route-time surfacing of `ipInfo` complements the existing
+	// decide-kind `input.ipInfo`: decide loads the persisted ipapi
+	// payload from the Session record at verify time, route now carries
+	// the live per-request lookup so a routing machine can reason on
+	// asn / isProxy / isMobile / isDatacenter at the frictionless entry
+	// (e.g. escalate iPhone-UA + isProxy:true to puzzle).
+	ipInfo?: IPInfoResponse;
 	// Full page URL the widget was rendered on (origin + path only; query
 	// string, fragment and any embedded credentials are stripped client- and
 	// server-side). Available on the `route` phase from the freshly decrypted


### PR DESCRIPTION
## Summary

Extends `RoutingMachineRawSignals` with the 9 raw TCP-handshake fields (`synNs / synackNs / ackNs / observedTtl / tcpMss / tcpWscale / tcpOptsFlags / tcpOptsOrder / tcpWindow`) and a per-request `ipInfo` payload. Spreads `req.ipInfo` into all three frictionless-handler raw{} sites (main, dedup replay, and `setRoutingContext`) and the PoW-submit post-pow site, gated on the discriminated-union `isValid:true` branch.

## Why

Prod tcp-probe rollout landed the raw fields on Session records but they aren't reachable from a routing DM until they're on `RoutingMachineRawSignals`. This is the plumbing PR — matcher schema + compile guards land separately in the captcha-private decision-machines package.

## Files

- `packages/types/src/decisionMachine/index.ts` — extend `RoutingMachineRawSignals`
- `packages/provider/src/api/captcha/getFrictionlessCaptchaChallenge/handler.ts` — spread `req.ipInfo` at the two routing-raw callsites
- `packages/provider/src/api/captcha/submitPoWCaptchaSolution.ts` — same for the post-pow site

## Compat

All new interface fields optional.

## Test plan

- [x] `npm run -w @prosopo/types build:tsc` clean
- [x] `npm run -w @prosopo/provider build:tsc` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)