### PR TITLE
fix(caddy): lift the body-read deadline for the detector-pool push

### DIFF
--- a/docker/provider.Caddyfile
+++ b/docker/provider.Caddyfile
@@ -152,6 +152,22 @@ http://:9090 {
 			X-Robots-Tag "none"
 		}
 
+		# The detector-pool push (`@prosopo/catcher`'s `pool:add`) carries
+		# the whole pool in one body — a 100-bundle pool is ~86 MB of JSON,
+		# ~27 MB gzipped on the wire. The global `timeouts` block caps a
+		# body read at 15s, which is the right anti-slowloris budget for
+		# every normal request but strangles this upload from anything
+		# slower than a datacentre uplink: Caddy aborts the stream part-way
+		# and answers 504 with only a few MB read, which looks like a
+		# provider fault rather than a client-side timeout. Override the
+		# read/write deadlines for this one admin path so the tight budget
+		# still applies everywhere else.
+		@detector_pool_push path /v1/prosopo/provider/admin/detector/pool/replace
+		request_body @detector_pool_push {
+			read_timeout 15m
+			write_timeout 15m
+		}
+
 		# enable prometheus metrics
 		metrics /metrics
 


### PR DESCRIPTION
## Problem

Pushing a detector pool (`@prosopo/catcher`'s `pool:add`, driven by `providerAddPool.yml`) failed against every production pronode with a bare `504 Gateway Timeout: <empty body>`.

Caddy's own access log showed the cause exactly:

```
POST /v1/prosopo/provider/admin/detector/pool/replace status=504 dur=14.891 bytes_read=8011170
```

14.89s is the global `timeouts { read_body 15s }`. A 100-bundle pool is ~86 MB of JSON (~26 MB gzipped); from anything slower than a datacentre uplink Caddy aborts the stream part-way — here after 8 MB of 88 MB — and answers 504. That reads as a provider fault rather than what it is, a client-side upload that outran the body-read budget.

## Fix

Scope a `request_body` read/write deadline to the admin pool path only. The 15s anti-slowloris budget is right for every normal request and still applies to all of them; only this one admin upload gets the longer window.

Verified with `caddy adapt` on-node (Caddy v2.11.4) — the handler lands ahead of `rate_limit` and `reverse_proxy` in both the per-host and pronode-global site blocks, since it sits in the shared `(provider_site)` snippet.

## Verification

Rolled to all 11 production pronodes via `providerRestartCaddy.yml` and re-ran the pool deploy: 11/11 `failed=0`, upload returns `200` with `persisted=true`. The same request that produced the 504 above now logs `status=200 dur=10.33 bytes_read=27240988`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)