### PR TITLE
test(database): add projection-contract test scaffold to catch drift

### DIFF
--- a/.changeset/projection-contract-scaffold.md
+++ b/.changeset/projection-contract-scaffold.md
@@ -1,0 +1,11 @@
+---
+"@prosopo/database": patch
+---
+
+Add reusable projection-contract test scaffold for `ProviderDatabase` mongo fetch methods.
+
+`packages/database/src/tests/integration/projectionContract.ts` exports `testProjectionContract`, a vitest helper that pins a (projection method, consumer) pair: insert a fully-populated fixture, fetch via the method under test, assert every field the consumer reads survives the projection. `packages/database/src/tests/integration/projectionContracts.integration.test.ts` wires initial contracts for `getPowCaptchaRecordByChallenge`, `getPuzzleCaptchaRecordByChallenge`, and `getClientRecord`.
+
+Motivation: same class of bug keeps landing (`getSessionRecordBySessionId` missing tcp-probe fields — #3107; `getDappUserCommitmentBy{Id,Account}` missing verify-path fields — #3116). Mongo projections narrow at write time and stay narrow, while downstream consumers add new field reads over time; TypeScript can't catch the mismatch because the return type is the full record, not the projected subset. This scaffold pins the contract per method and fails a targeted assertion the moment a projection stops covering what the consumer reads.
+
+Adding a new contract when a new projected fetch method lands, or extending the `consumerReads` manifest when a consumer starts reading a new field, is now the drift-prevention convention. `commitmentRecordProjection.integration.test.ts` and `sessionRecordProjection.integration.test.ts` remain as bespoke regression guards; the scaffold is additive, not a replacement.

--- a/packages/database/src/tests/integration/projectionContract.ts
+++ b/packages/database/src/tests/integration/projectionContract.ts
@@ -1,0 +1,106 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { expect, it } from "vitest";
+
+// Reusable projection-contract test.
+//
+// We keep hitting the same class of bug (see #3107, #3116): a mongoose
+// projection lists N fields, a downstream consumer reads M fields off
+// the returned record, and if any field in M is not in N it arrives as
+// `undefined` at the consumer. TypeScript doesn't catch this because the
+// return type is the full record — not the projected subset. The
+// consumer then silently no-ops (guard rules), trips the wrong branch
+// (validation), or fails schema validation at insert time
+// (`buildEscalation` re-persisting escalation sessions).
+//
+// This helper pins the (projection method, consumer) pair as a contract.
+// Every field the consumer reads is enumerated in `consumerReads`; the
+// test inserts a fully-populated fixture, fetches via the method under
+// test, and asserts every consumer-read field survives the projection.
+// Any future projection narrowing that drops a read field fails the
+// assertion with a message that points straight at the missing field.
+//
+// The manifest is manually maintained — but it's the ONE thing that has
+// to move together with the projection, and having it live next to the
+// test means reviewers can eyeball it against the consumer's field
+// accesses. If a consumer starts reading a new field, add it here;
+// forgetting to do so is exactly the class of bug we're guarding.
+
+/** Contract description for a single projected fetch method. */
+export interface ProjectionContract<TRecord extends object> {
+	/** Human-readable name for the test description. */
+	readonly name: string;
+	/**
+	 * Async setup: insert a fully-populated fixture and return the value
+	 * that will be passed to `fetch` (typically the fixture itself, so
+	 * `fetch` can key by id/challenge/sessionId/etc).
+	 */
+	readonly insert: () => Promise<TRecord>;
+	/**
+	 * Fetch under the projection. Returns the record, undefined/null on
+	 * miss, or an array (first element is asserted).
+	 */
+	readonly fetch: (
+		fixture: TRecord,
+	) => Promise<TRecord | TRecord[] | null | undefined>;
+	/**
+	 * Every field the downstream consumer reads off the returned record.
+	 * Enumerate exhaustively — this array IS the contract. If a
+	 * consumer starts reading a new field and this list is not updated,
+	 * the drift check silently no-ops on the new field. Reviewers must
+	 * eyeball this list against the consumer's `.field` accesses.
+	 */
+	readonly consumerReads: readonly (keyof TRecord)[];
+	/**
+	 * Optional consumer name for clearer assertion failures
+	 * (e.g. "verifyImageCaptchaSolution").
+	 */
+	readonly consumerName?: string;
+}
+
+/**
+ * Register a projection-contract test. Insert the fixture, fetch via
+ * the projected method, and assert every field the consumer reads is
+ * defined on the returned record. Fails with a targeted message that
+ * names the missing field and the consumer.
+ *
+ * Call inside a `describe` block so `beforeAll`/`afterAll` around
+ * MongoMemory + `TestProviderDatabase` are shared across contracts.
+ */
+export const testProjectionContract = <TRecord extends object>(
+	contract: ProjectionContract<TRecord>,
+): void => {
+	it(`projection contract: ${contract.name} returns every field its consumer reads`, async () => {
+		const fixture = await contract.insert();
+		const result = await contract.fetch(fixture);
+		const record = Array.isArray(result) ? result[0] : result;
+		if (!record) {
+			throw new Error(
+				`[${contract.name}] fetch returned no record — check that the fixture was inserted and the fetch filter matches`,
+			);
+		}
+		const consumer = contract.consumerName ?? "the consumer";
+		const missing: string[] = [];
+		for (const field of contract.consumerReads) {
+			if (record[field] === undefined) {
+				missing.push(String(field));
+			}
+		}
+		expect(
+			missing,
+			`[${contract.name}] ${consumer} reads ${missing.length === 1 ? "a field" : "fields"} that the projection stripped: ${missing.join(", ")}. Add ${missing.length === 1 ? "it" : "them"} to the projection.`,
+		).toEqual([]);
+	});
+};

--- a/packages/database/src/tests/integration/projectionContracts.integration.test.ts
+++ b/packages/database/src/tests/integration/projectionContracts.integration.test.ts
@@ -1,0 +1,259 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { LogLevel, getLogger } from "@prosopo/logger";
+import {
+	CaptchaStatus,
+	type CompositeIpAddress,
+	IpAddressType,
+	Tier,
+} from "@prosopo/types";
+import type {
+	ClientRecord,
+	PoWCaptchaRecord,
+	PuzzleCaptchaRecord,
+} from "@prosopo/types-database";
+import { MongoMemoryServer } from "mongodb-memory-server";
+import { afterAll, beforeAll, describe } from "vitest";
+import { ProviderDatabase } from "../../databases/provider.js";
+import { testProjectionContract } from "./projectionContract.js";
+
+// Central projection-drift guard.
+//
+// Each `testProjectionContract` call pins one (projection method,
+// consumer) pair. Insert a fully-populated fixture, fetch via the
+// projected method, assert every field the consumer reads survives.
+//
+// Add a new contract whenever a new projected fetch method is added
+// to `ProviderDatabase`, OR whenever a consumer starts reading a new
+// field off a projected record. See `projectionContract.ts` for the
+// helper docstring — the manifest here IS the contract.
+
+const logger = getLogger(LogLevel.enum.error, "projectionContracts.test");
+
+// Stub Redis: none of the read paths under test touch it.
+class TestProviderDatabase extends ProviderDatabase {
+	protected override async setupRedis(): Promise<void> {
+		// intentionally empty
+	}
+}
+
+const ipv4Composite = (lower: bigint): CompositeIpAddress => ({
+	lower,
+	type: IpAddressType.v4,
+});
+
+// Minimal ipInfo blob covering the discriminated `isValid: true` branch
+// that consumers typically narrow on.
+const validIpInfo = {
+	ip: "203.0.113.1",
+	isValid: true as const,
+	isVPN: false,
+	isTor: false,
+	isProxy: false,
+	isDatacenter: false,
+	isAbuser: false,
+	isMobile: false,
+	isSatellite: false,
+	isCrawler: false,
+	countryCode: "GB",
+	asnNumber: 64500,
+	abuserScore: 0,
+	companyAbuserScore: 0,
+};
+
+const bdp = () => ({
+	c1: [{ x: 100, y: 100, timestamp: 1_787_000_000_000, velocity: 0 }],
+	c2: [] as unknown[],
+	c3: [
+		{
+			x: 200,
+			y: 200,
+			timestamp: 1_787_000_000_500,
+			eventType: "click",
+			button: 0,
+			targetElement: "IMG",
+			ctrlKey: false,
+			shiftKey: false,
+			altKey: false,
+		},
+	],
+	d: "desktop",
+});
+
+describe("ProviderDatabase projection contracts", () => {
+	let mongod: MongoMemoryServer;
+	let db: TestProviderDatabase;
+
+	beforeAll(async () => {
+		mongod = await MongoMemoryServer.create();
+		db = new TestProviderDatabase({
+			mongo: { url: mongod.getUri(), dbname: "captchastorage" },
+			logger,
+		});
+		await db.connect();
+	});
+
+	afterAll(async () => {
+		await db.close();
+		await mongod.stop();
+	});
+
+	// ─── PoW captcha record ──────────────────────────────────────────────
+	// getPowCaptchaRecordByChallenge is called by
+	// `serverVerifyPowCaptchaSolution`. Consumer field manifest derived by
+	// `grep -oE "challengeRecord\.[a-zA-Z_]+"` on `powCaptcha/powTasks.ts`.
+	// Update this list when powTasks starts reading a new field.
+	testProjectionContract<PoWCaptchaRecord>({
+		name: "getPowCaptchaRecordByChallenge",
+		consumerName: "serverVerifyPowCaptchaSolution",
+		insert: async () => {
+			const challenge = "1___2___pow-projection-contract" as unknown as string;
+			const doc = {
+				challenge,
+				userAccount: "user-pow",
+				dappAccount: "dapp-pow",
+				requestedAtTimestamp: new Date(),
+				submittedAtTimestamp: new Date(),
+				ipAddress: ipv4Composite(1n),
+				headers: { host: "example.com", "user-agent": "Mozilla/5.0" },
+				ja4: "ja4-pow",
+				result: { status: CaptchaStatus.approved },
+				difficulty: 4,
+				providerSignature: "sig-pow",
+				sessionId: "session-pow",
+				ipInfo: validIpInfo,
+				deviceCapability: "desktop",
+				behavioralDataPacked: bdp(),
+				serverChecked: false,
+				userSubmitted: true,
+				coords: [[[300, 300]]] as [number, number][][],
+			};
+			await db.tables.powcaptcha.create(doc);
+			return doc as unknown as PoWCaptchaRecord;
+		},
+		fetch: (fixture) =>
+			db.getPowCaptchaRecordByChallenge(fixture.challenge as unknown as string),
+		consumerReads: [
+			"behavioralDataPacked",
+			"challenge",
+			"coords",
+			"dappAccount",
+			"deviceCapability",
+			"difficulty",
+			"headers",
+			"ipAddress",
+			"ipInfo",
+			"result",
+			"serverChecked",
+			"sessionId",
+			"submittedAtTimestamp",
+			"userAccount",
+		],
+	});
+
+	// ─── Puzzle captcha record ───────────────────────────────────────────
+	// getPuzzleCaptchaRecordByChallenge is called by
+	// `serverVerifyPuzzleCaptchaSolution`. Consumer field manifest derived
+	// by `grep -oE "challengeRecord\.[a-zA-Z_]+"` on
+	// `puzzleCaptcha/puzzleTasks.ts`. Update this list when puzzleTasks
+	// starts reading a new field.
+	testProjectionContract<PuzzleCaptchaRecord>({
+		name: "getPuzzleCaptchaRecordByChallenge",
+		consumerName: "serverVerifyPuzzleCaptchaSolution",
+		insert: async () => {
+			const challenge =
+				"1___2___puzzle-projection-contract" as unknown as string;
+			const doc = {
+				challenge,
+				userAccount: "user-puzzle",
+				dappAccount: "dapp-puzzle",
+				requestedAtTimestamp: new Date(),
+				submittedAtTimestamp: new Date(),
+				ipAddress: ipv4Composite(1n),
+				headers: { host: "example.com", "user-agent": "Mozilla/5.0" },
+				ja4: "ja4-puzzle",
+				result: { status: CaptchaStatus.approved },
+				targetX: 100,
+				targetY: 100,
+				originX: 0,
+				originY: 0,
+				tolerance: 10,
+				puzzleEvents: [
+					{ x: 10, y: 10, t: 1_787_000_000_000 },
+					{ x: 100, y: 100, t: 1_787_000_000_500 },
+				],
+				providerSignature: "sig-puzzle",
+				sessionId: "session-puzzle",
+				ipInfo: validIpInfo,
+				deviceCapability: "desktop",
+				behavioralDataPacked: bdp(),
+				serverChecked: false,
+				userSubmitted: true,
+				coords: [[[100, 100]]] as [number, number][][],
+			};
+			await db.tables.puzzlecaptcha.create(doc);
+			return doc as unknown as PuzzleCaptchaRecord;
+		},
+		fetch: (fixture) =>
+			db.getPuzzleCaptchaRecordByChallenge(
+				fixture.challenge as unknown as string,
+			),
+		consumerReads: [
+			"behavioralDataPacked",
+			"challenge",
+			"coords",
+			"dappAccount",
+			"deviceCapability",
+			"headers",
+			"ipAddress",
+			"ipInfo",
+			"puzzleEvents",
+			"result",
+			"serverChecked",
+			"sessionId",
+			"submittedAtTimestamp",
+			"targetX",
+			"targetY",
+			"tolerance",
+			"userAccount",
+			"userSubmitted",
+		],
+	});
+
+	// ─── Client record ───────────────────────────────────────────────────
+	// getClientRecord is called throughout the verify/routing paths to
+	// look up per-dapp settings and tier. Consumer field manifest derived
+	// by `grep -oE "clientRecord\??\.[a-zA-Z_]+"` on `packages/provider`.
+	testProjectionContract<ClientRecord>({
+		name: "getClientRecord",
+		consumerName: "provider tasks (settings/tier readers)",
+		insert: async () => {
+			const doc = {
+				account: "client-projection-contract",
+				tier: Tier.Free,
+				settings: {
+					domains: ["example.com"],
+					frictionlessThreshold: 0.5,
+					powDifficulty: 4,
+					captchaType: "image",
+				},
+			};
+			await db.tables.client.create(doc);
+			return doc as unknown as ClientRecord;
+		},
+		fetch: (fixture) => db.getClientRecord(fixture.account),
+		consumerReads: ["account", "settings", "tier"],
+	});
+});


### PR DESCRIPTION
## Summary

- New reusable test helper `packages/database/src/tests/integration/projectionContract.ts` — `testProjectionContract` pins a (projection method, consumer) pair. Insert a fully-populated fixture, fetch via the projected method, assert every field the consumer reads survives the projection.
- New `packages/database/src/tests/integration/projectionContracts.integration.test.ts` — one place to add a contract per projected `ProviderDatabase` fetch. Initial contracts: `getPowCaptchaRecordByChallenge`, `getPuzzleCaptchaRecordByChallenge`, `getClientRecord`.

## Why

Same class of bug keeps landing:

- #3107 — `getSessionRecordBySessionId` projection missing tcp-probe fields; DM decide rules silently no-op'd against real matching sessions.
- #3116 — `getDappUserCommitmentBy{Id,Account}` projections missing `behavioralDataPacked`, `deviceCapability`, `coords`, plus the by-account variant missing almost every field beyond `result`.

Root cause is structural: mongo projections narrow at write time and stay narrow, downstream consumers add new field reads over time, and TypeScript can't catch the mismatch because the return type is the full record — not the projected subset. Reviewers can miss it because the projection and its consumer often sit in different packages.

This scaffold pins the contract per method and fails a targeted assertion the moment a projection stops covering what its consumer reads. The `consumerReads` manifest is manually maintained but centralised next to the test, so reviewers can eyeball it against the consumer's field accesses.

The convention going forward:
- New projected fetch method → add a contract in `projectionContracts.integration.test.ts`.
- Consumer starts reading a new field off a projected record → extend `consumerReads` for that contract.

The two existing bespoke regression tests (`commitmentRecordProjection.integration.test.ts`, `sessionRecordProjection.integration.test.ts`) stay as-is — they encode more specific parity checks (by-id vs by-account, escalation re-persistence). The scaffold is additive.

## Test plan

- [x] `npm run -w @prosopo/database build:tsc` passes
- [x] `npx biome check packages/database/src/tests/integration/projection*` passes
- [x] `npx -w @prosopo/database vitest run --dir src/tests/integration` — 35/35 pass (scaffold adds 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)