### PR TITLE
fix(server): route verifyCaptcha at the ipMode-matching provider-list section

### DIFF
--- a/.changeset/eager-ways-go.md
+++ b/.changeset/eager-ways-go.md
@@ -1,0 +1,7 @@
+---
+"@prosopo/load-balancer": patch
+"@prosopo/server": patch
+---
+
+Fix provider URL matcher
+  

--- a/packages/load-balancer/src/balancer.ts
+++ b/packages/load-balancer/src/balancer.ts
@@ -83,6 +83,7 @@ export const getLoadBalancerUrl = (environment: EnvironmentTypes): string => {
 
 export const loadBalancer = async (
 	environment: EnvironmentTypes,
+	ipMode?: IpMode,
 ): Promise<HardcodedProvider[]> => {
 	if (environment === "development") {
 		return [
@@ -103,5 +104,9 @@ export const loadBalancer = async (
 			mode: "cors",
 		},
 	).then((res) => res.json());
-	return convertHostedProvider(providers);
+	// `ipMode` steers `convertHostedProvider` at the fetched JSON's
+	// `ipv4` / `ipv6` sub-object rather than the dual-stack default,
+	// so tokens minted with a single-stack sub-zone URL find their
+	// entry — see the `detectIpMode` doc-comment in @prosopo/server.
+	return convertHostedProvider(providers, ipMode);
 };

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -30,6 +30,38 @@ import {
 import { u8aToHex } from "@prosopo/util";
 import i18n from "i18next";
 
+// Detect which section of the provider list the token's `providerUrl`
+// was minted from.
+//
+// The provider list at https://provider-list.prosopo.io/ carries three
+// concurrent views of the same provider set: the dual-stack entries at
+// the top level (`https://pronode15.prosopo.io`), an `ipv4` sub-object
+// (`https://ipv4.pronode15.prosopo.io`), and an `ipv6` sub-object.
+// A session that pinned itself to a single-stack sub-zone advertises
+// the sub-zone URL on the token, so an exact-string lookup against the
+// dual-stack section returns nothing and the lambda logs
+// `Provider not found` — leaving every affected session's
+// `serverChecked` on mongo1 false.
+//
+// Deriving the ipMode from the token's own hostname and asking the
+// load-balancer for the matching section keeps the equality check
+// exact-string on both sides. Exported so tests can pin the exact
+// contract.
+export const detectIpMode = (
+	providerUrl: string | undefined,
+): "ipv4" | "ipv6" | undefined => {
+	if (!providerUrl) return undefined;
+	let hostname: string;
+	try {
+		hostname = new URL(providerUrl).hostname;
+	} catch {
+		return undefined;
+	}
+	if (hostname.startsWith("ipv4.")) return "ipv4";
+	if (hostname.startsWith("ipv6.")) return "ipv6";
+	return undefined;
+};
+
 export class ProsopoServer {
 	config: ProsopoServerConfigOutput;
 	dappAccount: string | undefined;
@@ -231,8 +263,17 @@ export class ProsopoServer {
 			const { providerUrl, challenge, timestamp, user, captchaType } =
 				ProcaptchaOutputSchema.parse(payload);
 
-			// check provides URL is valid
-			const providers = await loadBalancer(this.config.defaultEnvironment);
+			// Detect which section of the provider list this token was
+			// minted against — dual-stack, `ipv4`, or `ipv6` — and load
+			// only that section. The single-stack sections carry sub-zone
+			// URLs (`https://ipv4.pronode15.prosopo.io`), so an exact-string
+			// `find` against the dual-stack default would miss and the
+			// lambda would emit `Provider not found`. See `detectIpMode`.
+			const ipMode = detectIpMode(providerUrl);
+			const providers = await loadBalancer(
+				this.config.defaultEnvironment,
+				ipMode,
+			);
 
 			// find the provider by URL in providers
 			const provider = providers.find((p) => p.url === providerUrl);

--- a/packages/server/src/tests/detectIpMode.unit.test.ts
+++ b/packages/server/src/tests/detectIpMode.unit.test.ts
@@ -1,0 +1,106 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Locks in the ipMode-routing contract for `verifyCaptcha`.
+//
+// The provider list at https://provider-list.prosopo.io/ carries three
+// concurrent views — dual-stack at the top level
+// (`https://pronodeN.prosopo.io`), plus `ipv4` and `ipv6` sub-objects
+// containing single-stack sub-zone URLs
+// (`https://ipv4.pronodeN.prosopo.io`). A token whose session pinned
+// itself to a sub-zone advertises the sub-zone URL on its
+// `providerUrl` field; if the caller loads only the dual-stack default
+// section, the exact-string `providers.find(p => p.url === providerUrl)`
+// misses and the lambda emits `Provider not found`, leaving
+// `serverChecked` on the mongo captcha record false.
+//
+// `detectIpMode` derives which section the token was minted from so
+// the caller can ask the load-balancer for the matching one. The
+// alternative — canonicalising URLs by stripping the label — would
+// risk collapsing an ipv4-pinned lookup onto the dual-stack entry and
+// silently hiding a misroute; keeping the sections separate keeps the
+// equality check honest.
+
+import { describe, expect, it } from "vitest";
+import { detectIpMode } from "../server.js";
+
+describe("detectIpMode", () => {
+	// ── The regression itself ────────────────────────────────────────────
+
+	it("detects ipv4 on a single-stack sub-zone URL", () => {
+		expect(detectIpMode("https://ipv4.pronode15.prosopo.io")).toBe("ipv4");
+	});
+
+	it("detects ipv6 on a single-stack sub-zone URL", () => {
+		expect(detectIpMode("https://ipv6.pronode15.prosopo.io")).toBe("ipv6");
+	});
+
+	it("returns undefined for a dual-stack URL", () => {
+		expect(detectIpMode("https://pronode15.prosopo.io")).toBeUndefined();
+	});
+
+	// ── Path and trailing-slash tolerance ───────────────────────────────
+
+	it("detects ipv4 with a trailing slash", () => {
+		expect(detectIpMode("https://ipv4.pronode15.prosopo.io/")).toBe("ipv4");
+	});
+
+	it("detects ipv4 with a path", () => {
+		expect(
+			detectIpMode("https://ipv4.pronode15.prosopo.io/some/path?q=1"),
+		).toBe("ipv4");
+	});
+
+	// ── Only the exact label prefix is stripped ─────────────────────────
+	// `ipv4-shim.pronode15.prosopo.io` (hypothetical) is a different host
+	// from `ipv4.pronode15.prosopo.io`; treating it as ipv4-pinned would
+	// steer the lookup at the wrong section and silently look up the
+	// wrong provider. The prefix match must be exact.
+
+	it("does NOT treat an `ipv4-` prefix as ipv4", () => {
+		expect(
+			detectIpMode("https://ipv4-shim.pronode15.prosopo.io"),
+		).toBeUndefined();
+	});
+
+	it("does NOT treat `ipv4` as a substring elsewhere in the hostname", () => {
+		expect(
+			detectIpMode("https://pronode15.ipv4-thing.prosopo.io"),
+		).toBeUndefined();
+	});
+
+	// ── Scheme is irrelevant to the detection ──────────────────────────
+	// The registry only carries HTTPS entries today, but `detectIpMode`
+	// operates on the hostname alone so an HTTP URL would still be
+	// steered correctly if that ever changed. That's the point of doing
+	// the detection at the URL layer rather than by string prefix.
+
+	it("detects ipv4 regardless of scheme", () => {
+		expect(detectIpMode("http://ipv4.pronode15.prosopo.io")).toBe("ipv4");
+	});
+
+	// ── Malformed URLs ──────────────────────────────────────────────────
+	// A token whose `providerUrl` field is unparseable can't route to any
+	// section — return undefined and let `providers.find` return
+	// undefined too, so the caller emits the normal `Provider not found`
+	// path rather than throwing on the token.
+
+	it("returns undefined for an unparseable URL", () => {
+		expect(detectIpMode("not-a-url")).toBeUndefined();
+	});
+
+	it("returns undefined for an empty string", () => {
+		expect(detectIpMode("")).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## Summary

Every captcha session whose token pinned itself to a single-stack sub-zone (`https://ipv4.pronodeN.prosopo.io`) came back `verified: false` from the verifyCaptcha lambda. The provider list at https://provider-list.prosopo.io/ carries three concurrent views — dual-stack at the top level plus `ipv4` / `ipv6` sub-objects — but `loadBalancer` was only ever loading the dual-stack default. The exact-string `providers.find(p => p.url === providerUrl)` in `server.ts:238` missed on every sub-zone URL, the lambda emitted `msg: "Provider not found"`, and every affected captcha's `serverChecked` on mongo1 stayed false.

## The fix

**Route the lookup at the matching section instead of collapsing URLs.**

- `packages/server/src/server.ts` — new exported `detectIpMode(providerUrl)` returns `"ipv4"` / `"ipv6"` / `undefined` based on the hostname prefix. `isVerified` derives the mode from the token's own `providerUrl` and passes it through to `loadBalancer`.
- `packages/load-balancer/src/balancer.ts` — `loadBalancer(env, ipMode?)` now forwards the mode to the existing `convertHostedProvider(providers, ipMode)`. Without a mode the behaviour is unchanged (dual-stack default), so no other caller needs updating.

Chose ipMode routing over URL canonicalisation because collapsing `https://ipv4.pronode15.prosopo.io` onto `https://pronode15.prosopo.io` would hide a real misroute — a token pinned to one section satisfying a lookup against another. Keeping the sections separate keeps the equality check honest.

## Test plan

- [x] `packages/server/src/tests/detectIpMode.unit.test.ts` — 10 new tests covering ipv4/ipv6/dual-stack, path + trailing-slash tolerance, exact-label guards (`ipv4-shim.pronode15.prosopo.io` and substring-in-hostname must not be treated as ipv4), and unparseable inputs.
- [x] `npm run -w @prosopo/server test`: **57 passed / 57**.
- [x] `npm run -w @prosopo/server build:tsc`, `npm run -w @prosopo/load-balancer build:tsc`: clean.

## Deployment

Ships via the normal lambda deploy. No provider-list changes, no ansible changes, no wire-format changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)