### PR TITLE
fix(database): return tcp-probe fields from session projection

### DIFF
--- a/.changeset/session-projection-tcp-probe-fields.md
+++ b/.changeset/session-projection-tcp-probe-fields.md
@@ -1,0 +1,7 @@
+---
+"@prosopo/database": patch
+---
+
+Extend `getSessionRecordBySessionId` projection with the nine tcp-probe fields (`synNs`, `synackNs`, `ackNs`, `observedTtl`, `tcpMss`, `tcpWscale`, `tcpOptsFlags`, `tcpOptsOrder`, `tcpWindow`).
+
+The img / pow / puzzle verify paths forward these onto `DecisionMachineInput` so decide rules can match TCP fingerprints (e.g. `tcp-stack-dc-linux-ts-off`, `tcp-ttl-windows-ua-linux-stack`). The projection had never been extended past the pre-tcp-probe set, so every DM decide call received `undefined` for the whole group and the rules silently returned `null` against real traffic. Adds a regression guard in `sessionRecordProjection.integration.test.ts` that persists a session with every tcp-probe field and asserts each round-trips through the getter.

--- a/packages/database/src/databases/provider.ts
+++ b/packages/database/src/databases/provider.ts
@@ -1757,6 +1757,25 @@ export class ProviderDatabase
 				// path too. Keep this projection in sync with whatever
 				// fields the read-only callers need.
 				captchaType: 1,
+				// Raw per-connection TCP-handshake signals populated by the
+				// tcp-probe eBPF sidecar (see @prosopo/types Session for the
+				// wire semantics). The verify-time DM input surface exposes
+				// these to decide rules (e.g. `tcp-stack-dc-linux-ts-off`,
+				// `tcp-ttl-windows-ua-linux-stack`); every one of the img /
+				// pow / puzzle verify paths forwards `sessionRecord?.tcpX`
+				// into the DecisionMachineInput. Missed on the original
+				// projection: the rules got `undefined` for every field and
+				// silently never fired against real traffic even though
+				// matching sessions were sitting in the DB.
+				synNs: 1,
+				synackNs: 1,
+				ackNs: 1,
+				observedTtl: 1,
+				tcpMss: 1,
+				tcpWscale: 1,
+				tcpOptsFlags: 1,
+				tcpOptsOrder: 1,
+				tcpWindow: 1,
 				"headers.user-agent": 1,
 				"headers.accept": 1,
 				"headers.accept-language": 1,

--- a/packages/database/src/tests/integration/sessionRecordProjection.integration.test.ts
+++ b/packages/database/src/tests/integration/sessionRecordProjection.integration.test.ts
@@ -289,6 +289,65 @@ describe("getSessionRecordBySessionId projection", () => {
 		expect(got?.isEscalation).toBe(true);
 	});
 
+	// Regression guard for the 2026-08-20 finding: the verify-phase decision
+	// machines added TCP-fingerprint deny rules (`tcp-stack-dc-linux-ts-off`,
+	// `tcp-ttl-windows-ua-linux-stack`) that read `input.tcpOptsFlags`,
+	// `input.tcpOptsOrder`, and `input.observedTtl`. The img / pow / puzzle
+	// verify paths forward the sibling group of nine tcp-probe fields from
+	// `sessionRecord?.tcpX` into the DecisionMachineInput, but the projection
+	// here had never been extended past the pre-tcp-probe set. Result: DM
+	// input got `undefined` for every tcp-probe field, the rules returned
+	// null, and zero denies fired for weeks in production even though matching
+	// sessions were sitting in the DB (~11 exact-fingerprint hits per hour on
+	// the DC-linux tuple; thousands of windows-UA + linux-TTL sessions).
+	//
+	// Guard: persist a session with every tcp-probe field set, read it back,
+	// assert each one round-trips. A future projection narrowing that drops
+	// any of them re-introduces the silent no-op.
+	it("returns tcp-probe fields so DM decide rules can match TCP fingerprints", async () => {
+		const sessionId = "session-tcp-probe-roundtrip";
+		await db.tables.session.create({
+			sessionId,
+			createdAt: new Date(),
+			token: "tok-tcp-probe",
+			score: 0.1,
+			threshold: 0.5,
+			scoreComponents: { baseScore: 0.1 },
+			ipAddress: ipv4Composite(16843009n),
+			captchaType: CaptchaType.pow,
+			webView: false,
+			iFrame: false,
+			// Fingerprint the `tcp-stack-dc-linux-ts-off` rule denies on.
+			tcpOptsFlags: 19,
+			tcpOptsOrder: 786,
+			// Linux-family initial TTL (post-decrement) — the
+			// `tcp-ttl-windows-ua-linux-stack` rule denies on <=64 under a
+			// Windows UA.
+			observedTtl: 52,
+			// Remaining raw signals — surfaced on the DM input for future
+			// RTT / handshake-shape rules.
+			synNs: 1_700_000_000_000_000_000,
+			synackNs: 1_700_000_000_000_500_000,
+			ackNs: 1_700_000_000_000_800_000,
+			tcpMss: 1460,
+			tcpWscale: 7,
+			tcpWindow: 65535,
+		});
+
+		const got = await db.getSessionRecordBySessionId(sessionId);
+		if (!got) throw new Error("session not returned");
+
+		expect(got.tcpOptsFlags).toBe(19);
+		expect(got.tcpOptsOrder).toBe(786);
+		expect(got.observedTtl).toBe(52);
+		expect(got.synNs).toBe(1_700_000_000_000_000_000);
+		expect(got.synackNs).toBe(1_700_000_000_000_500_000);
+		expect(got.ackNs).toBe(1_700_000_000_000_800_000);
+		expect(got.tcpMss).toBe(1460);
+		expect(got.tcpWscale).toBe(7);
+		expect(got.tcpWindow).toBe(65535);
+	});
+
 	// Schema-contract guard: any field marked `required: true` on
 	// SessionRecordSchema must be present in the projection — otherwise
 	// callers like buildEscalation that forward the field into a new


### PR DESCRIPTION
## Summary

- `getSessionRecordBySessionId` had never been extended past its pre-tcp-probe projection, so the img / pow / puzzle verify paths forwarded `sessionRecord?.tcpOptsFlags` (and the eight sibling tcp-probe fields) as `undefined` into `DecisionMachineInput`.
- Result: the verify-phase DM decide rules that read those fields (`tcp-stack-dc-linux-ts-off`, `tcp-ttl-windows-ua-linux-stack`) silently returned `null` against real traffic. Matching sessions were sitting in the DB (~11 exact-fingerprint hits/hr on the DC-linux tuple; thousands of Windows-UA + linux-TTL sessions) but zero denies fired for them.
- Fix is projection-only: extend `getSessionRecordBySessionId` with the nine tcp-probe fields (`synNs`, `synackNs`, `ackNs`, `observedTtl`, `tcpMss`, `tcpWscale`, `tcpOptsFlags`, `tcpOptsOrder`, `tcpWindow`). No DM change, no schema change, no re-publish needed.

## Test plan

- [x] New `sessionRecordProjection.integration.test.ts` case persists a session with every tcp-probe field set and asserts each one round-trips through the getter
- [x] Verified the new test fails against the previous projection (`expect(got.tcpOptsFlags).toBe(19)` → received `undefined`) and passes with the fix
- [x] `npm run -w @prosopo/database build:tsc` clean
- [x] All six tests in `sessionRecordProjection.integration.test.ts` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)