### PR TITLE
refactor(captcha-severity): own the puzzle difficulty ladder

### DIFF
--- a/.changeset/puzzle-ladder-to-captcha-severity.md
+++ b/.changeset/puzzle-ladder-to-captcha-severity.md
@@ -1,0 +1,16 @@
+---
+"@prosopo/captcha-severity": minor
+"@prosopo/provider": patch
+---
+
+Move the puzzle difficulty ladder into `@prosopo/captcha-severity`, so every consumer derives a difficulty from one table.
+
+`PUZZLE_DIFFICULTY_LEVELS`, `MAX_AUTO_ESCALATION_LEVEL`, `MIN_DECOY_HOLE_DARKEN_MARGIN`, `clampDifficultyLevel` and `severityToPuzzleDifficulty` lived in `provider/src/tasks/puzzle/puzzleDifficulty.ts`, reachable only from inside the provider — the severity package's own docs described the ladder at length but did not hold it. Anything else that has to answer "what difficulty is this puzzle" had to restate the mapping, and the consumers that author and edit puzzle rules sit outside the provider.
+
+They can import it now. The severity package already answers "which of these policies is stricter" off `solvedImagesCount`; the ladder answers what a puzzle policy carrying that number is actually served at, which is the same question one step further in.
+
+Sampling a concrete render from a level's bands stays in the provider as `samplePuzzleDifficulty`: it needs `IPuzzleSettings` from `@prosopo/types` and a `node:crypto`-backed sampler, and the severity package's zero-dependency, browser-safe property is load-bearing for consumers that bundle it standalone.
+
+Adds `puzzleDifficultyToSeverity`, the inverse of `severityToPuzzleDifficulty`. Writers need that direction — a rule editor turning a chosen difficulty into the field the rule carries, or rule authoring normalising a count inherited from the image path. Each level spans two rounds, so without a canonical value per level a writer picks between numbers that produce the identical puzzle, and the difference survives only to break severity ties arbitrarily. The round-trip is pinned by tests.
+
+No behaviour change in the provider: same table, same thresholds, same clamping.

--- a/packages/captcha-severity/src/index.ts
+++ b/packages/captcha-severity/src/index.ts
@@ -51,7 +51,19 @@
  * schemas, and some consumers bundle this standalone under a hard source-size
  * ceiling that a runtime dependency on the `@prosopo/types` barrel has
  * breached before. A leaf with no imports cannot repeat that.
+ *
+ * It is also why the puzzle ladder re-exported below stops at the arithmetic:
+ * drawing a render out of a level's bands needs `IPuzzleSettings` and a
+ * `node:crypto` sampler, so that half stays in the provider.
  */
+
+/**
+ * The puzzle difficulty ladder. Severity ranks a policy; the ladder says what
+ * a puzzle policy carrying that severity is actually served at. Both answers
+ * belong to the same question, so they ship from one package — see
+ * `puzzleDifficulty.ts`.
+ */
+export * from "./puzzleDifficulty.js";
 
 /**
  * Spacing between adjacent severity tiers.

--- a/packages/captcha-severity/src/puzzleDifficulty.test.ts
+++ b/packages/captcha-severity/src/puzzleDifficulty.test.ts
@@ -141,8 +141,8 @@ describe("puzzleDifficultyToSeverity", () => {
 	it("leaves the site's own settings in force at level 0", () => {
 		// Level 0 samples no band, so the count it maps to must be one the
 		// provider reads as "nothing escalated this session".
-		expect(severityToPuzzleDifficulty(puzzleDifficultyToSeverity(0, 2), 2)).toBe(
-			0,
-		);
+		expect(
+			severityToPuzzleDifficulty(puzzleDifficultyToSeverity(0, 2), 2),
+		).toBe(0);
 	});
 });

--- a/packages/captcha-severity/src/puzzleDifficulty.test.ts
+++ b/packages/captcha-severity/src/puzzleDifficulty.test.ts
@@ -1,0 +1,148 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, expect, it } from "vitest";
+import {
+	MAX_AUTO_ESCALATION_LEVEL,
+	PUZZLE_DIFFICULTY_LEVELS,
+	clampDifficultyLevel,
+	puzzleDifficultyToSeverity,
+	severityToPuzzleDifficulty,
+} from "./puzzleDifficulty.js";
+
+describe("PUZZLE_DIFFICULTY_LEVELS table", () => {
+	it("is ordered strictly harder as the level rises", () => {
+		for (let i = 1; i < PUZZLE_DIFFICULTY_LEVELS.length; i++) {
+			const prev = PUZZLE_DIFFICULTY_LEVELS[i - 1];
+			const cur = PUZZLE_DIFFICULTY_LEVELS[i];
+			if (!prev || !cur) throw new Error("missing level");
+			// Harder = tighter tolerance, more decoys, decoys closer to the real
+			// cut's darkness, stronger decoy rims, smaller pieces.
+			expect(cur.tolerance.max).toBeLessThan(prev.tolerance.max);
+			expect(cur.decoyCount.min).toBeGreaterThanOrEqual(prev.decoyCount.min);
+			expect(cur.decoyHoleDarken.max).toBeLessThan(prev.decoyHoleDarken.max);
+			expect(cur.decoyEdgeDarkness.max).toBeGreaterThan(
+				prev.decoyEdgeDarkness.max,
+			);
+			expect(cur.pieceScale.max).toBeLessThan(prev.pieceScale.max);
+		}
+	});
+
+	it("overlaps adjacent bands so one render does not identify the level", () => {
+		// If bands were disjoint, a solver could read the level straight off the
+		// decoy count and know whether it had been flagged.
+		for (let i = 1; i < PUZZLE_DIFFICULTY_LEVELS.length; i++) {
+			const prev = PUZZLE_DIFFICULTY_LEVELS[i - 1];
+			const cur = PUZZLE_DIFFICULTY_LEVELS[i];
+			if (!prev || !cur) throw new Error("missing level");
+			expect(cur.decoyCount.min).toBeLessThanOrEqual(prev.decoyCount.max);
+			expect(cur.tolerance.max).toBeGreaterThanOrEqual(prev.tolerance.min);
+		}
+	});
+
+	it("indexes each band by its own position", () => {
+		PUZZLE_DIFFICULTY_LEVELS.forEach((band, index) => {
+			expect(band.level).toBe(index);
+		});
+	});
+});
+
+describe("severityToPuzzleDifficulty", () => {
+	it("maps no requested rounds to the baseline level", () => {
+		expect(severityToPuzzleDifficulty(undefined, 2)).toBe(0);
+	});
+
+	it("maps a request at or below the site baseline to the baseline level", () => {
+		expect(severityToPuzzleDifficulty(2, 2)).toBe(0);
+		expect(severityToPuzzleDifficulty(1, 2)).toBe(0);
+	});
+
+	it("rises monotonically with rounds requested above the baseline", () => {
+		const levels = [0, 1, 2, 3, 4, 5, 6, 7, 8, 12].map((extra) =>
+			severityToPuzzleDifficulty(2 + extra, 2, PUZZLE_DIFFICULTY_LEVELS.length),
+		);
+		for (let i = 1; i < levels.length; i++) {
+			expect(levels[i]).toBeGreaterThanOrEqual(levels[i - 1] as number);
+		}
+	});
+
+	it("is relative to the site baseline, not an absolute round count", () => {
+		// Same absolute count means different severity on sites whose ordinary
+		// challenge is a different length.
+		expect(severityToPuzzleDifficulty(6, 2)).toBeGreaterThan(
+			severityToPuzzleDifficulty(6, 6),
+		);
+	});
+
+	it("caps automatic escalation below the hardest level", () => {
+		// With image disabled there is no fallback modality, so the hardest
+		// level must not be reachable by escalation alone.
+		expect(severityToPuzzleDifficulty(100, 2)).toBe(MAX_AUTO_ESCALATION_LEVEL);
+		expect(MAX_AUTO_ESCALATION_LEVEL).toBeLessThan(
+			PUZZLE_DIFFICULTY_LEVELS.length - 1,
+		);
+	});
+});
+
+describe("clampDifficultyLevel", () => {
+	it("clamps out-of-range and non-finite input", () => {
+		expect(clampDifficultyLevel(-5)).toBe(0);
+		expect(clampDifficultyLevel(Number.NaN)).toBe(0);
+		expect(clampDifficultyLevel(99)).toBe(MAX_AUTO_ESCALATION_LEVEL);
+	});
+});
+
+describe("puzzleDifficultyToSeverity", () => {
+	// The property every writer depends on: a difficulty chosen in a rule
+	// editor, or normalised by a detector, must come back off the wire as the
+	// same difficulty the provider serves.
+	it("round-trips every reachable level, on any site baseline", () => {
+		for (const baseImageRounds of [1, 2, 5, 10]) {
+			for (let level = 0; level <= MAX_AUTO_ESCALATION_LEVEL; level++) {
+				const rounds = puzzleDifficultyToSeverity(level, baseImageRounds);
+				expect(severityToPuzzleDifficulty(rounds, baseImageRounds)).toBe(level);
+			}
+		}
+	});
+
+	it("round-trips the reserved level when the caller lifts the ceiling", () => {
+		const maxLevel = PUZZLE_DIFFICULTY_LEVELS.length - 1;
+		const rounds = puzzleDifficultyToSeverity(maxLevel, 2, maxLevel);
+		expect(severityToPuzzleDifficulty(rounds, 2, maxLevel)).toBe(maxLevel);
+	});
+
+	it("gives each level a distinct round count", () => {
+		const counts = Array.from(
+			{ length: MAX_AUTO_ESCALATION_LEVEL + 1 },
+			(_, level) => puzzleDifficultyToSeverity(level, 2),
+		);
+		expect(new Set(counts).size).toBe(counts.length);
+	});
+
+	it("clamps to the same ceiling severityToPuzzleDifficulty does", () => {
+		expect(puzzleDifficultyToSeverity(99, 2)).toBe(
+			puzzleDifficultyToSeverity(MAX_AUTO_ESCALATION_LEVEL, 2),
+		);
+		expect(puzzleDifficultyToSeverity(-1, 2)).toBe(2);
+		expect(puzzleDifficultyToSeverity(Number.NaN, 2)).toBe(2);
+	});
+
+	it("leaves the site's own settings in force at level 0", () => {
+		// Level 0 samples no band, so the count it maps to must be one the
+		// provider reads as "nothing escalated this session".
+		expect(severityToPuzzleDifficulty(puzzleDifficultyToSeverity(0, 2), 2)).toBe(
+			0,
+		);
+	});
+});

--- a/packages/captcha-severity/src/puzzleDifficulty.ts
+++ b/packages/captcha-severity/src/puzzleDifficulty.ts
@@ -1,0 +1,223 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * The puzzle difficulty ladder, and the conversions between it and the
+ * severity currency the rest of the system speaks.
+ *
+ * This lives beside `captchaPolicySeverity` because it answers the same
+ * question one step further in: that function ranks a policy by its
+ * `solvedImagesCount`, and this one says what a puzzle policy carrying that
+ * number will actually be served at. Anything asking "what difficulty is this
+ * puzzle" — the provider serving a challenge, and the rule-authoring and
+ * rule-editing consumers outside this repository — reads it from here, so a
+ * change to the ladder cannot land in one of them and not the others.
+ *
+ * Sampling a concrete render out of a level's bands stays in the provider
+ * (`tasks/puzzle/puzzleDifficulty.ts`): it needs `IPuzzleSettings` from
+ * `@prosopo/types` and a `node:crypto`-backed sampler, and this package's
+ * zero-dependency, browser-safe property is load-bearing — see the note on
+ * imports in `index.ts`.
+ *
+ * `level` is the difficulty of the challenge, and is unrelated to `Tier` in
+ * `@prosopo/types`, which is the customer's billing plan.
+ */
+
+export interface PuzzleDifficultyRange {
+	min: number;
+	max: number;
+}
+
+export interface PuzzleDifficultyBand {
+	/** Index into PUZZLE_DIFFICULTY_LEVELS. 0 is the site's ordinary puzzle. */
+	level: number;
+	/** Placement accuracy required, in px. Lower is stricter. */
+	tolerance: PuzzleDifficultyRange;
+	/** Decoy silhouettes scattered on the background. More is harder. */
+	decoyCount: PuzzleDifficultyRange;
+	/**
+	 * Multiplier on decoy pixels. Lower brings decoys closer to the real
+	 * cut's darkness, which is the anti-solver dial — see the invariant
+	 * below.
+	 */
+	decoyHoleDarken: PuzzleDifficultyRange;
+	/** Dark inner rim amplitude on each decoy, 0-255. Higher is harder. */
+	decoyEdgeDarkness: PuzzleDifficultyRange;
+	/** Piece size as a fraction of background width. Smaller is harder. */
+	pieceScale: PuzzleDifficultyRange;
+}
+
+/**
+ * Minimum gap that must remain between `decoyHoleDarken` and `holeDarken`.
+ *
+ * The real cutout has to stay the deepest region on the frame or a human
+ * cannot tell target from decoy at all. But pushed too far apart, a solver
+ * simply thresholds on brightness and ignores shape. The ladder walks
+ * `decoyHoleDarken` down toward `holeDarken` as difficulty rises; this floor
+ * is what stops it crossing over. Enforced by clamping every sampled value,
+ * not by trusting the band table to be authored correctly.
+ */
+export const MIN_DECOY_HOLE_DARKEN_MARGIN = 0.04;
+
+/**
+ * Highest level reachable by AUTOMATIC escalation.
+ *
+ * With image disabled there is no fallback modality: a user who genuinely
+ * cannot solve the hardest puzzle has no route through the site. L4 is
+ * therefore reserved for sessions already destined to fail verification (a
+ * `deferToVerify` block), where the difficulty exists only to cost an
+ * automated solver time — not to gate a human who might be legitimate.
+ */
+export const MAX_AUTO_ESCALATION_LEVEL = 3;
+
+/**
+ * Image rounds per difficulty step.
+ *
+ * `severityToPuzzleDifficulty` and `puzzleDifficultyToSeverity` are inverses
+ * of each other across this constant, which is what lets a UI offer one value
+ * per level instead of a free-text box where two adjacent numbers silently
+ * produce the same puzzle. The round-trip is pinned by the tests.
+ */
+export const PUZZLE_ROUNDS_PER_DIFFICULTY_LEVEL = 2;
+
+/**
+ * Ordered puzzle difficulty ladder.
+ *
+ * An image captcha expresses severity as a round count — "solve 2" vs "solve
+ * 8". A puzzle has no rounds (one puzzle per session, see
+ * `getPuzzleCaptchaChallenge`), so on a site with image disabled every
+ * escalation would otherwise collapse into an identical challenge and the
+ * graduated response would be lost. This ladder is the puzzle's equivalent
+ * currency.
+ *
+ * Each level is a BAND per knob, not a fixed config, for two reasons:
+ *
+ *   1. Per-challenge jitter stops a solver hard-coding thresholds against a
+ *      known render (fixed decoy count, fixed rim darkness, ...).
+ *   2. Adjacent bands deliberately OVERLAP, so a single observed challenge
+ *      does not identify which level it came from. Without overlap the
+ *      decoy count alone would leak the level, and a solver could tell
+ *      "I am suspected" from one render.
+ *
+ * L0 reproduces the shipped defaults (decoyCount 5, decoyEdgeDarkness 20,
+ * decoyHoleDarken 0.7, tolerance 15, pieceScale 0.15-0.45) so a site that
+ * never escalates sees no change in behaviour.
+ *
+ * The numbers above L0 are STARTING POINTS, not calibrated values. They need
+ * validating against observed human first-attempt solve rate per level,
+ * segmented by device class — see the shadow-calibration note on
+ * `severityToPuzzleDifficulty`.
+ */
+export const PUZZLE_DIFFICULTY_LEVELS: readonly PuzzleDifficultyBand[] = [
+	{
+		level: 0,
+		tolerance: { min: 14, max: 16 },
+		decoyCount: { min: 4, max: 6 },
+		decoyHoleDarken: { min: 0.68, max: 0.72 },
+		decoyEdgeDarkness: { min: 18, max: 22 },
+		pieceScale: { min: 0.15, max: 0.45 },
+	},
+	{
+		level: 1,
+		tolerance: { min: 12, max: 15 },
+		decoyCount: { min: 6, max: 10 },
+		decoyHoleDarken: { min: 0.66, max: 0.7 },
+		decoyEdgeDarkness: { min: 20, max: 24 },
+		pieceScale: { min: 0.14, max: 0.4 },
+	},
+	{
+		level: 2,
+		tolerance: { min: 10, max: 13 },
+		decoyCount: { min: 10, max: 16 },
+		decoyHoleDarken: { min: 0.64, max: 0.68 },
+		decoyEdgeDarkness: { min: 22, max: 27 },
+		pieceScale: { min: 0.12, max: 0.34 },
+	},
+	{
+		level: 3,
+		tolerance: { min: 8, max: 11 },
+		decoyCount: { min: 16, max: 26 },
+		decoyHoleDarken: { min: 0.62, max: 0.66 },
+		decoyEdgeDarkness: { min: 25, max: 30 },
+		pieceScale: { min: 0.1, max: 0.28 },
+	},
+	{
+		level: 4,
+		tolerance: { min: 6, max: 9 },
+		decoyCount: { min: 26, max: 40 },
+		decoyHoleDarken: { min: 0.6, max: 0.64 },
+		decoyEdgeDarkness: { min: 28, max: 34 },
+		pieceScale: { min: 0.09, max: 0.22 },
+	},
+];
+
+export const clampDifficultyLevel = (
+	level: number,
+	maxLevel: number = MAX_AUTO_ESCALATION_LEVEL,
+): number => {
+	const ceiling = Math.min(maxLevel, PUZZLE_DIFFICULTY_LEVELS.length - 1);
+	if (!Number.isFinite(level)) return 0;
+	return Math.max(0, Math.min(Math.floor(level), ceiling));
+};
+
+/**
+ * Map the severity currency every existing call-site already speaks — image
+ * rounds — onto a difficulty level.
+ *
+ * Severity is expressed as rounds ABOVE the site's ordinary count rather than
+ * an absolute, because the baseline (`env.config.captchas.solved.count`, or a
+ * rule's own `solvedImagesCount`) varies per site. "Two more rounds than
+ * normal" means the same thing everywhere; "four rounds" does not.
+ *
+ * Keeping one ordering here means the score ladder, the no-measurement gates,
+ * authored rules and traffic-filter policies cannot drift apart on what
+ * counts as more severe.
+ */
+export const severityToPuzzleDifficulty = (
+	requestedImageRounds: number | undefined,
+	baseImageRounds: number,
+	maxLevel: number = MAX_AUTO_ESCALATION_LEVEL,
+): number => {
+	if (requestedImageRounds === undefined) return 0;
+	const excess = requestedImageRounds - baseImageRounds;
+	if (!Number.isFinite(excess) || excess <= 0)
+		return clampDifficultyLevel(0, maxLevel);
+	if (excess <= 2) return clampDifficultyLevel(1, maxLevel);
+	if (excess <= 4) return clampDifficultyLevel(2, maxLevel);
+	if (excess <= 6) return clampDifficultyLevel(3, maxLevel);
+	return clampDifficultyLevel(4, maxLevel);
+};
+
+/**
+ * The round count that lands squarely on `level` — the inverse of
+ * `severityToPuzzleDifficulty`.
+ *
+ * Anything that has to *write* a puzzle policy needs this direction: a rule
+ * editor turning an operator's chosen difficulty into the field the rule
+ * carries, or rule authoring normalising a round count inherited from the
+ * image path. Each level spans two rounds, so without a canonical value per level a
+ * writer picks between numbers that produce the identical puzzle, and the
+ * difference survives only to break severity ties arbitrarily.
+ *
+ * `baseImageRounds` is the site's ordinary count, matching
+ * `severityToPuzzleDifficulty`'s second argument. Pass the same baseline to
+ * both or the round-trip does not hold.
+ */
+export const puzzleDifficultyToSeverity = (
+	level: number,
+	baseImageRounds: number,
+	maxLevel: number = MAX_AUTO_ESCALATION_LEVEL,
+): number =>
+	baseImageRounds +
+	clampDifficultyLevel(level, maxLevel) * PUZZLE_ROUNDS_PER_DIFFICULTY_LEVEL;

--- a/packages/provider/src/api/captcha/submitPoWCaptchaSolution.ts
+++ b/packages/provider/src/api/captcha/submitPoWCaptchaSolution.ts
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+import { severityToPuzzleDifficulty } from "@prosopo/captcha-severity";
 import { ProsopoApiError } from "@prosopo/common";
 import { DEFAULT_RENDER_SETTINGS } from "@prosopo/puzzle-assets";
 import {
@@ -29,10 +30,7 @@ import { flatten, getIPAddress } from "@prosopo/util";
 import type { NextFunction, Request, Response } from "express";
 import type { AugmentedRequest } from "../../express.js";
 import { coerceToEnabledCaptchaType } from "../../tasks/captchaTypeSelection.js";
-import {
-	samplePuzzleDifficulty,
-	severityToPuzzleDifficulty,
-} from "../../tasks/puzzle/puzzleDifficulty.js";
+import { samplePuzzleDifficulty } from "../../tasks/puzzle/puzzleDifficulty.js";
 import { Tasks } from "../../tasks/tasks.js";
 import {
 	derivePlatform,

--- a/packages/provider/src/tasks/frictionless/frictionlessTasks.ts
+++ b/packages/provider/src/tasks/frictionless/frictionlessTasks.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { severityToPuzzleDifficulty } from "@prosopo/captcha-severity";
 import type { Logger } from "@prosopo/logger";
 import { DEFAULT_RENDER_SETTINGS } from "@prosopo/puzzle-assets";
 import {
@@ -48,10 +49,7 @@ import { CaptchaManager } from "../captchaManager.js";
 import { coerceToEnabledCaptchaType } from "../captchaTypeSelection.js";
 import { DecisionMachineRunner } from "../decisionMachine/decisionMachineRunner.js";
 import { getBotScore } from "../detection/getBotScore.js";
-import {
-	samplePuzzleDifficulty,
-	severityToPuzzleDifficulty,
-} from "../puzzle/puzzleDifficulty.js";
+import { samplePuzzleDifficulty } from "../puzzle/puzzleDifficulty.js";
 import { type RoutingContext, applyRouter } from "./routingMachine.js";
 
 const DEFAULT_MAX_TIMESTAMP_AGE = 60 * 10 * 1000; // 10 minutes

--- a/packages/provider/src/tasks/puzzle/puzzleDifficulty.ts
+++ b/packages/provider/src/tasks/puzzle/puzzleDifficulty.ts
@@ -12,131 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import {
+	MAX_AUTO_ESCALATION_LEVEL,
+	MIN_DECOY_HOLE_DARKEN_MARGIN,
+	PUZZLE_DIFFICULTY_LEVELS,
+	type PuzzleDifficultyBand,
+	clampDifficultyLevel,
+} from "@prosopo/captcha-severity";
 import type { IPuzzleSettings } from "@prosopo/types";
 import { createStratifiedSampler } from "./stratifiedSampler.js";
 
 /**
- * Ordered puzzle difficulty ladder.
+ * Render half of the puzzle difficulty ladder: given a level, draw a concrete
+ * puzzle config from its bands.
  *
- * An image captcha expresses severity as a round count — "solve 2" vs "solve
- * 8". A puzzle has no rounds (one puzzle per session, see
- * `getPuzzleCaptchaChallenge`), so on a site with image disabled every
- * escalation would otherwise collapse into an identical challenge and the
- * graduated response would be lost. This ladder is the puzzle's equivalent
- * currency.
- *
- * Each level is a BAND per knob, not a fixed config, for two reasons:
- *
- *   1. Per-challenge jitter stops a solver hard-coding thresholds against a
- *      known render (fixed decoy count, fixed rim darkness, ...).
- *   2. Adjacent bands deliberately OVERLAP, so a single observed challenge
- *      does not identify which level it came from. Without overlap the
- *      decoy count alone would leak the level, and a solver could tell
- *      "I am suspected" from one render.
- *
- * `level` is the difficulty of the challenge, and is unrelated to
- * `Tier` in @prosopo/types, which is the customer's billing plan.
+ * The ladder itself — the band table, `severityToPuzzleDifficulty` and its
+ * inverse — lives in `@prosopo/captcha-severity`, so that every consumer
+ * derives a difficulty from one table: this provider, and the rule-authoring
+ * and rule-editing consumers outside this repository. Only the sampling stayed
+ * here: it needs `IPuzzleSettings` and a `node:crypto`-backed sampler, and
+ * that package is deliberately dependency-free and browser-safe.
  */
-
-export interface PuzzleDifficultyRange {
-	min: number;
-	max: number;
-}
-
-export interface PuzzleDifficultyBand {
-	/** Index into PUZZLE_DIFFICULTY_LEVELS. 0 is the site's ordinary puzzle. */
-	level: number;
-	/** Placement accuracy required, in px. Lower is stricter. */
-	tolerance: PuzzleDifficultyRange;
-	/** Decoy silhouettes scattered on the background. More is harder. */
-	decoyCount: PuzzleDifficultyRange;
-	/**
-	 * Multiplier on decoy pixels. Lower brings decoys closer to the real
-	 * cut's darkness, which is the anti-solver dial — see the invariant
-	 * below.
-	 */
-	decoyHoleDarken: PuzzleDifficultyRange;
-	/** Dark inner rim amplitude on each decoy, 0-255. Higher is harder. */
-	decoyEdgeDarkness: PuzzleDifficultyRange;
-	/** Piece size as a fraction of background width. Smaller is harder. */
-	pieceScale: PuzzleDifficultyRange;
-}
-
-/**
- * Minimum gap that must remain between `decoyHoleDarken` and `holeDarken`.
- *
- * The real cutout has to stay the deepest region on the frame or a human
- * cannot tell target from decoy at all. But pushed too far apart, a solver
- * simply thresholds on brightness and ignores shape. The ladder walks
- * `decoyHoleDarken` down toward `holeDarken` as difficulty rises; this floor
- * is what stops it crossing over. Enforced by clamping every sampled value,
- * not by trusting the band table to be authored correctly.
- */
-export const MIN_DECOY_HOLE_DARKEN_MARGIN = 0.04;
-
-/**
- * Highest level reachable by AUTOMATIC escalation.
- *
- * With image disabled there is no fallback modality: a user who genuinely
- * cannot solve the hardest puzzle has no route through the site. L4 is
- * therefore reserved for sessions already destined to fail verification (a
- * `deferToVerify` block), where the difficulty exists only to cost an
- * automated solver time — not to gate a human who might be legitimate.
- */
-export const MAX_AUTO_ESCALATION_LEVEL = 3;
-
-/**
- * L0 reproduces the shipped defaults (decoyCount 5, decoyEdgeDarkness 20,
- * decoyHoleDarken 0.7, tolerance 15, pieceScale 0.15-0.45) so a site that
- * never escalates sees no change in behaviour.
- *
- * The numbers above L0 are STARTING POINTS, not calibrated values. They need
- * validating against observed human first-attempt solve rate per level,
- * segmented by device class — see the shadow-calibration note on
- * `severityToPuzzleDifficulty`.
- */
-export const PUZZLE_DIFFICULTY_LEVELS: readonly PuzzleDifficultyBand[] = [
-	{
-		level: 0,
-		tolerance: { min: 14, max: 16 },
-		decoyCount: { min: 4, max: 6 },
-		decoyHoleDarken: { min: 0.68, max: 0.72 },
-		decoyEdgeDarkness: { min: 18, max: 22 },
-		pieceScale: { min: 0.15, max: 0.45 },
-	},
-	{
-		level: 1,
-		tolerance: { min: 12, max: 15 },
-		decoyCount: { min: 6, max: 10 },
-		decoyHoleDarken: { min: 0.66, max: 0.7 },
-		decoyEdgeDarkness: { min: 20, max: 24 },
-		pieceScale: { min: 0.14, max: 0.4 },
-	},
-	{
-		level: 2,
-		tolerance: { min: 10, max: 13 },
-		decoyCount: { min: 10, max: 16 },
-		decoyHoleDarken: { min: 0.64, max: 0.68 },
-		decoyEdgeDarkness: { min: 22, max: 27 },
-		pieceScale: { min: 0.12, max: 0.34 },
-	},
-	{
-		level: 3,
-		tolerance: { min: 8, max: 11 },
-		decoyCount: { min: 16, max: 26 },
-		decoyHoleDarken: { min: 0.62, max: 0.66 },
-		decoyEdgeDarkness: { min: 25, max: 30 },
-		pieceScale: { min: 0.1, max: 0.28 },
-	},
-	{
-		level: 4,
-		tolerance: { min: 6, max: 9 },
-		decoyCount: { min: 26, max: 40 },
-		decoyHoleDarken: { min: 0.6, max: 0.64 },
-		decoyEdgeDarkness: { min: 28, max: 34 },
-		pieceScale: { min: 0.09, max: 0.22 },
-	},
-];
 
 // One sampler per knob. Sharing a cursor would make the knobs advance in
 // lockstep and let a solver infer the whole config — and hence the level —
@@ -145,43 +41,6 @@ const toleranceSampler = createStratifiedSampler();
 const decoyCountSampler = createStratifiedSampler();
 const decoyHoleDarkenSampler = createStratifiedSampler();
 const decoyEdgeDarknessSampler = createStratifiedSampler();
-
-export const clampDifficultyLevel = (
-	level: number,
-	maxLevel: number = MAX_AUTO_ESCALATION_LEVEL,
-): number => {
-	const ceiling = Math.min(maxLevel, PUZZLE_DIFFICULTY_LEVELS.length - 1);
-	if (!Number.isFinite(level)) return 0;
-	return Math.max(0, Math.min(Math.floor(level), ceiling));
-};
-
-/**
- * Map the severity currency every existing call-site already speaks — image
- * rounds — onto a difficulty level.
- *
- * Severity is expressed as rounds ABOVE the site's ordinary count rather than
- * an absolute, because the baseline (`env.config.captchas.solved.count`, or a
- * rule's own `solvedImagesCount`) varies per site. "Two more rounds than
- * normal" means the same thing everywhere; "four rounds" does not.
- *
- * Keeping one ordering here means the score ladder, the no-measurement gates,
- * detector rules and traffic-filter policies cannot drift apart on what
- * counts as more severe.
- */
-export const severityToPuzzleDifficulty = (
-	requestedImageRounds: number | undefined,
-	baseImageRounds: number,
-	maxLevel: number = MAX_AUTO_ESCALATION_LEVEL,
-): number => {
-	if (requestedImageRounds === undefined) return 0;
-	const excess = requestedImageRounds - baseImageRounds;
-	if (!Number.isFinite(excess) || excess <= 0)
-		return clampDifficultyLevel(0, maxLevel);
-	if (excess <= 2) return clampDifficultyLevel(1, maxLevel);
-	if (excess <= 4) return clampDifficultyLevel(2, maxLevel);
-	if (excess <= 6) return clampDifficultyLevel(3, maxLevel);
-	return clampDifficultyLevel(4, maxLevel);
-};
 
 export interface SampledPuzzleDifficulty {
 	level: number;

--- a/packages/provider/src/tasks/puzzle/puzzleRenderer.ts
+++ b/packages/provider/src/tasks/puzzle/puzzleRenderer.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { MIN_DECOY_HOLE_DARKEN_MARGIN } from "@prosopo/captcha-severity";
 import {
 	DEFAULT_GEOMETRY,
 	DEFAULT_RENDER_SETTINGS,
@@ -29,7 +30,6 @@ import {
 	getPuzzleBackgroundBuffer,
 	initPuzzleBackgroundBuffer,
 } from "./backgroundBuffer.js";
-import { MIN_DECOY_HOLE_DARKEN_MARGIN } from "./puzzleDifficulty.js";
 import { createStratifiedSampler } from "./stratifiedSampler.js";
 
 export interface RenderedPuzzleImages {

--- a/packages/provider/src/tests/unit/tasks/puzzleDifficulty.unit.test.ts
+++ b/packages/provider/src/tests/unit/tasks/puzzleDifficulty.unit.test.ts
@@ -13,6 +13,10 @@
 // limitations under the License.
 
 import {
+	MIN_DECOY_HOLE_DARKEN_MARGIN,
+	PUZZLE_DIFFICULTY_LEVELS,
+} from "@prosopo/captcha-severity";
+import {
 	DEFAULT_RENDER_SETTINGS,
 	type PuzzleRenderSettings,
 } from "@prosopo/puzzle-assets";
@@ -24,14 +28,7 @@ import {
 	puzzleToleranceFieldSchema,
 } from "@prosopo/types";
 import { describe, expect, it } from "vitest";
-import {
-	MAX_AUTO_ESCALATION_LEVEL,
-	MIN_DECOY_HOLE_DARKEN_MARGIN,
-	PUZZLE_DIFFICULTY_LEVELS,
-	clampDifficultyLevel,
-	samplePuzzleDifficulty,
-	severityToPuzzleDifficulty,
-} from "../../../tasks/puzzle/puzzleDifficulty.js";
+import { samplePuzzleDifficulty } from "../../../tasks/puzzle/puzzleDifficulty.js";
 import { resolvePuzzleRenderSettings } from "../../../tasks/puzzle/puzzleRenderer.js";
 
 const HOLE_DARKEN = DEFAULT_RENDER_SETTINGS.holeDarken;
@@ -39,35 +36,6 @@ const HOLE_DARKEN = DEFAULT_RENDER_SETTINGS.holeDarken;
 const SAMPLES = 400;
 
 describe("PUZZLE_DIFFICULTY_LEVELS table", () => {
-	it("is ordered strictly harder as the level rises", () => {
-		for (let i = 1; i < PUZZLE_DIFFICULTY_LEVELS.length; i++) {
-			const prev = PUZZLE_DIFFICULTY_LEVELS[i - 1];
-			const cur = PUZZLE_DIFFICULTY_LEVELS[i];
-			if (!prev || !cur) throw new Error("missing level");
-			// Harder = tighter tolerance, more decoys, decoys closer to the real
-			// cut's darkness, stronger decoy rims, smaller pieces.
-			expect(cur.tolerance.max).toBeLessThan(prev.tolerance.max);
-			expect(cur.decoyCount.min).toBeGreaterThanOrEqual(prev.decoyCount.min);
-			expect(cur.decoyHoleDarken.max).toBeLessThan(prev.decoyHoleDarken.max);
-			expect(cur.decoyEdgeDarkness.max).toBeGreaterThan(
-				prev.decoyEdgeDarkness.max,
-			);
-			expect(cur.pieceScale.max).toBeLessThan(prev.pieceScale.max);
-		}
-	});
-
-	it("overlaps adjacent bands so one render does not identify the level", () => {
-		// If bands were disjoint, a solver could read the level straight off the
-		// decoy count and know whether it had been flagged.
-		for (let i = 1; i < PUZZLE_DIFFICULTY_LEVELS.length; i++) {
-			const prev = PUZZLE_DIFFICULTY_LEVELS[i - 1];
-			const cur = PUZZLE_DIFFICULTY_LEVELS[i];
-			if (!prev || !cur) throw new Error("missing level");
-			expect(cur.decoyCount.min).toBeLessThanOrEqual(prev.decoyCount.max);
-			expect(cur.tolerance.max).toBeGreaterThanOrEqual(prev.tolerance.min);
-		}
-	});
-
 	it("keeps every band inside the settings-schema bounds", () => {
 		for (const band of PUZZLE_DIFFICULTY_LEVELS) {
 			for (const v of [band.tolerance.min, band.tolerance.max]) {
@@ -93,51 +61,6 @@ describe("PUZZLE_DIFFICULTY_LEVELS table", () => {
 				expect(puzzlePieceScaleFieldSchema.safeParse(v).success).toBe(true);
 			}
 		}
-	});
-});
-
-describe("severityToPuzzleDifficulty", () => {
-	it("maps no requested rounds to the baseline level", () => {
-		expect(severityToPuzzleDifficulty(undefined, 2)).toBe(0);
-	});
-
-	it("maps a request at or below the site baseline to the baseline level", () => {
-		expect(severityToPuzzleDifficulty(2, 2)).toBe(0);
-		expect(severityToPuzzleDifficulty(1, 2)).toBe(0);
-	});
-
-	it("rises monotonically with rounds requested above the baseline", () => {
-		const levels = [0, 1, 2, 3, 4, 5, 6, 7, 8, 12].map((extra) =>
-			severityToPuzzleDifficulty(2 + extra, 2, PUZZLE_DIFFICULTY_LEVELS.length),
-		);
-		for (let i = 1; i < levels.length; i++) {
-			expect(levels[i]).toBeGreaterThanOrEqual(levels[i - 1] as number);
-		}
-	});
-
-	it("is relative to the site baseline, not an absolute round count", () => {
-		// Same absolute count means different severity on sites whose ordinary
-		// challenge is a different length.
-		expect(severityToPuzzleDifficulty(6, 2)).toBeGreaterThan(
-			severityToPuzzleDifficulty(6, 6),
-		);
-	});
-
-	it("caps automatic escalation below the hardest level", () => {
-		// With image disabled there is no fallback modality, so the hardest
-		// level must not be reachable by escalation alone.
-		expect(severityToPuzzleDifficulty(100, 2)).toBe(MAX_AUTO_ESCALATION_LEVEL);
-		expect(MAX_AUTO_ESCALATION_LEVEL).toBeLessThan(
-			PUZZLE_DIFFICULTY_LEVELS.length - 1,
-		);
-	});
-});
-
-describe("clampDifficultyLevel", () => {
-	it("clamps out-of-range and non-finite input", () => {
-		expect(clampDifficultyLevel(-5)).toBe(0);
-		expect(clampDifficultyLevel(Number.NaN)).toBe(0);
-		expect(clampDifficultyLevel(99)).toBe(MAX_AUTO_ESCALATION_LEVEL);
 	});
 });
 


### PR DESCRIPTION
## What

Moves the puzzle difficulty ladder out of the provider and into `@prosopo/captcha-severity`:

- `PUZZLE_DIFFICULTY_LEVELS`
- `MAX_AUTO_ESCALATION_LEVEL`
- `MIN_DECOY_HOLE_DARKEN_MARGIN`
- `clampDifficultyLevel`
- `severityToPuzzleDifficulty`

Adds `puzzleDifficultyToSeverity`, the inverse.

## Why

The table lived in `provider/src/tasks/puzzle/puzzleDifficulty.ts`, which isn't re-exported from the provider's barrel — so nothing outside that package could reach it. `captcha-severity` already documented the ladder at length (`CaptchaPolicySeverityInput`, `intraTierSeverity`) without holding it, and anything else that has to answer "what difficulty is this puzzle" had to restate the mapping. The consumers that author and edit puzzle rules sit outside the provider.

This package already answers "which of these policies is stricter" off `solvedImagesCount`. The ladder answers what a puzzle policy carrying that number is actually served at — the same question one step further in.

## Why the inverse is new

Writers need that direction: turning a chosen difficulty into the field a rule carries, or normalising a count inherited from the image path. Each level spans two rounds, so without a canonical value per level a writer picks between numbers that produce the identical puzzle, and the difference survives only to break severity ties arbitrarily. `puzzleDifficultyToSeverity(level, base)` round-trips through `severityToPuzzleDifficulty` — pinned by tests across four baselines and both ceilings.

## What deliberately did not move

`samplePuzzleDifficulty` stays in the provider. It needs `IPuzzleSettings` from `@prosopo/types` and a `node:crypto`-backed stratified sampler, and this package's zero-dependency, browser-safe property is load-bearing for consumers that bundle it standalone. The split is "what difficulty is this" (here) vs "draw me a render of it" (provider).

## Behaviour

None. Same table, same thresholds, same clamping — every value moved verbatim.

## Tests

- Ladder tests (ordering, band overlap, `severityToPuzzleDifficulty`, `clampDifficultyLevel`) moved into `captcha-severity`, plus new round-trip coverage for the inverse. 39 passing.
- The provider test keeps what is provider-specific: the schema-bounds check on the bands, the sampling invariants, and `resolvePuzzleRenderSettings`. It imports the table from `@prosopo/captcha-severity`.
- Provider unit suite: 79 files, 1209 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)