### PR TITLE
fix(provider): project clientMetaData so client session id correlation can pass

### DIFF
--- a/.changeset/client-session-id-projection.md
+++ b/.changeset/client-session-id-projection.md
@@ -1,0 +1,15 @@
+---
+"@prosopo/database": patch
+"@prosopo/client-example-server": patch
+"@prosopo/cypress-shared": patch
+---
+
+Fix client session id correlation rejecting every token.
+
+#3139 added `clientMetaData.clientSessionId` and a verify-time check that the solve carries the same session id the widget was rendered with. The check never passed: `getPowCaptchaRecordByChallenge` and `getPuzzleCaptchaRecordByChallenge` project an explicit field list, and `clientMetaData` was not in it. The verify path therefore read `undefined` and `isClientSessionMismatch(suppliedId, undefined)` returned true for *every* token carrying a session id, disapproving it with `API.CLIENT_SESSION_MISMATCH`.
+
+Nothing else was wrong: the widget attached the id, the wire format carried it, and the write path persisted it (the session record — read without a projection — had it all along). Only the read dropped it, which is why unit tests over the comparison helper and the escalation handoff all passed. `getSessionRecordBySessionId` had the same omission and is fixed too.
+
+This is the third instance of this class of bug — the projection-contract helper's own docstring already cites #3107 and #3116. The guard existed but its `consumerReads` manifest was not updated when #3139 started reading a new field, so the manifests for the PoW and puzzle contracts now list `clientMetaData` and their fixtures populate it. Reverting the projection fix makes that test fail with "serverVerifyPowCaptchaSolution reads a field that the projection stripped: clientMetaData".
+
+Adds an end-to-end Cypress spec (`clientSessionId.cy.ts`) that solves a real PoW captcha rendered with `data-sessionid` and asserts the dapp server's verify succeeds, plus a mismatch case that must be rejected — the half that proves the correlation actually runs rather than being silently skipped. This required wiring `clientSessionId` through the demo server's `/signup` into `isVerified`, which #3139 left unwired; that omission is why no e2e covered the feature.

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -200,6 +200,10 @@ jobs:
         run: |
           npx concurrently "npm run start:server" "npm run start:provider:admin" "npm run start:bundle" "npm run serve:bundle" "npx tsx ./demos/cypress-shared/scripts/wait-for-services.ts && npm -w @prosopo/cypress-shared run cypress:run:client-bundle-example:decisionMachineDenyPuzzle" --success "first" --kill-others
 
+      - name: Run the cypress tests for the client session id correlation
+        run: |
+          npx concurrently "npm run start:server" "npm run start:provider:admin" "npm run start:bundle" "npm run serve:bundle" "npx tsx ./demos/cypress-shared/scripts/wait-for-services.ts && npm -w @prosopo/cypress-shared run cypress:run:client-bundle-example:clientSessionId" --success "first" --kill-others
+
       - name: Run the cypress tests for user access policy blocks (request-time + defer-to-verify)
         run: |
           npx concurrently "npm run start:server" "npm run start:provider:admin" "npm run start:bundle" "npm run serve:bundle" "npx tsx ./demos/cypress-shared/scripts/wait-for-services.ts && npm -w @prosopo/cypress-shared run cypress:run:client-bundle-example:accessPolicy" --success "first" --kill-others

--- a/demos/client-bundle-example/src/pow-implicit-sessionid.html
+++ b/demos/client-bundle-example/src/pow-implicit-sessionid.html
@@ -1,0 +1,223 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <link href="https://cdn.muicss.com/mui-0.10.3/css/mui.min.css" rel="stylesheet" type="text/css"/>
+    <link href="styles/field.css" rel="stylesheet" type="text/css"/>
+
+    <script src="index.js"></script>
+    <title>Procaptcha demo: PoW - Client Session Id</title>
+<link href="styles/captcha.css" rel="stylesheet" type="text/css"/>
+    <script type="module">
+        // Function to update CAPTCHA status display is now provided by status-log-injector
+
+        // The site's own per-user session id. Rendered onto the widget via
+        // data-sessionid and sent again at verify as clientSessionId; the
+        // provider only accepts the token when the two agree.
+        //
+        // `?mismatch=1` deliberately verifies with a DIFFERENT id, which must
+        // be rejected — that is the half of the contract that proves the
+        // correlation is actually enforced rather than silently skipped.
+        const CLIENT_SESSION_ID = 'cypress-session-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+        const MISMATCHED_SESSION_ID = 'cypress-session-99999999-9999-9999-9999-999999999999';
+        const verifyingSessionId = () =>
+            new URLSearchParams(window.location.search).get('mismatch') === '1'
+                ? MISMATCHED_SESSION_ID
+                : CLIENT_SESSION_ID;
+
+        window.addEventListener('load', () => {
+
+            window.setIsError = (isError) => {
+                const messageContainer = document.getElementById('messageContainer');
+                messageContainer.style.color = isError ? 'red' : 'black';
+                messageContainer.style.display = 'block';
+            };
+
+            window.setMessage = (message) => {
+                document.getElementById('message').innerText = message;
+            };
+
+            window.onLoggedIn = (token) => {
+                updateCaptchaStatus('Logged in, fetching private resource', 'info');
+                const url = new URL("/private", config.serverUrl).href;
+                console.log("getting private resource with token ", token, "at", url);
+                fetch(url, {
+                    method: "GET",
+                    headers: {
+                        Origin: "http://localhost:9232", // TODO: change this to env var
+                        "Content-Type": "application/json",
+                        Authorization: `Bearer ${token}`,
+                    },
+                })
+                    .then(async (res) => {
+                        try {
+                            const jsonRes = await res.json();
+                            if (res.status === 200) {
+                                updateCaptchaStatus(`Successfully accessed private resource`, 'success');
+                                setMessage(jsonRes.message);
+                            } else {
+                                updateCaptchaStatus(`Failed to access private resource: ${res.status}`, 'error');
+                            }
+                        } catch (err) {
+                            console.log(err);
+                            updateCaptchaStatus(`Error parsing response: ${err}`, 'error');
+                        }
+                    })
+                    .catch((err) => {
+                        console.log(err);
+                        updateCaptchaStatus(`Fetch error: ${err}`, 'error');
+                    });
+            };
+
+            window.onActionHandler = () => {
+                updateCaptchaStatus('Form submission initiated', 'info');
+
+                const procaptchaElements = document.getElementsByName('procaptcha-response');
+
+                if (!procaptchaElements.length) {
+                    updateCaptchaStatus('Error: No CAPTCHA response found', 'error');
+                    alert("Must complete captcha");
+                    return
+                }
+
+                const procaptchaToken = procaptchaElements[0].value;
+                updateCaptchaStatus(`Token received: ${procaptchaToken.substring(0, 15)}...`, 'success');
+
+                const payload = {
+                    email: document.getElementById('email').value,
+                    name: document.getElementById('name').value,
+                    password: document.getElementById('password').value,
+                    siteKey: import.meta.env.PROSOPO_SITE_KEY_POW,
+                    "procaptcha-response": procaptchaToken,
+                    clientSessionId: verifyingSessionId(),
+                };
+                const url = new URL('signup', import.meta.env.PROSOPO_SERVER_URL).href;
+                console.log("posting to", url, "with payload", payload);
+                fetch(url, {
+                    method: "POST",
+                    headers: {
+                        "Content-Type": "application/json",
+                    },
+                    body: JSON.stringify(payload),
+                    contentType: "application/json",
+                }).then((response) => {
+                    return new Promise((resolve) => response.json()
+                        .then((json) => resolve({
+                            status: response.status,
+                            ok: response.ok,
+                            json,
+                        })))
+                })
+                    .then(async ({status, json, ok}) => {
+                        console.log("status", status, "json", json.message, "ok", ok);
+                        console.log("json", json)
+                        try {
+                            if (status !== 200) {
+                                updateCaptchaStatus(`API Error: ${json.message}`, 'error');
+                                setIsError(true);
+                                setMessage(json.message);
+                            } else {
+                                updateCaptchaStatus(`API Success: ${json.message}`, 'success');
+                                setIsError(false);
+                                setMessage(json.message);
+                            }
+                        } catch (err) {
+                            console.log(err);
+                            updateCaptchaStatus(`Error processing response: ${err}`, 'error');
+                        }
+                    })
+                    .catch((err) => {
+                        console.log(err);
+                        updateCaptchaStatus(`Fetch error: ${err}`, 'error');
+                        setIsError(true);
+                        setMessage("Error: " + err);
+                    });
+            };
+
+            updateCaptchaStatus('Page loaded - Initializing CAPTCHA system', 'info');
+
+            // Monitor DOM for CAPTCHA initialization
+            const observer = new MutationObserver((mutations) => {
+                mutations.forEach((mutation) => {
+                    if (mutation.addedNodes.length) {
+                        for (let i = 0; i < mutation.addedNodes.length; i++) {
+                            const node = mutation.addedNodes[i];
+                            if (node.classList && (node.classList.contains('procaptcha') ||
+                                  node.querySelector && node.querySelector('.procaptcha'))) {
+                                updateCaptchaStatus('CAPTCHA DOM elements initialized', 'info');
+                                observer.disconnect();
+                                break;
+                            }
+                        }
+                    }
+                });
+            });
+
+            observer.observe(document.body, { childList: true, subtree: true });
+        });
+
+
+        window.onCaptchaFailed = function () {
+            console.log('Challenge failed');
+            updateCaptchaStatus('Challenge failed - CAPTCHA verification could not be completed', 'error');
+        }
+
+        window.onCaptchaVerified = (output) => {
+            console.log('Challenge passed');
+            updateCaptchaStatus('Challenge passed successfully!', 'success');
+            updateCaptchaStatus(`Token generated: ${output.substring(0, 15)}...`, 'success');
+        }
+
+        // Add custom event listener for CAPTCHA verification stages
+        document.addEventListener('DOMContentLoaded', function() {
+            setTimeout(() => {
+                updateCaptchaStatus('CAPTCHA script loaded and initialized', 'info');
+                updateCaptchaStatus('Waiting for user interaction...', 'info');
+            }, 500);
+        });
+    </script>
+    <script id="procaptchaScript" type="module" src="%VITE_BUNDLE_URL%" async defer></script>
+</head>
+<body>
+
+<div class="mui-container">
+    <h1>Proof of Work CAPTCHA - Client Session Id</h1>
+    <p>Renders with <code>data-sessionid</code> and verifies with the same <code>clientSessionId</code>.</p>
+
+    <!-- CAPTCHA Status Display will be injected by the status-log-injector plugin -->
+
+    <form action="%PROSOPO_SERVER_URL%/signup" method="POST" class="mui-form">
+        <h2>Example Login Form</h2>
+        <div class="mui-textfield mui-textfield--float-label">
+            <label for="name">Name</label>
+            <input id="name" type="text" name="name" required/>
+        </div>
+        <div class="mui-textfield mui-textfield--float-label">
+            <label for="email">Email Address</label>
+            <input id="email" type="email" name="email" required/>
+        </div>
+        <div class="mui-textfield mui-textfield--float-label">
+            <label for="password">Password</label>
+            <input id="password" type="password" name="password" required/>
+        </div>
+        <div class="mui-textfield mui-textfield--float-label">
+            <!-- Dev sitekey -->
+            <div
+                    class="procaptcha"
+                    data-theme="light"
+                    data-sitekey="%PROSOPO_SITE_KEY_POW%"
+                    data-sessionid="cypress-session-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+                    data-failed-callback="onCaptchaFailed"
+                    data-callback="onCaptchaVerified"
+            ></div>
+        </div>
+        <div id="messageContainer" style="display: none; color: black;"><span id="message"></span></div>
+        <button type="button" class="mui-btn mui-btn--raised" onclick="onActionHandler()" data-cy="submit-button">Submit</button>
+    </form>
+
+    <!-- Console output display area -->
+    <div id="console-output" class="console-output" style="display: none;"></div>
+
+    <!-- Explanation will be injected by the explanation-injector plugin -->
+</div>
+</body>
+</html>

--- a/demos/client-example-server/src/controllers/auth.ts
+++ b/demos/client-example-server/src/controllers/auth.ts
@@ -313,6 +313,11 @@ const login = async (
 					token,
 					secret,
 					req.headers["x-client-ip"]?.toString() || NO_IP,
+					// login carries no email; the session id still has to reach
+					// the provider or a widget rendered with data-sessionid is
+					// silently unverified against its session.
+					undefined,
+					req.body[ApiParams.clientSessionId],
 				);
 
 				logger.info(() => ({

--- a/demos/client-example-server/src/controllers/auth.ts
+++ b/demos/client-example-server/src/controllers/auth.ts
@@ -147,6 +147,10 @@ const verify = async (
 	secret: string,
 	ip: string,
 	email?: string,
+	// The session id the widget was rendered with. Forwarded so the provider
+	// can confirm the token was earned in this same session; omitted, no
+	// correlation is attempted.
+	clientSessionId?: string,
 ) => {
 	if (verifyType === "api") {
 		// verify using the API endpoint
@@ -172,7 +176,12 @@ const verify = async (
 		return response.verified;
 	}
 	// verify using the TypeScript library
-	const verified = await prosopoServer.isVerified(token, ip, email);
+	const verified = await prosopoServer.isVerified(
+		token,
+		ip,
+		email,
+		clientSessionId,
+	);
 	logger.info(() => ({
 		data: {
 			verified,
@@ -225,6 +234,7 @@ const signup = async (
 			secret,
 			req.headers["x-client-ip"]?.toString() || "127.0.0.1",
 			email,
+			req.body[ApiParams.clientSessionId],
 		);
 
 		if (verified === true) {

--- a/demos/client-example-server/src/tests/auth.unit.test.ts
+++ b/demos/client-example-server/src/tests/auth.unit.test.ts
@@ -311,6 +311,7 @@ describe("signup", () => {
 			"0xtoken",
 			"203.0.113.9",
 			"user@example.com",
+			undefined,
 		);
 	});
 
@@ -329,6 +330,7 @@ describe("signup", () => {
 			"0xtoken",
 			"127.0.0.1",
 			"user@example.com",
+			undefined,
 		);
 	});
 });
@@ -633,6 +635,7 @@ describe("login", () => {
 			"0xtoken",
 			"NO_IP",
 			undefined,
+			undefined,
 		);
 	});
 
@@ -654,6 +657,32 @@ describe("login", () => {
 			"0xtoken",
 			"203.0.113.9",
 			undefined,
+			undefined,
+		);
+	});
+
+	test("forwards the caller's clientSessionId to the provider", async () => {
+		const user = await storedUser();
+		const { connection } = connectionWith(userModel({ found: user }));
+		await login(
+			connection,
+			serverConfig(),
+			VERIFY_ENDPOINT,
+			"local",
+			request({
+				body: { ...signupBody(), clientSessionId: "bumblebee-abc" },
+				headers: { "x-client-ip": "203.0.113.9" },
+			}),
+			responseStub().response,
+		);
+		// Positional: isVerified(token, ip, email, clientSessionId). Without
+		// this the widget can be rendered with data-sessionid and the dapp
+		// server silently drops it at verify, so no correlation happens.
+		expect(mocks.isVerified).toHaveBeenLastCalledWith(
+			"0xtoken",
+			"203.0.113.9",
+			undefined,
+			"bumblebee-abc",
 		);
 	});
 

--- a/demos/cypress-shared/cypress.clientSessionId.config.js
+++ b/demos/cypress-shared/cypress.clientSessionId.config.js
@@ -1,0 +1,81 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { builtinModules } from "node:module";
+import { loadEnv } from "@prosopo/dotenv";
+import { defineConfig } from "cypress";
+import { configureVisualRegression } from "cypress-visual-regression";
+import vitePreprocessor from "cypress-vite";
+
+loadEnv();
+
+const allExternal = [
+	...builtinModules,
+	...builtinModules.map((m) => `node:${m}`),
+];
+
+export default defineConfig({
+	video: true,
+	screenshotsFolder: "./cypress/snapshots/actual",
+	trashAssetsBeforeRuns: true,
+	headers: { "Accept-Encoding": "gzip, deflate" },
+	env: {
+		...process.env,
+		default_page: "/pow-implicit-sessionid.html",
+		visualRegressionType: "regression",
+		visualRegressionBaseDirectory: "cypress/snapshots/baseline",
+		visualRegressionDiffDirectory: "cypress/snapshots/diff",
+		visualRegressionGenerateDiff: "fail",
+		visualRegressionFailSilently: false,
+	},
+	e2e: {
+		setupNodeEvents(on, config) {
+			configureVisualRegression(on);
+			on(
+				"file:preprocessor",
+				vitePreprocessor({
+					watch: false,
+					esbuild: {
+						platform: "browser",
+					},
+					server: {
+						host: true,
+					},
+					build: {
+						ssr: false,
+						modulePreload: { polyfill: true },
+						rollupOptions: {
+							external: allExternal,
+						},
+					},
+					plugins: [],
+				}),
+			);
+			// Add task event for logging to the terminal
+			on("task", {
+				log(message) {
+					console.log(message);
+					return null; // Cypress requires tasks to return something
+				},
+			});
+		},
+		specPattern: ["cypress/e2e/**/clientSessionId.cy.ts"],
+	},
+	component: {
+		devServer: {
+			framework: "create-react-app",
+			bundler: "vite",
+		},
+	},
+});

--- a/demos/cypress-shared/cypress.image.config.js
+++ b/demos/cypress-shared/cypress.image.config.js
@@ -108,6 +108,12 @@ export default defineConfig({
 			// / CI step where it passes.
 			"cypress/e2e/**/sessionCaptchaTypeConsistency.cy.ts",
 			"cypress/e2e/**/escalationPuzzle.cy.ts",
+			// Drives pow-implicit-sessionid.html, which is the only page
+			// rendering the widget with data-sessionid. Under this catch-all
+			// it would mount the image page with no session id and fail
+			// before reaching the correlation it exists to test. Runs under
+			// cypress.clientSessionId.config.js.
+			"cypress/e2e/**/clientSessionId.cy.ts",
 		],
 	},
 	component: {

--- a/demos/cypress-shared/cypress/e2e/clientSessionId.cy.ts
+++ b/demos/cypress-shared/cypress/e2e/clientSessionId.cy.ts
@@ -1,0 +1,119 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// End-to-end cover for the client session id correlation (#3139).
+//
+// Why this exists: #3139 shipped with unit tests for the comparison helper
+// and for the escalation handoff, but nothing exercised a real
+// solve -> persist -> verify round trip against mongo. The bug that
+// followed was a read projection —
+// `getPowCaptchaRecordByChallenge` listed its fields explicitly and did not
+// include `clientMetaData`, so the verify path read `undefined` and
+// disapproved EVERY token that carried a session id. Client, wire format and
+// write path were all correct; only the read was wrong, which is precisely
+// the seam a unit test cannot see.
+//
+// The two cases below are both required. The happy path alone would still
+// pass if the correlation were silently skipped, so the mismatch case is what
+// proves the check actually runs.
+
+/// <reference types="cypress" />
+
+import "@cypress/xpath";
+import { checkboxClass, getWidgetElement } from "../support/commands.js";
+
+// Must match `data-sessionid` on pow-implicit-sessionid.html.
+const MATCHING_SESSION_ID =
+	"cypress-session-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+
+const solvePowAndSubmit = (uniqueId: string) => {
+	cy.intercept("POST", "/signup").as("signup");
+	cy.intercept("POST", "**/prosopo/provider/client/pow/solution").as(
+		"powSolution",
+	);
+
+	getWidgetElement(checkboxClass, { timeout: 15000 }).first().realClick();
+
+	// The solve itself must succeed and must carry the render-time session id
+	// on the wire. If this assertion fails the fault is client-side; if it
+	// passes but /signup rejects, the fault is server-side.
+	cy.wait("@powSolution", { timeout: 60000 }).then((interception) => {
+		expect(interception.response?.statusCode).to.equal(200);
+		expect(interception.response?.body?.verified).to.equal(true);
+		expect(
+			interception.request?.body?.clientMetaData?.clientSessionId,
+			"widget must attach the render-time session id to the solution",
+		).to.equal(MATCHING_SESSION_ID);
+	});
+
+	getWidgetElement(`${checkboxClass}:checked`, { timeout: 15000 }).should(
+		"have.length.gte",
+		1,
+	);
+
+	cy.get('input[id="name"]', { timeout: 10000 })
+		.should("be.visible")
+		.clear()
+		.type("test", { delay: 50 });
+	cy.get('input[id="email"]', { timeout: 10000 })
+		.should("be.visible")
+		.clear()
+		.type(`${uniqueId}@prosopo.io`, { delay: 50 });
+	cy.get('input[type="password"]', { timeout: 10000 })
+		.should("be.visible")
+		.clear()
+		.type("password", { delay: 50 });
+
+	cy.get('button[data-cy="submit-button"]', { timeout: 10000 })
+		.first()
+		.should("be.visible")
+		.should("not.be.disabled");
+	cy.get('button[data-cy="submit-button"]').first().realClick();
+};
+
+describe("Client session id correlation", () => {
+	it("verifies a token whose solve carries the same session id the widget rendered with", () => {
+		cy.visit(Cypress.env("default_page"));
+		cy.waitForProcaptchaScript();
+		getWidgetElement(checkboxClass).should("be.visible");
+
+		solvePowAndSubmit(`client-session-match-${Cypress._.random(0, 1e6)}`);
+
+		// The regression this guards: the projection dropped clientMetaData,
+		// so the provider compared the supplied id against `undefined` and
+		// answered CLIENT_SESSION_MISMATCH. That surfaced here as a 401.
+		cy.wait("@signup", { timeout: 20000 }).then((interception) => {
+			expect(
+				interception.response?.statusCode,
+				"matching clientSessionId must verify — a 401 here means the provider could not read the recorded session id",
+			).to.equal(200);
+		});
+	});
+
+	it("rejects a token verified with a different session id", () => {
+		// Same render-time id, different id at verify.
+		cy.visit(`${Cypress.env("default_page")}?mismatch=1`);
+		cy.waitForProcaptchaScript();
+		getWidgetElement(checkboxClass).should("be.visible");
+
+		solvePowAndSubmit(`client-session-mismatch-${Cypress._.random(0, 1e6)}`);
+
+		cy.wait("@signup", { timeout: 20000 }).then((interception) => {
+			expect(
+				interception.response?.statusCode,
+				"a token earned in another session must not verify",
+			).to.equal(401);
+		});
+	});
+});

--- a/demos/cypress-shared/package.json
+++ b/demos/cypress-shared/package.json
@@ -57,6 +57,8 @@
 		"cypress:run:client-bundle-example:frictionless": "NODE_TLS_REJECT_UNAUTHORIZED=0 CAPTCHA_TYPE=frictionless CYPRESS_BASE_URL='https://localhost:9232' cypress run --config-file cypress.frictionless.config.js --browser ${PROSOPO_CYPRESS_BROWSER:-chrome}",
 		"cypress:open:client-bundle-example:pow": "NODE_TLS_REJECT_UNAUTHORIZED=0 CAPTCHA_TYPE=pow CYPRESS_BASE_URL='https://localhost:9232' cypress open --config-file cypress.pow.config.js",
 		"cypress:run:client-bundle-example:pow": "NODE_TLS_REJECT_UNAUTHORIZED=0 CAPTCHA_TYPE=pow CYPRESS_BASE_URL='https://localhost:9232' cypress run --config-file cypress.pow.config.js --browser ${PROSOPO_CYPRESS_BROWSER:-chrome}",
+		"cypress:open:client-bundle-example:clientSessionId": "NODE_TLS_REJECT_UNAUTHORIZED=0 CAPTCHA_TYPE=pow CYPRESS_BASE_URL='https://localhost:9232' cypress open --config-file cypress.clientSessionId.config.js",
+		"cypress:run:client-bundle-example:clientSessionId": "NODE_TLS_REJECT_UNAUTHORIZED=0 CAPTCHA_TYPE=pow CYPRESS_BASE_URL='https://localhost:9232' cypress run --config-file cypress.clientSessionId.config.js --browser ${PROSOPO_CYPRESS_BROWSER:-chrome}",
 		"cypress:open:client-bundle-example:puzzle": "NODE_TLS_REJECT_UNAUTHORIZED=0 CAPTCHA_TYPE=puzzle CYPRESS_BASE_URL='https://localhost:9232' cypress open --config-file cypress.puzzle.config.js",
 		"cypress:run:client-bundle-example:puzzle": "NODE_TLS_REJECT_UNAUTHORIZED=0 CAPTCHA_TYPE=puzzle CYPRESS_BASE_URL='https://localhost:9232' cypress run --config-file cypress.puzzle.config.js --browser ${PROSOPO_CYPRESS_BROWSER:-chrome}",
 		"cypress:open:client-bundle-example:invisible": "NODE_TLS_REJECT_UNAUTHORIZED=0 CAPTCHA_TYPE=image CYPRESS_BASE_URL='https://localhost:9232' cypress open --config-file cypress.invisible.config.js",

--- a/packages/database/src/databases/provider.ts
+++ b/packages/database/src/databases/provider.ts
@@ -919,6 +919,11 @@ export class ProviderDatabase
 						serverChecked: 1,
 						userSubmitted: 1,
 						coords: 1,
+						// Read by the verify path to correlate the site's
+						// session id against the one recorded at solve time.
+						// Omitting it made every clientSessionId-carrying token
+						// look like it was solved in another session.
+						clientMetaData: 1,
 					} as { [key in keyof Partial<PoWCaptchaRecord>]: 1 })
 					.lean<PoWCaptchaRecord>();
 			if (record) {
@@ -1202,6 +1207,8 @@ export class ProviderDatabase
 						serverChecked: 1,
 						userSubmitted: 1,
 						coords: 1,
+						// See the PoW projection above — same verify-time read.
+						clientMetaData: 1,
 					} as { [key in keyof Partial<PuzzleCaptchaRecord>]: 1 })
 					.lean<PuzzleCaptchaRecord>();
 			if (record) {
@@ -1761,6 +1768,10 @@ export class ProviderDatabase
 				originSessionId: 1,
 				currentUrl: 1,
 				iframeUrl: 1,
+				// Mirrored up from the captcha record at solve time. Projected
+				// so session-level readers see the same clientSessionId the
+				// captcha record carries.
+				clientMetaData: 1,
 				// captchaType is required by the peek-before-consume path
 				// in `CaptchaManager.isValidRequest` — without it, every
 				// escalation peek would compare `undefined !== <requested>`

--- a/packages/database/src/tests/integration/projectionContracts.integration.test.ts
+++ b/packages/database/src/tests/integration/projectionContracts.integration.test.ts
@@ -139,6 +139,7 @@ describe("ProviderDatabase projection contracts", () => {
 				serverChecked: false,
 				userSubmitted: true,
 				coords: [[[300, 300]]] as [number, number][][],
+				clientMetaData: { clientSessionId: "bumblebee-pow-contract" },
 			};
 			await db.tables.powcaptcha.create(doc);
 			return doc as unknown as PoWCaptchaRecord;
@@ -148,6 +149,7 @@ describe("ProviderDatabase projection contracts", () => {
 		consumerReads: [
 			"behavioralDataPacked",
 			"challenge",
+			"clientMetaData",
 			"coords",
 			"dappAccount",
 			"deviceCapability",
@@ -202,6 +204,7 @@ describe("ProviderDatabase projection contracts", () => {
 				serverChecked: false,
 				userSubmitted: true,
 				coords: [[[100, 100]]] as [number, number][][],
+				clientMetaData: { clientSessionId: "bumblebee-puzzle-contract" },
 			};
 			await db.tables.puzzlecaptcha.create(doc);
 			return doc as unknown as PuzzleCaptchaRecord;
@@ -213,6 +216,7 @@ describe("ProviderDatabase projection contracts", () => {
 		consumerReads: [
 			"behavioralDataPacked",
 			"challenge",
+			"clientMetaData",
 			"coords",
 			"dappAccount",
 			"deviceCapability",


### PR DESCRIPTION
## The bug

#3139 added a verify-time check that a solve carries the same session id the widget was rendered with. **It never passed.**

`getPowCaptchaRecordByChallenge` and `getPuzzleCaptchaRecordByChallenge` project an explicit field list, and `clientMetaData` was not in it. So the verify path read `undefined`, and:

```ts
isClientSessionMismatch(suppliedId, undefined) // -> true, always
```

Every token carrying a session id was disapproved with `API.CLIENT_SESSION_MISMATCH`.

## Everything else was correct

This is worth stating precisely, because it explains why the tests passed:

- the widget attached the id (confirmed on the wire in a production HAR: `pow/solution` carried `clientMetaData: {clientSessionId: "..."}`)
- the wire format carried it
- the **write** persisted it — the *session* record, which is read without a projection, had it all along

Only the read dropped it. That is invisible to a unit test, because the mongoose return type is the full record, not the projected subset.

`getSessionRecordBySessionId` had the same omission and is fixed too.

## Third time for this class of bug

`projectionContract.ts`'s own docstring already cites #3107 and #3116. The guard existed — but its `consumerReads` manifest is manually maintained, and #3139 started reading a new field without updating it.

So the PoW and puzzle manifests now list `clientMetaData` and their fixtures populate it. **Verified the guard actually guards** by reverting the projection fix and re-running:

```
AssertionError: [getPowCaptchaRecordByChallenge] serverVerifyPowCaptchaSolution
reads a field that the projection stripped: clientMetaData. Add it to the projection.
```

## End-to-end cover

Adds `clientSessionId.cy.ts`, which solves a real PoW captcha rendered with `data-sessionid` and asserts the dapp server's verify succeeds — a full solve → persist → verify round trip against mongo, which is the seam nothing was covering.

It has two cases, and both are needed: the happy path alone would still pass if the correlation were silently skipped, so the **mismatch case** is what proves the check runs.

This required wiring `clientSessionId` through the demo server's `/signup` into `isVerified`, which #3139 left unwired. That omission is why no e2e covered the feature at all.

## Testing

- `projectionContracts.integration.test.ts`: 3 passed; fails as shown above without the fix
- `build:tsc` clean on `@prosopo/database` and `@prosopo/client-example-server`
- biome clean on all changed files
- new Cypress step wired into `cypress.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
