### PR TITLE
fix(cypress): stop the score ladder spec replaying its own warm-up session

### DIFF
--- a/.changeset/frictionless-ladder-cypress-dedup.md
+++ b/.changeset/frictionless-ladder-cypress-dedup.md
@@ -1,0 +1,7 @@
+---
+"@prosopo/cypress-shared": patch
+---
+
+Drop the warm-up visit from the score ladder spec.
+
+`/frictionless` deduplicates on user + IP + sitekey and replays a live session instead of scoring again, and the widget's identity is fingerprint-derived, so it is the same for every test in the run. The `beforeEach` warm-up visit mounted the widget, which created a score-0 session — and the request the test had just set its language header on got that session replayed back. Every banded case returned `pow`.

--- a/demos/cypress-shared/cypress/e2e/frictionlessLadder.cy.ts
+++ b/demos/cypress-shared/cypress/e2e/frictionlessLadder.cy.ts
@@ -75,13 +75,14 @@ describe("Frictionless score ladder picks the captcha type by score", () => {
 		}).then((response) => {
 			expect(response.status).to.equal(200);
 		});
-		// Prime the page + widget script cache. Each `it` re-visits after its
-		// intercepts are primed, because the frictionless widget fires
-		// /frictionless on mount (same pattern as routingFrictionless.cy.ts).
-		return cy.visit(Cypress.env("default_page")).then(() => {
-			cy.waitForProcaptchaScript();
-			getWidgetElement(checkboxClass).should("be.visible");
-		});
+		// Deliberately no priming visit here. The frictionless widget fires
+		// `/frictionless` on mount, so a warm-up visit creates a real session
+		// for (user, ip, sitekey) — and `/frictionless` deduplicates on that
+		// triple and replays a live session rather than scoring again. The
+		// warm-up's score-0 session was therefore handed straight back to the
+		// request the test had just set its language header on, and every
+		// banded case came back `pow`. `primeAndVisit` is the only visit, and
+		// it registers the intercepts before it.
 	});
 
 	after(() => {


### PR DESCRIPTION
`/frictionless` deduplicates on user + IP + sitekey and replays a live session rather than scoring again, and the widget's identity is derived from the browser fingerprint — so it is the same for every test in the run.

The spec's `beforeEach` mounted the widget once to warm the script cache. That mount created a real score-0 session, and the request the test had just set its language header on got that session replayed straight back. So the score never moved: the PoW case passed for the wrong reason and all four banded cases came back `pow`.

The warm-up visit is gone. `primeAndVisit` is the only visit and it registers the intercepts before it, so the first scored request of each test is the one the assertions read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)