### PR TITLE
fix(puzzle-assets): register browser.ts as a vite ESM entry

### DIFF
--- a/.changeset/loud-snails-scream.md
+++ b/.changeset/loud-snails-scream.md
@@ -1,0 +1,6 @@
+---
+"@prosopo/puzzle-assets": patch
+---
+
+Add vite export path
+  

--- a/packages/puzzle-assets/vite.esm.config.ts
+++ b/packages/puzzle-assets/vite.esm.config.ts
@@ -15,6 +15,13 @@
 import path from "node:path";
 import { ViteEsmConfig } from "@prosopo/config";
 
+// Both `.` and `./browser` are advertised in package.json exports. Vite
+// only emits `dist/browser.js` if it's declared as an entry — otherwise
+// downstream browser consumers can't resolve @prosopo/puzzle-assets/browser
+// after the ESM build runs.
 export default function () {
-	return ViteEsmConfig(path.basename("."), path.resolve("./tsconfig.json"));
+	return ViteEsmConfig(path.basename("."), path.resolve("./tsconfig.json"), [
+		"src/index.ts",
+		"src/browser.ts",
+	]);
 }


### PR DESCRIPTION
## Summary
Follow-up to #3115 — the `./browser` subpath is declared in package.json exports but the vite ESM build only emits `dist/index.js` unless the extra entry is listed. Downstream browser consumers (e.g. `@prosopo/portal`) fail to resolve `@prosopo/puzzle-assets/browser` at bundle time because `dist/browser.js` never gets produced.

`build:tsc` masks this locally — it transpiles every file under `src/` so the browser entry is present after tsc runs. But the `build` task Turborepo uses on CI only runs vite, so `dist/browser.js` is absent when downstream packages try to resolve the import.

## Fix
Pass `["src/index.ts", "src/browser.ts"]` as the entry list to `ViteEsmConfig`, mirroring how `@prosopo/config` already does it for its own `webpack.config` subpath.

## Test plan
- [x] Local: `rm -rf dist && npm run -w @prosopo/puzzle-assets build` now produces both `dist/index.js` and `dist/browser.js`
- [ ] CI: downstream portal build (prosopo/captcha-private#4242) resolves the `/browser` subpath cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)