### PR TITLE
feat(widget): manual start mode defers the frictionless flow until triggered

### DIFF
--- a/.changeset/manual-start-mode.md
+++ b/.changeset/manual-start-mode.md
@@ -1,0 +1,15 @@
+---
+"@prosopo/types": minor
+"@prosopo/procaptcha-frictionless": minor
+"@prosopo/procaptcha-bundle": minor
+"@prosopo/client-bundle-example": patch
+---
+
+Sites can now control when the widget starts working.
+
+By default the widget runs bot detection, starts the behavioural collectors and calls `/frictionless` as soon as it mounts. Rendering with `data-start-mode="manual"` (or `startMode: "manual"` in the render options) keeps all of that off the page load: the checkbox still appears immediately, at its final size, so nothing shifts, but the widget does nothing else until one of two things happens.
+
+- The site calls `window.procaptcha.start()`, optionally with a widget id, or dispatches a `procaptcha:start` event on `document`. The frictionless flow runs and the widget then waits for a click exactly as it does today.
+- The visitor clicks the checkbox. The frictionless flow runs and whichever challenge the provider chooses opens straight away, carrying that click's position, so the visitor is never asked to click twice.
+
+Both triggers are one-shot: whichever comes first wins and the other is ignored. `window.procaptcha.execute()` also starts a manual widget, opening its challenge immediately. Widgets in the default `auto` mode are unaffected.

--- a/demos/client-bundle-example/src/frictionless-manual-start.html
+++ b/demos/client-bundle-example/src/frictionless-manual-start.html
@@ -1,0 +1,224 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <link href="https://cdn.muicss.com/mui-0.10.3/css/mui.min.css" rel="stylesheet" type="text/css"/>
+    <link href="styles/field.css" rel="stylesheet" type="text/css"/>
+
+    <script src="index.js"></script>
+    <title>Procaptcha demo: Frictionless - Manual Start</title>
+<link href="styles/captcha.css" rel="stylesheet" type="text/css"/>
+    <script type="module">
+        // Function to update CAPTCHA status display is now provided by status-log-injector
+
+        window.onStartCaptcha = () => {
+            updateCaptchaStatus('window.procaptcha.start() called - frictionless flow starting', 'info');
+            window.procaptcha.start();
+        };
+
+        window.addEventListener('load', () => {
+
+            window.setIsError = (isError) => {
+                const messageContainer = document.getElementById('messageContainer');
+                messageContainer.style.color = isError ? 'red' : 'black';
+                messageContainer.style.display = 'block';
+            };
+
+            window.setMessage = (message) => {
+                document.getElementById('message').innerText = message;
+            };
+
+            window.onLoggedIn = (token) => {
+                updateCaptchaStatus('Logged in, fetching private resource', 'info');
+                const url = new URL("/private", config.serverUrl).href;
+                console.log("getting private resource with token ", token, "at", url);
+                fetch(url, {
+                    method: "GET",
+                    headers: {
+                        Origin: "http://localhost:9232", // TODO: change this to env var
+                        "Content-Type": "application/json",
+                        Authorization: `Bearer ${token}`,
+                    },
+                })
+                    .then(async (res) => {
+                        try {
+                            const jsonRes = await res.json();
+                            if (res.status === 200) {
+                                updateCaptchaStatus(`Successfully accessed private resource`, 'success');
+                                setMessage(jsonRes.message);
+                            } else {
+                                updateCaptchaStatus(`Failed to access private resource: ${res.status}`, 'error');
+                            }
+                        } catch (err) {
+                            console.log(err);
+                            updateCaptchaStatus(`Error parsing response: ${err}`, 'error');
+                        }
+                    })
+                    .catch((err) => {
+                        console.log(err);
+                        updateCaptchaStatus(`Fetch error: ${err}`, 'error');
+                    });
+            };
+
+            window.onActionHandler = () => {
+                updateCaptchaStatus('Form submission initiated', 'info');
+
+                const procaptchaElements = document.getElementsByName('procaptcha-response');
+
+                if (!procaptchaElements.length) {
+                    updateCaptchaStatus('Error: No CAPTCHA response found', 'error');
+                    alert("Must complete captcha");
+                    return
+                }
+
+                const procaptchaToken = procaptchaElements[0].value;
+                updateCaptchaStatus(`Token received: ${procaptchaToken.substring(0, 15)}...`, 'success');
+
+                const payload = {
+                    email: document.getElementById('email').value,
+                    name: document.getElementById('name').value,
+                    password: document.getElementById('password').value,
+                    siteKey: import.meta.env.PROSOPO_SITE_KEY_FRICTIONLESS,
+                    "procaptcha-response": procaptchaToken,
+                };
+                const url = new URL('signup', import.meta.env.PROSOPO_SERVER_URL).href;
+                console.log("posting to", url, "with payload", payload);
+                fetch(url, {
+                    method: "POST",
+                    headers: {
+                        "Content-Type": "application/json",
+                    },
+                    body: JSON.stringify(payload),
+                    contentType: "application/json",
+                }).then((response) => {
+                    return new Promise((resolve) => response.json()
+                        .then((json) => resolve({
+                            status: response.status,
+                            ok: response.ok,
+                            json,
+                        })))
+                })
+                    .then(async ({status, json, ok}) => {
+                        console.log("status", status, "json", json.message, "ok", ok);
+                        console.log("json", json)
+                        try {
+                            if (status !== 200) {
+                                updateCaptchaStatus(`API Error: ${json.message}`, 'error');
+                                setIsError(true);
+                                setMessage(json.message);
+                            } else {
+                                updateCaptchaStatus(`API Success: ${json.message}`, 'success');
+                                setIsError(false);
+                                setMessage(json.message);
+                            }
+                        } catch (err) {
+                            console.log(err);
+                            updateCaptchaStatus(`Error processing response: ${err}`, 'error');
+                        }
+                    })
+                    .catch((err) => {
+                        console.log(err);
+                        updateCaptchaStatus(`Fetch error: ${err}`, 'error');
+                        setIsError(true);
+                        setMessage("Error: " + err);
+                    });
+            };
+
+            updateCaptchaStatus('Page loaded - Initializing CAPTCHA system', 'info');
+
+            // Monitor DOM for CAPTCHA initialization
+            const observer = new MutationObserver((mutations) => {
+                mutations.forEach((mutation) => {
+                    if (mutation.addedNodes.length) {
+                        for (let i = 0; i < mutation.addedNodes.length; i++) {
+                            const node = mutation.addedNodes[i];
+                            if (node.classList && (node.classList.contains('procaptcha') ||
+                                  node.querySelector && node.querySelector('.procaptcha'))) {
+                                updateCaptchaStatus('CAPTCHA DOM elements initialized', 'info');
+                                observer.disconnect();
+                                break;
+                            }
+                        }
+                    }
+                });
+            });
+
+            observer.observe(document.body, { childList: true, subtree: true });
+        });
+
+
+        window.onCaptchaFailed = function () {
+            console.log('Challenge failed');
+            updateCaptchaStatus('Challenge failed - CAPTCHA verification could not be completed', 'error');
+        }
+
+        window.onCaptchaVerified = (output) => {
+            console.log('Challenge passed');
+            updateCaptchaStatus('Challenge passed successfully!', 'success');
+            updateCaptchaStatus(`Token generated: ${output.substring(0, 15)}...`, 'success');
+        }
+
+        // Add custom event listener for CAPTCHA verification stages
+        document.addEventListener('DOMContentLoaded', function() {
+            setTimeout(() => {
+                updateCaptchaStatus('CAPTCHA script loaded and initialized', 'info');
+                updateCaptchaStatus('Waiting for user interaction...', 'info');
+            }, 500);
+        });
+    </script>
+    <script id="procaptchaScript" type="module" src="%VITE_BUNDLE_URL%" async defer></script>
+</head>
+<body>
+
+<div class="mui-container">
+    <h1>Frictionless CAPTCHA - Manual Start</h1>
+    <p>
+        This example renders the widget with <code>data-start-mode="manual"</code>. The checkbox appears
+        immediately at its final size, but no bot detection, behavioural collection or provider request runs
+        until either the page calls <code>window.procaptcha.start()</code> (the button below) or the visitor
+        clicks the checkbox. A click that starts the flow also opens whichever challenge the provider picks,
+        so the visitor never has to click twice.
+    </p>
+
+    <!-- CAPTCHA Status Display will be injected by the status-log-injector plugin -->
+
+    <form action="%PROSOPO_SERVER_URL%/signup" method="POST" class="mui-form">
+        <h2>Example Login Form</h2>
+        <div class="mui-textfield mui-textfield--float-label">
+            <label for="name">Name</label>
+            <input id="name" type="text" name="name" required/>
+        </div>
+        <div class="mui-textfield mui-textfield--float-label">
+            <label for="email">Email Address</label>
+            <input id="email" type="email" name="email" required/>
+        </div>
+        <div class="mui-textfield mui-textfield--float-label">
+            <label for="password">Password</label>
+            <input id="password" type="password" name="password" required/>
+        </div>
+        <div class="mui-textfield mui-textfield--float-label">
+            <!-- Dev sitekey -->
+            <div
+                    class="procaptcha"
+                    data-theme="light"
+                    data-sitekey="%PROSOPO_SITE_KEY_FRICTIONLESS%"
+                    data-start-mode="manual"
+                    data-failed-callback="onCaptchaFailed"
+                    data-callback="onCaptchaVerified"
+            ></div>
+        </div>
+        <div class="mui-textfield">
+            <button type="button" class="mui-btn mui-btn--flat" onclick="onStartCaptcha()" data-cy="start-captcha-button">
+                Start CAPTCHA now
+            </button>
+        </div>
+        <div id="messageContainer" style="display: none; color: black;"><span id="message"></span></div>
+        <button type="button" class="mui-btn mui-btn--raised" onclick="onActionHandler()" data-cy="submit-button">Submit</button>
+    </form>
+
+    <!-- Console output display area -->
+    <div id="console-output" class="console-output" style="display: none;"></div>
+
+    <!-- Explanation will be injected by the explanation-injector plugin -->
+</div>
+</body>
+</html>

--- a/demos/client-bundle-example/src/plugins/navigation-injector.ts
+++ b/demos/client-bundle-example/src/plugins/navigation-injector.ts
@@ -47,6 +47,7 @@ export default function navigationInjector(): Plugin {
 			frictionless: {
 				implicit: { path: "frictionless-implicit.html", exists: true },
 				explicit: { path: "frictionless-explicit.html", exists: true },
+				manual: { path: "frictionless-manual-start.html", exists: true },
 			},
 			puzzle: {
 				implicit: { path: "puzzle-implicit.html", exists: true },

--- a/demos/client-bundle-example/vite.config.ts
+++ b/demos/client-bundle-example/vite.config.ts
@@ -174,6 +174,10 @@ export default defineConfig(({ command, mode }) => {
 						__dirname,
 						"src/frictionless-explicit.html",
 					),
+					"frictionless-manual-start": path.resolve(
+						__dirname,
+						"src/frictionless-manual-start.html",
+					),
 					"invisible-pow-explicit": path.resolve(
 						__dirname,
 						"src/invisible-pow-explicit.html",

--- a/packages/procaptcha-bundle/src/index.ts
+++ b/packages/procaptcha-bundle/src/index.ts
@@ -38,8 +38,7 @@ const BUNDLE_NAMES = ["procaptcha.bundle.iife.js", "procaptcha.bundle.js"];
  * stayed in the DOM, leaving a container with a logo and no checkbox. There
  * was no record of which element or render options produced it, so nothing
  * could put it back. Keeping the descriptor alongside the root is what lets
- * `reset()` remount rather than just destroy, and `start()` address its
- * `procaptcha:start` event to the right element.
+ * `reset()` remount rather than just destroy.
  */
 interface WidgetEntry {
 	root: Root;
@@ -86,9 +85,7 @@ const widgetFactory = new WidgetFactory(new WidgetThemeResolver());
  * Fire-and-forget by design — a failed prefetch is indistinguishable from no
  * prefetch, and the detection path falls back to resolving a provider itself.
  *
- * Skipped in manual start mode: the point of that mode is that nothing
- * reaches the provider until the site says so, and `customDetectBot` resolves
- * a provider itself when there is no prefetch to claim.
+ * Skipped in manual start mode so nothing reaches the provider on page load.
  */
 const startDetectorPrefetch = (
 	siteKey: string | null,
@@ -291,15 +288,9 @@ export const execute = () => {
 };
 
 /**
- * Starts the frictionless flow for a widget rendered with
- * `startMode: "manual"` (or `data-start-mode="manual"`). Pass a widget id to
- * start one widget, or omit it to start every widget on the page. Widgets in
- * the default `auto` mode, and manual widgets that have already started (by
- * an earlier call or the user clicking the checkbox), ignore it.
- *
- * Delivered as a `procaptcha:start` DOM event addressed to the widget's
- * element rather than by calling into React directly, which keeps direct-React
- * integrations on the same mechanism: they can dispatch the event themselves.
+ * Starts a widget rendered with `startMode: "manual"`; omit the id to start
+ * every widget. Sent as a `procaptcha:start` event so direct-React
+ * integrations can dispatch the same thing themselves.
  */
 export const start = (widgetId?: string): void => {
 	const ids: string[] =

--- a/packages/procaptcha-bundle/src/index.ts
+++ b/packages/procaptcha-bundle/src/index.ts
@@ -13,10 +13,17 @@
 // limitations under the License.
 
 import { getWindowCallback } from "@prosopo/procaptcha-common";
-import type { EnvironmentTypes, ProcaptchaRenderOptions } from "@prosopo/types";
+import {
+	type EnvironmentTypes,
+	PROCAPTCHA_START_EVENT,
+	type ProcaptchaRenderOptions,
+	type ProcaptchaStartEventDetail,
+	StartModeEnum,
+} from "@prosopo/types";
 import { at } from "@prosopo/util";
 import type { Root } from "react-dom/client";
 import { extractParams, getProcaptchaScript } from "./util/config.js";
+import { resolveStartMode } from "./util/startMode.js";
 import { WidgetFactory } from "./util/widgetFactory.js";
 import { WidgetThemeResolver } from "./util/widgetThemeResolver.js";
 
@@ -31,7 +38,8 @@ const BUNDLE_NAMES = ["procaptcha.bundle.iife.js", "procaptcha.bundle.js"];
  * stayed in the DOM, leaving a container with a logo and no checkbox. There
  * was no record of which element or render options produced it, so nothing
  * could put it back. Keeping the descriptor alongside the root is what lets
- * `reset()` remount rather than just destroy.
+ * `reset()` remount rather than just destroy, and `start()` address its
+ * `procaptcha:start` event to the right element.
  */
 interface WidgetEntry {
 	root: Root;
@@ -77,12 +85,17 @@ const widgetFactory = new WidgetFactory(new WidgetThemeResolver());
  *
  * Fire-and-forget by design — a failed prefetch is indistinguishable from no
  * prefetch, and the detection path falls back to resolving a provider itself.
+ *
+ * Skipped in manual start mode: the point of that mode is that nothing
+ * reaches the provider until the site says so, and `customDetectBot` resolves
+ * a provider itself when there is no prefetch to claim.
  */
 const startDetectorPrefetch = (
 	siteKey: string | null,
-	flags: { ipv4?: boolean; ipv6?: boolean },
+	flags: { ipv4?: boolean; ipv6?: boolean; startMode?: StartModeEnum },
 ): void => {
 	if (!siteKey) return;
+	if (flags.startMode === StartModeEnum.manual) return;
 	void Promise.all([
 		import("@prosopo/procaptcha-frictionless"),
 		import("@prosopo/procaptcha-common"),
@@ -117,6 +130,7 @@ const implicitRender = async () => {
 		const web3 = firstElement.getAttribute("data-web3");
 		const ipv4 = firstElement.getAttribute("data-ipv4") === "true";
 		const ipv6 = firstElement.getAttribute("data-ipv6") === "true";
+		const startMode = resolveStartMode(undefined, firstElement);
 		if (!siteKey) {
 			console.error("No site key found");
 			return;
@@ -127,12 +141,13 @@ const implicitRender = async () => {
 		// constant. Start it now so the round-trip overlaps the widget's own
 		// dynamic-import chain instead of queueing behind it —
 		// `customDetectBot` claims the in-flight promise when it eventually runs.
-		startDetectorPrefetch(siteKey, { ipv4, ipv6 });
+		startDetectorPrefetch(siteKey, { ipv4, ipv6, startMode });
 
 		const implicitRenderOptions: ProcaptchaRenderOptions = {
 			siteKey: siteKey,
 			ipv4,
 			ipv6,
+			startMode,
 		};
 
 		const root = await widgetFactory.createWidgets(
@@ -161,14 +176,16 @@ const implicitRender = async () => {
 			const callback = button.getAttribute("data-callback") || "";
 			const ipv4 = button.getAttribute("data-ipv4") === "true";
 			const ipv6 = button.getAttribute("data-ipv6") === "true";
+			const startMode = resolveStartMode(undefined, button);
 
-			startDetectorPrefetch(siteKey, { ipv4, ipv6 });
+			startDetectorPrefetch(siteKey, { ipv4, ipv6, startMode });
 
 			const buttonRenderOptions: ProcaptchaRenderOptions = {
 				siteKey: siteKey,
 				callback: callback,
 				ipv4,
 				ipv6,
+				startMode,
 			};
 
 			const root = await widgetFactory.createWidgets(
@@ -203,7 +220,10 @@ export const render = async (
 	element: Element,
 	renderOptions: ProcaptchaRenderOptions,
 ): Promise<string | undefined> => {
-	startDetectorPrefetch(renderOptions.siteKey, renderOptions);
+	startDetectorPrefetch(renderOptions.siteKey, {
+		...renderOptions,
+		startMode: resolveStartMode(renderOptions, element),
+	});
 
 	const hasInvisibleSize =
 		Object.prototype.hasOwnProperty.call(renderOptions, "size") &&
@@ -270,6 +290,43 @@ export const execute = () => {
 	document.dispatchEvent(executeEvent);
 };
 
+/**
+ * Starts the frictionless flow for a widget rendered with
+ * `startMode: "manual"` (or `data-start-mode="manual"`). Pass a widget id to
+ * start one widget, or omit it to start every widget on the page. Widgets in
+ * the default `auto` mode, and manual widgets that have already started (by
+ * an earlier call or the user clicking the checkbox), ignore it.
+ *
+ * Delivered as a `procaptcha:start` DOM event addressed to the widget's
+ * element rather than by calling into React directly, which keeps direct-React
+ * integrations on the same mechanism: they can dispatch the event themselves.
+ */
+export const start = (widgetId?: string): void => {
+	const ids: string[] =
+		undefined === widgetId ? Array.from(procaptchaWidgets.keys()) : [widgetId];
+
+	if (ids.length === 0) {
+		console.error("No Procaptcha widgets found to start");
+		return;
+	}
+
+	for (const id of ids) {
+		const entry = procaptchaWidgets.get(id);
+		if (!entry) {
+			console.error(`No Procaptcha widget found with id ${id}`);
+			continue;
+		}
+		const detail: ProcaptchaStartEventDetail = { element: entry.element };
+		document.dispatchEvent(
+			new CustomEvent<ProcaptchaStartEventDetail>(PROCAPTCHA_START_EVENT, {
+				detail,
+				bubbles: true,
+				cancelable: false,
+			}),
+		);
+	}
+};
+
 function findProcaptchaContainers(): Element[] {
 	const containers: Element[] = [];
 
@@ -310,11 +367,12 @@ declare global {
 			reset: typeof reset;
 			remove: typeof remove;
 			execute: typeof execute;
+			start: typeof start;
 		};
 	}
 }
 
-const start = () => {
+const boot = () => {
 	// onLoadUrlCallback defines the name of the callback function to be called when the script is loaded
 	// onRenderExplicit takes values of either explicit or implicit
 	const { onloadUrlCallback, renderExplicit } = extractParams(BUNDLE_NAMES);
@@ -352,7 +410,7 @@ const start = () => {
  * widget id to reset one widget, or omit it to reset every widget on the page.
  *
  * This remounts rather than merely unmounting. The previous implementation
- * unmounted every root and then called `start()`, which only re-renders when
+ * unmounted every root and then called `boot()`, which only re-renders when
  * the page uses implicit rendering — and even then only via the
  * `document.readyState` fallback, because the script's `load` event has long
  * since fired. On an explicitly-rendered page nothing came back at all: the
@@ -360,7 +418,7 @@ const start = () => {
  * request was ever made. Rebuilding from the stored descriptor makes reset
  * behave the same way on both paths.
  *
- * `start()` is deliberately not called here any more. It re-renders implicit
+ * `boot()` is deliberately not called here any more. It re-renders implicit
  * widgets, which would double up with the remount below, and it attaches
  * another `load` listener to the script tag on every call.
  */
@@ -409,7 +467,7 @@ export const remove = (widgetId?: string): void => {
 };
 
 // set the procaptcha attribute on the window
-window.procaptcha = { ready, render, reset, remove, execute };
+window.procaptcha = { ready, render, reset, remove, execute, start };
 
 // Dispatch a custom event to notify that window.procaptcha is ready
 const procaptchaReadyEvent = new CustomEvent(PROCAPTCHA_READY_EVENT, {
@@ -421,4 +479,4 @@ const procaptchaReadyEvent = new CustomEvent(PROCAPTCHA_READY_EVENT, {
 });
 document.dispatchEvent(procaptchaReadyEvent);
 
-start();
+boot();

--- a/packages/procaptcha-bundle/src/tests/procaptchaReady.unit.test.ts
+++ b/packages/procaptcha-bundle/src/tests/procaptchaReady.unit.test.ts
@@ -50,6 +50,7 @@ describe("procaptcha:ready event", () => {
 			expect(window.procaptcha?.ready).toBeDefined();
 			expect(window.procaptcha?.reset).toBeDefined();
 			expect(window.procaptcha?.execute).toBeDefined();
+			expect(window.procaptcha?.start).toBeDefined();
 		});
 
 		// Import the module which should set window.procaptcha and dispatch the event

--- a/packages/procaptcha-bundle/src/tests/start.unit.test.ts
+++ b/packages/procaptcha-bundle/src/tests/start.unit.test.ts
@@ -12,13 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/**
- * `window.procaptcha.start()` is how a site kicks off a widget rendered with
- * `startMode: "manual"`. It reaches the widget as a `procaptcha:start` event
- * addressed to the element the widget was rendered into, so that one call
- * can target one widget on a page that has several.
- */
-
 import {
 	PROCAPTCHA_START_EVENT,
 	type ProcaptchaStartEventDetail,

--- a/packages/procaptcha-bundle/src/tests/start.unit.test.ts
+++ b/packages/procaptcha-bundle/src/tests/start.unit.test.ts
@@ -1,0 +1,159 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * `window.procaptcha.start()` is how a site kicks off a widget rendered with
+ * `startMode: "manual"`. It reaches the widget as a `procaptcha:start` event
+ * addressed to the element the widget was rendered into, so that one call
+ * can target one widget on a page that has several.
+ */
+
+import {
+	PROCAPTCHA_START_EVENT,
+	type ProcaptchaStartEventDetail,
+	StartModeEnum,
+} from "@prosopo/types";
+import type { Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+	prefetchDetector: vi.fn(),
+	createWidgets: vi.fn(),
+}));
+
+vi.mock("@prosopo/procaptcha-frictionless", () => ({
+	prefetchDetector: mocks.prefetchDetector,
+}));
+
+vi.mock("@prosopo/procaptcha-common", () => ({
+	getWindowCallback: vi.fn(),
+	pickIpMode: vi.fn(() => undefined),
+}));
+
+vi.mock("../util/widgetFactory.js", () => ({
+	WidgetFactory: vi.fn(function () {
+		return { createWidgets: mocks.createWidgets };
+	}),
+}));
+
+const { render, remove, start } = await import("../index.js");
+
+const SITE_KEY = "5CcNvLUdiXFpzKDMjThGLSK9rhWHA1H4EF3zrgkpkjAdqmuP";
+
+const makeRoot = (): Root =>
+	({ unmount: vi.fn(), render: vi.fn() }) as unknown as Root;
+
+const flush = (): Promise<void> =>
+	new Promise((resolve) => setTimeout(resolve, 0));
+
+const renderWidget = async (
+	options: Partial<Parameters<typeof render>[1]> = {},
+): Promise<{ element: HTMLDivElement; id: string }> => {
+	mocks.createWidgets.mockResolvedValueOnce([makeRoot()]);
+	const element = document.createElement("div");
+	const id = await render(element, { siteKey: SITE_KEY, ...options });
+	if (!id) throw new Error("expected render to return a widget id");
+	return { element, id };
+};
+
+let received: ProcaptchaStartEventDetail[];
+const onStart = (event: Event): void => {
+	received.push((event as CustomEvent<ProcaptchaStartEventDetail>).detail);
+};
+
+beforeEach(async () => {
+	vi.clearAllMocks();
+	await remove();
+	received = [];
+	document.addEventListener(PROCAPTCHA_START_EVENT, onStart);
+});
+
+afterEach(() => {
+	document.removeEventListener(PROCAPTCHA_START_EVENT, onStart);
+});
+
+describe("start", () => {
+	it("addresses one event to each widget when no id is given", async () => {
+		const first = await renderWidget();
+		const second = await renderWidget();
+
+		start();
+
+		expect(received.map((detail) => detail.element)).toEqual([
+			first.element,
+			second.element,
+		]);
+	});
+
+	it("addresses the event to the widget whose id is given", async () => {
+		await renderWidget();
+		const second = await renderWidget();
+
+		start(second.id);
+
+		expect(received).toHaveLength(1);
+		expect(received[0]?.element).toBe(second.element);
+	});
+
+	it("reports an unknown id instead of dispatching", async () => {
+		const error = vi.spyOn(console, "error").mockImplementation(() => {});
+		await renderWidget();
+
+		start("procaptcha-widget-does-not-exist");
+
+		expect(received).toHaveLength(0);
+		expect(error).toHaveBeenCalledTimes(1);
+		error.mockRestore();
+	});
+
+	it("reports when there is nothing to start", () => {
+		const error = vi.spyOn(console, "error").mockImplementation(() => {});
+
+		start();
+
+		expect(received).toHaveLength(0);
+		expect(error).toHaveBeenCalledTimes(1);
+		error.mockRestore();
+	});
+
+	it("is exposed on window.procaptcha", () => {
+		expect(window.procaptcha.start).toBe(start);
+	});
+});
+
+describe("detector prefetch", () => {
+	it("runs on render in auto mode", async () => {
+		await renderWidget();
+		await flush();
+
+		expect(mocks.prefetchDetector).toHaveBeenCalledTimes(1);
+	});
+
+	it("is skipped in manual mode so nothing reaches the provider on load", async () => {
+		await renderWidget({ startMode: StartModeEnum.manual });
+		await flush();
+
+		expect(mocks.prefetchDetector).not.toHaveBeenCalled();
+	});
+
+	it("is skipped when the element asks for manual mode", async () => {
+		mocks.createWidgets.mockResolvedValueOnce([makeRoot()]);
+		const element = document.createElement("div");
+		element.setAttribute("data-start-mode", "manual");
+		await render(element, { siteKey: SITE_KEY });
+		await flush();
+
+		expect(mocks.prefetchDetector).not.toHaveBeenCalled();
+	});
+});

--- a/packages/procaptcha-bundle/src/tests/util/startMode.test.ts
+++ b/packages/procaptcha-bundle/src/tests/util/startMode.test.ts
@@ -1,0 +1,113 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {
+	type ProcaptchaClientConfigOutput,
+	ProcaptchaConfigSchema,
+	type ProcaptchaRenderOptions,
+	StartModeEnum,
+} from "@prosopo/types";
+import { JSDOM } from "jsdom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	START_MODE_ATTRIBUTE,
+	resolveStartMode,
+	setStartMode,
+} from "../../util/startMode.js";
+
+const SITE_KEY = "5site";
+
+const makeConfig = (): ProcaptchaClientConfigOutput =>
+	ProcaptchaConfigSchema.parse({ account: { address: SITE_KEY } });
+
+const makeElement = (attributes: Record<string, string> = {}): Element => {
+	const dom = new JSDOM("<!DOCTYPE html><html><body></body></html>");
+	const element = dom.window.document.createElement("div");
+	for (const [name, value] of Object.entries(attributes)) {
+		element.setAttribute(name, value);
+	}
+	return element;
+};
+
+const renderOptions = (
+	overrides: Partial<ProcaptchaRenderOptions> = {},
+): ProcaptchaRenderOptions => ({ siteKey: SITE_KEY, ...overrides });
+
+describe("resolveStartMode", () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("defaults to auto", () => {
+		expect(resolveStartMode(renderOptions(), makeElement())).toBe(
+			StartModeEnum.auto,
+		);
+		expect(resolveStartMode(undefined, makeElement())).toBe(StartModeEnum.auto);
+	});
+
+	it("reads the start mode from the render options", () => {
+		expect(
+			resolveStartMode(
+				renderOptions({ startMode: StartModeEnum.manual }),
+				makeElement(),
+			),
+		).toBe(StartModeEnum.manual);
+	});
+
+	it("reads the start mode from the data attribute", () => {
+		expect(
+			resolveStartMode(
+				renderOptions(),
+				makeElement({ [START_MODE_ATTRIBUTE]: "manual" }),
+			),
+		).toBe(StartModeEnum.manual);
+	});
+
+	it("prefers the render options over the attribute", () => {
+		expect(
+			resolveStartMode(
+				renderOptions({ startMode: StartModeEnum.auto }),
+				makeElement({ [START_MODE_ATTRIBUTE]: "manual" }),
+			),
+		).toBe(StartModeEnum.auto);
+	});
+
+	it("falls back to auto on an unknown value and says so", () => {
+		const error = vi.spyOn(console, "error").mockImplementation(() => {});
+
+		expect(
+			resolveStartMode(
+				renderOptions(),
+				makeElement({ [START_MODE_ATTRIBUTE]: "later" }),
+			),
+		).toBe(StartModeEnum.auto);
+		expect(error).toHaveBeenCalledTimes(1);
+		expect(error.mock.calls[0]?.[0]).toContain("later");
+	});
+});
+
+describe("setStartMode", () => {
+	it("writes the resolved mode onto the config", () => {
+		const config = makeConfig();
+		expect(config.startMode).toBe(StartModeEnum.auto);
+
+		setStartMode(
+			renderOptions(),
+			makeElement({ [START_MODE_ATTRIBUTE]: "manual" }),
+			config,
+		);
+
+		expect(config.startMode).toBe(StartModeEnum.manual);
+	});
+});

--- a/packages/procaptcha-bundle/src/util/captcha/captchaRenderer.tsx
+++ b/packages/procaptcha-bundle/src/util/captcha/captchaRenderer.tsx
@@ -25,6 +25,7 @@ import { type Root, createRoot } from "react-dom/client";
 import { setClientSessionId } from "../clientSession.js";
 import { createConfig } from "../configCreator.js";
 import { setLanguage } from "../language.js";
+import { setStartMode } from "../startMode.js";
 import { setValidChallengeLength } from "../timeout.js";
 import { BundleCaptcha } from "./components/bundleCaptcha.js";
 
@@ -94,6 +95,7 @@ class CaptchaRenderer {
 		setValidChallengeLength(renderOptions, element, config);
 		setLanguage(renderOptions, element, config);
 		setClientSessionId(renderOptions, element, config);
+		setStartMode(renderOptions, element, config);
 	}
 
 	protected makeEmotionCache(

--- a/packages/procaptcha-bundle/src/util/startMode.ts
+++ b/packages/procaptcha-bundle/src/util/startMode.ts
@@ -1,0 +1,62 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {
+	type ProcaptchaClientConfigOutput,
+	type ProcaptchaRenderOptions,
+	type StartMode,
+	StartModeEnum,
+	StartModeSchema,
+} from "@prosopo/types";
+
+export const START_MODE_ATTRIBUTE = "data-start-mode";
+
+/**
+ * Resolves when this widget should start the frictionless flow, from either:
+ * 1. renderOptions.startMode
+ * 2. the element's data-start-mode attribute
+ *
+ * Anything unrecognised falls back to `auto`, the historic behaviour, with a
+ * console error rather than a failed render — a typo in a data attribute
+ * should not take the captcha off the page.
+ */
+export const resolveStartMode = (
+	renderOptions: ProcaptchaRenderOptions | undefined,
+	element: Element,
+): StartMode => {
+	const requested =
+		renderOptions?.startMode || element.getAttribute(START_MODE_ATTRIBUTE);
+
+	if (!requested) {
+		return StartModeEnum.auto;
+	}
+
+	const parsed = StartModeSchema.safeParse(requested);
+	if (!parsed.success) {
+		console.error(
+			`Ignoring unknown start mode "${requested}"; expected one of ${StartModeSchema.options.join(", ")}`,
+		);
+		return StartModeEnum.auto;
+	}
+
+	return parsed.data;
+};
+
+export const setStartMode = (
+	renderOptions: ProcaptchaRenderOptions | undefined,
+	element: Element,
+	config: ProcaptchaClientConfigOutput,
+): void => {
+	config.startMode = resolveStartMode(renderOptions, element);
+};

--- a/packages/procaptcha-bundle/src/util/startMode.ts
+++ b/packages/procaptcha-bundle/src/util/startMode.ts
@@ -22,15 +22,7 @@ import {
 
 export const START_MODE_ATTRIBUTE = "data-start-mode";
 
-/**
- * Resolves when this widget should start the frictionless flow, from either:
- * 1. renderOptions.startMode
- * 2. the element's data-start-mode attribute
- *
- * Anything unrecognised falls back to `auto`, the historic behaviour, with a
- * console error rather than a failed render — a typo in a data attribute
- * should not take the captcha off the page.
- */
+// An unrecognised value falls back to `auto` rather than failing the render.
 export const resolveStartMode = (
 	renderOptions: ProcaptchaRenderOptions | undefined,
 	element: Element,

--- a/packages/procaptcha-frictionless/src/ProcaptchaFrictionless.tsx
+++ b/packages/procaptcha-frictionless/src/ProcaptchaFrictionless.tsx
@@ -50,9 +50,6 @@ const ProcaptchaPuzzleLoader = async () =>
 const ProcaptchaPowLoader = async () =>
 	(await import("@prosopo/procaptcha-pow")).ProcaptchaPow;
 
-// Mirrors the constant each inner widget declares for `window.procaptcha
-// .execute()`. Listened to here only in manual start mode, where no inner
-// widget exists yet to receive it.
 const PROCAPTCHA_EXECUTE_EVENT = "procaptcha:execute";
 
 type CheckboxEvent = MouseEvent | TouchEvent | KeyboardEvent;
@@ -130,16 +127,12 @@ export const ProcaptchaFrictionless = ({
 	// because `providerRetry` re-invokes `start` with no arguments, which would
 	// otherwise drop the flag on the first provider retry.
 	const nextMountAutoStartRef = useRef(false);
-	// `manual` start mode: the widget is inert until the site asks for it (a
-	// `procaptcha:start` event, e.g. `window.procaptcha.start()`) or the end
-	// user clicks the checkbox — whichever comes first. Nothing runs on page
-	// load: no detector, no behavioural collectors, no provider traffic.
+	// Manual start mode: nothing runs until a `procaptcha:start` event or a
+	// checkbox click, whichever comes first.
 	const manualStart = config.startMode === StartModeEnum.manual;
-	// One-shot guard for the manual triggers. Both the event and the click can
-	// fire, in either order; only the first runs the frictionless flow.
 	const manualStartedRef = useRef(false);
-	// The placeholder checkbox is built before `start()` exists in this scope,
-	// so its click handler is reached through a ref that is filled in below.
+	// The placeholder is built before `start()` exists in this scope, so its
+	// click handler goes through a ref filled in below.
 	const manualCheckboxHandlerRef = useRef(noopCheckboxHandler);
 
 	useEffect(() => {
@@ -164,9 +157,7 @@ export const ProcaptchaFrictionless = ({
 			stateRef.current.errorMessage,
 			i18n.isInitialized,
 			i18n.t,
-			// Auto mode is already fetching, so it shows the spinner. Manual mode
-			// has nothing in flight: show the real checkbox, at its final size,
-			// and let a click on it be the trigger.
+			// Manual mode has nothing in flight, so it shows a live checkbox.
 			!manualStart,
 			manualStart
 				? (event: CheckboxEvent) => manualCheckboxHandlerRef.current(event)
@@ -405,11 +396,8 @@ export const ProcaptchaFrictionless = ({
 		});
 	};
 
-	// Run the deferred frictionless flow. `autoStart` makes the widget the
-	// provider picks open its challenge as soon as it mounts, so a user who
-	// clicked the placeholder checkbox is not asked to click again; `coords`
-	// is that click's position, carried through to the solution salt exactly
-	// as the session-invalidated retry path does.
+	// `autoStart` + `coords` make the widget the provider picks open on mount
+	// from the click that started it, so the user never clicks twice.
 	const startManually = async (
 		autoStart: boolean,
 		coords?: RetryCoords,
@@ -418,8 +406,6 @@ export const ProcaptchaFrictionless = ({
 		manualStartedRef.current = true;
 		pendingRetryCoordsRef.current = coords ?? null;
 		nextMountAutoStartRef.current = autoStart;
-		// Swap the live checkbox for the spinner for the duration of the
-		// frictionless round-trip, matching what auto mode shows on load.
 		setComponentToRender(
 			renderPlaceholder(
 				config.theme,
@@ -434,7 +420,6 @@ export const ProcaptchaFrictionless = ({
 	};
 
 	manualCheckboxHandlerRef.current = async (event: CheckboxEvent) => {
-		// Checkbox has already rejected untrusted events by the time this runs.
 		let x = 0;
 		let y = 0;
 		const nativeEvent = event.nativeEvent;
@@ -445,14 +430,9 @@ export const ProcaptchaFrictionless = ({
 		await startManually(true, normaliseRetryCoords(x, y) ?? undefined);
 	};
 
-	// Manual mode triggers. `procaptcha:start` runs the frictionless flow and
-	// leaves the resulting widget waiting for a click, as auto mode would
-	// have. `procaptcha:execute` (the invisible-mode API) has no inner widget
-	// to land on yet, so it is honoured here by starting with `autoStart`.
-	// `container` is the widget's own element; an event addressed to a
-	// different widget's element is ignored. Direct-React consumers, who
-	// mount without a container, receive every event.
-	// biome-ignore lint/correctness/useExhaustiveDependencies: intentional — `startManually` captures the mount-time `start()`, as the auto-mode effect below does; the listener is keyed on the two values that decide whether it exists at all.
+	// `procaptcha:execute` has no inner widget to land on yet in manual mode,
+	// so it is honoured here with `autoStart`.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: intentional — `startManually` captures the mount-time `start()`, as the auto-mode effect below does.
 	useEffect(() => {
 		if (!manualStart) return;
 		const onStartEvent = (event: Event) => {
@@ -498,7 +478,6 @@ export const ProcaptchaFrictionless = ({
 		}`;
 		if (startedForKeyRef.current === key) return;
 		startedForKeyRef.current = key;
-		// Manual mode waits for one of the triggers above instead.
 		if (manualStart) return;
 		void start();
 	}, [config.account?.address, config.language, config.mode]);

--- a/packages/procaptcha-frictionless/src/ProcaptchaFrictionless.tsx
+++ b/packages/procaptcha-frictionless/src/ProcaptchaFrictionless.tsx
@@ -24,10 +24,14 @@ import {
 	CaptchaType,
 	type FrictionlessState,
 	type ModeType,
+	PROCAPTCHA_START_EVENT,
 	ProcaptchaConfigSchema,
 	type ProcaptchaFrictionlessProps,
+	type ProcaptchaStartEventDetail,
+	StartModeEnum,
 } from "@prosopo/types";
 import { darkTheme, lightTheme } from "@prosopo/widget-skeleton";
+import type { KeyboardEvent, MouseEvent, TouchEvent } from "react";
 import { useEffect, useRef, useState } from "react";
 import customDetectBot from "./customDetectBot.js";
 import { evaluateFrictionlessResult } from "./frictionlessResultGuard.js";
@@ -46,6 +50,15 @@ const ProcaptchaPuzzleLoader = async () =>
 const ProcaptchaPowLoader = async () =>
 	(await import("@prosopo/procaptcha-pow")).ProcaptchaPow;
 
+// Mirrors the constant each inner widget declares for `window.procaptcha
+// .execute()`. Listened to here only in manual start mode, where no inner
+// widget exists yet to receive it.
+const PROCAPTCHA_EXECUTE_EVENT = "procaptcha:execute";
+
+type CheckboxEvent = MouseEvent | TouchEvent | KeyboardEvent;
+
+const noopCheckboxHandler = async (_event: CheckboxEvent): Promise<void> => {};
+
 const renderPlaceholder = (
 	theme: string | undefined,
 	mode: ModeType,
@@ -53,6 +66,7 @@ const renderPlaceholder = (
 	isTranslationLoaded: boolean,
 	translationFn: (key: string) => string,
 	loading: boolean,
+	onChange: (event: CheckboxEvent) => Promise<void> = noopCheckboxHandler,
 ) => {
 	const checkboxTheme = "light" === theme ? lightTheme : darkTheme;
 
@@ -63,7 +77,7 @@ const renderPlaceholder = (
 	return (
 		<Checkbox
 			theme={checkboxTheme}
-			onChange={async () => {}}
+			onChange={onChange}
 			checked={false}
 			labelText={isTranslationLoaded ? translationFn("WIDGET.I_AM_HUMAN") : ""}
 			error={errorMessage}
@@ -116,6 +130,17 @@ export const ProcaptchaFrictionless = ({
 	// because `providerRetry` re-invokes `start` with no arguments, which would
 	// otherwise drop the flag on the first provider retry.
 	const nextMountAutoStartRef = useRef(false);
+	// `manual` start mode: the widget is inert until the site asks for it (a
+	// `procaptcha:start` event, e.g. `window.procaptcha.start()`) or the end
+	// user clicks the checkbox — whichever comes first. Nothing runs on page
+	// load: no detector, no behavioural collectors, no provider traffic.
+	const manualStart = config.startMode === StartModeEnum.manual;
+	// One-shot guard for the manual triggers. Both the event and the click can
+	// fire, in either order; only the first runs the frictionless flow.
+	const manualStartedRef = useRef(false);
+	// The placeholder checkbox is built before `start()` exists in this scope,
+	// so its click handler is reached through a ref that is filled in below.
+	const manualCheckboxHandlerRef = useRef(noopCheckboxHandler);
 
 	useEffect(() => {
 		if (!config.language) return;
@@ -139,7 +164,13 @@ export const ProcaptchaFrictionless = ({
 			stateRef.current.errorMessage,
 			i18n.isInitialized,
 			i18n.t,
-			true,
+			// Auto mode is already fetching, so it shows the spinner. Manual mode
+			// has nothing in flight: show the real checkbox, at its final size,
+			// and let a click on it be the trigger.
+			!manualStart,
+			manualStart
+				? (event: CheckboxEvent) => manualCheckboxHandlerRef.current(event)
+				: undefined,
 		),
 	);
 
@@ -374,6 +405,74 @@ export const ProcaptchaFrictionless = ({
 		});
 	};
 
+	// Run the deferred frictionless flow. `autoStart` makes the widget the
+	// provider picks open its challenge as soon as it mounts, so a user who
+	// clicked the placeholder checkbox is not asked to click again; `coords`
+	// is that click's position, carried through to the solution salt exactly
+	// as the session-invalidated retry path does.
+	const startManually = async (
+		autoStart: boolean,
+		coords?: RetryCoords,
+	): Promise<void> => {
+		if (manualStartedRef.current) return;
+		manualStartedRef.current = true;
+		pendingRetryCoordsRef.current = coords ?? null;
+		nextMountAutoStartRef.current = autoStart;
+		// Swap the live checkbox for the spinner for the duration of the
+		// frictionless round-trip, matching what auto mode shows on load.
+		setComponentToRender(
+			renderPlaceholder(
+				config.theme,
+				config.mode,
+				stateRef.current.errorMessage,
+				i18n.isInitialized,
+				i18n.t,
+				true,
+			),
+		);
+		await start();
+	};
+
+	manualCheckboxHandlerRef.current = async (event: CheckboxEvent) => {
+		// Checkbox has already rejected untrusted events by the time this runs.
+		let x = 0;
+		let y = 0;
+		const nativeEvent = event.nativeEvent;
+		if ("clientX" in nativeEvent && "clientY" in nativeEvent) {
+			x = nativeEvent.clientX;
+			y = nativeEvent.clientY;
+		}
+		await startManually(true, normaliseRetryCoords(x, y) ?? undefined);
+	};
+
+	// Manual mode triggers. `procaptcha:start` runs the frictionless flow and
+	// leaves the resulting widget waiting for a click, as auto mode would
+	// have. `procaptcha:execute` (the invisible-mode API) has no inner widget
+	// to land on yet, so it is honoured here by starting with `autoStart`.
+	// `container` is the widget's own element; an event addressed to a
+	// different widget's element is ignored. Direct-React consumers, who
+	// mount without a container, receive every event.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: intentional — `startManually` captures the mount-time `start()`, as the auto-mode effect below does; the listener is keyed on the two values that decide whether it exists at all.
+	useEffect(() => {
+		if (!manualStart) return;
+		const onStartEvent = (event: Event) => {
+			const detail = (event as CustomEvent<ProcaptchaStartEventDetail>).detail;
+			if (detail?.element && container && !detail.element.contains(container)) {
+				return;
+			}
+			void startManually(false);
+		};
+		const onExecuteEvent = () => {
+			void startManually(true);
+		};
+		document.addEventListener(PROCAPTCHA_START_EVENT, onStartEvent);
+		document.addEventListener(PROCAPTCHA_EXECUTE_EVENT, onExecuteEvent);
+		return () => {
+			document.removeEventListener(PROCAPTCHA_START_EVENT, onStartEvent);
+			document.removeEventListener(PROCAPTCHA_EXECUTE_EVENT, onExecuteEvent);
+		};
+	}, [manualStart, container]);
+
 	// Track which config identity has already been started for. Host
 	// pages often recreate the `callbacks` object (and sometimes the whole
 	// `config`) on every render, which — before this guard — re-fired
@@ -399,6 +498,8 @@ export const ProcaptchaFrictionless = ({
 		}`;
 		if (startedForKeyRef.current === key) return;
 		startedForKeyRef.current = key;
+		// Manual mode waits for one of the triggers above instead.
+		if (manualStart) return;
 		void start();
 	}, [config.account?.address, config.language, config.mode]);
 

--- a/packages/procaptcha-frictionless/src/tests/manualStart.test.tsx
+++ b/packages/procaptcha-frictionless/src/tests/manualStart.test.tsx
@@ -12,13 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/**
- * `startMode: "manual"` keeps the widget inert after mount — checkbox on the
- * page at its final size, but no detection and no provider traffic — until
- * the site asks for it or the user clicks. These tests pin the three ways the
- * deferred flow can start and that a click never has to be repeated.
- */
-
 import type { Ti18n } from "@prosopo/locale";
 import {
 	type Account,
@@ -148,12 +141,8 @@ const lastMountOf = (widget: InnerWidget) => {
 	return mount;
 };
 
-/**
- * jsdom marks everything it dispatches untrusted and exposes `isTrusted` as
- * a non-configurable accessor on its internal implementation object, so the
- * flag has to be pinned there for the Checkbox's trust guard to let the
- * click through.
- */
+// jsdom exposes `isTrusted` as a non-configurable accessor on its internal
+// implementation object, so the flag has to be pinned there.
 const setTrusted = (event: Event, trusted: boolean): void => {
 	for (const symbol of Object.getOwnPropertySymbols(event)) {
 		const impl: unknown = Reflect.get(event, symbol);
@@ -233,8 +222,6 @@ describe("manual start mode", () => {
 
 		expect(detectBot).not.toHaveBeenCalled();
 		expect(mocks.mounts).toHaveLength(0);
-		// A real checkbox, not the spinner auto mode shows while it fetches: the
-		// widget occupies its final footprint from the first paint.
 		expect(checkbox().disabled).toBe(false);
 		expect(spinner()).toBeNull();
 	});
@@ -264,8 +251,6 @@ describe("manual start mode", () => {
 
 			expect(detectBot).toHaveBeenCalledTimes(1);
 			const mount = lastMountOf("image").props;
-			// The site started it, not the user, so the challenge must not open
-			// on its own — same as an auto-mode mount.
 			expect(mount.autoStart).toBe(false);
 			expect(mount.startCoords).toBeUndefined();
 			expect(mount.frictionlessState?.sessionId).toBe(SESSION_ID);
@@ -343,9 +328,6 @@ describe("manual start mode", () => {
 
 			expect(detectBot).toHaveBeenCalledTimes(1);
 			const mount = lastMountOf("image").props;
-			// The click that started the flow is the click that opens the
-			// challenge: the user is never asked to tick the box twice, and the
-			// position reaches the solution salt as it would on a direct mount.
 			expect(mount.autoStart).toBe(true);
 			expect(mount.startCoords).toEqual({ x: 11, y: 22 });
 		});

--- a/packages/procaptcha-frictionless/src/tests/manualStart.test.tsx
+++ b/packages/procaptcha-frictionless/src/tests/manualStart.test.tsx
@@ -1,0 +1,406 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * `startMode: "manual"` keeps the widget inert after mount — checkbox on the
+ * page at its final size, but no detection and no provider traffic — until
+ * the site asks for it or the user clicks. These tests pin the three ways the
+ * deferred flow can start and that a click never has to be repeated.
+ */
+
+import type { Ti18n } from "@prosopo/locale";
+import {
+	type Account,
+	type BotDetectionFunction,
+	type BotDetectionFunctionResult,
+	CaptchaType,
+	ModeEnum,
+	PROCAPTCHA_START_EVENT,
+	type ProcaptchaClientConfigInput,
+	type ProcaptchaProps,
+	type ProcaptchaStartEventDetail,
+	type RandomProvider,
+	StartModeEnum,
+} from "@prosopo/types";
+import { type ReactElement, act, createElement } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+declare global {
+	var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+type InnerWidget = "pow" | "image" | "puzzle";
+
+const mocks = vi.hoisted(() => ({
+	mounts: [] as {
+		widget: "pow" | "image" | "puzzle";
+		props: ProcaptchaProps;
+	}[],
+}));
+
+const stub = (widget: InnerWidget) => (props: ProcaptchaProps) => {
+	mocks.mounts.push({ widget, props });
+	return createElement("div", { "data-widget": widget });
+};
+
+vi.mock("@prosopo/procaptcha-pow", () => ({ ProcaptchaPow: stub("pow") }));
+vi.mock("@prosopo/procaptcha-react", () => ({ Procaptcha: stub("image") }));
+vi.mock("@prosopo/procaptcha-puzzle", () => ({
+	ProcaptchaPuzzle: stub("puzzle"),
+}));
+
+vi.mock("@prosopo/procaptcha-common", async (importOriginal) => {
+	const actual =
+		await importOriginal<typeof import("@prosopo/procaptcha-common")>();
+	return { ...actual, isSecureBrowserContext: () => true };
+});
+
+const { ProcaptchaFrictionless } = await import("../ProcaptchaFrictionless.js");
+
+const SITE_KEY = "5siteKey";
+const SESSION_ID = "provider-session";
+
+const config = (
+	overrides: Partial<ProcaptchaClientConfigInput> = {},
+): ProcaptchaClientConfigInput => ({
+	account: { address: SITE_KEY },
+	userAccountAddress: "",
+	web2: true,
+	mode: ModeEnum.visible,
+	startMode: StartModeEnum.manual,
+	...overrides,
+});
+
+const i18nStub = {
+	isInitialized: true,
+	language: "en",
+	t: (key: string) => key,
+	changeLanguage: vi.fn(),
+} as unknown as Ti18n;
+
+const detectionResult = (): BotDetectionFunctionResult => ({
+	status: "ok",
+	captchaType: CaptchaType.image,
+	sessionId: SESSION_ID,
+	provider: { provider: { url: "https://provider.test" } } as RandomProvider,
+	userAccount: { account: { address: "5FakeUserAccountAddress" } } as Account,
+});
+
+const detectBotResolving = () =>
+	vi.fn<BotDetectionFunction>().mockResolvedValue(detectionResult());
+
+let host: HTMLDivElement;
+let root: Root;
+
+interface MountOptions {
+	config?: ProcaptchaClientConfigInput;
+	detectBot?: ReturnType<typeof detectBotResolving>;
+	container?: HTMLElement;
+}
+
+const mountWrapper = async (
+	options: MountOptions = {},
+): Promise<ReturnType<typeof detectBotResolving>> => {
+	const detectBot = options.detectBot ?? detectBotResolving();
+	await act(async () => {
+		root.render(
+			createElement(ProcaptchaFrictionless, {
+				config: options.config ?? config(),
+				callbacks: {},
+				restart: vi.fn(),
+				i18n: i18nStub,
+				detectBot,
+				container: options.container,
+			}) as ReactElement,
+		);
+	});
+	return detectBot;
+};
+
+const checkbox = (): HTMLInputElement => {
+	const element = host.querySelector<HTMLInputElement>(
+		'[data-cy="captcha-checkbox"]',
+	);
+	if (!element) throw new Error("expected the checkbox to be on the page");
+	return element;
+};
+
+const spinner = (): Element | null =>
+	host.querySelector('[aria-label="Loading spinner"]');
+
+const lastMountOf = (widget: InnerWidget) => {
+	const mount = mocks.mounts.filter((m) => m.widget === widget).at(-1);
+	if (!mount) throw new Error(`expected the ${widget} widget to have mounted`);
+	return mount;
+};
+
+/**
+ * jsdom marks everything it dispatches untrusted and exposes `isTrusted` as
+ * a non-configurable accessor on its internal implementation object, so the
+ * flag has to be pinned there for the Checkbox's trust guard to let the
+ * click through.
+ */
+const setTrusted = (event: Event, trusted: boolean): void => {
+	for (const symbol of Object.getOwnPropertySymbols(event)) {
+		const impl: unknown = Reflect.get(event, symbol);
+		if (impl && typeof impl === "object" && "isTrusted" in impl) {
+			Object.defineProperty(impl, "isTrusted", {
+				configurable: true,
+				get: () => trusted,
+				set: () => undefined,
+			});
+			return;
+		}
+	}
+	throw new Error("could not reach the jsdom event implementation");
+};
+
+interface ClickOptions {
+	trusted?: boolean;
+	clientX?: number;
+	clientY?: number;
+}
+
+const click = async (
+	element: Element,
+	options: ClickOptions = {},
+): Promise<void> => {
+	const event = new MouseEvent("click", {
+		bubbles: true,
+		cancelable: true,
+		clientX: options.clientX ?? 0,
+		clientY: options.clientY ?? 0,
+	});
+	setTrusted(event, options.trusted ?? true);
+	await act(async () => {
+		element.dispatchEvent(event);
+	});
+};
+
+const dispatchStart = async (
+	detail?: ProcaptchaStartEventDetail,
+): Promise<void> => {
+	await act(async () => {
+		document.dispatchEvent(
+			new CustomEvent<ProcaptchaStartEventDetail>(PROCAPTCHA_START_EVENT, {
+				detail,
+				bubbles: true,
+			}),
+		);
+	});
+};
+
+const dispatchExecute = async (): Promise<void> => {
+	await act(async () => {
+		document.dispatchEvent(new CustomEvent("procaptcha:execute"));
+	});
+};
+
+beforeEach(() => {
+	mocks.mounts.length = 0;
+	host = document.createElement("div");
+	document.body.appendChild(host);
+	act(() => {
+		root = createRoot(host);
+	});
+});
+
+afterEach(() => {
+	act(() => {
+		root.unmount();
+	});
+	host.remove();
+	vi.clearAllMocks();
+});
+
+describe("manual start mode", () => {
+	it("mounts a live checkbox without running detection", async () => {
+		const detectBot = await mountWrapper();
+
+		expect(detectBot).not.toHaveBeenCalled();
+		expect(mocks.mounts).toHaveLength(0);
+		// A real checkbox, not the spinner auto mode shows while it fetches: the
+		// widget occupies its final footprint from the first paint.
+		expect(checkbox().disabled).toBe(false);
+		expect(spinner()).toBeNull();
+	});
+
+	it("still runs detection on mount in auto mode", async () => {
+		const detectBot = await mountWrapper({
+			config: config({ startMode: StartModeEnum.auto }),
+		});
+
+		expect(detectBot).toHaveBeenCalledTimes(1);
+		expect(lastMountOf("image").props.autoStart).toBe(false);
+	});
+
+	it("defaults to auto when no start mode is given", async () => {
+		const detectBot = await mountWrapper({
+			config: config({ startMode: undefined }),
+		});
+
+		expect(detectBot).toHaveBeenCalledTimes(1);
+	});
+
+	describe("started by the site", () => {
+		it("runs detection on procaptcha:start and leaves the widget waiting for a click", async () => {
+			const detectBot = await mountWrapper();
+
+			await dispatchStart();
+
+			expect(detectBot).toHaveBeenCalledTimes(1);
+			const mount = lastMountOf("image").props;
+			// The site started it, not the user, so the challenge must not open
+			// on its own — same as an auto-mode mount.
+			expect(mount.autoStart).toBe(false);
+			expect(mount.startCoords).toBeUndefined();
+			expect(mount.frictionlessState?.sessionId).toBe(SESSION_ID);
+		});
+
+		it("honours an event addressed to its own element", async () => {
+			const widgetElement = document.createElement("div");
+			const container = document.createElement("div");
+			widgetElement.appendChild(container);
+			const detectBot = await mountWrapper({ container });
+
+			await dispatchStart({ element: widgetElement });
+
+			expect(detectBot).toHaveBeenCalledTimes(1);
+		});
+
+		it("ignores an event addressed to another widget's element", async () => {
+			const container = document.createElement("div");
+			document.createElement("div").appendChild(container);
+			const detectBot = await mountWrapper({ container });
+
+			await dispatchStart({ element: document.createElement("div") });
+
+			expect(detectBot).not.toHaveBeenCalled();
+			expect(checkbox().disabled).toBe(false);
+		});
+
+		it("receives every event when mounted without a container", async () => {
+			const detectBot = await mountWrapper();
+
+			await dispatchStart({ element: document.createElement("div") });
+
+			expect(detectBot).toHaveBeenCalledTimes(1);
+		});
+
+		it("opens the challenge straight away on procaptcha:execute", async () => {
+			const detectBot = await mountWrapper({
+				config: config({ mode: ModeEnum.invisible }),
+			});
+
+			await dispatchExecute();
+
+			expect(detectBot).toHaveBeenCalledTimes(1);
+			expect(lastMountOf("image").props.autoStart).toBe(true);
+		});
+
+		it("ignores the events once started", async () => {
+			const detectBot = await mountWrapper();
+
+			await dispatchStart();
+			await dispatchStart();
+			await dispatchExecute();
+
+			expect(detectBot).toHaveBeenCalledTimes(1);
+			expect(mocks.mounts).toHaveLength(1);
+		});
+
+		it("does not react to the events in auto mode", async () => {
+			const detectBot = await mountWrapper({
+				config: config({ startMode: StartModeEnum.auto }),
+			});
+			expect(detectBot).toHaveBeenCalledTimes(1);
+
+			await dispatchStart();
+
+			expect(detectBot).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	describe("started by the user", () => {
+		it("runs detection on a checkbox click and opens the challenge where the user clicked", async () => {
+			const detectBot = await mountWrapper();
+
+			await click(checkbox(), { clientX: 11, clientY: 22 });
+
+			expect(detectBot).toHaveBeenCalledTimes(1);
+			const mount = lastMountOf("image").props;
+			// The click that started the flow is the click that opens the
+			// challenge: the user is never asked to tick the box twice, and the
+			// position reaches the solution salt as it would on a direct mount.
+			expect(mount.autoStart).toBe(true);
+			expect(mount.startCoords).toEqual({ x: 11, y: 22 });
+		});
+
+		it("opens the challenge after a keyboard activation with no position", async () => {
+			const detectBot = await mountWrapper();
+
+			await click(checkbox());
+
+			expect(detectBot).toHaveBeenCalledTimes(1);
+			const mount = lastMountOf("image").props;
+			expect(mount.autoStart).toBe(true);
+			expect(mount.startCoords).toBeUndefined();
+		});
+
+		it("shows the spinner while the deferred flow runs", async () => {
+			let finish: ((result: BotDetectionFunctionResult) => void) | undefined;
+			const detectBot = vi.fn<BotDetectionFunction>().mockImplementation(
+				() =>
+					new Promise<BotDetectionFunctionResult>((resolve) => {
+						finish = resolve;
+					}),
+			);
+			await mountWrapper({ detectBot });
+
+			await click(checkbox(), { clientX: 1, clientY: 1 });
+
+			expect(spinner()).not.toBeNull();
+			expect(mocks.mounts).toHaveLength(0);
+
+			await act(async () => {
+				finish?.(detectionResult());
+			});
+
+			expect(spinner()).toBeNull();
+			expect(lastMountOf("image").props.autoStart).toBe(true);
+		});
+
+		it("ignores a synthetic click", async () => {
+			const detectBot = await mountWrapper();
+
+			await click(checkbox(), { trusted: false, clientX: 1, clientY: 1 });
+
+			expect(detectBot).not.toHaveBeenCalled();
+		});
+
+		it("starts once even if the site also asks", async () => {
+			const detectBot = await mountWrapper();
+
+			await click(checkbox(), { clientX: 3, clientY: 4 });
+			await dispatchStart();
+
+			expect(detectBot).toHaveBeenCalledTimes(1);
+			expect(mocks.mounts).toHaveLength(1);
+			expect(lastMountOf("image").props.startCoords).toEqual({ x: 3, y: 4 });
+		});
+	});
+});

--- a/packages/types/src/config/config.ts
+++ b/packages/types/src/config/config.ts
@@ -23,6 +23,7 @@ import { union } from "zod";
 import type { infer as zInfer } from "zod";
 import z, { boolean } from "zod";
 import { Mode, ModeEnum } from "./mode.js";
+import { StartModeEnum, StartModeSchema } from "./startMode.js";
 export { Mode, ModeEnum };
 export type { ModeType } from "./mode.js";
 import {
@@ -293,6 +294,11 @@ export const ProcaptchaConfigSchema = ProsopoClientConfigSchema.and(
 		// call can correlate it. Named `clientSessionId` here to keep it clear
 		// of the provider's own frictionless `sessionId`.
 		clientSessionId: string().optional(),
+		// When the frictionless flow runs. `manual` keeps the widget inert
+		// (checkbox visible, no detection or provider traffic) until the site
+		// calls `window.procaptcha.start()` or the user clicks the checkbox.
+		// See `StartModeEnum`.
+		startMode: StartModeSchema.optional().default(StartModeEnum.auto),
 	}),
 );
 

--- a/packages/types/src/config/config.ts
+++ b/packages/types/src/config/config.ts
@@ -294,10 +294,6 @@ export const ProcaptchaConfigSchema = ProsopoClientConfigSchema.and(
 		// call can correlate it. Named `clientSessionId` here to keep it clear
 		// of the provider's own frictionless `sessionId`.
 		clientSessionId: string().optional(),
-		// When the frictionless flow runs. `manual` keeps the widget inert
-		// (checkbox visible, no detection or provider traffic) until the site
-		// calls `window.procaptcha.start()` or the user clicks the checkbox.
-		// See `StartModeEnum`.
 		startMode: StartModeSchema.optional().default(StartModeEnum.auto),
 	}),
 );

--- a/packages/types/src/config/index.ts
+++ b/packages/types/src/config/index.ts
@@ -13,6 +13,7 @@
 // limitations under the License.
 export * from "./config.js";
 export * from "./mode.js";
+export * from "./startMode.js";
 export * from "./network.js";
 export * from "./timeouts.js";
 export * from "./frictionless.js";

--- a/packages/types/src/config/startMode.ts
+++ b/packages/types/src/config/startMode.ts
@@ -16,16 +16,9 @@ import type { infer as zInfer } from "zod";
 import { enum as zEnum } from "zod";
 
 /**
- * When the widget starts the frictionless flow (bot detection, behavioural
- * collectors and the `/frictionless` round-trip that picks a challenge).
- *
- * - `auto` (default): as soon as the widget mounts.
- * - `manual`: the widget renders its checkbox straight away, at its final
- *   size, but does nothing else until the site calls
- *   `window.procaptcha.start()` (or dispatches a `procaptcha:start` event),
- *   or the end user clicks the checkbox. In the latter case the click is
- *   carried through to the challenge the provider picks, so the user never
- *   has to click twice.
+ * When the widget starts the frictionless flow. `manual` renders the checkbox
+ * but defers everything else until `window.procaptcha.start()` is called or
+ * the user clicks the checkbox.
  */
 export enum StartModeEnum {
 	auto = "auto",
@@ -38,11 +31,7 @@ export const StartModeSchema = zEnum([
 ]);
 export type StartMode = zInfer<typeof StartModeSchema>;
 
-/**
- * DOM event that starts a widget rendered with `startMode: "manual"`.
- * Dispatched on `document`; `detail.element`, when present, restricts the
- * event to the widget rendered into that element.
- */
+// Dispatched on `document`. `detail.element` restricts it to one widget.
 export const PROCAPTCHA_START_EVENT = "procaptcha:start";
 
 export interface ProcaptchaStartEventDetail {

--- a/packages/types/src/config/startMode.ts
+++ b/packages/types/src/config/startMode.ts
@@ -1,0 +1,50 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { infer as zInfer } from "zod";
+import { enum as zEnum } from "zod";
+
+/**
+ * When the widget starts the frictionless flow (bot detection, behavioural
+ * collectors and the `/frictionless` round-trip that picks a challenge).
+ *
+ * - `auto` (default): as soon as the widget mounts.
+ * - `manual`: the widget renders its checkbox straight away, at its final
+ *   size, but does nothing else until the site calls
+ *   `window.procaptcha.start()` (or dispatches a `procaptcha:start` event),
+ *   or the end user clicks the checkbox. In the latter case the click is
+ *   carried through to the challenge the provider picks, so the user never
+ *   has to click twice.
+ */
+export enum StartModeEnum {
+	auto = "auto",
+	manual = "manual",
+}
+
+export const StartModeSchema = zEnum([
+	StartModeEnum.auto,
+	StartModeEnum.manual,
+]);
+export type StartMode = zInfer<typeof StartModeSchema>;
+
+/**
+ * DOM event that starts a widget rendered with `startMode: "manual"`.
+ * Dispatched on `document`; `detail.element`, when present, restricts the
+ * event to the widget rendered into that element.
+ */
+export const PROCAPTCHA_START_EVENT = "procaptcha:start";
+
+export interface ProcaptchaStartEventDetail {
+	element?: Element;
+}

--- a/packages/types/src/procaptcha-bundle/index.ts
+++ b/packages/types/src/procaptcha-bundle/index.ts
@@ -45,10 +45,6 @@ export interface ProcaptchaRenderOptions {
 	// solution; pass the same value to the server-side verify call and the
 	// provider will reject the token unless the two agree.
 	sessionId?: string;
-	// When the frictionless flow starts. Equivalent to the `data-start-mode`
-	// attribute. `manual` renders the checkbox immediately but defers bot
-	// detection and the `/frictionless` request until the site calls
-	// `window.procaptcha.start()` or the end user clicks the checkbox.
-	// Defaults to `auto`.
+	// Equivalent to the `data-start-mode` attribute. Defaults to `auto`.
 	startMode?: StartMode;
 }

--- a/packages/types/src/procaptcha-bundle/index.ts
+++ b/packages/types/src/procaptcha-bundle/index.ts
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import type { Languages } from "@prosopo/locale";
+import type { StartMode } from "../config/startMode.js";
 
 // note: do not use any Zod-related types inside the interface,
 // as this interface is re-exported by '@prosopo/procaptcha-wrapper' to external customers
@@ -44,4 +45,10 @@ export interface ProcaptchaRenderOptions {
 	// solution; pass the same value to the server-side verify call and the
 	// provider will reject the token unless the two agree.
 	sessionId?: string;
+	// When the frictionless flow starts. Equivalent to the `data-start-mode`
+	// attribute. `manual` renders the checkbox immediately but defers bot
+	// detection and the `/frictionless` request until the site calls
+	// `window.procaptcha.start()` or the end user clicks the checkbox.
+	// Defaults to `auto`.
+	startMode?: StartMode;
 }


### PR DESCRIPTION
Closes #2622

Rendering with `data-start-mode="manual"` (or `startMode: "manual"` in the render options) keeps bot detection, the collectors, the detector prefetch and the `/frictionless` request off page load. The checkbox still renders immediately at its final size, so nothing shifts.

The flow then starts on whichever comes first:

- `window.procaptcha.start(widgetId?)`, which dispatches a `procaptcha:start` event the widget listens for. The widget then waits for a click as it does today.
- The user clicking the checkbox. The challenge the provider picks mounts with `autoStart` and the click coordinates, so the user never clicks twice.

`execute()` also starts a manual widget. Auto mode is unchanged.

Changes: `StartModeEnum` and `startMode` in `@prosopo/types`; the manual placeholder and triggers in `ProcaptchaFrictionless`; `data-start-mode` resolution and `window.procaptcha.start()` in the bundle (the private bootstrap is renamed `boot`); a demo page; a changeset. Tests cover both triggers, event targeting, the one-shot guard, coords carry-through and the prefetch skip.

Docs: prosopo/docs#62, to merge after the release carrying this.