### PR TITLE
fix(caddyfile): use duration_ms so x-duration-ms is clean ASCII

### DIFF
--- a/docker/local.Caddyfile
+++ b/docker/local.Caddyfile
@@ -31,7 +31,7 @@ local.prosopo.io:4001 {
 		header_up x-remote-host "{remote_host}"
 		header_up x-method "{method}"
 		header_up x-client-ip "{client_ip}"
-		header_up x-duration-ms "{http.request.duration}"
+		header_up x-duration-ms "{http.request.duration_ms}"
 		header_up x-tls-resumed "{http.request.tls.resumed}"
 		header_up x-tls-proto "{http.request.tls.proto}"
 		header_up x-tls-proto-mutual "{http.request.tls.proto_mutual}"

--- a/docker/provider.Caddyfile
+++ b/docker/provider.Caddyfile
@@ -298,7 +298,7 @@ http://:9090 {
 			header_up x-remote-host "{remote_host}"
 			header_up x-method "{method}"
 			header_up x-client-ip "{client_ip}"
-			header_up x-duration-ms "{http.request.duration}"
+			header_up x-duration-ms "{http.request.duration_ms}"
 			header_up x-tls-resumed "{http.request.tls.resumed}"
 			header_up x-tls-proto "{http.request.tls.proto}"
 			header_up x-tls-proto-mutual "{http.request.tls.proto_mutual}"


### PR DESCRIPTION
## Problem

`x-duration-ms` forwards `{http.request.duration}`, which Caddy renders via Go's `time.Duration.String()`. Sub-millisecond values use the **micro sign** `µ` (U+00B5 = `0xC2 0xB5`). The Node upstream decodes HTTP header bytes as Latin-1, so `0xC2 0xB5` → `Â` + `µ`, which is then re-stored as UTF-8 and lands in Mongo as mojibake:

```
"x-duration-ms" : "707.46Âµs"
```

(`Âµ` = `c382c2b5`, exactly the Latin-1/UTF-8 double-decode of `µ` = `c2b5`.)

Pre-existing: `x-duration-ms` was the one header the old blanking guard failed to wipe (its value ticks up between the guard's two evaluations), so it's been storing `Âµs` on every sub-millisecond request.

## Fix

Use `{http.request.duration_ms}` — it returns `Seconds()*1e3` as a plain float: ASCII-only, no micro sign, and the value now actually matches the header's `ms` name (`0.70746` instead of `707.46µs`).

## Verified

Deployed to all three staging pronodes (healthz 200, no errors); deployed line confirmed `header_up x-duration-ms "{http.request.duration_ms}"`.

Follow-up to #3124 / #3135. Both `provider.Caddyfile` and `local.Caddyfile`; both pass `caddy fmt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)