### PR TITLE
fix(provider): stop computeFrictionlessScore returning NaN on non-numeric components

### DIFF
--- a/.changeset/frictionless-score-nan-non-numeric.md
+++ b/.changeset/frictionless-score-nan-non-numeric.md
@@ -1,0 +1,19 @@
+---
+"@prosopo/provider": patch
+---
+
+Fix `computeFrictionlessScore` returning `NaN` when `scoreComponents` carries a non-numeric field.
+
+The score was summed with `Object.values(...).reduce((acc, val) => acc + val, 0)` over every defined value. `ScoreComponents` also carries two non-numeric diagnostic fields — `triggeredDetectors` (`number[]`) and `shadowDomPenalty` (`boolean`) — and neither has an arithmetic weight anywhere in the scoring path. `+` on an array coerces the accumulator to a string, so any numeric component summed *after* an array turned the running total into string concatenation and the final `Math.min(1, ...)` into `NaN`:
+
+```
+0.42 + []    -> "0.42"
+"0.42" + 0.3 -> "0.420.3"
+Math.min(1, "0.420.3") -> NaN
+```
+
+This was reachable in production rather than theoretical. The Mongoose schema declares `triggeredDetectors` as an array path and Mongoose defaults array paths to `[]`, so the field is present on every session read back from the database even when the frictionless handler omitted it; the pow / puzzle / image tasks then spread `dnsAsymmetry` on afterwards, landing it after the array in key order. Every solve-time recompute on a session with `dnsAsymmetry > 0` produced `NaN`.
+
+Only numeric values now contribute. `shadowDomPenalty` no longer silently adds a full `1.0` when true. A genuinely numeric `NaN` component still propagates — `typeof NaN === "number"`, so it survives the filter deliberately — because a score that cannot be computed must not read as a low one.
+
+The recomputed value is not persisted (neither `sessions` nor `usercommitments` stores it) and no decide rule currently branches on `input.score`, so the impact to date was a `NaN` in the solve-time log line and in `DecisionMachineInput.score`.

--- a/packages/provider/src/tasks/frictionless/frictionlessTasksUtils.ts
+++ b/packages/provider/src/tasks/frictionless/frictionlessTasksUtils.ts
@@ -13,6 +13,34 @@
 // limitations under the License.
 import type { ScoreComponents } from "@prosopo/types";
 
+/**
+ * Sum the weighted components of a frictionless bot score, capped at 1.
+ *
+ * Only numeric components contribute. `ScoreComponents` also carries two
+ * non-numeric diagnostic fields — `triggeredDetectors` (number[]) and
+ * `shadowDomPenalty` (boolean) — and neither has an arithmetic weight
+ * anywhere in the scoring path.
+ *
+ * Filtering them out is load-bearing, not tidiness. `+` on an array coerces
+ * the accumulator to a string, so a single `triggeredDetectors: []` turned
+ * every subsequent component into string concatenation and the whole sum into
+ * NaN:
+ *
+ *   0.42 + []  -> "0.42"                  (string)
+ *   "0.42" + 0.3 -> "0.420.3"
+ *   Math.min(1, "0.420.3") -> NaN
+ *
+ * That was reachable in production rather than theoretical: the Mongoose
+ * schema declares `triggeredDetectors` as an array path, and Mongoose
+ * defaults array paths to `[]`, so the field is present on every session read
+ * back from the database even when the frictionless handler omitted it. The
+ * captcha tasks then spread `dnsAsymmetry` on afterwards, landing it after the
+ * array in key order and triggering the concatenation.
+ *
+ * NaN is still propagated when a genuinely numeric component is NaN —
+ * `typeof NaN === "number"`, so it survives the filter deliberately. A score
+ * that cannot be computed must not silently read as a low one.
+ */
 export const computeFrictionlessScore = (
 	scoreComponents:
 		| {
@@ -20,11 +48,12 @@ export const computeFrictionlessScore = (
 		  }
 		| ScoreComponents,
 ): number => {
+	const values: unknown[] = Object.values(scoreComponents);
 	return Number(
 		Math.min(
 			1,
-			Object.values(scoreComponents)
-				.filter((x) => x !== undefined)
+			values
+				.filter((x): x is number => typeof x === "number")
 				.reduce((acc, val) => acc + val, 0),
 		).toFixed(2),
 	);

--- a/packages/provider/src/tests/unit/tasks/frictionless/frictionlessTasksUtils.unit.test.ts
+++ b/packages/provider/src/tests/unit/tasks/frictionless/frictionlessTasksUtils.unit.test.ts
@@ -69,6 +69,95 @@ describe("frictionlessTasksUtils", () => {
 			const result = computeFrictionlessScore({});
 			expect(result).toBe(0);
 		});
+
+		// Regression: `acc + []` coerces the accumulator to a string, so any
+		// numeric component summed after an array turned the whole score into
+		// NaN. Mongoose defaults array paths to `[]`, so `triggeredDetectors`
+		// is present on every session read back from the database, and the
+		// captcha tasks spread `dnsAsymmetry` on afterwards — landing it after
+		// the array in key order. This is the exact shape that produced it.
+		it("ignores an empty triggeredDetectors array before a numeric component", () => {
+			const result = computeFrictionlessScore({
+				baseScore: 0.12402739646161609,
+				lScore: 0.3,
+				shadowDomPenalty: false,
+				triggeredDetectors: [],
+				dnsAsymmetry: 0.3,
+			});
+			expect(result).toBe(0.72);
+		});
+
+		it("ignores a populated triggeredDetectors array", () => {
+			const result = computeFrictionlessScore({
+				baseScore: 0.2,
+				triggeredDetectors: [3, 7],
+				dnsAsymmetry: 0.3,
+			});
+			expect(result).toBe(0.5);
+		});
+
+		// `shadowDomPenalty` is diagnostic metadata with no arithmetic weight
+		// anywhere in the scoring path. Summed directly, `true` would silently
+		// add a full 1.0 and cap every such session at the maximum score.
+		it("ignores shadowDomPenalty in both boolean states", () => {
+			expect(
+				computeFrictionlessScore({
+					baseScore: 0.2,
+					shadowDomPenalty: true,
+					lScore: 0.3,
+				}),
+			).toBe(0.5);
+			expect(
+				computeFrictionlessScore({
+					baseScore: 0.2,
+					shadowDomPenalty: false,
+					lScore: 0.3,
+				}),
+			).toBe(0.5);
+		});
+
+		it("is order-independent across the non-numeric fields", () => {
+			const expected = 0.72;
+			expect(
+				computeFrictionlessScore({
+					triggeredDetectors: [],
+					shadowDomPenalty: true,
+					baseScore: 0.12,
+					lScore: 0.3,
+					dnsAsymmetry: 0.3,
+				}),
+			).toBe(expected);
+			expect(
+				computeFrictionlessScore({
+					baseScore: 0.12,
+					lScore: 0.3,
+					dnsAsymmetry: 0.3,
+					triggeredDetectors: [],
+					shadowDomPenalty: true,
+				}),
+			).toBe(expected);
+		});
+
+		// A score that cannot be computed must not read as a low one, so a
+		// genuinely numeric NaN still propagates — `typeof NaN === "number"`.
+		it("still propagates NaN from a numeric component past an array", () => {
+			const result = computeFrictionlessScore({
+				baseScore: Number.NaN,
+				triggeredDetectors: [],
+				dnsAsymmetry: 0.3,
+			});
+			expect(result).toBeNaN();
+		});
+
+		it("still caps at 1 with non-numeric fields present", () => {
+			const result = computeFrictionlessScore({
+				baseScore: 0.8,
+				triggeredDetectors: [],
+				shadowDomPenalty: true,
+				lScore: 0.5,
+			});
+			expect(result).toBe(1);
+		});
 	});
 
 	describe("timestampDecayFunction", () => {


### PR DESCRIPTION
## What

`computeFrictionlessScore` summed every defined value in `scoreComponents`. That object also carries two non-numeric diagnostic fields — `triggeredDetectors` (`number[]`) and `shadowDomPenalty` (`boolean`) — and neither has an arithmetic weight anywhere in the scoring path.

`+` on an array coerces the accumulator to a string, so any numeric component summed **after** an array turned the running total into string concatenation and the final `Math.min(1, ...)` into `NaN`:

```
0.42 + []    -> "0.42"
"0.42" + 0.3 -> "0.420.3"
Math.min(1, "0.420.3") -> NaN
```

## Why it was reachable

Not theoretical. The Mongoose schema declares `triggeredDetectors` as an array path, and Mongoose defaults array paths to `[]`, so the field is present on **every** session read back from the database — even though the frictionless handler omits it when empty (`...(triggeredDetectors.length > 0 && { triggeredDetectors })`).

The pow / puzzle / image tasks then spread `dnsAsymmetry` on afterwards, landing it *after* the array in key insertion order. So every solve-time recompute on a session with `dnsAsymmetry > 0` produced `NaN`.

## Blast radius

Limited, which is why it went unnoticed. The recomputed value is **not persisted** — session scores are written by the frictionless handler (`baseScore + lScore`, full precision), and `usercommitments` has no `score` field at all. No decide rule currently reads `input.score`. So the impact to date is a `NaN` in the solve-time log line and in `DecisionMachineInput.score` — a latent landmine for the first decide rule that branches on it.

## Change

Only numeric values contribute. Two consequences:

- `triggeredDetectors: []` (and populated) no longer breaks the sum.
- `shadowDomPenalty` no longer silently adds a full `1.0` when true, which would have capped any such session at the maximum score.

A genuinely numeric `NaN` still propagates — `typeof NaN === "number"`, so it survives the filter deliberately. A score that cannot be computed must not read as a low one, and the existing tests assert that contract.

## Tests

5 new cases in `frictionlessTasksUtils.unit.test.ts`, including a realistic production component shape. Verified they fail against the old implementation and pass against the new one:

```
against OLD implementation:  Tests  5 failed | 13 passed (18)
against NEW implementation:  Tests  18 passed (18)
```

Covers: empty and populated `triggeredDetectors`, `shadowDomPenalty` in both boolean states, order-independence across the non-numeric fields, NaN still propagating past an array, and the cap still applying.

`npm run -w @prosopo/provider build:tsc` and `biome check` both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
