### PR TITLE
fix(procaptcha-frictionless): share one detector assignment across widgets on a page

### DIFF
--- a/.changeset/share-detector-prefetch-across-widgets.md
+++ b/.changeset/share-detector-prefetch-across-widgets.md
@@ -1,0 +1,11 @@
+---
+"@prosopo/procaptcha-frictionless": patch
+---
+
+Let every widget on a page share one detector-bundle assignment instead of only the first.
+
+`takePrefetchedDetector` removed the in-flight entry on claim, so on a page carrying several widgets the first claimed the prefetch and every other widget issued its own provider resolve plus `assignDetectorBundle`. One production integration mounts a widget per form — eight on a property page — so a single page view cost eight assign calls rather than one, enough on its own to push ordinary visitors past a per-IP rate detector.
+
+Sharing is sound: `detectorSessionId` binds to a `bundleId` in Redis purely so the provider can resolve which cipher keys decrypt that widget's SIMD readings. Widgets sharing an assignment run the same bundle, so those are the right keys — it is a lookup, not a one-shot token.
+
+The guarantee the removal existed for is kept by two narrower mechanisms: a prefetch that rejects drops itself from the map, so no later widget inherits a failed pin, and entries go stale after 60s so a widget mounting much later re-resolves rather than reusing an aged provider pin. Retries were never affected either way — `customDetectBot` only claims on a first attempt.

--- a/packages/procaptcha-frictionless/src/detectorPrefetch.ts
+++ b/packages/procaptcha-frictionless/src/detectorPrefetch.ts
@@ -52,7 +52,21 @@ export interface PrefetchedDetector {
 	assigned: AssignDetectorBundleResponse;
 }
 
-const inFlight = new Map<string, Promise<PrefetchedDetector>>();
+interface PrefetchEntry {
+	promise: Promise<PrefetchedDetector>;
+	startedAt: number;
+}
+
+const inFlight = new Map<string, PrefetchEntry>();
+
+/**
+ * How long a started prefetch stays claimable. A page that mounts several
+ * widgets does so within a tick or two of each other, so a short window is
+ * enough for them to share one assignment; anything mounting much later
+ * (a modal opened minutes in, say) re-resolves rather than reusing a provider
+ * pin that has since gone stale.
+ */
+const PREFETCH_TTL_MS = 60_000;
 
 const keyOf = (
 	environment: EnvironmentTypes,
@@ -76,6 +90,7 @@ export const prefetchDetector = (
 ): void => {
 	const key = keyOf(environment, ipMode, siteKey);
 	if (inFlight.has(key)) return;
+	const startedAt = Date.now();
 
 	const promise = (async (): Promise<PrefetchedDetector> => {
 		const provider = await getProcaptchaRandomActiveProvider(
@@ -90,13 +105,37 @@ export const prefetchDetector = (
 	// Attach a no-op catch so a failed prefetch never becomes an unhandled
 	// rejection. `takePrefetchedDetector`'s consumer still sees the rejection on
 	// the original promise and falls back.
-	promise.catch(() => undefined);
-	inFlight.set(key, promise);
+	//
+	// Drop the entry if it rejects, so a later widget re-resolves instead of
+	// inheriting a pin that has already failed. This is what the previous
+	// delete-on-claim was protecting against; doing it on rejection instead
+	// keeps that guarantee while letting concurrent widgets share a success.
+	promise.catch(() => {
+		if (inFlight.get(key)?.promise === promise) inFlight.delete(key);
+	});
+	inFlight.set(key, { promise, startedAt });
 };
 
 /**
- * Claim a prefetched assignment, if one was started for this exact key. The
- * entry is removed, so a retry does not reuse a pin that may have just failed.
+ * Claim a prefetched assignment, if one was started for this exact key and is
+ * still fresh.
+ *
+ * The entry is deliberately NOT removed on claim. It used to be, which meant
+ * that on a page carrying several widgets only the first shared the prefetch
+ * and every other widget issued its own provider resolve + assign. One
+ * production integration mounts a widget per form — eight on a property page —
+ * so a single page view cost eight assign calls instead of one, enough to push
+ * ordinary visitors past a rate detector.
+ *
+ * Sharing one assignment across widgets is sound: `detectorSessionId` binds to
+ * a bundleId in Redis purely so the provider can resolve which cipher keys
+ * decrypt that widget's SIMD readings. Widgets sharing an assignment run the
+ * same bundle, so the same keys are the right ones. It is a lookup, not a
+ * one-shot token.
+ *
+ * A failed prefetch still removes itself (see `prefetchDetector`), and entries
+ * go stale after PREFETCH_TTL_MS, so neither a failed nor an aged provider pin
+ * is handed out.
  */
 export const takePrefetchedDetector = (
 	environment: EnvironmentTypes,
@@ -104,9 +143,13 @@ export const takePrefetchedDetector = (
 	siteKey: string,
 ): Promise<PrefetchedDetector> | undefined => {
 	const key = keyOf(environment, ipMode, siteKey);
-	const promise = inFlight.get(key);
-	if (promise) inFlight.delete(key);
-	return promise;
+	const entry = inFlight.get(key);
+	if (!entry) return undefined;
+	if (Date.now() - entry.startedAt > PREFETCH_TTL_MS) {
+		inFlight.delete(key);
+		return undefined;
+	}
+	return entry.promise;
 };
 
 /** Test seam — drops any in-flight prefetches. */

--- a/packages/procaptcha-frictionless/src/tests/detectorPrefetch.multiWidget.test.ts
+++ b/packages/procaptcha-frictionless/src/tests/detectorPrefetch.multiWidget.test.ts
@@ -1,0 +1,70 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { EnvironmentTypesSchema } from "@prosopo/types";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	clearPrefetchedDetectors,
+	prefetchDetector,
+	takePrefetchedDetector,
+} from "../detectorPrefetch.js";
+
+const ENV = EnvironmentTypesSchema.enum.development;
+const SITE_KEY = "5siteKeyAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+
+const take = (): Promise<unknown> | undefined =>
+	takePrefetchedDetector(ENV, undefined, SITE_KEY);
+
+afterEach(() => {
+	clearPrefetchedDetectors();
+	vi.useRealTimers();
+	vi.restoreAllMocks();
+});
+
+describe("detector prefetch sharing", () => {
+	it("hands the same assignment to every widget that claims it", async () => {
+		// A page mounting one widget per form used to cost one provider
+		// resolve + assign per widget, because the entry was removed on the
+		// first claim. Eight widgets on a property page meant eight assign
+		// calls per page view.
+		prefetchDetector(ENV, undefined, SITE_KEY);
+		const claims = [take(), take(), take(), take()];
+		expect(claims.every((c) => c !== undefined)).toBe(true);
+		expect(new Set(claims).size).toBe(1);
+	});
+
+	it("stops handing out an assignment once it has failed", async () => {
+		// The delete-on-claim this replaces existed to stop a later widget
+		// inheriting a pin that had already failed; that guarantee is kept by
+		// dropping the entry on rejection instead.
+		prefetchDetector(ENV, undefined, SITE_KEY);
+		const claimed = take();
+		expect(claimed).toBeDefined();
+		await claimed?.catch(() => undefined);
+		expect(take()).toBeUndefined();
+	});
+
+	it("does not hand out a stale pin", () => {
+		vi.useFakeTimers();
+		prefetchDetector(ENV, undefined, SITE_KEY);
+		expect(take()).toBeDefined();
+		vi.advanceTimersByTime(61_000);
+		expect(take()).toBeUndefined();
+	});
+
+	it("keeps assignments for different site keys apart", () => {
+		prefetchDetector(ENV, undefined, SITE_KEY);
+		expect(takePrefetchedDetector(ENV, undefined, "other-key")).toBeUndefined();
+	});
+});

--- a/packages/procaptcha-frictionless/src/tests/detectorPrefetch.test.ts
+++ b/packages/procaptcha-frictionless/src/tests/detectorPrefetch.test.ts
@@ -64,13 +64,36 @@ describe("detectorPrefetch", () => {
 		expect(assignDetectorBundle).toHaveBeenCalledWith(SITE_KEY);
 	});
 
-	it("is single-use, so a retry does not reuse a stale provider pin", async () => {
+	it("is shareable, so every widget on a page claims the same assignment", async () => {
+		// Previously single-use. That meant a page mounting one widget per form
+		// paid a provider resolve + assign per widget; one production
+		// integration mounts eight, so a page view cost eight assign calls.
+		// Sharing is sound because detectorSessionId binds to a bundleId purely
+		// so the provider can resolve which cipher keys decrypt that widget's
+		// readings, and widgets sharing an assignment run the same bundle.
 		getProcaptchaRandomActiveProvider.mockResolvedValue(provider);
 		assignDetectorBundle.mockResolvedValue({ useProviderBundle: true });
 
 		prefetchDetector(ENV, undefined, SITE_KEY);
 		const first = takePrefetchedDetector(ENV, undefined, SITE_KEY);
 		await (first as Promise<unknown>);
+
+		expect(takePrefetchedDetector(ENV, undefined, SITE_KEY)).toBe(first);
+		expect(getProcaptchaRandomActiveProvider).toHaveBeenCalledTimes(1);
+		expect(assignDetectorBundle).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not hand a failed pin to a later widget", async () => {
+		// The guarantee the old single-use behaviour existed for. It now comes
+		// from dropping the entry on rejection instead, and from customDetectBot
+		// only claiming on a first attempt — a retry re-resolves by construction.
+		getProcaptchaRandomActiveProvider.mockRejectedValue(
+			new Error("no provider"),
+		);
+
+		prefetchDetector(ENV, undefined, SITE_KEY);
+		const first = takePrefetchedDetector(ENV, undefined, SITE_KEY);
+		await (first as Promise<unknown>).catch(() => undefined);
 
 		expect(takePrefetchedDetector(ENV, undefined, SITE_KEY)).toBeUndefined();
 	});


### PR DESCRIPTION
`takePrefetchedDetector` removed the in-flight entry on claim. On a page carrying several widgets that meant the first widget shared the prefetch and **every other widget issued its own provider resolve plus `assignDetectorBundle`**.

Measured on a live integration with Chrome CDP: 8 widget instances on one page (a widget per form), bundle included twice, and **16 assign calls fire on a single page load** — all within 0.0s of each other. Idling 45s adds none, so it is not a retry or polling loop; it is one call per widget per bundle include.

## The guarantee delete-on-claim was protecting

Its comment said *"so a retry does not reuse a pin that may have just failed"*. That is kept, by two narrower mechanisms:

- a prefetch that **rejects** removes itself, so no later widget inherits a failed pin
- entries go **stale after 60s**, so a widget mounting much later (a modal opened minutes in) re-resolves rather than reusing an aged provider pin

Retries were never affected either way — `customDetectBot` only claims on a first attempt (`isFirstAttempt`), so a retry re-resolves by construction.

## Test change worth a look

The existing test was named `is single-use, so a retry does not reuse a stale provider pin`. It asserted the *mechanism*, not the guarantee, so it failed against this change even though the guarantee holds. Rewritten to pin shareability, with a sibling test covering the failed-pin case, plus a new file for the multi-widget, TTL and site-key-isolation cases.

`8/8 files, 49 tests, no type errors`.
