### PR TITLE
fix(provider): project the session fields callers read, and let routers set puzzle overrides

### DIFF
--- a/.changeset/session-projection-and-routing-puzzle-overrides.md
+++ b/.changeset/session-projection-and-routing-puzzle-overrides.md
@@ -1,0 +1,16 @@
+---
+"@prosopo/types-database": patch
+"@prosopo/database": patch
+"@prosopo/provider": patch
+"@prosopo/types": patch
+---
+
+Project the session fields callers read, and let routing machines set puzzle overrides.
+
+`getSessionRecordBySessionId` lists its fields explicitly but declared a full `Session` return type. That type lie let callers read fields the projection never selected — they get `undefined`, with no error anywhere. This is the fourth time it has shipped: after the tcp-probe fields (verify-time TCP decide rules received `undefined` and never fired) and `clientMetaData` (#3141), this round found the entropy fingerprints plus the `g`/`i`/`sw`/`md`/`bn`/`fs` flags — which silently disabled the origin-session fallback in `getSessionRecordWithOriginFallback` *and* made it issue a redundant second query on every escalation, since every `needsX` check was trivially true and the origin read back `undefined` too — along with `ruleType` (fed into `DecisionMachineInput` by all three verify paths, so any decide rule gating on the matched access rule was dead), `powDifficulty` and `isProtect`.
+
+Adds the 13 missing fields, then makes it structural: the projection is now `SESSION_PROJECTION` and the return type is derived from it as `ProjectedSession`, so reading an unprojected field is a compile error. The other three projected queries were audited and are correct; `getClientRecord` is safe by construction for the same reason, its return type being `Pick`-narrowed to match.
+
+Separately, `RoutingMachineOutput` gains `puzzleTolerance` and `puzzle`, so a routing machine that inherits a trafficFilter `challenge` policy can reproduce it exactly. `getPuzzleCaptchaChallenge` re-derives its overrides from a live trafficFilter verdict, which a machine-chosen puzzle has no counterpart for, so the values are persisted on the session and layered in there. Both are bounded by the same field validators the portal uses.
+
+Also: `deriveTrafficPolicies` forwards a site's per-category `trafficFilter` policies to routing and decision machines, so a machine can tell "the operator rejects this egress class" from "the operator deliberately accepts it"; `sendCaptcha` now persists the router's `reason`, which previously never reached the session on the route phase and was invisible in the portal; and `runArtifactExport`'s schema generic is corrected from `z.ZodSchema<T>` (which pins Input === Output === T, so any `.default()` in the tree made `T` unify with the input shape) to `z.ZodType<T, z.ZodTypeDef, unknown>`.

--- a/packages/database/src/databases/provider.ts
+++ b/packages/database/src/databases/provider.ts
@@ -71,8 +71,10 @@ import {
 	type IUserDataSlim,
 	type PoWCaptchaRecord,
 	PoWCaptchaRecordSchema,
+	type ProjectedSession,
 	type PuzzleCaptchaRecord,
 	PuzzleCaptchaRecordSchema,
+	SESSION_PROJECTION,
 	type ScheduledTask,
 	type ScheduledTaskRecord,
 	ScheduledTaskRecordSchema,
@@ -1731,93 +1733,12 @@ export class ProviderDatabase
 	 */
 	async getSessionRecordBySessionId(
 		sessionId: string,
-	): Promise<Session | undefined> {
+	): Promise<ProjectedSession | undefined> {
 		const filter: Pick<SessionRecord, "sessionId"> = { sessionId };
-		// Projection lists every field a caller of this function actually
-		// reads. `headers` is selected by individual key rather than as a
-		// whole blob: the flattened `req.headers` persisted at frictionless
-		// time can contain `x-tls-clienthello` (a base64-encoded full TLS
-		// ClientHello, multi-KB per session). That field is only consumed
-		// by `ja4Middleware` from the live `req.headers` at the entry
-		// point — never re-read off the persisted Session — so it just
-		// bloats every subsequent lookup. The enumerated list below covers
-		// the headers `buildEscalation` forwards onto the escalation
-		// session. New headers that need to round-trip must be added
-		// here explicitly.
+		// See SESSION_PROJECTION for what is selected and why.
 		const doc = await this.tables.session
-			.findOne(filter, {
-				sessionId: 1,
-				token: 1,
-				score: 1,
-				threshold: 1,
-				scoreComponents: 1,
-				ipAddress: 1,
-				ipInfo: 1,
-				webView: 1,
-				iFrame: 1,
-				isEscalation: 1,
-				decryptedHeadHash: 1,
-				siteKey: 1,
-				reason: 1,
-				mode: 1,
-				solvedImagesCount: 1,
-				userSitekeyIpHash: 1,
-				simdReadings: 1,
-				bundleId: 1,
-				dnsEvent: 1,
-				originSessionId: 1,
-				currentUrl: 1,
-				iframeUrl: 1,
-				// Mirrored up from the captcha record at solve time. Projected
-				// so session-level readers see the same clientSessionId the
-				// captcha record carries.
-				clientMetaData: 1,
-				// captchaType is required by the peek-before-consume path
-				// in `CaptchaManager.isValidRequest` — without it, every
-				// escalation peek would compare `undefined !== <requested>`
-				// and forcibly return INCORRECT_CAPTCHA_TYPE on the happy
-				// path too. Keep this projection in sync with whatever
-				// fields the read-only callers need.
-				captchaType: 1,
-				// Raw per-connection TCP-handshake signals populated by the
-				// tcp-probe eBPF sidecar (see @prosopo/types Session for the
-				// wire semantics). The verify-time DM input surface exposes
-				// these to decide rules (e.g. `tcp-stack-dc-linux-ts-off`,
-				// `tcp-ttl-windows-ua-linux-stack`); every one of the img /
-				// pow / puzzle verify paths forwards `sessionRecord?.tcpX`
-				// into the DecisionMachineInput. Missed on the original
-				// projection: the rules got `undefined` for every field and
-				// silently never fired against real traffic even though
-				// matching sessions were sitting in the DB.
-				synNs: 1,
-				synackNs: 1,
-				ackNs: 1,
-				observedTtl: 1,
-				tcpMss: 1,
-				tcpWscale: 1,
-				tcpOptsFlags: 1,
-				tcpOptsOrder: 1,
-				tcpWindow: 1,
-				"headers.user-agent": 1,
-				"headers.accept": 1,
-				"headers.accept-language": 1,
-				"headers.accept-encoding": 1,
-				"headers.sec-ch-ua": 1,
-				"headers.sec-ch-ua-mobile": 1,
-				"headers.sec-ch-ua-platform": 1,
-				"headers.sec-ch-ua-platform-version": 1,
-				"headers.sec-fetch-dest": 1,
-				"headers.sec-fetch-mode": 1,
-				"headers.sec-fetch-site": 1,
-				"headers.sec-fetch-user": 1,
-				"headers.referer": 1,
-				"headers.origin": 1,
-				"headers.prosopo-user": 1,
-				"headers.prosopo-site-key": 1,
-				"headers.prosopo-type": 1,
-				"headers.x-tls-version": 1,
-			})
-			.lean<Session>();
+			.findOne(filter, SESSION_PROJECTION)
+			.lean<ProjectedSession>();
 		return doc || undefined;
 	}
 

--- a/packages/provider/src/api/captcha/getFrictionlessCaptchaChallenge/handler.ts
+++ b/packages/provider/src/api/captcha/getFrictionlessCaptchaChallenge/handler.ts
@@ -31,7 +31,10 @@ import { v4 as uuidv4 } from "uuid";
 import { getCompositeIpAddress } from "../../../compositeIpAddress.js";
 import type { AugmentedRequest } from "../../../express.js";
 import { Tasks } from "../../../tasks/index.js";
-import { derivePlatform } from "../../../utils/devicePlatform.js";
+import {
+	derivePlatform,
+	deriveTrafficPolicies,
+} from "../../../utils/devicePlatform.js";
 import { hashUserAgent } from "../../../utils/hashUserAgent.js";
 import { hashUserIp } from "../../../utils/hashUserIp.js";
 import { normalizeRequestIp } from "../../../utils/normalizeRequestIp.js";
@@ -254,6 +257,9 @@ export default (
 						: undefined;
 				const dedupFlatHeaders = flatten(req.headers);
 				const dedupUserAgent = String(req.headers["user-agent"] ?? "");
+				const dedupTrafficPolicies = deriveTrafficPolicies(
+					clientRecord.settings?.trafficFilter,
+				);
 				const dedupUserScope = getRequestUserScope(
 					dedupFlatHeaders,
 					req.ja4,
@@ -356,6 +362,9 @@ export default (
 									}),
 									...(dedup.session.iframeUrl && {
 										iframeUrl: dedup.session.iframeUrl,
+									}),
+									...(dedupTrafficPolicies && {
+										trafficPolicies: dedupTrafficPolicies,
 									}),
 								},
 							},
@@ -720,6 +729,9 @@ export default (
 					? req.ipInfo.isMobile
 					: undefined;
 			const safeUserAgent = userAgent ?? "";
+			const trafficPolicies = deriveTrafficPolicies(
+				clientRecord.settings?.trafficFilter,
+			);
 			tasks.frictionlessManager.setRoutingContext({
 				dappAccount: dapp,
 				userAccount: user,
@@ -749,6 +761,9 @@ export default (
 						req.ipInfo.isValid && { ipInfo: req.ipInfo }),
 					...(currentUrl && { currentUrl }),
 					...(iframeUrl && { iframeUrl }),
+					// Which egress categories this site blocks, so egress-sensitive
+					// route rules can skip sites that accept VPN / proxy / DC users.
+					...(trafficPolicies && { trafficPolicies }),
 				},
 			});
 

--- a/packages/provider/src/api/captcha/getPuzzleCaptchaChallenge.ts
+++ b/packages/provider/src/api/captcha/getPuzzleCaptchaChallenge.ts
@@ -210,8 +210,15 @@ export default (
 					? trafficVerdict.puzzleTolerance
 					: undefined;
 
+			// Overrides a routing machine asked for, persisted on the session.
+			// The router runs only where the live trafficFilter verdict did
+			// NOT match (it evaluates after the request-time filter), so in
+			// practice these are mutually exclusive; the live verdict wins if
+			// both are somehow present.
 			const tolerance =
-				trafficPuzzleTolerance ?? clientSettings?.settings?.puzzleTolerance;
+				trafficPuzzleTolerance ??
+				sessionRecord?.puzzleTolerance ??
+				clientSettings?.settings?.puzzleTolerance;
 
 			// Resolve per-render puzzle tunables the same way as tolerance:
 			// asset defaults <- clientSettings.puzzle <- trafficFilter category
@@ -221,9 +228,11 @@ export default (
 				trafficVerdict.kind === "challenge"
 					? trafficVerdict.puzzleSettings
 					: undefined;
+			const routedPuzzleSettings =
+				trafficPuzzleSettings ?? sessionRecord?.puzzle;
 			const effectivePuzzleSettings = resolvePuzzleRenderSettings(
 				clientSettings?.settings?.puzzle,
-				trafficPuzzleSettings,
+				routedPuzzleSettings,
 			);
 			// Piece size is drawn per-challenge from the effective scale
 			// range so a solver can't hard-code the expected silhouette
@@ -231,7 +240,7 @@ export default (
 			// order as the render settings above.
 			const effectivePieceSize = resolvePuzzlePieceSize(
 				clientSettings?.settings?.puzzle,
-				trafficPuzzleSettings,
+				routedPuzzleSettings,
 			);
 			const challenge =
 				await tasks.puzzleCaptchaManager.getPuzzleCaptchaChallenge(

--- a/packages/provider/src/api/captcha/submitPoWCaptchaSolution.ts
+++ b/packages/provider/src/api/captcha/submitPoWCaptchaSolution.ts
@@ -26,7 +26,10 @@ import type { NextFunction, Request, Response } from "express";
 import type { AugmentedRequest } from "../../express.js";
 import { downgradePuzzleIfUnavailable } from "../../tasks/puzzle/puzzleRenderer.js";
 import { Tasks } from "../../tasks/tasks.js";
-import { derivePlatform } from "../../utils/devicePlatform.js";
+import {
+	derivePlatform,
+	deriveTrafficPolicies,
+} from "../../utils/devicePlatform.js";
 import { getMaintenanceMode } from "../admin/apiToggleMaintenanceModeEndpoint.js";
 import { rawTlsSignalsForSession } from "../rawTlsSignalsMiddleware.js";
 import { resolveTestSiteKeyVerdict } from "../testSiteKey.js";
@@ -131,6 +134,10 @@ export default (env: ProviderEnvironment) =>
 				},
 			}));
 
+			const trafficPolicies = deriveTrafficPolicies(
+				clientRecord.settings?.trafficFilter,
+			);
+
 			tasks.powCaptchaManager.setPostPowContext({
 				ip: req.ip || "",
 				countryCode,
@@ -156,6 +163,9 @@ export default (env: ProviderEnvironment) =>
 					...(req.ipInfo &&
 						"isValid" in req.ipInfo &&
 						req.ipInfo.isValid && { ipInfo: req.ipInfo }),
+					// Which egress categories this site blocks, so egress-sensitive
+					// route rules can skip sites that accept VPN / proxy / DC users.
+					...(trafficPolicies && { trafficPolicies }),
 				},
 			});
 

--- a/packages/provider/src/tasks/captchaManager.ts
+++ b/packages/provider/src/tasks/captchaManager.ts
@@ -36,6 +36,7 @@ import type {
 	IProviderDatabase,
 	IUserDataSlim,
 	PoWCaptchaRecord,
+	ProjectedSession,
 	PuzzleCaptchaRecord,
 } from "@prosopo/types-database";
 import type { ProviderEnvironment } from "@prosopo/types-env";
@@ -198,7 +199,7 @@ export class CaptchaManager {
 	 */
 	public async getSessionRecordWithOriginFallback(
 		sessionId: string,
-	): Promise<Session | undefined> {
+	): Promise<ProjectedSession | undefined> {
 		const session = await this.db.getSessionRecordBySessionId(sessionId);
 		if (!session) return undefined;
 		if (!session.originSessionId) return session;

--- a/packages/provider/src/tasks/decisionMachine/decisionMachineRunner.ts
+++ b/packages/provider/src/tasks/decisionMachine/decisionMachineRunner.ts
@@ -467,7 +467,13 @@ export class DecisionMachineRunner {
 		artifact: DecisionMachineArtifact,
 		exportNames: string[],
 		options: { input: unknown; optional?: boolean },
-		schema: z.ZodSchema<T>,
+		// `z.ZodType<T, _, unknown>` rather than `z.ZodSchema<T>`: the latter
+		// pins Input === Output === T, so a schema with `.default()`s
+		// anywhere in its tree (RoutingMachineOutputSchema's puzzle settings)
+		// makes T unify with the *input* shape and the parsed result stops
+		// matching the declared output type. This says only "a schema that
+		// produces T from unknown input", which is what the caller wants.
+		schema: z.ZodType<T, z.ZodTypeDef, unknown>,
 	): Promise<T | undefined> {
 		const { exports } = loadMachine(artifact.source);
 		const named = this.findExport(exports, exportNames);

--- a/packages/provider/src/tasks/frictionless/frictionlessTasks.ts
+++ b/packages/provider/src/tasks/frictionless/frictionlessTasks.ts
@@ -247,6 +247,9 @@ export class FrictionlessManager extends CaptchaManager {
 		// → provider). Kept as a bag rather than expanded into 9 positional
 		// params to avoid pushing createSession's arity past 40.
 		rawTlsSignals?: Partial<RawTlsSignals>,
+		// Puzzle render overrides the routing machine asked for. Same bag
+		// rationale as rawTlsSignals above.
+		puzzleOverrides?: Pick<Session, "puzzleTolerance" | "puzzle">,
 	): Promise<Session> {
 		const sessionRecord: Session = {
 			sessionId: `${getSessionIDPrefix(this.config.host)}-${uuidv4()}`,
@@ -260,6 +263,12 @@ export class FrictionlessManager extends CaptchaManager {
 			mode,
 			solvedImagesCount,
 			powDifficulty,
+			// Only persisted for puzzle sessions — see the caller, which
+			// nulls these out for other captcha types.
+			...(puzzleOverrides?.puzzleTolerance !== undefined && {
+				puzzleTolerance: puzzleOverrides.puzzleTolerance,
+			}),
+			...(puzzleOverrides?.puzzle && { puzzle: puzzleOverrides.puzzle }),
 			userSitekeyIpHash,
 			webView,
 			iFrame,
@@ -396,7 +405,7 @@ export class FrictionlessManager extends CaptchaManager {
 					? effectiveParams.powDifficulty
 					: undefined,
 		};
-		const routed = this.routingContext
+		const routed: RoutingMachineOutput = this.routingContext
 			? await applyRouter(
 					this.decisionMachineRunner,
 					this.usageCounters,
@@ -435,6 +444,30 @@ export class FrictionlessManager extends CaptchaManager {
 			finalCaptchaType === CaptchaType.pow
 				? (routed.powDifficulty ?? effectiveParams.powDifficulty)
 				: undefined;
+		// Puzzle tunables the router asked for. Persisted on the session so
+		// getPuzzleCaptchaChallenge can layer them over the site defaults —
+		// that endpoint re-derives its overrides from a live trafficFilter
+		// verdict, and a router-chosen puzzle has no verdict to re-derive
+		// from. Dropped unless the resolved type actually is a puzzle, so a
+		// downgraded session never carries stale render settings.
+		const finalPuzzleOverrides: Pick<Session, "puzzleTolerance" | "puzzle"> =
+			finalCaptchaType === CaptchaType.puzzle
+				? {
+						...(routed.puzzleTolerance !== undefined && {
+							puzzleTolerance: routed.puzzleTolerance,
+						}),
+						...(routed.puzzle && { puzzle: routed.puzzle }),
+					}
+				: {};
+		// A router that overrode the captcha type is the more specific
+		// explanation of what was served, so its reason wins over the one the
+		// score ladder left on the session params. Mirrors the postPow path,
+		// which already does `routed.reason ?? originSession.reason`. Without
+		// this a route-phase selection reason never reached the session and
+		// was invisible in the portal.
+		const finalReason =
+			(routed.reason as FrictionlessReason | undefined) ??
+			(effectiveParams.reason as FrictionlessReason | undefined);
 		const blocked =
 			finalCaptchaType === CaptchaType.image
 				? effectiveParams.blocked
@@ -454,7 +487,7 @@ export class FrictionlessManager extends CaptchaManager {
 			effectiveParams.webView ?? false,
 			effectiveParams.iFrame ?? false,
 			effectiveParams.decryptedHeadHash,
-			effectiveParams.reason as FrictionlessReason | undefined,
+			finalReason,
 			blocked,
 			undefined,
 			effectiveParams.ipInfo,
@@ -491,6 +524,7 @@ export class FrictionlessManager extends CaptchaManager {
 				tcpOptsOrder: effectiveParams.tcpOptsOrder,
 				tcpWindow: effectiveParams.tcpWindow,
 			},
+			finalPuzzleOverrides,
 		);
 
 		// Fire-and-forget served-counter writes. Skipped when there's no

--- a/packages/provider/src/tasks/imgCaptcha/imgCaptchaTasks.ts
+++ b/packages/provider/src/tasks/imgCaptcha/imgCaptchaTasks.ts
@@ -77,6 +77,7 @@ import {
 	isClientSessionMismatch,
 	toStoredClientMetaData,
 } from "../../utils/clientMetaData.js";
+import { deriveTrafficPolicies } from "../../utils/devicePlatform.js";
 import { CaptchaManager } from "../captchaManager.js";
 import { DecisionMachineRunner } from "../decisionMachine/decisionMachineRunner.js";
 import {
@@ -1126,6 +1127,12 @@ export class ImgCaptchaManager extends CaptchaManager {
 				tcpOptsFlags: sessionRecord?.tcpOptsFlags,
 				tcpOptsOrder: sessionRecord?.tcpOptsOrder,
 				tcpWindow: sessionRecord?.tcpWindow,
+				// Which egress categories this site blocks. Gates the
+				// egress-sensitive TCP-stack deny rules — a VPN
+				// concentrator legitimately terminates the handshake, so
+				// on a site that accepts VPN users the observed stack
+				// says nothing about the client.
+				trafficPolicies: deriveTrafficPolicies(trafficFilter),
 			};
 
 			try {

--- a/packages/provider/src/tasks/powCaptcha/powTasks.ts
+++ b/packages/provider/src/tasks/powCaptcha/powTasks.ts
@@ -74,6 +74,7 @@ import {
 	isClientSessionMismatch,
 	toStoredClientMetaData,
 } from "../../utils/clientMetaData.js";
+import { deriveTrafficPolicies } from "../../utils/devicePlatform.js";
 import { CaptchaManager } from "../captchaManager.js";
 import { DecisionMachineRunner } from "../decisionMachine/decisionMachineRunner.js";
 import {
@@ -1039,6 +1040,12 @@ export class PowCaptchaManager extends CaptchaManager {
 					tcpOptsFlags: sessionRecord?.tcpOptsFlags,
 					tcpOptsOrder: sessionRecord?.tcpOptsOrder,
 					tcpWindow: sessionRecord?.tcpWindow,
+					// Which egress categories this site blocks. Gates the
+					// egress-sensitive TCP-stack deny rules — a VPN
+					// concentrator legitimately terminates the handshake, so
+					// on a site that accepts VPN users the observed stack
+					// says nothing about the client.
+					trafficPolicies: deriveTrafficPolicies(trafficFilter),
 				};
 
 				const decision = await this.decisionMachineRunner.decide(

--- a/packages/provider/src/tasks/puzzleCaptcha/puzzleTasks.ts
+++ b/packages/provider/src/tasks/puzzleCaptcha/puzzleTasks.ts
@@ -64,6 +64,7 @@ import {
 	isClientSessionMismatch,
 	toStoredClientMetaData,
 } from "../../utils/clientMetaData.js";
+import { deriveTrafficPolicies } from "../../utils/devicePlatform.js";
 import { CaptchaManager } from "../captchaManager.js";
 import { DecisionMachineRunner } from "../decisionMachine/decisionMachineRunner.js";
 import {
@@ -913,6 +914,12 @@ export class PuzzleCaptchaManager extends CaptchaManager {
 				tcpOptsFlags: sessionRecord?.tcpOptsFlags,
 				tcpOptsOrder: sessionRecord?.tcpOptsOrder,
 				tcpWindow: sessionRecord?.tcpWindow,
+				// Which egress categories this site blocks. Gates the
+				// egress-sensitive TCP-stack deny rules — a VPN
+				// concentrator legitimately terminates the handshake, so
+				// on a site that accepts VPN users the observed stack
+				// says nothing about the client.
+				trafficPolicies: deriveTrafficPolicies(trafficFilter),
 			};
 
 			const decision = await this.decisionMachineRunner.decide(

--- a/packages/provider/src/tests/integration/routingDecisionMachines.integration.test.ts
+++ b/packages/provider/src/tests/integration/routingDecisionMachines.integration.test.ts
@@ -164,8 +164,23 @@ describe("Routing Decision Machines (live local Mongo + Redis)", () => {
 			body: JSON.stringify({}),
 		});
 
+	// Raw routing signals a test wants to vary. Cast at the call site because
+	// the tcp-probe / trafficPolicies fields are optional additions to
+	// RoutingMachineRawSignals.
+	type ExtraRawSignals = Partial<
+		Record<"tcpOptsOrder" | "tcpWscale" | "tcpMss", number>
+	> & {
+		trafficPolicies?: Record<
+			string,
+			{ action: string } & Record<string, unknown>
+		>;
+		ipInfo?: Record<string, unknown>;
+	};
+
 	const sendCaptchaViaRouter = async (
 		baselineType: CaptchaType.image | CaptchaType.pow | CaptchaType.puzzle,
+		extraRaw: ExtraRawSignals = {},
+		userAgent: string = SAMPLE_USER_AGENT,
 	) => {
 		// Drive the FrictionlessManager directly — the routing-machine path is
 		// what we care about, not the bot-detection ladder upstream of it.
@@ -202,8 +217,15 @@ describe("Routing Decision Machines (live local Mongo + Redis)", () => {
 			ip: "1.2.3.4",
 			countryCode: "GB",
 			score: 0.4,
-			platform: { isApple: false, isWebView: false, isMobile: false },
-			raw: { headers: {}, userAgent: SAMPLE_USER_AGENT },
+			imageMaxRounds: 5,
+			platform: { isApple: true, isWebView: false, isMobile: false },
+			raw: {
+				headers: {},
+				userAgent,
+				...extraRaw,
+			} as unknown as Parameters<
+				typeof tasks.frictionlessManager.setRoutingContext
+			>[0]["raw"],
 		});
 		switch (baselineType) {
 			case CaptchaType.image:
@@ -354,5 +376,415 @@ describe("Routing Decision Machines (live local Mongo + Redis)", () => {
 		for (const v of values) {
 			expect(v).toBeGreaterThanOrEqual(1);
 		}
+	});
+
+	// ------------------------------------------------------------------
+	// Router-supplied puzzle render overrides.
+	//
+	// A router that inherits a trafficFilter `challenge` policy has to be able
+	// to reproduce it exactly, and those policies carry puzzle tunables.
+	// getPuzzleCaptchaChallenge re-derives its overrides from a live
+	// trafficFilter verdict, which a router-chosen puzzle has no counterpart
+	// for — so the values ride on RoutingMachineOutput, get persisted on the
+	// session, and are read back at challenge time.
+	// ------------------------------------------------------------------
+
+	// `sessionId` is optional on the response type but always present on the
+	// captcha-serving paths these tests drive; assert rather than widen the
+	// helper, so a missing id fails loudly instead of silently skipping.
+	const latestSession = async (sessionId: string | undefined) => {
+		expect(sessionId).toBeDefined();
+		return env.getDb().getSessionRecordBySessionId(sessionId as string);
+	};
+
+	it("persists router-supplied puzzleTolerance and puzzle settings on the session", async () => {
+		await removeAll();
+		const source = `module.exports.route = function() {
+			return {
+				captchaType: 'puzzle',
+				puzzleTolerance: 7,
+				puzzle: { decoyCount: 14, pieceScale: { min: 0.2, max: 0.35 } }
+			};
+		};`;
+		expect((await putMachine(source, "puzzle-overrides")).status).toBe(200);
+
+		const response = await sendCaptchaViaRouter(CaptchaType.pow);
+		expect(response[ApiParams.captchaType]).toBe(CaptchaType.puzzle);
+
+		const session = await latestSession(response[ApiParams.sessionId]);
+		expect(session?.puzzleTolerance).toBe(7);
+		expect(session?.puzzle).toEqual({
+			decoyCount: 14,
+			pieceScale: { min: 0.2, max: 0.35 },
+		});
+	});
+
+	it("accepts a partial puzzle override without filling in the rest", async () => {
+		await removeAll();
+		const source = `module.exports.route = function() {
+			return { captchaType: 'puzzle', puzzle: { decoyCount: 30 } };
+		};`;
+		expect((await putMachine(source, "puzzle-partial")).status).toBe(200);
+
+		const response = await sendCaptchaViaRouter(CaptchaType.pow);
+		const session = await latestSession(response[ApiParams.sessionId]);
+		expect(session?.puzzle).toEqual({ decoyCount: 30 });
+		expect(session?.puzzleTolerance).toBeUndefined();
+	});
+
+	it("does not persist puzzle overrides on a non-puzzle session", async () => {
+		await removeAll();
+		const source = `module.exports.route = function() {
+			return {
+				captchaType: 'image',
+				solvedImagesCount: 2,
+				puzzleTolerance: 7,
+				puzzle: { decoyCount: 14 }
+			};
+		};`;
+		expect((await putMachine(source, "puzzle-on-image")).status).toBe(200);
+
+		const response = await sendCaptchaViaRouter(CaptchaType.pow);
+		expect(response[ApiParams.captchaType]).toBe(CaptchaType.image);
+		const session = await latestSession(response[ApiParams.sessionId]);
+		expect(session?.puzzleTolerance).toBeUndefined();
+		expect(session?.puzzle).toBeUndefined();
+	});
+
+	// RoutingMachineOutputSchema reuses the site-wide field validators, so a
+	// machine cannot hand the renderer a value the portal would reject. An
+	// invalid output fails validation and the whole route falls back to
+	// baseline.
+	it("rejects an out-of-bounds puzzleTolerance and falls back to baseline", async () => {
+		await removeAll();
+		const source = `module.exports.route = function() {
+			return { captchaType: 'puzzle', puzzleTolerance: 100000 };
+		};`;
+		expect((await putMachine(source, "puzzle-bad-tolerance")).status).toBe(200);
+
+		const response = await sendCaptchaViaRouter(CaptchaType.pow);
+		expect(response[ApiParams.captchaType]).toBe(CaptchaType.pow);
+	});
+
+	it("rejects an out-of-bounds decoyCount and falls back to baseline", async () => {
+		await removeAll();
+		const source = `module.exports.route = function() {
+			return { captchaType: 'puzzle', puzzle: { decoyCount: 9999 } };
+		};`;
+		expect((await putMachine(source, "puzzle-bad-decoy")).status).toBe(200);
+
+		const response = await sendCaptchaViaRouter(CaptchaType.pow);
+		expect(response[ApiParams.captchaType]).toBe(CaptchaType.pow);
+	});
+
+	// ------------------------------------------------------------------
+	// trafficPolicies reach the machine, and the undeclared-middlebox rule
+	// behaves as designed end to end.
+	// ------------------------------------------------------------------
+
+	const IPHONE_UA =
+		"Mozilla/5.0 (iPhone; CPU iPhone OS 18_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.5 Mobile/15E148 Safari/604.1";
+	const CLEAN_IPINFO = {
+		ip: "1.2.3.4",
+		isValid: true,
+		isVPN: false,
+		isTor: false,
+		isProxy: false,
+		isDatacenter: false,
+		isAbuser: false,
+		isMobile: false,
+		isSatellite: false,
+		isCrawler: false,
+		countryCode: "GB",
+	};
+	// Arbitrary sentinel SYN values. These tests exist to prove the provider
+	// plumbs `trafficPolicies` and the puzzle overrides through to a routing
+	// machine and back onto the session — NOT to test any particular
+	// fingerprint. The real signature values are operator-authored detection
+	// content and live with the machines, not in this repo.
+	const SENTINEL_MATCH_STACK = { tcpOptsOrder: 111111, tcpWscale: 99 };
+	const SENTINEL_MISS_STACK = { tcpOptsOrder: 222222, tcpWscale: 98 };
+
+	// Stands in for any egress-classifying machine: it reads a raw TCP signal
+	// and, when the signal matches and the intel feed says the IP is clean,
+	// inherits whichever of the site's vpn / datacenter policies is strictest.
+	const POLICY_INHERITING_MACHINE = `
+		module.exports.route = function(input) {
+			var raw = input.raw || {};
+			var ip = raw.ipInfo || {};
+			if (!ip.isValid) return undefined;
+			if (ip.isVPN || ip.isProxy || ip.isDatacenter) return undefined;
+			if (raw.tcpOptsOrder !== ${SENTINEL_MATCH_STACK.tcpOptsOrder}) return undefined;
+			if (raw.tcpWscale !== ${SENTINEL_MATCH_STACK.tcpWscale}) return undefined;
+			var p = raw.trafficPolicies || {};
+			var candidates = [p.vpn, p.datacenter].filter(Boolean);
+			var blocking = candidates.filter(function (c) { return c.action === 'block'; });
+			if (blocking.length) return undefined;
+			var challenge = candidates.filter(function (c) { return c.action === 'challenge'; })[0];
+			if (!challenge || !challenge.captchaType) return undefined;
+			var out = { captchaType: challenge.captchaType, reason: 'TEST_POLICY_INHERITED' };
+			if (challenge.puzzleTolerance !== undefined) out.puzzleTolerance = challenge.puzzleTolerance;
+			if (challenge.puzzle) out.puzzle = challenge.puzzle;
+			if (challenge.solvedImagesCount !== undefined) out.solvedImagesCount = challenge.solvedImagesCount;
+			return out;
+		};
+	`;
+
+	it("forwards trafficPolicies to the machine and inherits the challenge policy end to end", async () => {
+		await removeAll();
+		expect(
+			(await putMachine(POLICY_INHERITING_MACHINE, "undeclared-middlebox"))
+				.status,
+		).toBe(200);
+
+		const response = await sendCaptchaViaRouter(
+			CaptchaType.pow,
+			{
+				...SENTINEL_MATCH_STACK,
+				ipInfo: CLEAN_IPINFO,
+				trafficPolicies: {
+					vpn: {
+						action: "challenge",
+						captchaType: "puzzle",
+						puzzleTolerance: 6,
+						puzzle: { decoyCount: 20 },
+					},
+				},
+			},
+			IPHONE_UA,
+		);
+
+		expect(response[ApiParams.captchaType]).toBe(CaptchaType.puzzle);
+		const session = await latestSession(response[ApiParams.sessionId]);
+		expect(session?.reason).toBe("TEST_POLICY_INHERITED");
+		expect(session?.puzzleTolerance).toBe(6);
+		expect(session?.puzzle).toEqual({ decoyCount: 20 });
+	});
+
+	it("leaves the baseline alone when the site configured no VPN or datacenter policy", async () => {
+		await removeAll();
+		expect(
+			(await putMachine(POLICY_INHERITING_MACHINE, "undeclared-no-policy"))
+				.status,
+		).toBe(200);
+
+		const response = await sendCaptchaViaRouter(
+			CaptchaType.pow,
+			{ ...SENTINEL_MATCH_STACK, ipInfo: CLEAN_IPINFO },
+			IPHONE_UA,
+		);
+		expect(response[ApiParams.captchaType]).toBe(CaptchaType.pow);
+	});
+
+	it("leaves the baseline alone when the TCP signal does not match", async () => {
+		await removeAll();
+		expect(
+			(await putMachine(POLICY_INHERITING_MACHINE, "undeclared-native")).status,
+		).toBe(200);
+
+		const response = await sendCaptchaViaRouter(
+			CaptchaType.pow,
+			{
+				...SENTINEL_MISS_STACK,
+				ipInfo: CLEAN_IPINFO,
+				trafficPolicies: {
+					vpn: { action: "challenge", captchaType: "puzzle" },
+				},
+			},
+			IPHONE_UA,
+		);
+		expect(response[ApiParams.captchaType]).toBe(CaptchaType.pow);
+	});
+
+	it("defers to the verify-time deny rule when the policy is block", async () => {
+		await removeAll();
+		expect(
+			(await putMachine(POLICY_INHERITING_MACHINE, "undeclared-block")).status,
+		).toBe(200);
+
+		const response = await sendCaptchaViaRouter(
+			CaptchaType.pow,
+			{
+				...SENTINEL_MATCH_STACK,
+				ipInfo: CLEAN_IPINFO,
+				trafficPolicies: { vpn: { action: "block" } },
+			},
+			IPHONE_UA,
+		);
+		expect(response[ApiParams.captchaType]).toBe(CaptchaType.pow);
+	});
+
+	it("inherits the datacenter policy when only datacenter is configured", async () => {
+		await removeAll();
+		expect(
+			(await putMachine(POLICY_INHERITING_MACHINE, "undeclared-dc")).status,
+		).toBe(200);
+
+		const response = await sendCaptchaViaRouter(
+			CaptchaType.pow,
+			{
+				...SENTINEL_MATCH_STACK,
+				ipInfo: CLEAN_IPINFO,
+				trafficPolicies: {
+					datacenter: {
+						action: "challenge",
+						captchaType: "image",
+						solvedImagesCount: 3,
+					},
+				},
+			},
+			IPHONE_UA,
+		);
+		expect(response[ApiParams.captchaType]).toBe(CaptchaType.image);
+		const session = await latestSession(response[ApiParams.sessionId]);
+		expect(session?.solvedImagesCount).toBe(3);
+	});
+
+	// The machine consults vpn / datacenter only; a proxy-only policy must
+	// not be borrowed.
+	it("ignores a proxy-only policy for the middlebox signature", async () => {
+		await removeAll();
+		expect(
+			(await putMachine(POLICY_INHERITING_MACHINE, "undeclared-proxy-only"))
+				.status,
+		).toBe(200);
+
+		const response = await sendCaptchaViaRouter(
+			CaptchaType.pow,
+			{
+				...SENTINEL_MATCH_STACK,
+				ipInfo: CLEAN_IPINFO,
+				trafficPolicies: {
+					proxy: { action: "challenge", captchaType: "puzzle" },
+				},
+			},
+			IPHONE_UA,
+		);
+		expect(response[ApiParams.captchaType]).toBe(CaptchaType.pow);
+	});
+
+	it("does not fire when the intel feed already tagged the IP", async () => {
+		await removeAll();
+		expect(
+			(await putMachine(POLICY_INHERITING_MACHINE, "undeclared-tagged")).status,
+		).toBe(200);
+
+		const response = await sendCaptchaViaRouter(
+			CaptchaType.pow,
+			{
+				...SENTINEL_MATCH_STACK,
+				ipInfo: { ...CLEAN_IPINFO, isVPN: true },
+				trafficPolicies: {
+					vpn: { action: "challenge", captchaType: "puzzle" },
+				},
+			},
+			IPHONE_UA,
+		);
+		expect(response[ApiParams.captchaType]).toBe(CaptchaType.pow);
+	});
+
+	// ------------------------------------------------------------------
+	// Projection regression guard.
+	//
+	// getSessionRecordBySessionId projects an explicit field list. Three
+	// separate features have silently degraded because a field was written to
+	// Mongo but never selected on the way back out, so the reader saw
+	// `undefined` with no error anywhere. The return type is now derived from
+	// the projection (ProjectedSession), which catches new cases at compile
+	// time — this test covers the runtime half: that the fields really do
+	// round-trip through Mongo.
+	// ------------------------------------------------------------------
+	it("round-trips every field a caller reads off a session record", async () => {
+		await removeAll();
+		const source = `module.exports.route = function() {
+			return { captchaType: 'puzzle', puzzleTolerance: 9, puzzle: { decoyCount: 11 } };
+		};`;
+		expect((await putMachine(source, "projection-roundtrip")).status).toBe(200);
+
+		const response = await sendCaptchaViaRouter(
+			CaptchaType.pow,
+			{ ...SENTINEL_MATCH_STACK, tcpMss: 1460, ipInfo: CLEAN_IPINFO },
+			IPHONE_UA,
+		);
+		const sessionId = response[ApiParams.sessionId];
+		// tcp-probe signals reach the record through setSessionParams, not the
+		// routing context, so write them the way the middleware does.
+		await env.getDb().updateSessionRecord(sessionId as string, {
+			...SENTINEL_MATCH_STACK,
+			tcpMss: 1460,
+		});
+		const session = await latestSession(sessionId);
+		expect(session).toBeDefined();
+
+		// Router-chosen puzzle tunables.
+		expect(session?.puzzleTolerance).toBe(9);
+		expect(session?.puzzle).toEqual({ decoyCount: 11 });
+		// tcp-probe signals the verify-time decide rules gate on.
+		expect(session?.tcpOptsOrder).toBe(111111);
+		expect(session?.tcpWscale).toBe(99);
+		expect(session?.tcpMss).toBe(1460);
+		// Core identity / scoring fields.
+		expect(session?.sessionId).toBe(response[ApiParams.sessionId]);
+		expect(session?.siteKey).toBe(dappAccount);
+		expect(session?.score).toBe(0.4);
+		expect(session?.ipInfo?.isValid).toBe(true);
+	});
+
+	// The entropy fingerprints and the compact g/i/sw/md/bn/fs flags were
+	// written but never projected, so `getSessionRecordWithOriginFallback`
+	// saw every one as undefined: it always believed the escalation session
+	// was missing them, always issued a second query for the origin, and
+	// always copied nothing back because the origin read as undefined too.
+	it("projects the entropy fingerprints and capability flags", async () => {
+		await removeAll();
+		tasks.frictionlessManager.setSessionParams({
+			token: `tok-entropy-${Date.now()}`,
+			score: 0.4,
+			threshold: 0.5,
+			scoreComponents: { baseScore: 0.4 },
+			ipAddress: { lower: 16909060n, type: IpAddressType.v4 },
+			webView: false,
+			iFrame: false,
+			decryptedHeadHash: "",
+			siteKey: dappAccount,
+			headers: {},
+			entropyMathRandomFingerprint: "mathfp",
+			entropyCryptoFingerprint: "cryptofp",
+			entropyWallClockOffsetMs: 42,
+			entropyMathRandomFirst: 0.5,
+			g: "gval",
+			i: true,
+			sw: true,
+			md: true,
+			bn: true,
+			fs: true,
+			isProtect: true,
+		});
+		const response = await tasks.frictionlessManager.sendPowCaptcha({
+			powDifficulty: 7,
+		});
+		// `ruleType` is written by the access-policy path
+		// (blacklistRequestInspector), not by setSessionParams — set it the
+		// same way that path would so the projection is what is under test.
+		await env
+			.getDb()
+			.updateSessionRecord(response[ApiParams.sessionId] as string, {
+				ruleType: ["some-rule"],
+			});
+		const session = await latestSession(response[ApiParams.sessionId]);
+
+		expect(session?.entropyMathRandomFingerprint).toBe("mathfp");
+		expect(session?.entropyCryptoFingerprint).toBe("cryptofp");
+		expect(session?.entropyWallClockOffsetMs).toBe(42);
+		expect(session?.entropyMathRandomFirst).toBe(0.5);
+		expect(session?.g).toBe("gval");
+		expect(session?.i).toBe(true);
+		expect(session?.sw).toBe(true);
+		expect(session?.md).toBe(true);
+		expect(session?.bn).toBe(true);
+		expect(session?.fs).toBe(true);
+		expect(session?.isProtect).toBe(true);
+		expect(session?.ruleType).toEqual(["some-rule"]);
+		expect(session?.powDifficulty).toBe(7);
 	});
 });

--- a/packages/provider/src/tests/unit/tasks/frictionless/routerPuzzleOverrides.unit.test.ts
+++ b/packages/provider/src/tests/unit/tasks/frictionless/routerPuzzleOverrides.unit.test.ts
@@ -1,0 +1,180 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// A routing machine that inherits a trafficFilter `challenge` policy needs to
+// reproduce it exactly, and those policies can carry puzzle tunables.
+// `getPuzzleCaptchaChallenge` re-derives its overrides from a live
+// trafficFilter verdict, which a router-chosen puzzle has no counterpart for —
+// so the router's values are persisted on the session for that endpoint to
+// read. These tests pin the persistence half.
+
+import {
+	CaptchaType,
+	FrictionlessPenalties,
+	type KeyringPair,
+	type ProsopoConfigOutput,
+	type RoutingMachineOutput,
+	type Session,
+} from "@prosopo/types";
+import type { IProviderDatabase } from "@prosopo/types-database";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { applyRouterMock } = vi.hoisted(() => ({
+	applyRouterMock: vi.fn(),
+}));
+
+vi.mock("../../../../tasks/frictionless/routingMachine.js", () => ({
+	applyRouter: applyRouterMock,
+}));
+
+import { getCompositeIpAddress } from "../../../../compositeIpAddress.js";
+import { FrictionlessManager } from "../../../../tasks/frictionless/frictionlessTasks.js";
+import type { RoutingContext } from "../../../../tasks/frictionless/routingMachine.js";
+
+const SITE_KEY = "5EjTA28bKSbFPPyMbUjNtArxyqjwq38r1BapVmLZShaqEedV";
+
+describe("router-supplied puzzle overrides reach the session record", () => {
+	let db: IProviderDatabase;
+	let storeSessionRecord: ReturnType<typeof vi.fn>;
+	let manager: FrictionlessManager;
+
+	const context: RoutingContext = {
+		dappAccount: SITE_KEY,
+		userAccount: "user",
+		ip: "1.2.3.4",
+		score: 0.9,
+		platform: { isMobile: false, isApple: true, isWebView: false },
+		raw: { headers: {}, userAgent: "ua" },
+		imageMaxRounds: 8,
+	};
+
+	const storedSession = (): Session => {
+		const call = storeSessionRecord.mock.calls[0];
+		if (!call) throw new Error("no session was stored");
+		return call[0] as Session;
+	};
+
+	const routerReturns = (output: RoutingMachineOutput): void => {
+		applyRouterMock.mockResolvedValue(output);
+	};
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		storeSessionRecord = vi.fn();
+		db = { storeSessionRecord } as unknown as IProviderDatabase;
+
+		const pair = {
+			sign: vi.fn(),
+			address: "testAddress",
+		} as unknown as KeyringPair;
+
+		const config = {
+			penalties: FrictionlessPenalties.parse({}),
+			captchas: { solved: { count: 2 }, unsolved: { count: 0 } },
+			lRules: { en: 1 },
+		} as unknown as ProsopoConfigOutput;
+
+		manager = new FrictionlessManager(db, pair, config);
+		manager.setSessionParams({
+			token: "tok",
+			score: 0.9,
+			threshold: 0.5,
+			scoreComponents: { baseScore: 0.9 },
+			ipAddress: getCompositeIpAddress("1.2.3.4"),
+			siteKey: SITE_KEY,
+			webView: false,
+			iFrame: false,
+			decryptedHeadHash: "",
+		});
+		manager.setRoutingContext(context);
+	});
+
+	it("persists puzzleTolerance and puzzle settings on a puzzle session", async () => {
+		routerReturns({
+			captchaType: CaptchaType.puzzle,
+			puzzleTolerance: 5,
+			puzzle: { decoyCount: 12, pieceScale: { min: 0.2, max: 0.4 } },
+		});
+
+		await manager.sendPuzzleCaptcha();
+
+		expect(storedSession().puzzleTolerance).toBe(5);
+		expect(storedSession().puzzle).toEqual({
+			decoyCount: 12,
+			pieceScale: { min: 0.2, max: 0.4 },
+		});
+	});
+
+	it("persists a partial override without inventing the other fields", async () => {
+		routerReturns({
+			captchaType: CaptchaType.puzzle,
+			puzzle: { decoyCount: 30 },
+		});
+
+		await manager.sendPuzzleCaptcha();
+
+		expect(storedSession().puzzle).toEqual({ decoyCount: 30 });
+		expect(storedSession().puzzleTolerance).toBeUndefined();
+	});
+
+	it("persists tolerance alone when no render settings were named", async () => {
+		routerReturns({ captchaType: CaptchaType.puzzle, puzzleTolerance: 8 });
+
+		await manager.sendPuzzleCaptcha();
+
+		expect(storedSession().puzzleTolerance).toBe(8);
+		expect(storedSession().puzzle).toBeUndefined();
+	});
+
+	it("leaves both undefined when the router named neither", async () => {
+		routerReturns({ captchaType: CaptchaType.puzzle });
+
+		await manager.sendPuzzleCaptcha();
+
+		expect(storedSession().puzzleTolerance).toBeUndefined();
+		expect(storedSession().puzzle).toBeUndefined();
+	});
+
+	// A router can pick a non-puzzle type, and downgradePuzzleIfUnavailable can
+	// turn a puzzle into something else. Neither session should carry stale
+	// render settings the endpoint would never read.
+	it("drops the overrides when the router chose an image", async () => {
+		routerReturns({
+			captchaType: CaptchaType.image,
+			solvedImagesCount: 2,
+			puzzleTolerance: 5,
+			puzzle: { decoyCount: 12 },
+		});
+
+		await manager.sendPuzzleCaptcha();
+
+		expect(storedSession().captchaType).toBe(CaptchaType.image);
+		expect(storedSession().puzzleTolerance).toBeUndefined();
+		expect(storedSession().puzzle).toBeUndefined();
+	});
+
+	it("drops the overrides when the router chose pow", async () => {
+		routerReturns({
+			captchaType: CaptchaType.pow,
+			puzzleTolerance: 5,
+			puzzle: { decoyCount: 12 },
+		});
+
+		await manager.sendPuzzleCaptcha();
+
+		expect(storedSession().captchaType).toBe(CaptchaType.pow);
+		expect(storedSession().puzzleTolerance).toBeUndefined();
+		expect(storedSession().puzzle).toBeUndefined();
+	});
+});

--- a/packages/provider/src/tests/unit/utils/devicePlatform.unit.test.ts
+++ b/packages/provider/src/tests/unit/utils/devicePlatform.unit.test.ts
@@ -12,8 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import {
+	CaptchaType,
+	type ITrafficFilter,
+	TrafficFilterAction,
+} from "@prosopo/types";
 import { describe, expect, it } from "vitest";
-import { derivePlatform } from "../../../utils/devicePlatform.js";
+import {
+	derivePlatform,
+	deriveTrafficPolicies,
+} from "../../../utils/devicePlatform.js";
 
 const IPHONE_UA =
 	"Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1";
@@ -80,5 +88,71 @@ describe("derivePlatform", () => {
 		it("falls back to UA when ipInfo missing — Mac Safari is not mobile", () => {
 			expect(derivePlatform(MAC_UA, false).isMobile).toBe(false);
 		});
+	});
+});
+
+describe("deriveTrafficPolicies", () => {
+	const block = { action: TrafficFilterAction.Block } as const;
+	const challenge = { action: TrafficFilterAction.Challenge } as const;
+
+	it("returns undefined when there is no trafficFilter", () => {
+		expect(deriveTrafficPolicies(undefined)).toBeUndefined();
+	});
+
+	it("returns undefined when no category is configured", () => {
+		const tf: Partial<ITrafficFilter> = {
+			abuserScoreThreshold: 0.9,
+			skipExtrasOnValidDnsPath: true,
+			datacenterNameAllowlist: ["Cloudflare"],
+		};
+		expect(deriveTrafficPolicies(tf)).toBeUndefined();
+	});
+
+	it("carries challenge policies through, not just blocks", () => {
+		const tf: Partial<ITrafficFilter> = { vpn: challenge, datacenter: block };
+		expect(deriveTrafficPolicies(tf)).toEqual({
+			vpn: challenge,
+			datacenter: block,
+		});
+	});
+
+	it("preserves the challenge policy's captcha overrides", () => {
+		const vpn = {
+			action: TrafficFilterAction.Challenge,
+			captchaType: CaptchaType.image,
+			solvedImagesCount: 4,
+		} as const;
+		const tf: Partial<ITrafficFilter> = { vpn };
+		expect(deriveTrafficPolicies(tf)?.vpn).toEqual(vpn);
+	});
+
+	it("omits a category that is absent from the filter", () => {
+		const tf: Partial<ITrafficFilter> = { datacenter: block };
+		const policies = deriveTrafficPolicies(tf);
+		expect(policies).toEqual({ datacenter: block });
+		expect(policies?.vpn).toBeUndefined();
+	});
+
+	it("covers every policy-carrying category", () => {
+		const tf: Partial<ITrafficFilter> = {
+			vpn: block,
+			proxy: block,
+			tor: block,
+			datacenter: block,
+			abuser: block,
+			mobile: block,
+			satellite: block,
+			crawler: block,
+		};
+		expect(Object.keys(deriveTrafficPolicies(tf) ?? {}).sort()).toEqual([
+			"abuser",
+			"crawler",
+			"datacenter",
+			"mobile",
+			"proxy",
+			"satellite",
+			"tor",
+			"vpn",
+		]);
 	});
 });

--- a/packages/provider/src/utils/devicePlatform.ts
+++ b/packages/provider/src/utils/devicePlatform.ts
@@ -12,8 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import type { RoutingMachinePlatform } from "@prosopo/types";
+import type {
+	ITrafficFilter,
+	RoutingMachinePlatform,
+	TrafficCategoryPolicies,
+} from "@prosopo/types";
 
+// NB: `isApple` covers desktop macOS as well as iOS. A rule that needs
+// "iPhone / iPad specifically" must test the UA itself — see the iOS UA
+// gate in the decision machines' route checks.
 const APPLE_UA_REGEX = /iPhone|iPad|iPod|Macintosh|Mac OS X/i;
 const MOBILE_UA_REGEX = /Mobile|Android|iPhone|iPad|iPod|Opera Mini|IEMobile/i;
 
@@ -35,3 +42,43 @@ export const derivePlatform = (
 			? ipInfo.isMobile
 			: MOBILE_UA_REGEX.test(userAgent),
 });
+
+// Categories on TrafficFilterSchema that carry a TrafficCategoryPolicy. The
+// schema's other keys (thresholds, allow/deny name lists, skipExtras…) are
+// not egress classes and have no `action`.
+const TRAFFIC_FILTER_CATEGORIES = [
+	"vpn",
+	"proxy",
+	"tor",
+	"datacenter",
+	"abuser",
+	"mobile",
+	"satellite",
+	"crawler",
+] as const satisfies readonly (keyof TrafficCategoryPolicies)[];
+
+/**
+ * Project a site's `trafficFilter` down to just its per-category policies, for
+ * consumption by routing / decision machines. Machines use these both to tell
+ * whether the operator rejects an egress class at all, and to inherit the
+ * operator's configured action when they classify one themselves — see
+ * `TrafficCategoryPolicies`.
+ *
+ * Returns `undefined` when no category is configured, so the field can be
+ * omitted from the machine input entirely.
+ */
+export const deriveTrafficPolicies = (
+	trafficFilter: Partial<ITrafficFilter> | undefined,
+): TrafficCategoryPolicies | undefined => {
+	if (!trafficFilter) return undefined;
+	const policies: TrafficCategoryPolicies = {};
+	let any = false;
+	for (const category of TRAFFIC_FILTER_CATEGORIES) {
+		const policy = trafficFilter[category];
+		if (policy) {
+			policies[category] = policy;
+			any = true;
+		}
+	}
+	return any ? policies : undefined;
+};

--- a/packages/types-database/src/types/provider.ts
+++ b/packages/types-database/src/types/provider.ts
@@ -727,6 +727,12 @@ export const SessionRecordSchema = new Schema<SessionRecord>({
 	mode: { type: String, enum: ModeEnum, required: false },
 	solvedImagesCount: { type: Number, required: false },
 	powDifficulty: { type: Number, required: false },
+	// Puzzle render overrides chosen by the routing machine. Stored as a
+	// free-form subdocument so the shape stays in step with
+	// PuzzleSettingsSchema without a second place to update — the value is
+	// already validated by RoutingMachineOutputSchema before it gets here.
+	puzzleTolerance: { type: Number, required: false },
+	puzzle: { type: Object, required: false },
 	storedAtTimestamp: { type: Date, required: false, expires: ONE_DAY },
 	lastUpdatedTimestamp: { type: Date, required: false },
 	// See `StoredCaptcha.pendingStage` — same semantics on Session records.
@@ -983,6 +989,150 @@ ClientContextEntropyRecordSchema.index(
 	{ unique: true },
 );
 
+/**
+ * Field list for `ProviderDatabase.getSessionRecordBySessionId`.
+ *
+ * Hoisted to a `const` so the method's return type is *derived* from it — see
+ * {@link ProjectedSession}. A caller that reads a field this projection does
+ * not select now fails to compile, instead of silently receiving `undefined`
+ * at runtime.
+ *
+ * That silent failure has shipped three times: the tcp-probe fields (decide
+ * rules got `undefined` and never fired), the entropy fingerprints plus the
+ * g / i / sw / md / bn / fs flags (which disabled the origin-session fallback
+ * in `captchaManager.getSessionRecordWithOriginFallback` *and* made it issue a
+ * redundant second query on every escalation), and the router's puzzle render
+ * overrides. Adding a field to `Session` no longer implies it is readable
+ * here; it has to be added below as well, and the compiler now says so.
+ *
+ * `headers` is selected by individual key rather than as a whole blob: the
+ * flattened `req.headers` persisted at frictionless time can contain
+ * `x-tls-clienthello` (a base64-encoded full TLS ClientHello, multi-KB per
+ * session). That field is only consumed by `ja4Middleware` from the live
+ * `req.headers` at the entry point — never re-read off the persisted Session —
+ * so it just bloats every subsequent lookup. The enumerated list covers the
+ * headers `buildEscalation` forwards onto the escalation session. New headers
+ * that need to round-trip must be added here explicitly.
+ */
+export const SESSION_PROJECTION = {
+	sessionId: 1,
+	token: 1,
+	score: 1,
+	threshold: 1,
+	scoreComponents: 1,
+	ipAddress: 1,
+	ipInfo: 1,
+	webView: 1,
+	iFrame: 1,
+	isEscalation: 1,
+	decryptedHeadHash: 1,
+	siteKey: 1,
+	reason: 1,
+	mode: 1,
+	solvedImagesCount: 1,
+	// Puzzle render overrides a routing machine asked for.
+	// getPuzzleCaptchaChallenge reads these off the session to
+	// layer over the site defaults — without them projected the
+	// overrides silently never apply.
+	puzzleTolerance: 1,
+	puzzle: 1,
+	// Read by captchaManager.peek* to report the session's own
+	// difficulty alongside solvedImagesCount.
+	powDifficulty: 1,
+	// Fed into DecisionMachineInput.ruleType by the pow / image /
+	// puzzle verify paths, so decide rules can gate on which
+	// access rule matched at frictionless entry.
+	ruleType: 1,
+	// Carried onto escalation sessions by `buildEscalation` so the
+	// escalated record keeps the Protect tag.
+	isProtect: 1,
+	// Entropy fingerprints and the compact client-capability flags.
+	// Read in two places, both of which silently degraded without
+	// them: `buildEscalation` copies them onto the escalation
+	// session, and `getSessionRecordWithOriginFallback` compares
+	// them against the origin session to decide whether a second
+	// lookup is even needed. Unprojected, every one read as
+	// undefined — so the fallback always fired and always copied
+	// nothing.
+	entropyMathRandomFingerprint: 1,
+	entropyCryptoFingerprint: 1,
+	entropyWallClockOffsetMs: 1,
+	entropyMathRandomFirst: 1,
+	g: 1,
+	i: 1,
+	sw: 1,
+	md: 1,
+	bn: 1,
+	fs: 1,
+	userSitekeyIpHash: 1,
+	simdReadings: 1,
+	bundleId: 1,
+	dnsEvent: 1,
+	originSessionId: 1,
+	currentUrl: 1,
+	iframeUrl: 1,
+	// Mirrored up from the captcha record at solve time. Projected
+	// so session-level readers see the same clientSessionId the
+	// captcha record carries.
+	clientMetaData: 1,
+	// captchaType is required by the peek-before-consume path
+	// in `CaptchaManager.isValidRequest` — without it, every
+	// escalation peek would compare `undefined !== <requested>`
+	// and forcibly return INCORRECT_CAPTCHA_TYPE on the happy
+	// path too. Keep this projection in sync with whatever
+	// fields the read-only callers need.
+	captchaType: 1,
+	// Raw per-connection TCP-handshake signals populated by the
+	// tcp-probe eBPF sidecar (see @prosopo/types Session for the
+	// wire semantics). The verify-time DM input surface exposes
+	// these to decide rules (e.g. `tcp-stack-dc-linux-ts-off`,
+	// `tcp-ttl-windows-ua-linux-stack`); every one of the img /
+	// pow / puzzle verify paths forwards `sessionRecord?.tcpX`
+	// into the DecisionMachineInput. Missed on the original
+	// projection: the rules got `undefined` for every field and
+	// silently never fired against real traffic even though
+	// matching sessions were sitting in the DB.
+	synNs: 1,
+	synackNs: 1,
+	ackNs: 1,
+	observedTtl: 1,
+	tcpMss: 1,
+	tcpWscale: 1,
+	tcpOptsFlags: 1,
+	tcpOptsOrder: 1,
+	tcpWindow: 1,
+	"headers.user-agent": 1,
+	"headers.accept": 1,
+	"headers.accept-language": 1,
+	"headers.accept-encoding": 1,
+	"headers.sec-ch-ua": 1,
+	"headers.sec-ch-ua-mobile": 1,
+	"headers.sec-ch-ua-platform": 1,
+	"headers.sec-ch-ua-platform-version": 1,
+	"headers.sec-fetch-dest": 1,
+	"headers.sec-fetch-mode": 1,
+	"headers.sec-fetch-site": 1,
+	"headers.sec-fetch-user": 1,
+	"headers.referer": 1,
+	"headers.origin": 1,
+	"headers.prosopo-user": 1,
+	"headers.prosopo-site-key": 1,
+	"headers.prosopo-type": 1,
+	"headers.x-tls-version": 1,
+} as const;
+
+/**
+ * The subset of `Session` that {@link SESSION_PROJECTION} actually returns.
+ *
+ * Dotted header keys are not `keyof Session`, so `Extract` drops them and
+ * `headers` is re-added whole — the projected subset still arrives under that
+ * key, just with fewer entries.
+ */
+export type ProjectedSession = Pick<
+	Session,
+	Extract<keyof typeof SESSION_PROJECTION, keyof Session> | "headers"
+>;
+
 export interface IProviderDatabase extends IDatabase {
 	// biome-ignore lint/suspicious/noExplicitAny: <explanation>
 	tables: Tables<any>;
@@ -1236,7 +1386,9 @@ export interface IProviderDatabase extends IDatabase {
 
 	storeBlockedSession(sessionRecord: Session): Promise<void>;
 
-	getSessionRecordBySessionId(sessionId: string): Promise<Session | undefined>;
+	getSessionRecordBySessionId(
+		sessionId: string,
+	): Promise<ProjectedSession | undefined>;
 
 	getSessionRecordByToken(token: string): Promise<Session | undefined>;
 

--- a/packages/types/src/decisionMachine/index.ts
+++ b/packages/types/src/decisionMachine/index.ts
@@ -18,6 +18,12 @@ import {
 	CaptchaType,
 	DecisionMachineCaptchaTypeSchema,
 } from "../client/captchaType/captchaType.js";
+import {
+	type IPuzzleSettings,
+	type ITrafficCategoryPolicy,
+	PuzzleSettingsSchema,
+	puzzleToleranceFieldSchema,
+} from "../client/settings.js";
 import type { PuzzleEvent, RequestHeaders } from "../provider/api.js";
 import type { ScoreComponents } from "../provider/database.js";
 import type { SimdReadings } from "../provider/detection.js";
@@ -72,6 +78,45 @@ export type DecisionMachineBehavioralDataPacked = {
 	c2: unknown[];
 	c3: unknown[];
 	d: string;
+};
+
+/**
+ * The site's per-category `settings.trafficFilter` policies, projected down to
+ * just the egress categories (the filter's thresholds and name lists are left
+ * behind). Derived server-side by `deriveTrafficPolicies` and surfaced to
+ * routing / decision machines.
+ *
+ * Two distinct jobs:
+ *
+ * 1. **Consent gate.** A rule that reasons about middleboxes must know whether
+ *    the operator actually rejects that egress class. A VPN concentrator
+ *    legitimately terminates the client's TCP handshake, so on a site that
+ *    welcomes VPN users the observed stack says nothing and the check must not
+ *    run. `action === "block"` is the only value that counts as "not opted in".
+ *
+ * 2. **Policy inheritance.** A machine that classifies a connection as, say,
+ *    a VPN the IP-intel feed missed should act exactly as the operator
+ *    configured for VPNs — deny when they block, serve their nominated captcha
+ *    when they challenge — rather than invent its own escalation.
+ *
+ * An absent key means the operator left that category unconfigured. A missing
+ * bag entirely (no trafficFilter, or a provider that pre-dates the field) means
+ * nothing is configured, so machines must fall through to no extra friction.
+ *
+ * NB `puzzleTolerance` / `puzzle` render overrides on a challenge policy are
+ * not expressible in `RoutingMachineOutput`, so a machine inheriting a
+ * challenge policy can honour `captchaType`, `powDifficulty` and
+ * `solvedImagesCount` only.
+ */
+export type TrafficCategoryPolicies = {
+	vpn?: ITrafficCategoryPolicy;
+	proxy?: ITrafficCategoryPolicy;
+	tor?: ITrafficCategoryPolicy;
+	datacenter?: ITrafficCategoryPolicy;
+	abuser?: ITrafficCategoryPolicy;
+	mobile?: ITrafficCategoryPolicy;
+	satellite?: ITrafficCategoryPolicy;
+	crawler?: ITrafficCategoryPolicy;
 };
 
 export type DecisionMachineInput = {
@@ -129,6 +174,10 @@ export type DecisionMachineInput = {
 	tcpOptsFlags?: number;
 	tcpOptsOrder?: number;
 	tcpWindow?: number;
+	// The site's per-category traffic-filter policies. Gates the
+	// egress-sensitive TCP-stack rules and supplies the action they inherit —
+	// see TrafficCategoryPolicies.
+	trafficPolicies?: TrafficCategoryPolicies;
 };
 
 export type DecisionMachineOutput = {
@@ -307,6 +356,10 @@ export interface RoutingMachineRawSignals {
 	// client / persisted session pre-dates the field.
 	currentUrl?: string;
 	iframeUrl?: string;
+	// The site's per-category traffic-filter policies. Gates the
+	// egress-sensitive middlebox route rules and supplies the challenge
+	// policy they inherit — see TrafficCategoryPolicies.
+	trafficPolicies?: TrafficCategoryPolicies;
 }
 
 export type RoutingMachinePhase = "route" | "postPow";
@@ -335,6 +388,16 @@ export interface RoutingMachineOutput {
 	// (e.g. why it chose image over pow). Persisted to `session.reason` by the
 	// provider. Free-form string because machines are operator-authored.
 	reason?: string;
+	// Puzzle-only tunables, with the same override semantics as a
+	// trafficFilter `challenge` policy: lower tolerance = stricter accuracy,
+	// and `puzzle` carries per-render overrides (decoy count, scale range, …).
+	// Both are persisted on the Session and layered in by
+	// getPuzzleCaptchaChallenge, because that endpoint re-derives its
+	// overrides from the live trafficFilter verdict and a machine-chosen
+	// puzzle has no matching verdict to re-derive from.
+	// Ignored unless the resolved captchaType is `puzzle`.
+	puzzleTolerance?: number;
+	puzzle?: IPuzzleSettings;
 }
 
 export const RoutingMachineOutputSchema = z.object({
@@ -346,4 +409,9 @@ export const RoutingMachineOutputSchema = z.object({
 	solvedImagesCount: z.number().int().positive().optional(),
 	powDifficulty: z.number().positive().optional(),
 	reason: z.string().optional(),
+	// Bounded by the same validators the site-wide settings use, so a machine
+	// cannot hand the renderer a tolerance or decoy count the portal would
+	// reject.
+	puzzleTolerance: puzzleToleranceFieldSchema.optional(),
+	puzzle: PuzzleSettingsSchema.optional(),
 });

--- a/packages/types/src/provider/database.ts
+++ b/packages/types/src/provider/database.ts
@@ -31,7 +31,7 @@ import {
 } from "zod";
 import type { IPInfoResponse } from "../api/ipapi.js";
 import { CaptchaType } from "../client/index.js";
-import type { ContextType } from "../client/settings.js";
+import type { ContextType, IPuzzleSettings } from "../client/settings.js";
 import { ModeEnum } from "../config/mode.js";
 import {
 	type CaptchaResult,
@@ -565,6 +565,13 @@ export type Session = {
 	mode?: ModeEnum;
 	solvedImagesCount?: number;
 	powDifficulty?: number;
+	// Puzzle-only render overrides chosen by the routing machine, persisted
+	// so getPuzzleCaptchaChallenge can layer them in. That endpoint otherwise
+	// re-derives its overrides from a live trafficFilter verdict, which a
+	// machine-chosen puzzle has no counterpart for. Same semantics as the
+	// trafficFilter challenge-policy fields of the same names.
+	puzzleTolerance?: number;
+	puzzle?: IPuzzleSettings;
 	storedAtTimestamp?: Date;
 	lastUpdatedTimestamp?: Date;
 	// See StoredCaptcha.pendingStage — same semantics on Session records.


### PR DESCRIPTION
Surfaced while investigating a customer report of MacBooks on commercial VPNs being handed 3-round image captchas. Two independent problems, both in this repo; the detection-rule half lives in `captcha-private`.

## 1. `getSessionRecordBySessionId` under-projected

The query lists its fields explicitly but declared a full `Session` return type. That type lie let callers read fields the projection never selected — they get `undefined`, with no error anywhere. It has now shipped three times:

| field(s) | consequence |
|---|---|
| tcp-probe fields | verify-time TCP decide rules received `undefined` and never fired against real traffic (already documented in a comment on the projection) |
| entropy fingerprints + `g`/`i`/`sw`/`md`/`bn`/`fs` | every `needsX` check in `getSessionRecordWithOriginFallback` was trivially true, so it **always** issued a redundant second query for the origin session and **always** copied nothing back, because the origin read `undefined` too. Same fields silently dropped by `buildEscalation` |
| `ruleType` | fed into `DecisionMachineInput` by all three verify paths, so any decide rule gating on the matched access rule was dead |

Adds the 13 missing fields, then makes it structural so it can't recur:

```ts
export type ProjectedSession = Pick<
	Session,
	Extract<keyof typeof SESSION_PROJECTION, keyof Session> | "headers"
>;
```

Reading an unprojected field is now a **compile error**. It immediately caught `getSessionRecordWithOriginFallback` still declaring `Promise<Session>`.

I audited the other three projected queries in `provider.ts` — `getPowCaptchaRecordByChallenge`, `getPuzzleCaptchaRecordByChallenge` and `getClientRecord` are all correct. `getClientRecord` is safe *by construction* for the same reason: its return type is `Pick`-narrowed to match the projection. That's the pattern this PR generalises.

## 2. Routing machines could not express puzzle tunables

`RoutingMachineOutput` had no `puzzleTolerance` / `puzzle`, so a machine inheriting a trafficFilter `challenge` policy could not reproduce it. `getPuzzleCaptchaChallenge` re-derives those from a live trafficFilter verdict, which a machine-chosen puzzle has no counterpart for — so the values are persisted on the session and layered in there, beneath a live verdict.

Both are validated by the same field validators the portal uses, so a machine can't hand the renderer an out-of-range value, and they're dropped unless the resolved type really is a puzzle.

This required correcting `runArtifactExport`'s generic: `z.ZodSchema<T>` pins Input === Output === T, so any `.default()` in the schema tree made `T` unify with the *input* shape and the parsed result stopped matching the declared output type.

## Also

- `deriveTrafficPolicies` projects `settings.trafficFilter` down to its per-category policies and forwards them to routing/decision machines, so a machine can distinguish "the operator rejects this egress class" from "the operator deliberately accepts it", and can inherit the operator's configured action rather than inventing its own escalation.
- `sendCaptcha` now persists the router's `reason` (mirroring the postPow path). A route-phase selection reason previously never reached the session and was invisible in the portal.
- A note on `derivePlatform` that `isApple` matches desktop macOS — the root cause of the customer report, since iOS-calibrated rules were gated on that flag.

## Testing

- Integration coverage grows **6 → 20** cases (live Mongo + Redis + provider API).
- Provider unit suite: 1173 passing, including a new `routerPuzzleOverrides` file.
- Worth noting: **the projection bug was caught by an integration test, not a unit test.** The unit tests assert on the object handed to `storeSessionRecord`, so they cannot see what Mongo gives back. The first version of the integration tests failed and exposed it.
- 11 pre-existing failures in `imgCaptcha.integration.test.ts` are unrelated — verified identical on a stashed tree.

Test fixtures use arbitrary sentinel TCP values. Real fingerprints are operator-authored detection content and stay with the machines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)