### PR TITLE
feat(provider): return sessionId from the verify endpoints

### DIFF
--- a/.changeset/verify-session-id.md
+++ b/.changeset/verify-session-id.md
@@ -1,0 +1,8 @@
+---
+"@prosopo/types": minor
+"@prosopo/provider": minor
+---
+
+Return the verified record's `sessionId` on the verify endpoints.
+
+`VerificationResponse` gains an optional `sessionId`, populated by the image, PoW and puzzle verify paths from the challenge/commitment record they looked up. It lets a caller correlate its own logs with the provider's: the sessionId is carried in neither the procaptcha token nor the verify request body, so the provider is the only party that can supply it. Absent when no record was found, or when the flow carried no session. Not tier-gated, since it is a correlation handle rather than a scoring signal.

--- a/packages/provider/src/api/verify.ts
+++ b/packages/provider/src/api/verify.ts
@@ -249,6 +249,7 @@ export function prosopoVerifyRouter(env: ProviderEnvironment): Router {
 						response[ApiParams.score],
 						response[ApiParams.commitmentId],
 						response[ApiParams.status],
+						response[ApiParams.sessionId],
 					);
 				res.json(verificationResponse);
 			} catch (err) {
@@ -378,7 +379,7 @@ export function prosopoVerifyRouter(env: ProviderEnvironment): Router {
 				// Will throw an error if the signature is invalid
 				verifySignature(dappSignature, timestamp.toString(), dappPair);
 
-				const { verified, score, reason } =
+				const { verified, score, reason, sessionId } =
 					await tasks.powCaptchaManager.serverVerifyPowCaptchaSolution(
 						dapp,
 						challenge,
@@ -400,6 +401,7 @@ export function prosopoVerifyRouter(env: ProviderEnvironment): Router {
 						req.i18n.t,
 						score,
 						reason,
+						sessionId,
 					);
 
 				return res.json(verificationResponse);
@@ -530,7 +532,7 @@ export function prosopoVerifyRouter(env: ProviderEnvironment): Router {
 				// Will throw an error if the signature is invalid
 				verifySignature(dappSignature, timestamp.toString(), dappPair);
 
-				const { verified, score } =
+				const { verified, score, sessionId } =
 					await tasks.puzzleCaptchaManager.serverVerifyPuzzleCaptchaSolution(
 						dapp,
 						challenge,
@@ -551,6 +553,8 @@ export function prosopoVerifyRouter(env: ProviderEnvironment): Router {
 						clientRecord,
 						req.i18n.t,
 						score,
+						undefined,
+						sessionId,
 					);
 
 				return res.json(verificationResponse);

--- a/packages/provider/src/tasks/captchaManager.ts
+++ b/packages/provider/src/tasks/captchaManager.ts
@@ -683,6 +683,7 @@ export class CaptchaManager {
 		translateFn: (key: string) => string,
 		score?: number,
 		reason?: string,
+		sessionId?: string,
 	) {
 		return {
 			status: translateFn(
@@ -697,6 +698,8 @@ export class CaptchaManager {
 				reason && {
 					[ApiParams.reason]: reason,
 				}),
+			// Not tier-gated — a log correlation handle, not a scoring signal.
+			...(sessionId && { [ApiParams.sessionId]: sessionId }),
 		};
 	}
 

--- a/packages/provider/src/tasks/imgCaptcha/imgCaptchaTasks.ts
+++ b/packages/provider/src/tasks/imgCaptcha/imgCaptchaTasks.ts
@@ -703,6 +703,7 @@ export class ImgCaptchaManager extends CaptchaManager {
 			return {
 				status: "API.USER_ALREADY_VERIFIED",
 				verified: false,
+				...(solution.sessionId && { sessionId: solution.sessionId }),
 			};
 		}
 
@@ -714,6 +715,7 @@ export class ImgCaptchaManager extends CaptchaManager {
 			return {
 				status: solution.result.reason || "API.USER_NOT_VERIFIED",
 				verified: false,
+				...(solution.sessionId && { sessionId: solution.sessionId }),
 			};
 		}
 
@@ -734,6 +736,7 @@ export class ImgCaptchaManager extends CaptchaManager {
 			return {
 				status: "API.USER_NOT_VERIFIED_TIME_EXPIRED",
 				verified: false,
+				...(solution.sessionId && { sessionId: solution.sessionId }),
 			};
 		}
 
@@ -1185,6 +1188,7 @@ export class ImgCaptchaManager extends CaptchaManager {
 			verified: isApproved,
 			commitmentId: solution.id.toString(),
 			...(score && { score }),
+			...(solution.sessionId && { sessionId: solution.sessionId }),
 		};
 	}
 
@@ -1199,6 +1203,7 @@ export class ImgCaptchaManager extends CaptchaManager {
 		score?: number,
 		commitmentId?: Hash,
 		reason?: string,
+		sessionId?: string,
 	): ImageVerificationResponse {
 		return {
 			...super.getVerificationResponse(
@@ -1207,6 +1212,7 @@ export class ImgCaptchaManager extends CaptchaManager {
 				translateFn,
 				score,
 				reason,
+				sessionId,
 			),
 			...(commitmentId && {
 				[ApiParams.commitmentId]: commitmentId,

--- a/packages/provider/src/tasks/powCaptcha/powTasks.ts
+++ b/packages/provider/src/tasks/powCaptcha/powTasks.ts
@@ -618,12 +618,19 @@ export class PowCaptchaManager extends CaptchaManager {
 		spamFilter?: ISpamFilterRules,
 		trafficFilter?: ITrafficFilter,
 		storeMetadata = false,
-	): Promise<{ verified: boolean; score?: number; reason?: string }> {
+	): Promise<{
+		verified: boolean;
+		score?: number;
+		reason?: string;
+		sessionId?: string;
+	}> {
 		const notVerified = (
 			reason: string,
-		): { verified: false; reason: string } => ({
+			sessionId?: string,
+		): { verified: false; reason: string; sessionId?: string } => ({
 			verified: false,
 			reason,
+			...(sessionId && { sessionId }),
 		});
 
 		// Bind the challenge/dappAccount context once so every log line in this
@@ -652,7 +659,10 @@ export class PowCaptchaManager extends CaptchaManager {
 		}
 
 		if (challengeRecord.serverChecked)
-			return notVerified("API.USER_ALREADY_VERIFIED");
+			return notVerified(
+				"API.USER_ALREADY_VERIFIED",
+				challengeRecord.sessionId,
+			);
 
 		const challengeDappAccount = challengeRecord.dappAccount;
 
@@ -1085,9 +1095,15 @@ export class PowCaptchaManager extends CaptchaManager {
 		}
 
 		if (failReason) {
-			return notVerified(failReason);
+			return notVerified(failReason, challengeRecord.sessionId);
 		}
 
-		return { verified: true, ...(score ? { score } : {}) };
+		return {
+			verified: true,
+			...(score ? { score } : {}),
+			...(challengeRecord.sessionId && {
+				sessionId: challengeRecord.sessionId,
+			}),
+		};
 	}
 }

--- a/packages/provider/src/tasks/puzzleCaptcha/puzzleTasks.ts
+++ b/packages/provider/src/tasks/puzzleCaptcha/puzzleTasks.ts
@@ -454,8 +454,13 @@ export class PuzzleCaptchaManager extends CaptchaManager {
 		spamFilter?: ISpamFilterRules,
 		trafficFilter?: ITrafficFilter,
 		storeMetadata = false,
-	): Promise<{ verified: boolean; score?: number }> {
-		const notVerifiedResponse = { verified: false };
+	): Promise<{ verified: boolean; score?: number; sessionId?: string }> {
+		// Shared by every not-verified exit; sessionId is stamped on below
+		// once the record is loaded, so each exit needn't repeat it.
+		const notVerifiedResponse: {
+			verified: false;
+			sessionId?: string;
+		} = { verified: false };
 
 		// Bind the challenge/dappAccount context once so every log line in this
 		// method carries it without repeating the fields in each `data` block.
@@ -471,6 +476,8 @@ export class PuzzleCaptchaManager extends CaptchaManager {
 
 			return notVerifiedResponse;
 		}
+
+		notVerifiedResponse.sessionId = challengeRecord.sessionId;
 
 		if (challengeRecord.result.status !== CaptchaStatus.approved) {
 			throw new ProsopoApiError("CAPTCHA.INVALID_SOLUTION", {
@@ -916,6 +923,12 @@ export class PuzzleCaptchaManager extends CaptchaManager {
 			});
 		}
 
-		return { verified: true, ...(score ? { score } : {}) };
+		return {
+			verified: true,
+			...(score ? { score } : {}),
+			...(challengeRecord.sessionId && {
+				sessionId: challengeRecord.sessionId,
+			}),
+		};
 	}
 }

--- a/packages/provider/src/tests/unit/tasks/captchaManager.unit.test.ts
+++ b/packages/provider/src/tests/unit/tasks/captchaManager.unit.test.ts
@@ -1730,6 +1730,38 @@ describe("CaptchaManager", () => {
 				score: 0.5,
 			});
 		});
+		it("should return the sessionId even on the free tier, which hides the score", () => {
+			const result = captchaManager.getVerificationResponse(
+				true,
+				{
+					account: "account",
+					tier: Tier.Free,
+				} as unknown as ClientRecord,
+				() => "translated",
+				0.5,
+				undefined,
+				"session-abc",
+			);
+			expect(result).toEqual({
+				status: "translated",
+				verified: true,
+				sessionId: "session-abc",
+			});
+		});
+		it("should omit the sessionId when there isn't one", () => {
+			const result = captchaManager.getVerificationResponse(
+				true,
+				{
+					account: "account",
+					tier: Tier.Professional,
+				} as unknown as ClientRecord,
+				() => "translated",
+				0.5,
+				undefined,
+				undefined,
+			);
+			expect(result).not.toHaveProperty("sessionId");
+		});
 	});
 
 	describe("decryptBehavioralData", () => {

--- a/packages/provider/src/tests/unit/tasks/powCaptcha/powTasks.unit.test.ts
+++ b/packages/provider/src/tests/unit/tasks/powCaptcha/powTasks.unit.test.ts
@@ -570,6 +570,56 @@ describe("PowCaptchaManager", () => {
 			);
 		});
 
+		it("should return the record's sessionId, on both the verified and already-checked paths", async () => {
+			const dappAccount = "dappAccount";
+			const timestamp = 123456789;
+			const userAccount = "testUserAccount";
+			const challenge: PoWChallengeId = `${timestamp}${POW_SEPARATOR}${userAccount}${POW_SEPARATOR}${dappAccount}`;
+			const timeout = 1000;
+			const challengeRecord: Partial<PoWCaptchaStored> = {
+				challenge,
+				dappAccount,
+				userAccount,
+				sessionId: "session-abc",
+				requestedAtTimestamp: new Date(timestamp),
+				submittedAtTimestamp: new Date(),
+				serverChecked: false,
+				result: { status: CaptchaStatus.approved },
+				ipAddress: getCompositeIpAddress(getIPAddress("1.1.1.1")),
+			};
+			// biome-ignore lint/suspicious/noExplicitAny: TODO fix
+			(db.getPowCaptchaRecordByChallenge as any).mockResolvedValue(
+				challengeRecord,
+			);
+			// biome-ignore lint/suspicious/noExplicitAny: TODO fix
+			(verifyRecency as any).mockImplementation(() => true);
+
+			const verified = await powCaptchaManager.serverVerifyPowCaptchaSolution(
+				dappAccount,
+				challenge,
+				timeout,
+				mockEnv,
+			);
+			expect(verified.verified).toBe(true);
+			expect(verified.sessionId).toBe("session-abc");
+
+			// A replay exits before the session is ever loaded, but the record
+			// it read still carries the id.
+			// biome-ignore lint/suspicious/noExplicitAny: TODO fix
+			(db.getPowCaptchaRecordByChallenge as any).mockResolvedValue({
+				...challengeRecord,
+				serverChecked: true,
+			});
+			const replayed = await powCaptchaManager.serverVerifyPowCaptchaSolution(
+				dappAccount,
+				challenge,
+				timeout,
+				mockEnv,
+			);
+			expect(replayed.verified).toBe(false);
+			expect(replayed.sessionId).toBe("session-abc");
+		});
+
 		it("should return verified:false if a challenge cannot be found", async () => {
 			const dappAccount = "dappAccount";
 			const timestamp = 123456678;

--- a/packages/types/src/provider/api.ts
+++ b/packages/types/src/provider/api.ts
@@ -390,6 +390,9 @@ export interface VerificationResponse extends ApiResponse {
 	[ApiParams.verified]: boolean;
 	[ApiParams.score]?: number;
 	[ApiParams.reason]?: string;
+	// For log correlation only. Neither the token nor the verify request
+	// carries it, so the caller cannot know it without us echoing it back.
+	[ApiParams.sessionId]?: string;
 }
 
 export interface UpdateDecisionMachineResponse extends ApiResponse {


### PR DESCRIPTION
Echoes the verified record's `sessionId` back on the verify response so callers can correlate their logs with the provider's.

Pairs with prosopo/captcha-private#4274, which logs it in the siteverify lambda. Towards prosopo/captcha-private#2566.

https://claude.ai/code/session_01VtU7Yg2wLWZeoKL35AB2h9