### PR TITLE
feat(types,provider): share the captcha-type severity ranking

### DIFF
--- a/.changeset/shared-captcha-type-rank.md
+++ b/.changeset/shared-captcha-type-rank.md
@@ -1,0 +1,14 @@
+---
+"@prosopo/types": patch
+"@prosopo/provider": patch
+---
+
+Extract the captcha-type severity ranking into `@prosopo/types` as `rankCaptchaType` / `isStricterCaptchaType`.
+
+"Which captcha type is stricter" is one idea with several callers. The provider's traffic filter uses it to combine multiple `challenge` matches on a single request (`resolveChallengePolicy`), and the decision machines use it to resolve an undeclared middlebox against a site's vpn / datacenter policies (`resolveMiddleboxPolicy`, in the captcha-private `@prosopo/decision-machines` package). Each kept its own copy of the table. They agreed on the ordering — image > puzzle > pow > frictionless — but nothing held them to it, and the decision-machines copy carried a comment describing itself as "mirroring the provider's own CAPTCHA_TYPE_RANK", which is the duplication admitting itself.
+
+The new module is a deliberate leaf with no runtime imports. It takes a **type-only** import of `CaptchaType` and keys its table by plain strings, because `captchaType.ts` imports zod to build its schemas — so referencing the enum as a value would pull zod into every consumer. That matters for the decision machines specifically: they are bundled standalone and published through an API whose `decisionMachineSource` field is capped at 65,536 characters, and a runtime dependency on the `@prosopo/types` barrel has breached that ceiling before. Keeping the module import-free lets esbuild shake the barrel down to the rank table alone — measured at +250 bytes per machine with no zod in any bundle.
+
+`isStricterCaptchaType` is strictly-greater, so an equal rank keeps the incumbent. Callers reduce left to right and the competing policies can carry different render tunables (`solvedImagesCount`, `powDifficulty`, `puzzleTolerance`), so a tie has to resolve to the first consistently rather than by table order. That was previously implicit in both copies and is now pinned by tests.
+
+No behaviour change — the ordering and the tie-break are identical to what both call sites already did.

--- a/packages/provider/src/tasks/spam/checkTrafficFilter.ts
+++ b/packages/provider/src/tasks/spam/checkTrafficFilter.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import {
-	CaptchaType,
+	type CaptchaType,
 	type IPInfoResponse,
 	type IPInfoResult,
 	type IPuzzleSettings,
@@ -21,6 +21,7 @@ import {
 	type ITrafficFilter,
 	ResultReason,
 	TrafficFilterAction,
+	isStricterCaptchaType,
 	trafficFilterAbuserScoreThresholdDefault,
 } from "@prosopo/types";
 
@@ -301,16 +302,10 @@ export const checkTrafficFilter = (
 // request. `block` outranks any challenge (short-circuited earlier in
 // `checkTrafficFilter`); among captcha types, image outranks puzzle
 // outranks pow — a stricter check is monotonically preferred so the
-// operator's hardest configured policy wins.
-const CAPTCHA_TYPE_RANK: Record<CaptchaType, number> = {
-	[CaptchaType.image]: 4,
-	[CaptchaType.puzzle]: 3,
-	[CaptchaType.pow]: 2,
-	[CaptchaType.frictionless]: 1,
-};
-
-const rankCaptchaType = (t: CaptchaType | undefined): number =>
-	t === undefined ? 0 : (CAPTCHA_TYPE_RANK[t] ?? 0);
+// operator's hardest configured policy wins. The ranking itself lives in
+// `@prosopo/types` (`isStricterCaptchaType`), shared with the decision
+// machines' `resolveMiddleboxPolicy`, which resolves the same "strictest of
+// the competing policies" question for undeclared middleboxes.
 
 export type ResolvedChallengePolicy = {
 	captchaType?: CaptchaType;
@@ -344,10 +339,7 @@ export const resolveChallengePolicy = (
 
 	let winningCaptchaType: CaptchaType | undefined;
 	for (const m of challenges) {
-		if (
-			rankCaptchaType(m.policy.captchaType) >
-			rankCaptchaType(winningCaptchaType)
-		) {
+		if (isStricterCaptchaType(m.policy.captchaType, winningCaptchaType)) {
 			winningCaptchaType = m.policy.captchaType;
 		}
 	}

--- a/packages/types/src/client/captchaType/captchaTypeRank.test.ts
+++ b/packages/types/src/client/captchaType/captchaTypeRank.test.ts
@@ -1,0 +1,96 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, expect, it } from "vitest";
+import { CaptchaType } from "./captchaType.js";
+import { isStricterCaptchaType, rankCaptchaType } from "./captchaTypeRank.js";
+
+describe("rankCaptchaType", () => {
+	// Pinned as an explicit ordered list rather than pairwise, so a change to
+	// any one rank is a visible diff here.
+	it("ranks image > puzzle > pow > frictionless", () => {
+		const ordered = [
+			CaptchaType.frictionless,
+			CaptchaType.pow,
+			CaptchaType.puzzle,
+			CaptchaType.image,
+		];
+		const ranks = ordered.map(rankCaptchaType);
+		expect(ranks).toEqual([...ranks].sort((a, b) => a - b));
+		expect(new Set(ranks).size).toBe(ordered.length);
+	});
+
+	// Everything unknown sits below every real type, so a policy naming no
+	// captcha type never beats one that does.
+	it("ranks undefined and unrecognised values at 0", () => {
+		expect(rankCaptchaType(undefined)).toBe(0);
+		expect(rankCaptchaType("")).toBe(0);
+		expect(rankCaptchaType("not-a-captcha-type")).toBe(0);
+	});
+
+	it("accepts the enum and its bare string value identically", () => {
+		expect(rankCaptchaType(CaptchaType.image)).toBe(rankCaptchaType("image"));
+		expect(rankCaptchaType(CaptchaType.puzzle)).toBe(rankCaptchaType("puzzle"));
+		expect(rankCaptchaType(CaptchaType.pow)).toBe(rankCaptchaType("pow"));
+		expect(rankCaptchaType(CaptchaType.frictionless)).toBe(
+			rankCaptchaType("frictionless"),
+		);
+	});
+
+	// The table is keyed by plain strings, so a renamed enum member would
+	// silently start ranking 0. This catches that.
+	it("has a rank for every member of the CaptchaType enum", () => {
+		for (const value of Object.values(CaptchaType)) {
+			expect(rankCaptchaType(value)).toBeGreaterThan(0);
+		}
+	});
+});
+
+describe("isStricterCaptchaType", () => {
+	// Adjacent pairs, both orderings — non-adjacent comparisons would still
+	// pass with an off-by-one in the table.
+	it.each([
+		[CaptchaType.image, CaptchaType.puzzle, true],
+		[CaptchaType.puzzle, CaptchaType.image, false],
+		[CaptchaType.puzzle, CaptchaType.pow, true],
+		[CaptchaType.pow, CaptchaType.puzzle, false],
+		[CaptchaType.pow, CaptchaType.frictionless, true],
+		[CaptchaType.frictionless, CaptchaType.pow, false],
+	])(
+		"isStricterCaptchaType(%s, %s) === %s",
+		(candidate, incumbent, expected) => {
+			expect(isStricterCaptchaType(candidate, incumbent)).toBe(expected);
+		},
+	);
+
+	// Strictly greater, so a tie keeps the incumbent. Callers reduce left to
+	// right and the competing policies can carry different render tunables,
+	// so the tie has to resolve to the first consistently.
+	it("is false for equal ranks, so the incumbent is kept", () => {
+		for (const value of Object.values(CaptchaType)) {
+			expect(isStricterCaptchaType(value, value)).toBe(false);
+		}
+	});
+
+	it("treats any real type as stricter than undefined", () => {
+		for (const value of Object.values(CaptchaType)) {
+			expect(isStricterCaptchaType(value, undefined)).toBe(true);
+			expect(isStricterCaptchaType(undefined, value)).toBe(false);
+		}
+	});
+
+	it("is false when both sides are unset", () => {
+		expect(isStricterCaptchaType(undefined, undefined)).toBe(false);
+	});
+});

--- a/packages/types/src/client/captchaType/captchaTypeRank.ts
+++ b/packages/types/src/client/captchaType/captchaTypeRank.ts
@@ -1,0 +1,71 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Relative severity of the captcha types, and the helpers for picking the
+ * strictest when several policies compete for the same request.
+ *
+ * "Strictest" is one idea with several callers: the traffic filter combining
+ * multiple `challenge` matches on one request (`resolveChallengePolicy`), and
+ * the decision machines resolving an undeclared middlebox against a site's
+ * vpn / datacenter policies (`resolveMiddleboxPolicy`). Both previously kept
+ * their own copy of the table. They agreed, but nothing held them to it.
+ *
+ * The type-only import of `CaptchaType` and the plain-string keys are
+ * deliberate, not sloppiness. `captchaType.ts` imports zod to build its
+ * schemas, so referencing the enum as a *value* here would pull zod into
+ * anything that imports this module. The decision machines are bundled
+ * standalone and published through an API with a 65,536-char ceiling, and a
+ * runtime dependency on the `@prosopo/types` barrel has already breached that
+ * once. Keeping this module free of runtime imports lets esbuild shake it
+ * down to the table alone.
+ */
+
+import type { CaptchaType } from "./captchaType.js";
+
+/**
+ * Higher is stricter: image > puzzle > pow > frictionless.
+ *
+ * Keyed by the enum's string values rather than the enum itself, so callers
+ * that carry a captcha type as a bare `string` — as the decision machines'
+ * policy bags do — can rank it without importing the enum.
+ */
+const CAPTCHA_TYPE_RANK: Record<string, number> = {
+	image: 4,
+	puzzle: 3,
+	pow: 2,
+	frictionless: 1,
+};
+
+/**
+ * Severity of a captcha type. Unset or unrecognised ranks 0, below every real
+ * type, so a policy that names no captcha type never outranks one that does.
+ */
+export const rankCaptchaType = (
+	captchaType: CaptchaType | string | undefined,
+): number =>
+	captchaType === undefined ? 0 : (CAPTCHA_TYPE_RANK[captchaType] ?? 0);
+
+/**
+ * True when `candidate` is strictly stricter than `incumbent`.
+ *
+ * Strictly, so an equal rank keeps the incumbent — callers reduce left to
+ * right, and the two sides can carry different render tunables
+ * (`solvedImagesCount`, `powDifficulty`, `puzzleTolerance`), so a tie has to
+ * resolve to the first consistently rather than by table order.
+ */
+export const isStricterCaptchaType = (
+	candidate: CaptchaType | string | undefined,
+	incumbent: CaptchaType | string | undefined,
+): boolean => rankCaptchaType(candidate) > rankCaptchaType(incumbent);

--- a/packages/types/src/client/index.ts
+++ b/packages/types/src/client/index.ts
@@ -15,4 +15,5 @@ export * from "./user.js";
 export * from "./settings.js";
 export * from "./testSiteKeys.js";
 export * from "./captchaType/captchaType.js";
+export * from "./captchaType/captchaTypeRank.js";
 export * from "./captchaType/captchaTypeSpec.js";


### PR DESCRIPTION
Superseded by #3182, which places the shared ranking in a dedicated zero-dependency package rather than in `@prosopo/types`, and covers all three call sites instead of two.

Closed unmerged. See #3182 for the change that landed.
