### PR TITLE
chore: strip non-essential comments from the manual start mode change

### DIFF
--- a/.changeset/strip-manual-start-comments.md
+++ b/.changeset/strip-manual-start-comments.md
@@ -1,0 +1,4 @@
+---
+---
+
+Comment-only cleanup following #3181; no functional change.

--- a/packages/procaptcha-bundle/src/index.ts
+++ b/packages/procaptcha-bundle/src/index.ts
@@ -84,8 +84,6 @@ const widgetFactory = new WidgetFactory(new WidgetThemeResolver());
  *
  * Fire-and-forget by design — a failed prefetch is indistinguishable from no
  * prefetch, and the detection path falls back to resolving a provider itself.
- *
- * Skipped in manual start mode so nothing reaches the provider on page load.
  */
 const startDetectorPrefetch = (
 	siteKey: string | null,
@@ -287,11 +285,7 @@ export const execute = () => {
 	document.dispatchEvent(executeEvent);
 };
 
-/**
- * Starts a widget rendered with `startMode: "manual"`; omit the id to start
- * every widget. Sent as a `procaptcha:start` event so direct-React
- * integrations can dispatch the same thing themselves.
- */
+/** Starts a `startMode: "manual"` widget; omit the id to start all of them. */
 export const start = (widgetId?: string): void => {
 	const ids: string[] =
 		undefined === widgetId ? Array.from(procaptchaWidgets.keys()) : [widgetId];

--- a/packages/procaptcha-bundle/src/util/startMode.ts
+++ b/packages/procaptcha-bundle/src/util/startMode.ts
@@ -22,7 +22,6 @@ import {
 
 export const START_MODE_ATTRIBUTE = "data-start-mode";
 
-// An unrecognised value falls back to `auto` rather than failing the render.
 export const resolveStartMode = (
 	renderOptions: ProcaptchaRenderOptions | undefined,
 	element: Element,

--- a/packages/procaptcha-frictionless/src/ProcaptchaFrictionless.tsx
+++ b/packages/procaptcha-frictionless/src/ProcaptchaFrictionless.tsx
@@ -127,12 +127,9 @@ export const ProcaptchaFrictionless = ({
 	// because `providerRetry` re-invokes `start` with no arguments, which would
 	// otherwise drop the flag on the first provider retry.
 	const nextMountAutoStartRef = useRef(false);
-	// Manual start mode: nothing runs until a `procaptcha:start` event or a
-	// checkbox click, whichever comes first.
 	const manualStart = config.startMode === StartModeEnum.manual;
 	const manualStartedRef = useRef(false);
-	// The placeholder is built before `start()` exists in this scope, so its
-	// click handler goes through a ref filled in below.
+	// The placeholder is built before `start()` exists in this scope.
 	const manualCheckboxHandlerRef = useRef(noopCheckboxHandler);
 
 	useEffect(() => {
@@ -157,7 +154,6 @@ export const ProcaptchaFrictionless = ({
 			stateRef.current.errorMessage,
 			i18n.isInitialized,
 			i18n.t,
-			// Manual mode has nothing in flight, so it shows a live checkbox.
 			!manualStart,
 			manualStart
 				? (event: CheckboxEvent) => manualCheckboxHandlerRef.current(event)
@@ -396,8 +392,6 @@ export const ProcaptchaFrictionless = ({
 		});
 	};
 
-	// `autoStart` + `coords` make the widget the provider picks open on mount
-	// from the click that started it, so the user never clicks twice.
 	const startManually = async (
 		autoStart: boolean,
 		coords?: RetryCoords,
@@ -430,8 +424,6 @@ export const ProcaptchaFrictionless = ({
 		await startManually(true, normaliseRetryCoords(x, y) ?? undefined);
 	};
 
-	// `procaptcha:execute` has no inner widget to land on yet in manual mode,
-	// so it is honoured here with `autoStart`.
 	// biome-ignore lint/correctness/useExhaustiveDependencies: intentional — `startManually` captures the mount-time `start()`, as the auto-mode effect below does.
 	useEffect(() => {
 		if (!manualStart) return;

--- a/packages/types/src/config/startMode.ts
+++ b/packages/types/src/config/startMode.ts
@@ -15,11 +15,6 @@
 import type { infer as zInfer } from "zod";
 import { enum as zEnum } from "zod";
 
-/**
- * When the widget starts the frictionless flow. `manual` renders the checkbox
- * but defers everything else until `window.procaptcha.start()` is called or
- * the user clicks the checkbox.
- */
 export enum StartModeEnum {
 	auto = "auto",
 	manual = "manual",
@@ -31,7 +26,6 @@ export const StartModeSchema = zEnum([
 ]);
 export type StartMode = zInfer<typeof StartModeSchema>;
 
-// Dispatched on `document`. `detail.element` restricts it to one widget.
 export const PROCAPTCHA_START_EVENT = "procaptcha:start";
 
 export interface ProcaptchaStartEventDetail {

--- a/packages/types/src/procaptcha-bundle/index.ts
+++ b/packages/types/src/procaptcha-bundle/index.ts
@@ -45,6 +45,5 @@ export interface ProcaptchaRenderOptions {
 	// solution; pass the same value to the server-side verify call and the
 	// provider will reject the token unless the two agree.
 	sessionId?: string;
-	// Equivalent to the `data-start-mode` attribute. Defaults to `auto`.
 	startMode?: StartMode;
 }


### PR DESCRIPTION
Follow-up to #3181, which merged before this commit landed. Comments only, no behaviour change.