### PR TITLE
fix(caddyfile): drop client-cert header_up lines that 502 every request

### DIFF
--- a/docker/local.Caddyfile
+++ b/docker/local.Caddyfile
@@ -20,15 +20,12 @@ local.prosopo.io:4001 {
 		# Single-line, no "^{placeholder}$" "" blanking guard — that guard was
 		# self-defeating (Caddy expands the placeholder in the search arg too,
 		# so it always matched and wiped the value). See provider.Caddyfile for
-		# the full explanation. Every placeholder here is a valid caddy v2.8.4
-		# shorthand / {http.request.*} field that resolves to its value or "".
+		# the full explanation. The client-certificate header family was
+		# removed rather than un-guarded: captcha clients present no client
+		# cert so every one was empty, and un-blanking x-tls-client-certificate-pem
+		# forwards a multi-line PEM, which is an invalid HTTP header value and
+		# 502s the request. The provider reads none of them.
 		header_up x-tls-version "{tls_version}"
-		header_up x-tls-client-subject "{tls_client_subject}"
-		header_up x-tls-client-serial "{tls_client_serial}"
-		header_up x-tls-client-issuer "{tls_client_issuer}"
-		header_up x-tls-client-fingerprint "{tls_client_fingerprint}"
-		header_up x-tls-client-certificate-pem "{tls_client_certificate_pem}"
-		header_up x-tls-client-certificate-der-base64 "{tls_client_certificate_der_base64}"
 		header_up x-tls-cipher "{tls_cipher}"
 		header_up x-remote-port "{remote_port}"
 		header_up x-remote-host "{remote_host}"
@@ -39,12 +36,6 @@ local.prosopo.io:4001 {
 		header_up x-tls-proto "{http.request.tls.proto}"
 		header_up x-tls-proto-mutual "{http.request.tls.proto_mutual}"
 		header_up x-tls-server-name "{http.request.tls.server_name}"
-		header_up x-tls-public-key "{http.request.tls.client.public_key}"
-		header_up x-tls-public-key-sha256 "{http.request.tls.client.public_key_sha256}"
-		header_up x-tls-client-san-dns-names "{http.request.tls.client.san.dns_names}"
-		header_up x-tls-client-san-emails "{http.request.tls.client.san.emails}"
-		header_up x-tls-client-san-ips "{http.request.tls.client.san.ips}"
-		header_up x-tls-client-san-uris "{http.request.tls.client.san.uris}"
 	}
 
 	log {

--- a/docker/provider.Caddyfile
+++ b/docker/provider.Caddyfile
@@ -270,26 +270,29 @@ http://:9090 {
 
 			header_up X-Request-ID "{http.request_id}"
 
-			# NOTE: each of these was previously a two-line pair — the value
-			# line plus a `header_up X "^{placeholder}$" ""` "blank if
-			# unexpanded" guard. That guard was self-defeating: Caddy expands
-			# placeholders inside the search argument too, so the regex always
-			# equalled the value just set and every stable field was replaced
-			# with "". In production this blanked x-tls-resumed, x-tls-version,
-			# x-tls-server-name, x-client-ip, x-method, x-remote-host, etc. on
-			# 100% of requests (only x-duration-ms survived, because its value
-			# ticks up between the two evaluations so the regex no longer
-			# matched). Every placeholder below is a valid Caddy shorthand or
-			# {http.request.*} field, which resolves to its value or to an
-			# empty string when absent — never to a literal — so the guard is
-			# unnecessary. See replacer.go / shorthands.go in caddy v2.8.4.
+			# These were previously two-line pairs — a value line plus a
+			# `header_up X "^{placeholder}$" ""` "blank if unexpanded" guard.
+			# The guard was self-defeating: Caddy expands placeholders inside
+			# the search argument too, so the regex always equalled the value
+			# just set and every stable field was replaced with "". In
+			# production that blanked x-tls-resumed, x-tls-version,
+			# x-tls-server-name, x-client-ip, etc. on 100% of requests (only
+			# x-duration-ms survived, because its value ticks up between the
+			# two evaluations so the regex no longer matched). Each placeholder
+			# below is a valid Caddy shorthand / {http.request.*} field that
+			# resolves to its value or "", never a literal — no guard needed.
+			#
+			# The client-certificate header family that used to live here
+			# (x-tls-client-subject / serial / issuer / fingerprint /
+			# certificate-pem / certificate-der-base64 / public-key* / san.*)
+			# was removed, not un-guarded: captcha clients never present a
+			# client certificate so every one was empty, and the guard had been
+			# silently swallowing them. Unblanking x-tls-client-certificate-pem
+			# forwarded a multi-line PEM as a single header value, which is an
+			# invalid HTTP header and 502'd every request. The provider reads
+			# none of them (only x-tls-clienthello + the tcp-probe headers), so
+			# they are dropped entirely.
 			header_up x-tls-version "{tls_version}"
-			header_up x-tls-client-subject "{tls_client_subject}"
-			header_up x-tls-client-serial "{tls_client_serial}"
-			header_up x-tls-client-issuer "{tls_client_issuer}"
-			header_up x-tls-client-fingerprint "{tls_client_fingerprint}"
-			header_up x-tls-client-certificate-pem "{tls_client_certificate_pem}"
-			header_up x-tls-client-certificate-der-base64 "{tls_client_certificate_der_base64}"
 			header_up x-tls-cipher "{tls_cipher}"
 			header_up x-remote-port "{remote_port}"
 			header_up x-remote-host "{remote_host}"
@@ -300,17 +303,6 @@ http://:9090 {
 			header_up x-tls-proto "{http.request.tls.proto}"
 			header_up x-tls-proto-mutual "{http.request.tls.proto_mutual}"
 			header_up x-tls-server-name "{http.request.tls.server_name}"
-			# public_key / public_key_sha256 exist only under the client cert
-			# namespace in caddy (there is no bare http.request.tls.public_key
-			# field); the previous names were invalid and would have forwarded
-			# a literal once the guard was removed. These resolve to "" unless
-			# the client presents a certificate (captcha clients never do).
-			header_up x-tls-public-key "{http.request.tls.client.public_key}"
-			header_up x-tls-public-key-sha256 "{http.request.tls.client.public_key_sha256}"
-			header_up x-tls-client-san-dns-names "{http.request.tls.client.san.dns_names}"
-			header_up x-tls-client-san-emails "{http.request.tls.client.san.emails}"
-			header_up x-tls-client-san-ips "{http.request.tls.client.san.ips}"
-			header_up x-tls-client-san-uris "{http.request.tls.client.san.uris}"
 		}
 	}
 


### PR DESCRIPTION
## Follow-up to #3124 — fixes a 502 regression

#3124 removed the self-defeating `header_up X "^{placeholder}$" ""` blanking guard. That was correct for the connection/TLS-session headers, but it also un-blanked the **client-certificate** header family — and `x-tls-client-certificate-pem` resolves to a **multi-line PEM**, which is an invalid HTTP header value. Go's reverse-proxy client rejects it, so **every proxied request 502'd**.

Caught on staging immediately after deploying #3124:
```
net/http: invalid header field value for "X-Tls-Client-Certificate-Pem"
... status 502 ... reverseproxy.statusError
```

## Fix

Captcha clients never present a client certificate, so the entire `x-tls-client-*` / `x-tls-public-key*` family was **always empty** — the guard had just been hiding it. The provider reads none of them (only `x-tls-clienthello` and the tcp-probe `x-tls-*` headers), so they're **dropped entirely** rather than re-guarded.

Kept (and now populating, which was the point of #3124): `x-tls-resumed`, `x-tls-version`, `x-tls-cipher`, `x-tls-server-name`, `x-tls-proto`, `x-tls-proto-mutual`, `x-client-ip`, `x-method`, `x-remote-host`, `x-remote-port`, `x-duration-ms`.

## Verified on staging

Deployed to all three staging pronodes:
- `healthz` **200** on pronode2/3/4, **zero** invalid-header / 502 errors.
- Caddy resolves the value — access log shows `"tls":{"resumed":false,...}` — and the deployed config forwards `{http.request.tls.resumed}` unblanked.

Both `provider.Caddyfile` and `local.Caddyfile` updated; both pass `caddy fmt`.

> ⚠️ #3124 is already on `main` and is **not production-safe** as-is (it 502s every request). This should merge before any provider deploy that picks up the merged Caddyfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
