### PR TITLE
perf(provider,database): cache DM scripts + keyset-paginate the pending-stage sweep

### DIFF
--- a/.changeset/dm-script-cache-and-pending-stage-keyset.md
+++ b/.changeset/dm-script-cache-and-pending-stage-keyset.md
@@ -1,0 +1,10 @@
+---
+"@prosopo/provider": patch
+"@prosopo/database": patch
+"@prosopo/types-database": patch
+---
+
+Cache compiled decision-machine sandboxes; keyset-paginate the pending-stage sweep.
+
+- `DecisionMachineRunner` now hits `vm.createContext` + `new vm.Script` at most once per source blob (keyed by SHA-256). Exports `invalidateDecisionMachineScriptCache` and `invalidateAllDecisionMachineArtifactCaches`, both called from `updateDecisionMachine` after any artifact upload.
+- `getUnstoredDappUserCommitments` / `getUnstoredDappUserPoWCommitments` / `getUnstoredSessionRecords` switch from `skip(N)` pagination to keyset (`_id > afterId`). Compound partial index `{pendingStage:1, _id:1}` on all four collections so filter + sort ride one index. Fixes the sweep that was scanning 470k–1.2M docs per page under a large pending backlog.

--- a/packages/database/src/databases/provider.ts
+++ b/packages/database/src/databases/provider.ts
@@ -1391,22 +1391,34 @@ export class ProviderDatabase
 	/** @description Get Dapp User captcha commitments from the commitments table that have not been counted towards the
 	 * client's total.
 	 *
-	 * Served by the `pendingStage_partial` index. Records have
-	 * `pendingStage: true` set on insert and on every mutation (see
+	 * Served by the compound `pendingStage_partial` index
+	 * (`{pendingStage:1, _id:1}` partial where pendingStage:true). Records
+	 * have `pendingStage: true` set on insert and on every mutation (see
 	 * `updateDappUserCommitment`, `markDappUserCommitmentsChecked`,
 	 * `approveDappUserCommitment`, `disapproveDappUserCommitment`,
 	 * `storePendingImageCommitment`). `markDappUserCommitmentsStored` clears
 	 * the flag after a successful stage, guarded by `lastUpdatedTimestamp`
 	 * so an in-flight update isn't lost.
+	 *
+	 * Keyset pagination: pass the `_id` of the last row from the previous
+	 * page as `afterId` to resume. The old `skip(N)` shape walked N docs
+	 * per page even with the right index; under a 1M-row pending backlog
+	 * that hit multi-second query durations and thrashed the WT cache,
+	 * dragging every co-tenant query with it.
 	 */
 	async getUnstoredDappUserCommitments(
 		limit = 1000,
-		skip = 0,
+		afterId?: unknown,
 	): Promise<UserCommitmentRecord[]> {
+		const filter: { pendingStage: true; _id?: { $gt: unknown } } = {
+			pendingStage: true,
+		};
+		if (afterId !== undefined) {
+			filter._id = { $gt: afterId };
+		}
 		const docs = await this.tables?.commitment
-			.find({ pendingStage: true })
+			.find(filter)
 			.sort({ _id: 1 })
-			.skip(skip)
 			.limit(limit)
 			.lean<UserCommitmentRecord[]>();
 		return docs || [];
@@ -1534,14 +1546,20 @@ export class ProviderDatabase
 	 */
 	async getUnstoredDappUserPoWCommitments(
 		limit = 1000,
-		skip = 0,
+		afterId?: unknown,
 	): Promise<PoWCaptchaRecord[]> {
-		// Served by the `pendingStage_partial` index — see
-		// `getUnstoredDappUserCommitments` for the lifecycle of the flag.
+		// Served by the compound `pendingStage_partial` index — see
+		// `getUnstoredDappUserCommitments` for the lifecycle of the flag
+		// and the keyset-pagination contract.
+		const filter: { pendingStage: true; _id?: { $gt: unknown } } = {
+			pendingStage: true,
+		};
+		if (afterId !== undefined) {
+			filter._id = { $gt: afterId };
+		}
 		const docs = await this.tables?.powcaptcha
-			.find({ pendingStage: true })
+			.find(filter)
 			.sort({ _id: 1 })
-			.skip(skip)
 			.limit(limit)
 			.lean<PoWCaptchaRecord[]>();
 		return docs || [];
@@ -1976,22 +1994,25 @@ export class ProviderDatabase
 	/** Get unstored session records
 	 * @description Get session records that have not been stored yet.
 	 *
-	 * Served by the `pendingStage_partial` index — see
-	 * `getUnstoredDappUserCommitments` for the lifecycle of the flag.
-	 * `checkAndRemoveSession` also flips the flag so consumed sessions
-	 * propagate to the central DB via the next sweep.
-	 * @param limit
-	 * @param skip
+	 * Served by the compound `pendingStage_partial` index — see
+	 * `getUnstoredDappUserCommitments` for the lifecycle of the flag and
+	 * the keyset-pagination contract. `checkAndRemoveSession` also flips
+	 * the flag so consumed sessions propagate to the central DB via the
+	 * next sweep.
 	 */
-	getUnstoredSessionRecords(limit = 1000, skip = 0): Promise<SessionRecord[]> {
+	getUnstoredSessionRecords(
+		limit = 1000,
+		afterId?: unknown,
+	): Promise<SessionRecord[]> {
+		const filter: { pendingStage: true; _id?: { $gt: unknown } } = {
+			pendingStage: true,
+		};
+		if (afterId !== undefined) {
+			filter._id = { $gt: afterId };
+		}
 		return Promise.resolve(this.tables?.session)
 			.then((tbl) =>
-				tbl
-					?.find({ pendingStage: true })
-					.sort({ _id: 1 })
-					.skip(skip)
-					.limit(limit)
-					.lean<SessionRecord[]>(),
+				tbl?.find(filter).sort({ _id: 1 }).limit(limit).lean<SessionRecord[]>(),
 			)
 			.then((docs) => docs || []);
 	}

--- a/packages/provider/src/tasks/client/clientTasks.ts
+++ b/packages/provider/src/tasks/client/clientTasks.ts
@@ -38,6 +38,10 @@ import type {
 } from "@prosopo/types-database";
 import { majorityAverage, parseUrl } from "@prosopo/util";
 import { validateSiteKey } from "../../api/validateAddress.js";
+import {
+	invalidateAllDecisionMachineArtifactCaches,
+	invalidateDecisionMachineScriptCache,
+} from "../decisionMachine/decisionMachineRunner.js";
 
 const SAMPLE_SIZE = 75;
 const isValidPrivateKey = (privateKeyString: string) => {
@@ -120,10 +124,10 @@ export class ClientTaskManager {
 			let processedCommitments = 0;
 
 			await this.processBatchesWithCursor(
-				async (skip: number) =>
+				async (afterId?: unknown) =>
 					await this.providerDB.getUnstoredDappUserCommitments(
 						BATCH_SIZE,
-						skip,
+						afterId,
 					),
 				async (batch) => {
 					const filteredBatch = (
@@ -149,15 +153,16 @@ export class ClientTaskManager {
 					}
 					processedCommitments += filteredBatch.length;
 				},
+				(row) => (row as { _id?: unknown })._id,
 			);
 
 			// Process PoW records with cursor
 			let processedPowRecords = 0;
 			await this.processBatchesWithCursor(
-				async (skip: number) =>
+				async (afterId?: unknown) =>
 					await this.providerDB.getUnstoredDappUserPoWCommitments(
 						BATCH_SIZE,
-						skip,
+						afterId,
 					),
 				async (batch) => {
 					const filteredBatch = lastTask?.updated
@@ -173,13 +178,14 @@ export class ClientTaskManager {
 					}
 					processedPowRecords += filteredBatch.length;
 				},
+				(row) => (row as { _id?: unknown })._id,
 			);
 
 			// process session records with cursor
 			let processedSessionRecords = 0;
 			await this.processBatchesWithCursor(
-				async (skip: number) =>
-					await this.providerDB.getUnstoredSessionRecords(BATCH_SIZE, skip),
+				async (afterId?: unknown) =>
+					await this.providerDB.getUnstoredSessionRecords(BATCH_SIZE, afterId),
 				async (batch) => {
 					const filteredBatch = lastTask?.updated
 						? batch.filter((record) => this.isRecordUpdated(record))
@@ -194,6 +200,7 @@ export class ClientTaskManager {
 					}
 					processedSessionRecords += filteredBatch.length;
 				},
+				(row) => (row as { _id?: unknown })._id,
 			);
 
 			await this.providerDB.updateScheduledTaskStatus(
@@ -466,6 +473,15 @@ export class ClientTaskManager {
 			updatedAt: now,
 		});
 
+		// Flush both DM caches so the new artifact + source take effect on the
+		// next request instead of waiting for TTL. Script cache is content-
+		// addressed (a new source gets a new key) so `clear()` is defensive
+		// against a source that reuses a prior SHA; the artifact cache is
+		// keyed by (scope, kind, dappAccount) so a same-key overwrite would
+		// otherwise return stale for up to 5 minutes.
+		invalidateAllDecisionMachineArtifactCaches();
+		invalidateDecisionMachineScriptCache();
+
 		return {
 			scope,
 			dappAccount,
@@ -634,17 +650,31 @@ export class ClientTaskManager {
 		);
 	}
 
+	/**
+	 * Drive a keyset-paginated sweep. Each iteration passes the `_id` of the
+	 * previous batch's last row to `fetchBatch` so the query resumes from
+	 * `_id > afterId` — see `getUnstoredDappUserCommitments` for why we
+	 * moved off `skip(N)`. `getLastId` extracts the resumption cursor from
+	 * a batch row; both `PoWCaptchaRecord` and `UserCommitmentRecord` are
+	 * `mongoose.Document` subtypes so `_id` is always present at runtime
+	 * even though our stored types don't spell it out.
+	 */
 	private async processBatchesWithCursor<T>(
-		fetchBatch: (skip: number) => Promise<T[]>,
+		fetchBatch: (afterId?: unknown) => Promise<T[]>,
 		processBatch: (batch: T[]) => Promise<void>,
+		getLastId: (row: T) => unknown,
 	): Promise<void> {
-		let skip = 0;
+		let afterId: unknown | undefined;
 		while (true) {
-			const batch = await fetchBatch(skip);
+			const batch = await fetchBatch(afterId);
 			if (!batch.length) break;
 
 			await processBatch(batch);
-			skip += batch.length;
+			const last = batch[batch.length - 1];
+			if (last === undefined) break;
+			const nextId = getLastId(last);
+			if (nextId === undefined) break;
+			afterId = nextId;
 		}
 	}
 }

--- a/packages/provider/src/tasks/decisionMachine/decisionMachineRunner.ts
+++ b/packages/provider/src/tasks/decisionMachine/decisionMachineRunner.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { createHash } from "node:crypto";
 import vm from "node:vm";
 import type { Logger } from "@prosopo/logger";
 import {
@@ -41,6 +42,76 @@ const EXEC_TIMEOUT_MS =
 	Number.parseInt(process.env.DECISION_MACHINE_EXEC_TIMEOUT_MS ?? "", 10) ||
 	2000;
 
+/**
+ * Module-level cache of loaded machine sandboxes, keyed by SHA-256 of
+ * `artifact.source`. Each entry holds the extracted `module.exports` for a
+ * given source blob so subsequent invocations skip both `new vm.Script(...)`
+ * (JIT compilation) and `script.runInContext(...)` (top-level execution).
+ *
+ * Shared across every `DecisionMachineRunner` instance in the process —
+ * multiple task classes (pow / img / puzzle / frictionless) each construct
+ * their own runner, and there's no reason to compile the same source once
+ * per runner. The exported functions are treated as stateless: they run
+ * against the caller's `input` and don't mutate module-local state.
+ *
+ * Invalidation is triggered externally via {@link invalidateDecisionMachineScriptCache}
+ * — call after any `upsertDecisionMachineArtifact` so a new artifact takes
+ * effect immediately rather than waiting for the artifact TTL to expire.
+ * Absent an explicit invalidate the cache is content-addressed: a new source
+ * gets a new key, the old entry just sits until process restart.
+ */
+interface CachedMachine {
+	exports: Record<string, unknown>;
+}
+
+const machineCache = new Map<string, CachedMachine>();
+
+const hashSource = (source: string): string =>
+	createHash("sha256").update(source).digest("hex");
+
+/**
+ * Compile + execute the artifact source in a fresh vm sandbox on first use,
+ * then reuse the resulting `module.exports` for every subsequent invocation
+ * of the same source. See {@link machineCache}.
+ */
+const loadMachine = (source: string): CachedMachine => {
+	const key = hashSource(source);
+	const cached = machineCache.get(key);
+	if (cached) return cached;
+
+	const sandbox = {
+		module: { exports: {} as unknown },
+		exports: {} as Record<string, unknown>,
+	};
+	const context = vm.createContext(sandbox);
+	const script = new vm.Script(source, {
+		filename: "decision-machine.js",
+	});
+	script.runInContext(context, { timeout: LOAD_TIMEOUT_MS });
+
+	const exported = (sandbox.module as { exports: unknown }).exports;
+	const exportsObj: Record<string, unknown> =
+		typeof exported === "function"
+			? { default: exported }
+			: exported && typeof exported === "object"
+				? (exported as Record<string, unknown>)
+				: {};
+
+	const entry: CachedMachine = { exports: exportsObj };
+	machineCache.set(key, entry);
+	return entry;
+};
+
+/**
+ * Clear the module-level script cache. Call after any decision-machine
+ * artifact upload so the new source is executed on the next request instead
+ * of waiting for the artifact TTL. Also clear every `DecisionMachineRunner`
+ * instance's artifact cache — see {@link DecisionMachineRunner.invalidateAllArtifactCaches}.
+ */
+export const invalidateDecisionMachineScriptCache = (): void => {
+	machineCache.clear();
+};
+
 /** How long cached artifacts are considered fresh (ms). */
 const ARTIFACT_CACHE_TTL_MS =
 	Number.parseInt(
@@ -64,10 +135,44 @@ interface NamedExport {
 	fn: (...args: unknown[]) => unknown;
 }
 
+/**
+ * WeakSet-style registry of every live runner. Populated in the constructor
+ * and consulted by {@link invalidateAllDecisionMachineArtifactCaches} so an
+ * artifact upload can flush every runner's in-memory artifact cache in one
+ * call. Held as `WeakRef` so a runner that goes out of scope is garbage
+ * collected — this map only ever grows in prod (runners are constructed
+ * per task class at process start and live for the process's lifetime) so
+ * a plain array would also work, but `WeakRef` is defensive.
+ */
+const liveRunners = new Set<WeakRef<DecisionMachineRunner>>();
+
+/**
+ * Flush every runner's in-memory artifact cache. Companion to
+ * {@link invalidateDecisionMachineScriptCache}. Call both after any
+ * `upsertDecisionMachineArtifact` upload.
+ */
+export const invalidateAllDecisionMachineArtifactCaches = (): void => {
+	for (const ref of liveRunners) {
+		const runner = ref.deref();
+		if (runner === undefined) {
+			liveRunners.delete(ref);
+			continue;
+		}
+		runner.invalidateArtifactCache();
+	}
+};
+
 export class DecisionMachineRunner {
 	private readonly artifactCache = new Map<string, CachedArtifact>();
 
-	constructor(private readonly db: IProviderDatabase) {}
+	constructor(private readonly db: IProviderDatabase) {
+		liveRunners.add(new WeakRef(this));
+	}
+
+	/** Drop every entry in this runner's artifact cache. */
+	public invalidateArtifactCache(): void {
+		this.artifactCache.clear();
+	}
 
 	/** Build a cache key for a given scope + kind + dappAccount tuple. */
 	private static cacheKey(
@@ -348,12 +453,15 @@ export class DecisionMachineRunner {
 	}
 
 	/**
-	 * Load the artifact source into a fresh vm sandbox, locate a callable
-	 * matching one of {exportNames} (or `module.exports` itself if it's a
-	 * function), invoke it with {input}, and validate the result with
-	 * {schema}. Returns undefined when {options.optional} is true and no
-	 * matching export exists. Otherwise throws on missing export, invalid
-	 * output, or sandbox failure.
+	 * Look up the (cached) module exports for `artifact.source`, locate a
+	 * callable matching one of {exportNames} (or the cached `default` slot
+	 * if `module.exports` was itself a function), invoke it with {input},
+	 * and validate the result with {schema}. Returns undefined when
+	 * {options.optional} is true and no matching export exists. Otherwise
+	 * throws on missing export, invalid output, or sandbox failure.
+	 *
+	 * The vm.Script compilation + top-level `runInContext` runs at most
+	 * once per source blob (see {@link loadMachine} / {@link machineCache}).
 	 */
 	private async runArtifactExport<T>(
 		artifact: DecisionMachineArtifact,
@@ -361,18 +469,8 @@ export class DecisionMachineRunner {
 		options: { input: unknown; optional?: boolean },
 		schema: z.ZodSchema<T>,
 	): Promise<T | undefined> {
-		const sandbox = {
-			module: { exports: {} as unknown },
-			exports: {} as Record<string, unknown>,
-		};
-		const context = vm.createContext(sandbox);
-		const script = new vm.Script(artifact.source, {
-			filename: "decision-machine.js",
-		});
-		script.runInContext(context, { timeout: LOAD_TIMEOUT_MS });
-
-		const exported = (sandbox.module as { exports: unknown }).exports;
-		const named = this.findExport(exported, exportNames);
+		const { exports } = loadMachine(artifact.source);
+		const named = this.findExport(exports, exportNames);
 		if (!named) {
 			if (options.optional) return undefined;
 			throw new Error(

--- a/packages/provider/src/tests/unit/tasks/client/clientTasks.unit.test.ts
+++ b/packages/provider/src/tests/unit/tasks/client/clientTasks.unit.test.ts
@@ -253,6 +253,33 @@ describe("ClientTaskManager", () => {
 		expect(providerDB.getUnstoredDappUserCommitments).not.toHaveBeenCalled();
 	});
 
+	it("paginates unstored commitments by `_id` keyset — subsequent fetches carry the last _id", async () => {
+		const page1: (Pick<UserCommitment, "id"> & { _id: string })[] = [
+			{ id: "c1", _id: "id-1" },
+			{ id: "c2", _id: "id-2" },
+		];
+		const page2: (Pick<UserCommitment, "id"> & { _id: string })[] = [
+			{ id: "c3", _id: "id-3" },
+		];
+
+		// biome-ignore lint/suspicious/noExplicitAny: mock-only shape
+		const commMock = providerDB.getUnstoredDappUserCommitments as any;
+		commMock
+			.mockResolvedValueOnce(page1)
+			.mockResolvedValueOnce(page2)
+			.mockResolvedValueOnce([]);
+		// biome-ignore lint/suspicious/noExplicitAny: mock-only shape
+		(providerDB.createScheduledTaskStatus as any).mockResolvedValueOnce({});
+		// biome-ignore lint/suspicious/noExplicitAny: mock-only shape
+		(providerDB.updateScheduledTaskStatus as any).mockResolvedValueOnce({});
+
+		await clientTaskManager.storeCommitmentsExternal();
+
+		expect(commMock).toHaveBeenNthCalledWith(1, expect.any(Number), undefined);
+		expect(commMock).toHaveBeenNthCalledWith(2, expect.any(Number), "id-2");
+		expect(commMock).toHaveBeenNthCalledWith(3, expect.any(Number), "id-3");
+	});
+
 	it("should store commitments externally if mongoCaptchaUri is set", async () => {
 		const mockCommitments: Pick<UserCommitment, "id">[] = [
 			{ id: "commitment1" },

--- a/packages/provider/src/tests/unit/tasks/decisionMachine/decisionMachineRunner.unit.test.ts
+++ b/packages/provider/src/tests/unit/tasks/decisionMachine/decisionMachineRunner.unit.test.ts
@@ -26,7 +26,11 @@ import {
 } from "@prosopo/types";
 import type { IProviderDatabase } from "@prosopo/types-database";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { DecisionMachineRunner } from "../../../../tasks/decisionMachine/decisionMachineRunner.js";
+import {
+	DecisionMachineRunner,
+	invalidateAllDecisionMachineArtifactCaches,
+	invalidateDecisionMachineScriptCache,
+} from "../../../../tasks/decisionMachine/decisionMachineRunner.js";
 
 const stubLogger = (): Logger => {
 	const noop = (): void => {};
@@ -554,6 +558,162 @@ describe("DecisionMachineRunner", () => {
 
 			const result = await runner.getRequiredCounters(baseRouteInput());
 			expect(result).toEqual([]);
+		});
+	});
+
+	describe("script cache", () => {
+		beforeEach(() => {
+			// Clean slate for cache tests — leftover entries from other tests
+			// would let a runner service a call without invoking db.
+			invalidateDecisionMachineScriptCache();
+			invalidateAllDecisionMachineArtifactCaches();
+		});
+
+		it("compiles a given source at most once across many invocations", async () => {
+			// Use a source whose module.exports counter proves the top-level
+			// `runInContext` ran once — a fresh compile+run would reset the
+			// counter to 0 every call, so a growing counter is a cache hit.
+			const source = `
+				var invocations = 0;
+				module.exports.decide = function() {
+					invocations++;
+					return { decision: "allow", reason: "hit " + invocations };
+				};
+			`;
+			const artifact = buildArtifact(source, DecisionMachineScope.Global);
+			(
+				db.getDecisionMachineArtifact as unknown as ReturnType<typeof vi.fn>
+			).mockResolvedValue(artifact);
+
+			const first = await runner.decide({
+				userAccount: "user",
+				dappAccount: "dapp",
+				captchaResult: "passed",
+				headers: {},
+			});
+			const second = await runner.decide({
+				userAccount: "user",
+				dappAccount: "dapp",
+				captchaResult: "passed",
+				headers: {},
+			});
+			const third = await runner.decide({
+				userAccount: "user",
+				dappAccount: "dapp",
+				captchaResult: "passed",
+				headers: {},
+			});
+
+			expect(first.reason).toBe("hit 1");
+			expect(second.reason).toBe("hit 2");
+			expect(third.reason).toBe("hit 3");
+		});
+
+		it("shares compiled scripts across separate runner instances", async () => {
+			const source = `
+				var invocations = 0;
+				module.exports.decide = function() {
+					invocations++;
+					return { decision: "allow", reason: "hit " + invocations };
+				};
+			`;
+			const artifact = buildArtifact(source, DecisionMachineScope.Global);
+
+			const dbA = {
+				getDecisionMachineArtifact: vi
+					.fn()
+					.mockResolvedValueOnce(undefined)
+					.mockResolvedValueOnce(artifact),
+			} as unknown as IProviderDatabase;
+			const runnerA = new DecisionMachineRunner(dbA);
+			const first = await runnerA.decide({
+				userAccount: "user",
+				dappAccount: "dapp",
+				captchaResult: "passed",
+				headers: {},
+			});
+
+			const dbB = {
+				getDecisionMachineArtifact: vi
+					.fn()
+					.mockResolvedValueOnce(undefined)
+					.mockResolvedValueOnce(artifact),
+			} as unknown as IProviderDatabase;
+			const runnerB = new DecisionMachineRunner(dbB);
+			const second = await runnerB.decide({
+				userAccount: "user",
+				dappAccount: "dapp",
+				captchaResult: "passed",
+				headers: {},
+			});
+
+			expect(first.reason).toBe("hit 1");
+			expect(second.reason).toBe("hit 2");
+		});
+
+		it("invalidateDecisionMachineScriptCache forces a fresh compile", async () => {
+			const source = `
+				var invocations = 0;
+				module.exports.decide = function() {
+					invocations++;
+					return { decision: "allow", reason: "hit " + invocations };
+				};
+			`;
+			const artifact = buildArtifact(source, DecisionMachineScope.Global);
+			(
+				db.getDecisionMachineArtifact as unknown as ReturnType<typeof vi.fn>
+			).mockResolvedValue(artifact);
+
+			const first = await runner.decide({
+				userAccount: "user",
+				dappAccount: "dapp",
+				captchaResult: "passed",
+				headers: {},
+			});
+			invalidateDecisionMachineScriptCache();
+			const second = await runner.decide({
+				userAccount: "user",
+				dappAccount: "dapp",
+				captchaResult: "passed",
+				headers: {},
+			});
+
+			expect(first.reason).toBe("hit 1");
+			expect(second.reason).toBe("hit 1");
+		});
+
+		it("invalidateAllDecisionMachineArtifactCaches forces a re-fetch", async () => {
+			const artifactOld = buildArtifact(
+				'module.exports.decide = () => ({ decision: "allow", reason: "old" });',
+				DecisionMachineScope.Global,
+			);
+			const artifactNew = buildArtifact(
+				'module.exports.decide = () => ({ decision: "allow", reason: "new" });',
+				DecisionMachineScope.Global,
+			);
+			(db.getDecisionMachineArtifact as unknown as ReturnType<typeof vi.fn>)
+				.mockResolvedValueOnce(undefined) // dapp scope
+				.mockResolvedValueOnce(artifactOld) // global scope, first fetch
+				.mockResolvedValueOnce(undefined) // dapp scope after invalidate
+				.mockResolvedValueOnce(artifactNew); // global scope, second fetch
+
+			const first = await runner.decide({
+				userAccount: "user",
+				dappAccount: "dapp",
+				captchaResult: "passed",
+				headers: {},
+			});
+			invalidateAllDecisionMachineArtifactCaches();
+			const second = await runner.decide({
+				userAccount: "user",
+				dappAccount: "dapp",
+				captchaResult: "passed",
+				headers: {},
+			});
+
+			expect(first.reason).toBe("old");
+			expect(second.reason).toBe("new");
+			expect(db.getDecisionMachineArtifact).toHaveBeenCalledTimes(4);
 		});
 	});
 });

--- a/packages/types-database/src/types/provider.ts
+++ b/packages/types-database/src/types/provider.ts
@@ -317,12 +317,17 @@ PoWCaptchaRecordSchema.index(
 		},
 	},
 );
-// Tiny partial index serving the StoreCommitmentsExternal sweep. Only
-// records with `pendingStage: true` are indexed — typically a small
-// rolling set — so the query examines only the pending rows instead of
-// scanning the whole powcaptchas collection.
+// Compound partial index serving the StoreCommitmentsExternal sweep. Only
+// records with `pendingStage: true` are indexed and the `_id` component
+// preserves sort ordering, so the paginated sweep can use ONE index for
+// both the filter AND the `sort({_id:1})` without falling back to the
+// `_id` index (which would then filter `pendingStage:true` in memory,
+// touching the whole collection). The keyset sweep in
+// `getUnstoredDappUserPoWCommitments` compares `_id > afterId` on this
+// index directly. Old callers passing `skip(N)` still work but are O(N)
+// on the pending set only — much smaller than the collection scan.
 PoWCaptchaRecordSchema.index(
-	{ pendingStage: 1 },
+	{ pendingStage: 1, _id: 1 },
 	{
 		name: "pendingStage_partial",
 		partialFilterExpression: { pendingStage: true },
@@ -440,8 +445,10 @@ PuzzleCaptchaRecordSchema.index({ "ipInfo.countryCode": 1 });
 PuzzleCaptchaRecordSchema.index({ "ipInfo.isVPN": 1 });
 PuzzleCaptchaRecordSchema.index({ ipInfo: 1 });
 PuzzleCaptchaRecordSchema.index({ parsedUserAgentInfo: 1 });
+// Compound `{pendingStage:1, _id:1}` partial — see PoWCaptchaRecordSchema's
+// pendingStage_partial for rationale.
 PuzzleCaptchaRecordSchema.index(
-	{ pendingStage: 1 },
+	{ pendingStage: 1, _id: 1 },
 	{
 		name: "pendingStage_partial",
 		partialFilterExpression: { pendingStage: true },
@@ -576,8 +583,12 @@ UserCommitmentRecordSchema.index({ requestHash: -1 });
 UserCommitmentRecordSchema.index({ pending: 1 });
 UserCommitmentRecordSchema.index({ ipInfo: 1 });
 UserCommitmentRecordSchema.index({ parsedUserAgentInfo: 1 });
+// Compound `{pendingStage:1, _id:1}` partial — see PoWCaptchaRecordSchema's
+// pendingStage_partial for rationale. Fixes the runaway
+// `getUnstoredDappUserCommitments` sweep that was choosing the plain `_id: 1`
+// index and scanning ~1M docs per page under a large pending backlog.
 UserCommitmentRecordSchema.index(
-	{ pendingStage: 1 },
+	{ pendingStage: 1, _id: 1 },
 	{
 		name: "pendingStage_partial",
 		partialFilterExpression: { pendingStage: true },
@@ -881,10 +892,10 @@ SessionRecordSchema.index(
 	{ "result.status": 1 },
 	{ background: true, sparse: true },
 );
-// See PoWCaptchaRecordSchema's pendingStage_partial — same purpose for
-// the unstored-session sweep.
+// Compound `{pendingStage:1, _id:1}` partial — see PoWCaptchaRecordSchema's
+// pendingStage_partial for rationale.
 SessionRecordSchema.index(
-	{ pendingStage: 1 },
+	{ pendingStage: 1, _id: 1 },
 	{
 		name: "pendingStage_partial",
 		partialFilterExpression: { pendingStage: true },
@@ -1051,9 +1062,16 @@ export interface IProviderDatabase extends IDatabase {
 
 	getCheckedDappUserCommitments(): Promise<UserCommitmentRecord[]>;
 
+	/**
+	 * Keyset-paginated sweep of pending user commitments. Callers pass the
+	 * `_id` of the last row from the previous page (or omit for the first
+	 * page); the query resumes from `_id > afterId` sorted ascending. Backed
+	 * by the compound `pendingStage_partial` index — cost scales with page
+	 * size, not with total collection size.
+	 */
 	getUnstoredDappUserCommitments(
 		limit?: number,
-		skip?: number,
+		afterId?: unknown,
 	): Promise<UserCommitmentRecord[]>;
 
 	markDappUserCommitmentsStored(
@@ -1079,9 +1097,13 @@ export interface IProviderDatabase extends IDatabase {
 		emailNormalised: string,
 	): Promise<number>;
 
+	/**
+	 * Keyset-paginated sweep of pending PoW captchas. See
+	 * {@link getUnstoredDappUserCommitments} for the resumption contract.
+	 */
 	getUnstoredDappUserPoWCommitments(
 		limit?: number,
-		skip?: number,
+		afterId?: unknown,
 	): Promise<PoWCaptchaRecord[]>;
 
 	markDappUserPoWCommitmentsChecked(challengeIds: string[]): Promise<void>;
@@ -1245,9 +1267,13 @@ export interface IProviderDatabase extends IDatabase {
 		userSitekeyIpHash: string,
 	): Promise<SessionRecord | undefined>;
 
+	/**
+	 * Keyset-paginated sweep of pending session records. See
+	 * {@link getUnstoredDappUserCommitments} for the resumption contract.
+	 */
 	getUnstoredSessionRecords(
 		limit: number,
-		skip: number,
+		afterId?: unknown,
 	): Promise<SessionRecord[]>;
 
 	markSessionRecordsStored(


### PR DESCRIPTION
## Summary

Two tail-latency fixes, both driven by production observations from oo2:

1. **DM script cache** —  was calling `vm.createContext` + `new vm.Script` + `runInContext` on every request, discarding the compiled representation after a single invocation.
2. **Pending-stage keyset pagination** — the `StoreCommitmentsExternal` sweep was using `.sort({_id:1}).skip(N).limit(1000)` over `find({pendingStage: true})`. Mongo was picking the `_id:1` index for the sort and filtering `pendingStage` in memory, examining 470k-1.2M documents per page under a >1M-row backlog.

## Prod signal

Slow queries observed in the last hour before writing this PR:

- Every mongo query >5s was the same shape: `db.commitments.find({pendingStage:true}).sort({_id:1}).skip(N).limit(1000)`, plan `IXSCAN {_id:1}`, docsExamined 470,473-1,229,561, durationMillis 5,729-30,031.
- The nodes running the sweep hit multi-second tails on **every** endpoint, DM or not — `/dns/event` (no DM) and `/detector/assign` (no DM) also touched 3s max, confirming the tail was the co-tenant mongo storm, not the DM.
- DM script compilation is separately measurable at ~10-20ms per invocation at p50.

## DM script cache

- Module-level content-addressed cache keyed by SHA-256 of `artifact.source`. Shared across every runner instance in the process (pow / img / puzzle / frictionless each construct their own), so a source blob is compiled at most once regardless of how many runners see it.
- `sandbox` context is retained per cache entry; the exported functions are treated as stateless. Every compiled DM in the tree is a pure function over the input.
- Two invalidation hooks:
  - `invalidateDecisionMachineScriptCache()` — module-level, clears the script cache
  - `invalidateAllDecisionMachineArtifactCaches()` — walks every live runner via a `WeakRef` registry and clears its per-instance artifact cache
- Both are called from `ClientTaskManager.updateDecisionMachine` after `upsertDecisionMachineArtifact`, so a new artifact takes effect on the next request instead of waiting 5 minutes for TTL.

## Pending-stage sweep

- `getUnstoredDappUserCommitments` / `getUnstoredDappUserPoWCommitments` / `getUnstoredSessionRecords` switch from `skip(N)` to keyset: filter carries `{_id: {\$gt: afterId}}`, sort by `{_id:1}`, limit only.
- Compound partial indexes on all four affected collections: `{pendingStage:1, _id:1}` partial where `pendingStage:true`. One index covers both the filter and the sort — the planner no longer has any reason to pick the plain `_id` index.
- `processBatchesWithCursor` threads the last row's `_id` through each iteration via a `getLastId` extractor.

## Tests

- DM runner unit tests: added coverage that (a) a source blob is compiled at most once across many invocations, (b) the cache is shared across separate runner instances, (c) both invalidate functions force a re-compile / re-fetch.
- `ClientTaskManager` unit test: new assertion that each subsequent `fetchBatch` call carries the previous page tail `_id`.
- Full provider suite: 1106/1106 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)