### PR TITLE
feat(captcha-severity): share the captcha severity ranking across all three call sites

### DIFF
--- a/.changeset/captcha-severity-package.md
+++ b/.changeset/captcha-severity-package.md
@@ -1,0 +1,19 @@
+---
+"@prosopo/captcha-severity": minor
+"@prosopo/provider": patch
+---
+
+Add `@prosopo/captcha-severity` and use it for the access rules and the traffic filter.
+
+"Which captcha challenge is stricter" is one idea with three callers, and each answered it with its own table: the traffic filter combining multiple `challenge` matches on one request (`resolveChallengePolicy`), the access rules breaking ties between equally-specific rules (`ruleHarshness`), and the decision machines resolving an undeclared middlebox against a site's vpn / datacenter policies (`resolveMiddleboxPolicy`, in captcha-private). They agreed on the order — image > puzzle > pow > frictionless — but nothing held them to it, and they disagreed on the encoding.
+
+The new package has **zero dependencies**, deliberately. Captcha types are string enums, so a plain `string` parameter accepts them without importing `CaptchaType` — and that import would not be free, because it lives in a module that pulls zod in for its schemas. The decision machines are bundled standalone and published through an API capped at 65,536 characters, a ceiling a runtime dependency on the `@prosopo/types` barrel has breached before.
+
+Two APIs, because "stricter" means two different things:
+
+- `rankCaptchaType` / `isStricterCaptchaType` compare the **type alone**, for callers that choose the type independently of its settings — as the traffic filter does, picking the strictest type and then separately merging the hardest parameters from every matched category.
+- `captchaPolicySeverity` / `isStricterCaptchaPolicy` compare a **whole policy**, type first and its own difficulty setting second, for callers where one complete policy must beat another — the access rules and the decision machines, where a tie on type alone would otherwise be decided by argument order.
+
+**Fixes an ordering bug in the access rules.** `ruleHarshness` scored `base + solvedImagesCount` with tiers 10 apart, and `solvedImagesCount` is validated by `imageMaxRoundsFieldSchema` — `number().int().min(2)`, with no upper bound and an `imageMaxRounds` default of 32. A `Restrict[pow]` rule carrying 32 rounds therefore scored 42 and outranked a `Restrict[image]` rule at 30, exactly inverting the intended order; 11 rounds on a puzzle rule was enough to do it. The intra-type component is now clamped below the tier gap, so no setting can lift a rule over a stricter captcha type.
+
+One further behaviour change: pow rules now break ties on `powDifficulty` rather than `solvedImagesCount`. Detector-authored pow rules drop `solvedImagesCount` (see `applyAccountAnomalyRules`), so every pow rule previously scored at the bottom of its tier regardless of difficulty. Image and puzzle both keep `solvedImagesCount` — it is the severity currency they share, which the provider maps onto a puzzle difficulty level via `severityToPuzzleDifficulty` rather than treating as a literal round count.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12648,6 +12648,10 @@
 			"resolved": "packages/api-route",
 			"link": true
 		},
+		"node_modules/@prosopo/captcha-severity": {
+			"resolved": "packages/captcha-severity",
+			"link": true
+		},
 		"node_modules/@prosopo/cli": {
 			"resolved": "packages/cli",
 			"link": true
@@ -30851,6 +30855,254 @@
 				"undici-types": "~6.20.0"
 			}
 		},
+		"packages/captcha-severity": {
+			"name": "@prosopo/captcha-severity",
+			"version": "1.0.0",
+			"license": "Apache-2.0",
+			"devDependencies": {
+				"@prosopo/config": "3.3.12",
+				"@types/node": "22.10.2",
+				"del-cli": "6.0.0",
+				"tslib": "2.7.0",
+				"typescript": "5.6.2",
+				"vite": "8.1.5",
+				"vitest": "4.1.10"
+			},
+			"engines": {
+				"node": "^24",
+				"npm": "^11"
+			}
+		},
+		"packages/captcha-severity/node_modules/@types/node": {
+			"version": "22.10.2",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.2.tgz",
+			"integrity": "sha512-Xxr6BBRCAOQixvonOye19wnzyDiUtTeqldOOmj3CkeblonbccA12PFwlufvRdrpjXxqnmUaeiU5EOA+7s5diUQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~6.20.0"
+			}
+		},
+		"packages/captcha-severity/node_modules/@vitest/expect": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+			"integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@standard-schema/spec": "^1.1.0",
+				"@types/chai": "^5.2.2",
+				"@vitest/spy": "4.1.10",
+				"@vitest/utils": "4.1.10",
+				"chai": "^6.2.2",
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"packages/captcha-severity/node_modules/@vitest/mocker": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+			"integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/spy": "4.1.10",
+				"estree-walker": "^3.0.3",
+				"magic-string": "^0.30.21"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"msw": "^2.4.9",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"msw": {
+					"optional": true
+				},
+				"vite": {
+					"optional": true
+				}
+			}
+		},
+		"packages/captcha-severity/node_modules/@vitest/pretty-format": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+			"integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"packages/captcha-severity/node_modules/@vitest/runner": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+			"integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/utils": "4.1.10",
+				"pathe": "^2.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"packages/captcha-severity/node_modules/@vitest/snapshot": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+			"integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "4.1.10",
+				"@vitest/utils": "4.1.10",
+				"magic-string": "^0.30.21",
+				"pathe": "^2.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"packages/captcha-severity/node_modules/@vitest/spy": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+			"integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"packages/captcha-severity/node_modules/@vitest/utils": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+			"integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "4.1.10",
+				"convert-source-map": "^2.0.0",
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"packages/captcha-severity/node_modules/convert-source-map": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"packages/captcha-severity/node_modules/estree-walker": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^1.0.0"
+			}
+		},
+		"packages/captcha-severity/node_modules/vitest": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+			"integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/expect": "4.1.10",
+				"@vitest/mocker": "4.1.10",
+				"@vitest/pretty-format": "4.1.10",
+				"@vitest/runner": "4.1.10",
+				"@vitest/snapshot": "4.1.10",
+				"@vitest/spy": "4.1.10",
+				"@vitest/utils": "4.1.10",
+				"es-module-lexer": "^2.0.0",
+				"expect-type": "^1.3.0",
+				"magic-string": "^0.30.21",
+				"obug": "^2.1.1",
+				"pathe": "^2.0.3",
+				"picomatch": "^4.0.3",
+				"std-env": "^4.0.0-rc.1",
+				"tinybench": "^2.9.0",
+				"tinyexec": "^1.0.2",
+				"tinyglobby": "^0.2.15",
+				"tinyrainbow": "^3.1.0",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+				"why-is-node-running": "^2.3.0"
+			},
+			"bin": {
+				"vitest": "vitest.mjs"
+			},
+			"engines": {
+				"node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"@edge-runtime/vm": "*",
+				"@opentelemetry/api": "^1.9.0",
+				"@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+				"@vitest/browser-playwright": "4.1.10",
+				"@vitest/browser-preview": "4.1.10",
+				"@vitest/browser-webdriverio": "4.1.10",
+				"@vitest/coverage-istanbul": "4.1.10",
+				"@vitest/coverage-v8": "4.1.10",
+				"@vitest/ui": "4.1.10",
+				"happy-dom": "*",
+				"jsdom": "*",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@edge-runtime/vm": {
+					"optional": true
+				},
+				"@opentelemetry/api": {
+					"optional": true
+				},
+				"@types/node": {
+					"optional": true
+				},
+				"@vitest/browser-playwright": {
+					"optional": true
+				},
+				"@vitest/browser-preview": {
+					"optional": true
+				},
+				"@vitest/browser-webdriverio": {
+					"optional": true
+				},
+				"@vitest/coverage-istanbul": {
+					"optional": true
+				},
+				"@vitest/coverage-v8": {
+					"optional": true
+				},
+				"@vitest/ui": {
+					"optional": true
+				},
+				"happy-dom": {
+					"optional": true
+				},
+				"jsdom": {
+					"optional": true
+				},
+				"vite": {
+					"optional": false
+				}
+			}
+		},
 		"packages/cli": {
 			"name": "@prosopo/cli",
 			"version": "3.8.4",
@@ -34328,6 +34580,7 @@
 				"@prosopo/api": "4.1.4",
 				"@prosopo/api-express-router": "3.1.80",
 				"@prosopo/api-route": "2.6.56",
+				"@prosopo/captcha-severity": "1.0.0",
 				"@prosopo/common": "3.1.52",
 				"@prosopo/database": "4.0.26",
 				"@prosopo/datasets": "3.1.76",

--- a/packages/captcha-severity/package.json
+++ b/packages/captcha-severity/package.json
@@ -1,0 +1,46 @@
+{
+	"name": "@prosopo/captcha-severity",
+	"version": "1.0.0",
+	"description": "Relative severity of the captcha types, and the helpers for picking the strictest when policies compete",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
+	"engines": {
+		"node": "^24",
+		"npm": "^11"
+	},
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js",
+			"require": "./dist/cjs/index.cjs"
+		}
+	},
+	"scripts": {
+		"clean": "del-cli --verbose dist tsconfig.tsbuildinfo",
+		"build": "npm run build:cross-env -- --mode ${NODE_ENV:-development}",
+		"build:cross-env": "vite build --config vite.esm.config.ts",
+		"build:tsc": "tsc --build --verbose",
+		"build:cjs": "NODE_ENV=${NODE_ENV:-development}; vite build --config vite.cjs.config.ts --mode $NODE_ENV",
+		"test": "NODE_ENV=${NODE_ENV:-test}; npx vitest run --config ./vite.test.config.ts",
+		"typecheck": "tsc --project tsconfig.types.json"
+	},
+	"type": "module",
+	"sideEffects": false,
+	"dependencies": {},
+	"devDependencies": {
+		"@prosopo/config": "3.3.12",
+		"@types/node": "22.10.2",
+		"del-cli": "6.0.0",
+		"tslib": "2.7.0",
+		"typescript": "5.6.2",
+		"vite": "8.1.5",
+		"vitest": "4.1.10"
+	},
+	"author": "Prosopo Limited",
+	"license": "Apache-2.0",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/prosopo/captcha.git",
+		"directory": "packages/captcha-severity"
+	}
+}

--- a/packages/captcha-severity/src/index.test.ts
+++ b/packages/captcha-severity/src/index.test.ts
@@ -1,0 +1,254 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, expect, it } from "vitest";
+import {
+	captchaPolicySeverity,
+	isStricterCaptchaPolicy,
+	isStricterCaptchaType,
+	rankCaptchaType,
+} from "./index.js";
+
+// The four members of CaptchaType, as bare strings. Not imported from
+// @prosopo/types — this package deliberately has no dependencies, and the
+// coupling is asserted on the consuming side instead.
+const TYPES = ["image", "puzzle", "pow", "frictionless"] as const;
+const STRICTEST_FIRST = ["image", "puzzle", "pow", "frictionless"] as const;
+
+// Well above imageMaxRoundsDefault (32). `solvedImagesCount` is validated by
+// `number().int().min(2)` with no upper bound, so "absurd" is reachable.
+const ABSURD_ROUNDS = 100_000;
+
+describe("rankCaptchaType", () => {
+	it("ranks image > puzzle > pow > frictionless", () => {
+		const ascending = [...STRICTEST_FIRST].reverse();
+		const ranks = ascending.map(rankCaptchaType);
+		expect(ranks).toEqual([...ranks].sort((a, b) => a - b));
+		expect(new Set(ranks).size).toBe(ascending.length);
+	});
+
+	it("ranks unset and unrecognised values at 0", () => {
+		expect(rankCaptchaType(undefined)).toBe(0);
+		expect(rankCaptchaType("")).toBe(0);
+		expect(rankCaptchaType("not-a-captcha-type")).toBe(0);
+	});
+
+	// frictionless used to tie with unset at 0 in the access-rule table.
+	it("ranks frictionless above unset", () => {
+		expect(rankCaptchaType("frictionless")).toBeGreaterThan(
+			rankCaptchaType(undefined),
+		);
+	});
+});
+
+describe("isStricterCaptchaType — type only, settings ignored", () => {
+	// Adjacent pairs in both orderings — non-adjacent comparisons would still
+	// pass with an off-by-one in the table.
+	it.each([
+		["image", "puzzle", true],
+		["puzzle", "image", false],
+		["puzzle", "pow", true],
+		["pow", "puzzle", false],
+		["pow", "frictionless", true],
+		["frictionless", "pow", false],
+	])(
+		"isStricterCaptchaType(%s, %s) === %s",
+		(candidate, incumbent, expected) => {
+			expect(isStricterCaptchaType(candidate, incumbent)).toBe(expected);
+		},
+	);
+
+	it("is false for equal types, so the incumbent is kept", () => {
+		for (const type of TYPES) {
+			expect(isStricterCaptchaType(type, type)).toBe(false);
+		}
+	});
+
+	it("treats any real type as stricter than unset", () => {
+		for (const type of TYPES) {
+			expect(isStricterCaptchaType(type, undefined)).toBe(true);
+			expect(isStricterCaptchaType(undefined, type)).toBe(false);
+		}
+	});
+
+	it("is false when both sides are unset", () => {
+		expect(isStricterCaptchaType(undefined, undefined)).toBe(false);
+	});
+});
+
+describe("captchaPolicySeverity — type dominates", () => {
+	it("orders by type before any setting", () => {
+		expect(captchaPolicySeverity({ captchaType: "image" })).toBeGreaterThan(
+			captchaPolicySeverity({ captchaType: "puzzle" }),
+		);
+		expect(captchaPolicySeverity({ captchaType: "puzzle" })).toBeGreaterThan(
+			captchaPolicySeverity({ captchaType: "pow" }),
+		);
+		expect(captchaPolicySeverity({ captchaType: "pow" })).toBeGreaterThan(
+			captchaPolicySeverity({ captchaType: "frictionless" }),
+		);
+	});
+
+	/**
+	 * The regression this package exists to prevent.
+	 *
+	 * The access rules previously scored `base + solvedImagesCount` with tiers
+	 * 10 apart, so a `Restrict[pow]` carrying 32 rounds (the default
+	 * `imageMaxRounds`) scored 42 and beat a `Restrict[image]` at 30. No
+	 * setting may lift a policy over a stricter captcha type.
+	 */
+	it("never lets a setting lift a policy over a stricter type", () => {
+		for (let i = 0; i < STRICTEST_FIRST.length - 1; i++) {
+			const stricter = STRICTEST_FIRST[i] as string;
+			const weaker = STRICTEST_FIRST[i + 1] as string;
+			const maxedOutWeaker = captchaPolicySeverity({
+				captchaType: weaker,
+				solvedImagesCount: ABSURD_ROUNDS,
+				powDifficulty: ABSURD_ROUNDS,
+			});
+			expect(maxedOutWeaker).toBeLessThan(
+				captchaPolicySeverity({ captchaType: stricter }),
+			);
+		}
+	});
+
+	it("scores an unset or unrecognised type at 0 regardless of settings", () => {
+		expect(
+			captchaPolicySeverity({ solvedImagesCount: 12, powDifficulty: 10 }),
+		).toBe(0);
+		expect(
+			captchaPolicySeverity({
+				captchaType: "not-a-captcha-type",
+				solvedImagesCount: 12,
+			}),
+		).toBe(0);
+	});
+});
+
+describe("captchaPolicySeverity — intra-tier axes", () => {
+	// image: more rounds is harder.
+	it("ranks image by solvedImagesCount", () => {
+		expect(
+			captchaPolicySeverity({ captchaType: "image", solvedImagesCount: 9 }),
+		).toBeGreaterThan(
+			captchaPolicySeverity({ captchaType: "image", solvedImagesCount: 2 }),
+		);
+	});
+
+	// pow: higher difficulty is harder.
+	it("ranks pow by powDifficulty", () => {
+		expect(
+			captchaPolicySeverity({ captchaType: "pow", powDifficulty: 8 }),
+		).toBeGreaterThan(
+			captchaPolicySeverity({ captchaType: "pow", powDifficulty: 4 }),
+		);
+	});
+
+	// puzzle shares the image severity currency: it has no rounds, so the
+	// provider maps solvedImagesCount onto a puzzle difficulty level. Detector
+	// rules keep the field on puzzle rules precisely for this.
+	it("ranks puzzle by solvedImagesCount, the shared severity currency", () => {
+		expect(
+			captchaPolicySeverity({ captchaType: "puzzle", solvedImagesCount: 9 }),
+		).toBeGreaterThan(
+			captchaPolicySeverity({ captchaType: "puzzle", solvedImagesCount: 2 }),
+		);
+	});
+
+	it("treats an unset setting as the bottom of its tier", () => {
+		expect(captchaPolicySeverity({ captchaType: "image" })).toBe(
+			captchaPolicySeverity({ captchaType: "image", solvedImagesCount: 0 }),
+		);
+		expect(
+			captchaPolicySeverity({ captchaType: "image", solvedImagesCount: 2 }),
+		).toBeGreaterThan(captchaPolicySeverity({ captchaType: "image" }));
+	});
+
+	// Each type reads only its own axis, so a setting that belongs to another
+	// type cannot move it.
+	it("ignores settings that do not govern the type", () => {
+		expect(
+			captchaPolicySeverity({ captchaType: "image", powDifficulty: 10 }),
+		).toBe(captchaPolicySeverity({ captchaType: "image" }));
+		expect(
+			captchaPolicySeverity({ captchaType: "pow", solvedImagesCount: 32 }),
+		).toBe(captchaPolicySeverity({ captchaType: "pow" }));
+		expect(
+			captchaPolicySeverity({ captchaType: "puzzle", powDifficulty: 10 }),
+		).toBe(captchaPolicySeverity({ captchaType: "puzzle" }));
+	});
+
+	// A negative or non-finite value must not drag a policy below its own tier.
+	it("clamps negative and non-finite settings", () => {
+		for (const bad of [-1, -ABSURD_ROUNDS, Number.NaN]) {
+			expect(
+				captchaPolicySeverity({
+					captchaType: "image",
+					solvedImagesCount: bad,
+				}),
+			).toBe(captchaPolicySeverity({ captchaType: "image" }));
+		}
+	});
+});
+
+describe("isStricterCaptchaPolicy — type then settings", () => {
+	it("breaks a same-type tie on the governing setting", () => {
+		expect(
+			isStricterCaptchaPolicy(
+				{ captchaType: "image", solvedImagesCount: 9 },
+				{ captchaType: "image", solvedImagesCount: 2 },
+			),
+		).toBe(true);
+		expect(
+			isStricterCaptchaPolicy(
+				{ captchaType: "image", solvedImagesCount: 2 },
+				{ captchaType: "image", solvedImagesCount: 9 },
+			),
+		).toBe(false);
+	});
+
+	it("still lets the type dominate the setting", () => {
+		expect(
+			isStricterCaptchaPolicy(
+				{ captchaType: "pow", powDifficulty: 10 },
+				{ captchaType: "image", solvedImagesCount: 2 },
+			),
+		).toBe(false);
+		expect(
+			isStricterCaptchaPolicy(
+				{ captchaType: "image", solvedImagesCount: 2 },
+				{ captchaType: "pow", powDifficulty: 10 },
+			),
+		).toBe(true);
+	});
+
+	it("is false for genuinely equal policies, so the incumbent is kept", () => {
+		expect(
+			isStricterCaptchaPolicy(
+				{ captchaType: "image", solvedImagesCount: 3 },
+				{ captchaType: "image", solvedImagesCount: 3 },
+			),
+		).toBe(false);
+	});
+
+	// The difference from the type-only comparison, stated directly.
+	it("differs from isStricterCaptchaType on a same-type pair", () => {
+		const harder = { captchaType: "image", solvedImagesCount: 9 };
+		const milder = { captchaType: "image", solvedImagesCount: 2 };
+		expect(isStricterCaptchaType(harder.captchaType, milder.captchaType)).toBe(
+			false,
+		);
+		expect(isStricterCaptchaPolicy(harder, milder)).toBe(true);
+	});
+});

--- a/packages/captcha-severity/src/index.ts
+++ b/packages/captcha-severity/src/index.ts
@@ -1,0 +1,230 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * How severe a captcha challenge is, and the helpers for picking the strictest
+ * when several policies compete for one request.
+ *
+ * Three call sites ask this question, and each used to answer it with its own
+ * table:
+ *
+ *   - the traffic filter, combining multiple `challenge` matches on a single
+ *     request (`resolveChallengePolicy`);
+ *   - the access rules, breaking ties between equally-specific rules
+ *     (`ruleHarshness`);
+ *   - the decision machines, resolving an undeclared middlebox against a
+ *     site's vpn / datacenter policies (`resolveMiddleboxPolicy`).
+ *
+ * They agreed on the order — image > puzzle > pow > frictionless — but nothing
+ * held them to it, and they disagreed on the encoding, which is where the
+ * tier-crossing bug documented on `TIER_GAP` came from.
+ *
+ * ## Two questions, two APIs
+ *
+ * "Stricter" means different things depending on what is being compared:
+ *
+ *   - **Type only** — is an image challenge stricter than a puzzle one?
+ *     `rankCaptchaType` / `isStricterCaptchaType`. Used where the type is
+ *     chosen independently of its settings, as the traffic filter does: it
+ *     picks the strictest type across matches, then separately merges the
+ *     hardest parameters from *all* matched categories.
+ *
+ *   - **Whole policy** — is `image` with 2 rounds stricter than `image` with
+ *     9? `captchaPolicySeverity` / `isStricterCaptchaPolicy`. Used where one
+ *     complete policy has to beat another, as the access rules and the
+ *     decision machines do — there the settings ride along with the type and
+ *     a tie on type alone would be decided by argument order.
+ *
+ * ## Zero dependencies, deliberately
+ *
+ * This package imports nothing, not even `@prosopo/types` for the
+ * `CaptchaType` enum. Captcha types are string enums, so a plain `string`
+ * parameter accepts them without the import — and the import would not be
+ * free. `CaptchaType` lives in a module that pulls zod in to build its
+ * schemas, and the decision machines are bundled standalone and published
+ * through an API capped at 65,536 characters, a ceiling a runtime dependency
+ * on the `@prosopo/types` barrel has breached before. A leaf with no imports
+ * cannot repeat that.
+ */
+
+/**
+ * Spacing between adjacent severity tiers.
+ *
+ * `captchaPolicySeverity` adds an intra-tier component on top of a tier, so
+ * that a 12-round image challenge outranks a 2-round one. The gap has to
+ * exceed anything that component can contribute, or the sum crosses into the
+ * next tier and the ordering inverts.
+ *
+ * That is not hypothetical. The access rules previously used gaps of 10 with
+ * `base + solvedImagesCount`, and `solvedImagesCount` is validated by
+ * `imageMaxRoundsFieldSchema` — `number().int().min(2)`, with **no upper
+ * bound** and a default `imageMaxRounds` of 32. So a `Restrict[pow]` rule
+ * carrying 32 rounds scored 10 + 32 = 42 and outranked a `Restrict[image]`
+ * rule at 30, exactly inverting the intended order. A `Restrict[puzzle]` with
+ * 11 rounds was enough to do it.
+ *
+ * 10,000 clears every bounded axis outright (`powDifficulty` maxes at 10,
+ * `puzzleTolerance` at 1000) and any plausible round count, and the intra-tier
+ * component is clamped below the gap regardless — so the ordering holds
+ * structurally rather than by luck.
+ */
+const TIER_GAP = 10_000;
+
+/** Largest intra-tier contribution, so a saturated tier can never reach the next. */
+const MAX_INTRA_TIER = TIER_GAP - 1;
+
+/**
+ * Severity tier per captcha type. Higher is stricter.
+ *
+ * Keyed by the enum's string values rather than the enum itself, so callers
+ * carrying a captcha type as a bare `string` — as the decision machines'
+ * policy bags do — rank it without importing `CaptchaType`.
+ */
+const CAPTCHA_TYPE_TIER: Record<string, number> = {
+	image: 4 * TIER_GAP,
+	puzzle: 3 * TIER_GAP,
+	pow: 2 * TIER_GAP,
+	frictionless: 1 * TIER_GAP,
+};
+
+/**
+ * The tunables that make one challenge of a given type harder than another.
+ *
+ * Structurally compatible with `ITrafficCategoryPolicy`, an `AccessRule`, and
+ * the decision machines' `TrafficCategoryPolicyBag`, so all three pass their
+ * own objects straight in.
+ *
+ * `puzzleTolerance` is deliberately absent, which is worth spelling out
+ * because a puzzle's difficulty plainly does depend on it. It is a *render*
+ * tunable: the traffic filter merges it across every matched category
+ * independently of which policy wins the type contest (taking the minimum),
+ * so it describes how the eventual puzzle is drawn rather than which policy
+ * was strictest. Nothing ranks policies by it today, and adding it here would
+ * silently start doing so.
+ *
+ * What carries puzzle severity instead is `solvedImagesCount`, on a puzzle
+ * rule. That reads like a mistake and is not: a puzzle has no rounds — one
+ * puzzle per session — so there is nothing for a round count to mean
+ * literally. The number is reused as a severity level, which the provider
+ * converts with `severityToPuzzleDifficulty` (see
+ * `provider/src/tasks/puzzle/puzzleDifficulty.ts`) into an index into
+ * `PUZZLE_DIFFICULTY_LEVELS`, the banded ladder that actually renders a
+ * harder puzzle. Detector-authored rules therefore keep the field on puzzle
+ * rules on purpose, and drop it for `pow`, which has its own dial — see
+ * `applyAccountAnomalyRules`.
+ */
+export interface CaptchaPolicySeverityInput {
+	captchaType?: string | undefined;
+	/**
+	 * Higher is harder. A literal round count on `image`; on `puzzle` a
+	 * severity level that the provider maps onto `PUZZLE_DIFFICULTY_LEVELS`
+	 * rather than running that many rounds. Ignored on `pow`.
+	 */
+	solvedImagesCount?: number | undefined;
+	/** PoW difficulty. Higher is harder. `pow`'s own dial. */
+	powDifficulty?: number | undefined;
+}
+
+const clampIntraTier = (value: number): number =>
+	Number.isFinite(value) ? Math.min(Math.max(value, 0), MAX_INTRA_TIER) : 0;
+
+/**
+ * Severity of a captcha type on its own, ignoring any settings.
+ *
+ * An unset or unrecognised type ranks 0 — below every real type — so a policy
+ * that names no captcha type never outranks one that does.
+ *
+ * Note that `frictionless` ranks *above* unset, where the access rules
+ * previously scored both at 0. Restrict-with-frictionless is not a
+ * configuration that makes operational sense, so nothing depended on the old
+ * tie; ranking it as a real type is the consistent reading.
+ */
+export const rankCaptchaType = (captchaType: string | undefined): number =>
+	captchaType === undefined ? 0 : (CAPTCHA_TYPE_TIER[captchaType] ?? 0);
+
+/**
+ * True when `candidate` is a stricter captcha *type* than `incumbent`,
+ * ignoring settings.
+ *
+ * Strictly greater, so an equal type keeps the incumbent. Callers reduce left
+ * to right, so a tie has to resolve to the first consistently rather than by
+ * table order. Where the settings should break that tie, use
+ * `isStricterCaptchaPolicy` instead.
+ */
+export const isStricterCaptchaType = (
+	candidate: string | undefined,
+	incumbent: string | undefined,
+): boolean => rankCaptchaType(candidate) > rankCaptchaType(incumbent);
+
+/**
+ * How much harder this policy's settings make it than the mildest challenge of
+ * the same type. Each type has one axis that governs its difficulty; the
+ * others are irrelevant to it and ignored.
+ *
+ * Unset means "not hardened", i.e. the bottom of the tier — an operator who
+ * set a value wants it to count for something against one who did not.
+ *
+ * `image` and `puzzle` share `solvedImagesCount` because it is the severity
+ * currency both speak: a puzzle has no rounds, so the provider maps the same
+ * number onto a puzzle difficulty level (`severityToPuzzleDifficulty`) instead
+ * of running that many rounds. `pow` has its own dial and detector-authored
+ * rules drop `solvedImagesCount` for it, so reading it there would rank every
+ * pow rule at the bottom of its tier regardless of how hard it actually is.
+ */
+const intraTierSeverity = (policy: CaptchaPolicySeverityInput): number => {
+	switch (policy.captchaType) {
+		case "image":
+		case "puzzle":
+			return clampIntraTier(policy.solvedImagesCount ?? 0);
+		case "pow":
+			return clampIntraTier(policy.powDifficulty ?? 0);
+		default:
+			// frictionless has no difficulty axis, and an unrecognised type has
+			// no tier for an intra-tier value to sit in.
+			return 0;
+	}
+};
+
+/**
+ * Severity of a complete policy: its captcha type, then its own difficulty
+ * setting as the tie-break within that type.
+ *
+ * The type always dominates. The intra-tier component is clamped below
+ * `TIER_GAP`, so no round count, difficulty or tolerance can lift a policy
+ * over a stricter captcha type — a 12-round pow challenge is still milder
+ * than a 2-round image one.
+ *
+ * Returns 0 for an unset or unrecognised type, whatever the settings say.
+ */
+export const captchaPolicySeverity = (
+	policy: CaptchaPolicySeverityInput,
+): number => {
+	const tier = rankCaptchaType(policy.captchaType);
+	if (tier === 0) return 0;
+	return tier + intraTierSeverity(policy);
+};
+
+/**
+ * True when `candidate` is a stricter policy than `incumbent`, comparing the
+ * captcha type first and its difficulty setting second.
+ *
+ * Strictly greater, so two policies of equal severity keep the incumbent —
+ * callers reduce left to right and must resolve a genuine tie to the first
+ * consistently.
+ */
+export const isStricterCaptchaPolicy = (
+	candidate: CaptchaPolicySeverityInput,
+	incumbent: CaptchaPolicySeverityInput,
+): boolean =>
+	captchaPolicySeverity(candidate) > captchaPolicySeverity(incumbent);

--- a/packages/captcha-severity/tsconfig.cjs.json
+++ b/packages/captcha-severity/tsconfig.cjs.json
@@ -1,0 +1,13 @@
+{
+	"extends": "../../tsconfig.cjs.json",
+	"compilerOptions": {
+		"rootDir": "./src",
+		"outDir": "./dist/cjs"
+	},
+	"include": ["src"],
+	"references": [
+		{
+			"path": "../../dev/config/tsconfig.cjs.json"
+		}
+	]
+}

--- a/packages/captcha-severity/tsconfig.json
+++ b/packages/captcha-severity/tsconfig.json
@@ -4,12 +4,7 @@
 		"rootDir": "./src",
 		"outDir": "./dist"
 	},
-	"include": [
-		"src",
-		"src/**/*.ts",
-		"src/**/*.json",
-		"src/**/*.d.ts"
-	],
+	"include": ["src", "src/**/*.ts", "src/**/*.json", "src/**/*.d.ts"],
 	"references": [
 		{
 			"path": "../../dev/config/tsconfig.json"

--- a/packages/captcha-severity/tsconfig.json
+++ b/packages/captcha-severity/tsconfig.json
@@ -1,0 +1,18 @@
+{
+	"extends": "../../tsconfig.esm.json",
+	"compilerOptions": {
+		"rootDir": "./src",
+		"outDir": "./dist"
+	},
+	"include": [
+		"src",
+		"src/**/*.ts",
+		"src/**/*.json",
+		"src/**/*.d.ts"
+	],
+	"references": [
+		{
+			"path": "../../dev/config/tsconfig.json"
+		}
+	]
+}

--- a/packages/captcha-severity/tsconfig.json
+++ b/packages/captcha-severity/tsconfig.json
@@ -4,7 +4,13 @@
 		"rootDir": "./src",
 		"outDir": "./dist"
 	},
-	"include": ["src", "src/**/*.ts", "src/**/*.json", "src/**/*.d.ts"],
+	"include": [
+		"src",
+		"src/**/*.ts",
+		"src/**/*.tsx",
+		"src/**/*.json",
+		"src/**/*.d.ts"
+	],
 	"references": [
 		{
 			"path": "../../dev/config/tsconfig.json"

--- a/packages/captcha-severity/tsconfig.types.json
+++ b/packages/captcha-severity/tsconfig.types.json
@@ -1,0 +1,11 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"emitDeclarationOnly": true,
+		"declaration": true,
+		"declarationMap": false,
+		"composite": false,
+		"sourceMap": false,
+		"inlineSourceMap": false
+	}
+}

--- a/packages/captcha-severity/vite.cjs.config.ts
+++ b/packages/captcha-severity/vite.cjs.config.ts
@@ -1,0 +1,24 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import path from "node:path";
+import { ViteCommonJSConfig } from "@prosopo/config";
+
+export default function () {
+	return ViteCommonJSConfig(
+		path.basename("."),
+		path.resolve("./tsconfig.json"),
+		"src/index.ts",
+	);
+}

--- a/packages/captcha-severity/vite.esm.config.ts
+++ b/packages/captcha-severity/vite.esm.config.ts
@@ -1,0 +1,24 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import path from "node:path";
+import { ViteEsmConfig } from "@prosopo/config";
+
+export default function () {
+	return ViteEsmConfig(
+		path.basename("."),
+		path.resolve("./tsconfig.json"),
+		"src/index.ts",
+	);
+}

--- a/packages/captcha-severity/vite.test.config.ts
+++ b/packages/captcha-severity/vite.test.config.ts
@@ -1,0 +1,17 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { ViteTestConfig } from "@prosopo/config";
+
+export default ViteTestConfig();

--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -26,6 +26,7 @@
 		"@prosopo/api": "4.1.4",
 		"@prosopo/api-express-router": "3.1.80",
 		"@prosopo/api-route": "2.6.56",
+		"@prosopo/captcha-severity": "1.0.0",
 		"@prosopo/common": "3.1.52",
 		"@prosopo/database": "4.0.26",
 		"@prosopo/datasets": "3.1.76",

--- a/packages/provider/src/api/blacklistRequestInspector.ts
+++ b/packages/provider/src/api/blacklistRequestInspector.ts
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import { randomUUID } from "node:crypto";
+import { captchaPolicySeverity } from "@prosopo/captcha-severity";
 import type { Logger } from "@prosopo/logger";
 import {
 	ApiPrefix,
@@ -211,22 +212,6 @@ const ruleSpecificity = (
 	return score;
 };
 
-// Per-captcha-type harshness ranks for Restrict rules. Used as the
-// equal-specificity tiebreaker (issue #3713). Gaps of 10 between tiers
-// leave room for `solvedImagesCount` to break ties within the image
-// tier without crossing into the puzzle tier — a 12-round image still
-// ranks above puzzle/pow, which is the intended ordering.
-const CAPTCHA_TYPE_HARSHNESS: Record<CaptchaType, number> = {
-	[CaptchaType.image]: 30,
-	[CaptchaType.puzzle]: 20,
-	[CaptchaType.pow]: 10,
-	// Frictionless isn't a routing target for Restrict rules but include it
-	// so the Record is total over CaptchaType — keeps the type-checker honest
-	// if the enum grows. Restrict-with-frictionless wouldn't make operational
-	// sense and ranks at the bottom of the captcha tiers if it ever appears.
-	[CaptchaType.frictionless]: 0,
-};
-
 // Harshness within an equal-specificity tier (issue #3713). On equal
 // specificity, the harshest matching rule wins:
 //   Block  >  Restrict[image, rounds DESC]  >  Restrict[puzzle]  >  Restrict[pow]
@@ -234,6 +219,29 @@ const CAPTCHA_TYPE_HARSHNESS: Record<CaptchaType, number> = {
 // less-specific Block, because the operator deliberately narrowed scope
 // for that combination. Harshness only decides ties between rules at the
 // same specificity, replacing the prior Block-vs-Restrict-only tiebreaker.
+//
+// The ordering comes from `@prosopo/captcha-severity`, shared with the
+// traffic filter's `resolveChallengePolicy` and the decision machines'
+// `resolveMiddleboxPolicy` — all three rank competing policies by the same
+// notion of "stricter". `captchaPolicySeverity` ranks the captcha type first
+// and its own difficulty setting second, so a rule's settings break ties
+// within a type without ever crossing between types.
+//
+// This previously kept its own table with tiers 10 apart and a raw
+// `base + solvedImagesCount`. `solvedImagesCount` is validated by
+// `imageMaxRoundsFieldSchema` (`number().int().min(2)`, no upper bound, and
+// `imageMaxRounds` defaults to 32), so a Restrict[pow] carrying 32 rounds
+// scored 42 and outranked a Restrict[image] at 30 — inverting the intended
+// order. The intra-type component is now clamped below the tier gap, so no
+// setting can lift a rule over a stricter captcha type.
+//
+// One deliberate change: pow rules now break ties on `powDifficulty` rather
+// than `solvedImagesCount`. Detector-authored pow rules drop
+// `solvedImagesCount` (see applyAccountAnomalyRules), so every pow rule
+// previously scored at the bottom of its tier regardless of difficulty.
+// Image and puzzle both keep `solvedImagesCount` — it is the severity
+// currency they share, which the provider maps onto a puzzle difficulty
+// level via `severityToPuzzleDifficulty` rather than a literal round count.
 //
 // `deferToVerify` doesn't affect this ordering: it controls *when* a Block
 // fires (request-time vs verify-time), not how severe it is. The flag
@@ -243,12 +251,7 @@ const ruleHarshness = (rule: AccessRule): number => {
 	if (rule.type === AccessPolicyType.Block) {
 		return Number.MAX_SAFE_INTEGER;
 	}
-	if (rule.captchaType === undefined) {
-		return 0;
-	}
-	const base = CAPTCHA_TYPE_HARSHNESS[rule.captchaType];
-	const rounds = rule.solvedImagesCount ?? 0;
-	return base + rounds;
+	return captchaPolicySeverity(rule);
 };
 
 /**

--- a/packages/provider/src/tasks/spam/checkTrafficFilter.ts
+++ b/packages/provider/src/tasks/spam/checkTrafficFilter.ts
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { isStricterCaptchaType } from "@prosopo/captcha-severity";
 import {
-	CaptchaType,
+	type CaptchaType,
 	type IPInfoResponse,
 	type IPInfoResult,
 	type IPuzzleSettings,
@@ -301,16 +302,9 @@ export const checkTrafficFilter = (
 // request. `block` outranks any challenge (short-circuited earlier in
 // `checkTrafficFilter`); among captcha types, image outranks puzzle
 // outranks pow — a stricter check is monotonically preferred so the
-// operator's hardest configured policy wins.
-const CAPTCHA_TYPE_RANK: Record<CaptchaType, number> = {
-	[CaptchaType.image]: 4,
-	[CaptchaType.puzzle]: 3,
-	[CaptchaType.pow]: 2,
-	[CaptchaType.frictionless]: 1,
-};
-
-const rankCaptchaType = (t: CaptchaType | undefined): number =>
-	t === undefined ? 0 : (CAPTCHA_TYPE_RANK[t] ?? 0);
+// operator's hardest configured policy wins. The ordering comes from
+// `@prosopo/captcha-severity`, shared with the access rules'
+// `ruleHarshness` and the decision machines' `resolveMiddleboxPolicy`.
 
 export type ResolvedChallengePolicy = {
 	captchaType?: CaptchaType;
@@ -344,10 +338,7 @@ export const resolveChallengePolicy = (
 
 	let winningCaptchaType: CaptchaType | undefined;
 	for (const m of challenges) {
-		if (
-			rankCaptchaType(m.policy.captchaType) >
-			rankCaptchaType(winningCaptchaType)
-		) {
+		if (isStricterCaptchaType(m.policy.captchaType, winningCaptchaType)) {
 			winningCaptchaType = m.policy.captchaType;
 		}
 	}

--- a/packages/provider/tsconfig.cjs.json
+++ b/packages/provider/tsconfig.cjs.json
@@ -27,6 +27,9 @@
 			"path": "../logger/tsconfig.cjs.json"
 		},
 		{
+			"path": "../captcha-severity/tsconfig.cjs.json"
+		},
+		{
 			"path": "../database/tsconfig.cjs.json"
 		},
 		{

--- a/packages/provider/tsconfig.json
+++ b/packages/provider/tsconfig.json
@@ -33,6 +33,9 @@
 			"path": "../../dev/config"
 		},
 		{
+			"path": "../captcha-severity"
+		},
+		{
 			"path": "../database"
 		},
 		{


### PR DESCRIPTION
Supersedes #3180, which put the ranking in `@prosopo/types` and covered only two of the three call sites.

## The duplication

"Which captcha challenge is stricter" is one idea with three callers, and each answered it with its own table:

| call site | table | values | extra |
|---|---|---|---|
| `checkTrafficFilter.ts` — traffic filter | `CAPTCHA_TYPE_RANK` | 4/3/2/1 | — |
| `blacklistRequestInspector.ts` — access rules | `CAPTCHA_TYPE_HARSHNESS` | 30/20/10/**0** | `+ solvedImagesCount`, Block = `MAX_SAFE_INTEGER` |
| a downstream routing consumer | `CAPTCHA_TYPE_RANK` | 4/3/2/1 | — |

Same order — **image > puzzle > pow > frictionless** — but nothing held them to it, and they disagreed on the encoding.

## Bug fixed: the access-rule scale is unsound

`ruleHarshness` scored `base + solvedImagesCount` with tiers **10 apart**. `solvedImagesCount` is validated by `imageMaxRoundsFieldSchema` — `number().int().min(2)`, **no upper bound** — and `imageMaxRounds` defaults to **32**. So:

```
Restrict[image,  0 rounds] = 30
Restrict[puzzle, 11 rounds] = 31   <-- outranks image
Restrict[pow,    32 rounds] = 42   <-- outranks image
```

The intended order inverts. The intra-type component is now clamped below the tier gap, so no setting can lift a rule over a stricter captcha type — asserted directly, including at absurd round counts.

## Two APIs, because "stricter" means two things

- **`rankCaptchaType` / `isStricterCaptchaType`** — the **type alone**. For callers that choose the type independently of its settings: the traffic filter picks the strictest type, then *separately* merges the hardest parameters from every matched category.
- **`captchaPolicySeverity` / `isStricterCaptchaPolicy`** — a **whole policy**, type first and its own difficulty second. For callers where one complete policy must beat another, and where `image(2 rounds)` vs `image(9 rounds)` would otherwise tie on type and be decided by argument order.

## Zero dependencies, deliberately

The package imports nothing — not even `@prosopo/types` for `CaptchaType`. Captcha types are string enums, so a plain `string` parameter accepts them without the import, and that import is not free: `captchaType.ts` pulls zod in to build its schemas. Downstream consumers bundle this standalone under a hard source-size ceiling, which a runtime dependency on the `@prosopo/types` barrel has breached before. A leaf with no imports cannot repeat that.

## Per-type difficulty axes

Which setting breaks a tie *within* a type is not uniform, and getting it wrong is silent:

- **image** → `solvedImagesCount`, a literal round count.
- **puzzle** → `solvedImagesCount` too. This reads like a mistake and is not — a puzzle has no rounds, so the number is a *severity level* that the provider converts via `severityToPuzzleDifficulty` into an index into `PUZZLE_DIFFICULTY_LEVELS`. Verified end-to-end from rule authoring through `accessPolicy.ts` to `frictionlessTasks.ts`.
- **pow** → `powDifficulty`. Rules authored for pow drop `solvedImagesCount`, so reading it there ranked every pow rule at the bottom of its tier regardless of difficulty. This is a behaviour change, and a fix.

`puzzleTolerance` is deliberately excluded: it is a render tunable, merged across matched categories independently of which policy wins, and nothing ranks policies by it today.

## Tests

25 cases in the new package: the ordering pinned as an ordered list; adjacent pairs in both orderings; equal rank keeping the incumbent; every axis read only by the type that governs it; negative / non-finite clamping; and the regression above asserted against absurd round counts.

The 5 existing `rankCandidateRules` harshness tests in `blacklistRequestInspector.unit.test.ts` pass unchanged, confirming the access-rule semantics are preserved.

## Note — unrelated pre-existing failures on `main`

`blacklistRequestInspector.unit.test.ts` has **20 failures on `origin/main` with this branch's changes stashed** (`TypeError: classifyBrowser is not a function`), and `trafficFilterRequestTime.unit.test.ts` one more (`clampImageRounds is not a function`). Both are mock-wiring issues in those test files, not introduced here — I diffed the failing-test sets to confirm this branch adds none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
