### PR TITLE
fix(procaptcha): reload the image captcha instead of closing it

### DIFF
--- a/.changeset/fix-image-captcha-reload.md
+++ b/.changeset/fix-image-captcha-reload.md
@@ -1,0 +1,8 @@
+---
+"@prosopo/procaptcha": patch
+"@prosopo/procaptcha-frictionless": patch
+"@prosopo/procaptcha-react": patch
+"@prosopo/types": patch
+---
+
+Fix the reload button on the image captcha closing the challenge instead of loading a new one. Reload now asks the frictionless wrapper for a fresh session and re-mounts the widget so a new challenge opens straight away, and the checkbox click position is carried over to the replacement solve

--- a/packages/procaptcha-frictionless/src/ProcaptchaFrictionless.tsx
+++ b/packages/procaptcha-frictionless/src/ProcaptchaFrictionless.tsx
@@ -35,6 +35,7 @@ import {
 	type RetryCoords,
 	consumeRetryMountProps,
 	handleSessionInvalidated,
+	normaliseRetryCoords,
 } from "./sessionInvalidatedRecovery.js";
 
 // Each session uses exactly one solver — chosen by the /frictionless response.
@@ -105,6 +106,16 @@ export const ProcaptchaFrictionless = ({
 	// After we've retried once, a second NO_SESSION_FOUND falls back to the
 	// inner widget's own `frictionlessState.restart()` path.
 	const sessionInvalidatedFiredRef = useRef(false);
+	// Bumped on every mount so the replacement widget gets a fresh React
+	// `key`. Without it a re-render for the same captcha type reconciles onto
+	// the existing element, and the inner widget keeps the manager it built on
+	// first mount — still closed over the sessionId we've just replaced.
+	const mountCountRef = useRef(0);
+	// Set when the next mount must open its challenge without waiting for a
+	// checkbox click. Held in a ref rather than passed down through `start()`
+	// because `providerRetry` re-invokes `start` with no arguments, which would
+	// otherwise drop the flag on the first provider retry.
+	const nextMountAutoStartRef = useRef(false);
 
 	useEffect(() => {
 		if (!config.language) return;
@@ -215,6 +226,19 @@ export const ProcaptchaFrictionless = ({
 			void start();
 		};
 
+		// The user pressed reload on the challenge. The provider consumed this
+		// session when it issued the challenge, so there is no way to ask it
+		// for another one — mint a new session by re-running frictionless and
+		// re-mount the widget with `autoStart`, which is what makes a new
+		// challenge appear instead of the modal simply closing. Not one-shot:
+		// the user may keep asking for a different challenge.
+		const onReload = (x?: number, y?: number) => {
+			pendingRetryCoordsRef.current = normaliseRetryCoords(x, y);
+			nextMountAutoStartRef.current = true;
+			resetState(0);
+			void start();
+		};
+
 		// Consume any pending retry coords now — the resumed widget owns them
 		// for exactly one auto-fired `manager.start(x, y)`. Cleared so a
 		// subsequent escalation/re-render doesn't accidentally re-inject.
@@ -222,14 +246,22 @@ export const ProcaptchaFrictionless = ({
 		// over pending retry coords when both are present, because escalation
 		// is the current transition and the pending retry belongs to a prior
 		// widget instance that never got to consume them.
+		const forcedAutoStart = nextMountAutoStartRef.current;
+		nextMountAutoStartRef.current = false;
 		const { autoStart: resumedAutoStart, startCoords: retryStartCoords } =
-			consumeRetryMountProps(pendingRetryCoordsRef, autoStart);
+			consumeRetryMountProps(
+				pendingRetryCoordsRef,
+				autoStart || forcedAutoStart,
+			);
 		const startCoords = escalationCoords ?? retryStartCoords;
+		mountCountRef.current += 1;
+		const mountKey = mountCountRef.current;
 
 		if (captchaType === CaptchaType.image) {
 			const Procaptcha = await ProcaptchaLoader();
 			setComponentToRender(
 				<Procaptcha
+					key={mountKey}
 					config={config}
 					callbacks={callbacks}
 					frictionlessState={frictionlessState}
@@ -237,12 +269,14 @@ export const ProcaptchaFrictionless = ({
 					autoStart={resumedAutoStart}
 					startCoords={startCoords}
 					onSessionInvalidated={onSessionInvalidated}
+					onReload={onReload}
 				/>,
 			);
 		} else if (captchaType === CaptchaType.puzzle) {
 			const ProcaptchaPuzzle = await ProcaptchaPuzzleLoader();
 			setComponentToRender(
 				<ProcaptchaPuzzle
+					key={mountKey}
 					config={config}
 					callbacks={callbacks}
 					frictionlessState={frictionlessState}
@@ -256,6 +290,7 @@ export const ProcaptchaFrictionless = ({
 			const ProcaptchaPow = await ProcaptchaPowLoader();
 			setComponentToRender(
 				<ProcaptchaPow
+					key={mountKey}
 					config={config}
 					callbacks={callbacks}
 					frictionlessState={frictionlessState}

--- a/packages/procaptcha-frictionless/src/sessionInvalidatedRecovery.ts
+++ b/packages/procaptcha-frictionless/src/sessionInvalidatedRecovery.ts
@@ -26,13 +26,10 @@ export type RetryCoords = { x: number; y: number };
 export type MutableRef<T> = { current: T };
 
 /**
- * Semantics of the outer recovery handler. Returns whether the caller
- * should proceed to re-run the frictionless flow (`start()`), and mutates
- * the passed refs to record the one-shot fire + pending coords.
+ * The checkbox click position a re-mounted widget should start from, or
+ * `null` when there isn't a real one to carry over.
  *
- * - Second calls are ignored (one-shot per outer widget lifetime) so a
- *   persistently broken session doesn't loop.
- * - Coords are recorded only for a real trusted checkbox click. A partial
+ * - Coords are kept only for a real trusted checkbox click. A partial
  *   pair (only x or only y numeric) is treated as "no coords" so we
  *   never accidentally embed `NaN` into the solution salt.
  * - `(0, 0)` is treated as "no coords" too — that's what the widgets
@@ -42,6 +39,23 @@ export type MutableRef<T> = { current: T };
  *   is identical; we discard the pair here so future readers can tell
  *   the two apart.
  */
+export const normaliseRetryCoords = (
+	x: number | undefined,
+	y: number | undefined,
+): RetryCoords | null => {
+	if (typeof x !== "number" || typeof y !== "number") return null;
+	if (x === 0 && y === 0) return null;
+	return { x, y };
+};
+
+/**
+ * Semantics of the outer recovery handler. Returns whether the caller
+ * should proceed to re-run the frictionless flow (`start()`), and mutates
+ * the passed refs to record the one-shot fire + pending coords.
+ *
+ * Second calls are ignored (one-shot per outer widget lifetime) so a
+ * persistently broken session doesn't loop.
+ */
 export const handleSessionInvalidated = (
 	x: number | undefined,
 	y: number | undefined,
@@ -50,9 +64,7 @@ export const handleSessionInvalidated = (
 ): { shouldRestart: boolean } => {
 	if (firedRef.current) return { shouldRestart: false };
 	firedRef.current = true;
-	const bothNumeric = typeof x === "number" && typeof y === "number";
-	const isRealClick = bothNumeric && (x !== 0 || y !== 0);
-	pendingCoordsRef.current = isRealClick ? { x, y } : null;
+	pendingCoordsRef.current = normaliseRetryCoords(x, y);
 	return { shouldRestart: true };
 };
 

--- a/packages/procaptcha-frictionless/src/tests/sessionInvalidatedRecovery.test.ts
+++ b/packages/procaptcha-frictionless/src/tests/sessionInvalidatedRecovery.test.ts
@@ -18,6 +18,7 @@ import {
 	type RetryCoords,
 	consumeRetryMountProps,
 	handleSessionInvalidated,
+	normaliseRetryCoords,
 } from "../sessionInvalidatedRecovery.js";
 
 const ref = <T>(initial: T): MutableRef<T> => ({ current: initial });
@@ -125,5 +126,28 @@ describe("consumeRetryMountProps", () => {
 		const mount = consumeRetryMountProps(coordsRef, false);
 
 		expect(mount).toEqual({ autoStart: false, startCoords: undefined });
+	});
+});
+
+describe("normaliseRetryCoords", () => {
+	it("keeps a real click", () => {
+		expect(normaliseRetryCoords(120, 340)).toEqual({ x: 120, y: 340 });
+	});
+
+	it("keeps a click that sits on one axis", () => {
+		expect(normaliseRetryCoords(0, 340)).toEqual({ x: 0, y: 340 });
+	});
+
+	it("drops (0, 0) — the autoStart / untrusted-event default, not a click", () => {
+		expect(normaliseRetryCoords(0, 0)).toBeNull();
+	});
+
+	it("drops a half-pair rather than letting NaN reach the salt", () => {
+		expect(normaliseRetryCoords(120, undefined)).toBeNull();
+		expect(normaliseRetryCoords(undefined, 340)).toBeNull();
+	});
+
+	it("drops a missing pair", () => {
+		expect(normaliseRetryCoords(undefined, undefined)).toBeNull();
 	});
 });

--- a/packages/procaptcha-react/src/components/ProcaptchaWidget.tsx
+++ b/packages/procaptcha-react/src/components/ProcaptchaWidget.tsx
@@ -41,6 +41,14 @@ const ProcaptchaWidget = (props: ProcaptchaProps) => {
 	const [state, updateState] = useProcaptcha(useState, useRef);
 	const [loading, setLoading] = useState(false);
 	const hpRef = useRef<HTMLInputElement>(null);
+	// Read at call time rather than captured, so a wrapper that re-renders
+	// with a new handler is still the one the reload button reaches.
+	const onReloadRef = useRef(props.onReload);
+	onReloadRef.current = props.onReload;
+	// Whether the reload button is delegated is decided at mount: handing the
+	// manager a handler the wrapper never supplied would leave reload with
+	// nothing to re-mint the challenge with.
+	const delegatesReload = useRef(Boolean(props.onReload));
 	// Held in a ref so the closure variables that capture the checkbox
 	// click coords (set on start) survive across re-renders and are
 	// still in scope when submit() runs. PoW and Puzzle widgets do the
@@ -55,6 +63,9 @@ const ProcaptchaWidget = (props: ProcaptchaProps) => {
 			callbacks,
 			frictionlessState,
 			() => hpRef.current?.value || undefined,
+			delegatesReload.current
+				? (x?: number, y?: number) => onReloadRef.current?.(x, y)
+				: undefined,
 		),
 	);
 	// See procaptcha-pow ProcaptchaWidget — same session-invalidation

--- a/packages/procaptcha-react/src/tests/procaptchaWidget.unit.test.tsx
+++ b/packages/procaptcha-react/src/tests/procaptchaWidget.unit.test.tsx
@@ -571,4 +571,21 @@ describe("the manager itself", () => {
 		render({ callbacks: undefined as unknown as ProcaptchaProps["callbacks"] });
 		expect(managerArgs[0]?.[3]).toEqual({});
 	});
+
+	test("hands reload back to the wrapper that offered to handle it", () => {
+		// Under frictionless the wrapper is the only thing that can mint the
+		// session a replacement challenge needs, so the manager must ask it
+		// rather than reloading itself.
+		const onReload = vi.fn<(x?: number, y?: number) => void>();
+		render({ onReload });
+		managerArgs[0]?.[6]?.(120, 340);
+		expect(onReload).toHaveBeenCalledWith(120, 340);
+	});
+
+	test("keeps reload to itself when no wrapper offered to handle it", () => {
+		// A delegate the host never supplied would leave reload with nothing
+		// to re-mint the challenge with — the modal would just close.
+		render();
+		expect(managerArgs[0]?.[6]).toBeUndefined();
+	});
 });

--- a/packages/procaptcha/src/modules/Manager.ts
+++ b/packages/procaptcha/src/modules/Manager.ts
@@ -76,6 +76,12 @@ export function Manager(
 	// Reads the live honeypot input value at submit time. Returns undefined
 	// when the honeypot is disabled or the input hasn't been filled.
 	getHoneypotValue?: () => string | undefined,
+	// Hands the reload button back to the caller. Supplied when something
+	// above the manager owns re-minting the challenge — under frictionless the
+	// sessionId this challenge was issued against has already been consumed
+	// provider-side, so only the wrapper (which can run /frictionless again)
+	// can produce a fresh one. When absent the manager reloads itself.
+	onReloadRequest?: (x?: number, y?: number) => void,
 ) {
 	const events = getDefaultEvents(callbacks);
 
@@ -415,13 +421,25 @@ export function Manager(
 	const reload = async () => {
 		// disable the time limit
 		clearTimeout();
-		// trigger the onClose event
+		// trigger the onReload event
 		events.onReload();
+		if (onReloadRequest) {
+			// Drop the spent challenge but leave the frictionless flow alone:
+			// the caller re-runs it and re-mounts us against the new session.
+			// Restarting frictionless from here instead would tear the widget
+			// back down to an unticked checkbox, which is what made reload
+			// look like it merely closed the modal.
+			resetState();
+			onReloadRequest(checkboxClickX, checkboxClickY);
+			return;
+		}
 		// abandon the captcha process and restart frictionless, if it exists
 		resetState(frictionlessState?.restart);
 		if (!frictionlessState?.restart) {
-			// start the captcha process again unless we need a new session
-			await start();
+			// start the captcha process again unless we need a new session,
+			// keeping the checkbox click position so the replacement solution
+			// still carries the real entry point rather than (0, 0)
+			await start(checkboxClickX, checkboxClickY);
 		}
 	};
 

--- a/packages/procaptcha/src/tests/manager.unit.test.ts
+++ b/packages/procaptcha/src/tests/manager.unit.test.ts
@@ -213,6 +213,7 @@ interface Harness {
 		onReload: Mock<() => void>;
 	};
 	restart: Mock<() => void>;
+	onReloadRequest: Mock<(x?: number, y?: number) => void>;
 }
 
 interface HarnessOptions {
@@ -221,6 +222,9 @@ interface HarnessOptions {
 	frictionlessState?: FrictionlessState;
 	withFrictionless?: boolean;
 	honeypot?: () => string | undefined;
+	/** Mirrors the widget only handing the manager a delegate when its
+	 * wrapper actually supplied one. */
+	delegateReload?: boolean;
 }
 
 const build = (options: HarnessOptions = {}): Harness => {
@@ -238,6 +242,7 @@ const build = (options: HarnessOptions = {}): Harness => {
 		onReload: vi.fn<() => void>(),
 	};
 	const restart = vi.fn<() => void>();
+	const onReloadRequest = vi.fn<(x?: number, y?: number) => void>();
 	const callbackInput: ProcaptchaCallbacks = callbacks(events);
 	const frictionlessState =
 		options.frictionlessState ??
@@ -253,8 +258,16 @@ const build = (options: HarnessOptions = {}): Harness => {
 		callbackInput,
 		frictionlessState,
 		options.honeypot,
+		options.delegateReload ? onReloadRequest : undefined,
 	);
-	return { manager, state: currentState, updates, events, restart };
+	return {
+		manager,
+		state: currentState,
+		updates,
+		events,
+		restart,
+		onReloadRequest,
+	};
 };
 
 /** The last value the manager pushed for a given state field. */
@@ -1107,5 +1120,55 @@ describe("reload", () => {
 		await harness.manager.reload();
 		expect(harness.events.onReload).toHaveBeenCalledTimes(1);
 		expect(mocks.getCaptchaChallenge).toHaveBeenCalledTimes(1);
+	});
+
+	test("re-opens the modal on the fresh challenge rather than leaving it closed", async () => {
+		// The bug this guards: reload used to leave the widget torn down, so
+		// pressing it read as "the reload button closes the captcha".
+		const harness = build({ withFrictionless: false });
+		await harness.manager.reload();
+		expect(lastUpdate(harness, "showModal")).toBe(true);
+		expect(lastUpdate(harness, "challenge")).toEqual(challengeResponse());
+	});
+
+	test("keeps the checkbox click position on the replacement challenge", async () => {
+		// Reloading used to re-start from (0, 0), so the replacement solve
+		// reported no entry point at all.
+		const harness = build({ withFrictionless: false });
+		await harness.manager.start(120, 340);
+		await harness.manager.reload();
+		Object.assign(harness.state, { solutions: [[["hash-1", 10, 20]]] });
+		await harness.manager.submit();
+		const solutions = mocks.submitCaptchaSolution.mock.calls[0]?.[2];
+		const first = solutions?.[0];
+		if (!first) throw new Error("no solution submitted");
+		expect(extractData(first.salt)).toEqual([120, 340, 10, 20]);
+	});
+
+	test("hands reload to the caller when one owns re-minting the challenge", async () => {
+		// Under frictionless the provider consumed this session when it issued
+		// the challenge, so only the wrapper can produce a new one.
+		const harness = build({ delegateReload: true });
+		await harness.manager.start(120, 340);
+		await harness.manager.reload();
+		expect(harness.events.onReload).toHaveBeenCalledTimes(1);
+		expect(harness.onReloadRequest).toHaveBeenCalledWith(120, 340);
+	});
+
+	test("does not restart frictionless when the caller owns reload", async () => {
+		// Restarting frictionless drops the user back to an unticked checkbox,
+		// which is what made reload look like a close button.
+		const harness = build({ delegateReload: true });
+		await harness.manager.reload();
+		expect(harness.restart).not.toHaveBeenCalled();
+		expect(mocks.getCaptchaChallenge).not.toHaveBeenCalled();
+	});
+
+	test("clears the spent challenge before handing reload over", async () => {
+		const harness = build({ delegateReload: true });
+		await harness.manager.start();
+		await harness.manager.reload();
+		expect(harness.events.onReset).toHaveBeenCalledTimes(1);
+		expect(lastUpdate(harness, "challenge")).toBeUndefined();
 	});
 });

--- a/packages/types/src/procaptcha/props.ts
+++ b/packages/types/src/procaptcha/props.ts
@@ -118,4 +118,15 @@ export interface ProcaptchaProps {
 	// `onSessionInvalidated` fires without asking the user to click the
 	// checkbox a second time.
 	startCoords?: { x: number; y: number };
+	// Called by the inner widget when the user presses the reload button on
+	// the challenge. The frictionless wrapper owns the response: the
+	// sessionId behind the current challenge has already been consumed by the
+	// provider, so a replacement challenge needs a replacement session. The
+	// wrapper re-runs the frictionless flow and re-mounts the widget with
+	// `autoStart`, so the user gets a new challenge rather than being dropped
+	// back to an unticked checkbox. Coords are the checkbox click position
+	// the user already made, preserved for the same reason as on
+	// `onSessionInvalidated`. When absent the widget falls back to the
+	// manager's own reload behaviour.
+	onReload?: (x?: number, y?: number) => void;
 }


### PR DESCRIPTION
Closes #2556

## The bug

Pressing reload on an image captcha closed the modal and left the user back at an unticked checkbox — no new challenge ever appeared.

Under frictionless (which is how every bundle-mounted widget runs), `Manager.reload` called `frictionlessState.restart()`. That is `BundleCaptcha`'s key bump: it tears the whole widget down, re-runs detection from scratch and mounts the replacement in its idle state. From the user's side, reload is a close button.

## Why the widget can't just refetch

`isValidRequest` calls `checkAndRemoveSession`, so the provider consumes the sessionId when it issues the challenge. The widget has no way to get a second challenge on its own — only something that can call `/frictionless` again can mint the session a replacement needs.

## The fix

Reload is delegated upwards. `ProcaptchaFrictionless` passes an `onReload` handler to the image widget; the manager calls it instead of restarting frictionless, and the wrapper re-runs the frictionless flow and re-mounts the inner widget with `autoStart`, so the new challenge opens straight away.

Two things ride along:

- **Click coords survive a reload.** They're carried into the replacement mount, and the standalone (non-frictionless) reload path now restarts from the recorded position rather than `(0, 0)`.
- **Re-mounts carry a fresh React key.** Without one, a re-render for the same captcha type reconciles onto the existing element, so the inner widget keeps the manager it built on first mount — still closed over the sessionId that was just replaced. This was also latent on the `NO_SESSION_FOUND` recovery path, which re-renders the same widget type.

A widget mounted without an `onReload` (direct React consumers) keeps the previous behaviour.

## Tests

- `manager.unit.test.ts` — reload re-opens the modal on the fresh challenge, preserves the click coords, delegates when a caller owns re-minting, and does not restart frictionless in that case
- `procaptchaWidget.unit.test.tsx` — the widget hands the manager a reload delegate only when its wrapper supplied one
- `sessionInvalidatedRecovery.test.ts` — coords normalisation extracted and covered directly

Unit suites pass for procaptcha, procaptcha-react, procaptcha-frictionless, procaptcha-bundle, procaptcha-pow, procaptcha-puzzle and procaptcha-common. `captchaWidget.unit.test.tsx > renders an item with no image url as an empty image` fails on `main` too — unrelated and untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017BFjuF4jwJmQijZZ38yrQi

## Relationship to #2560

#2560 (open since May) attempts the same ticket by having `reload` always call `start()` against the existing frictionless session. That path re-requests a challenge with a sessionId the provider already consumed in `checkAndRemoveSession`, so it lands on `CAPTCHA.NO_SESSION_FOUND` rather than a new challenge. It also predates the escalation/session-recovery work in `ProcaptchaFrictionless`. This PR supersedes it.
