### PR TITLE
fix(native-ja4): publish the package to npm instead of keeping it private

### DIFF
--- a/.changeset/publish-native-ja4.md
+++ b/.changeset/publish-native-ja4.md
@@ -1,0 +1,13 @@
+---
+"@prosopo/native-ja4": patch
+---
+
+Publish `@prosopo/native-ja4` to npm instead of keeping it private.
+
+`@prosopo/provider` has listed `@prosopo/native-ja4` in its `dependencies` since 5.5.0, but the package carried `"private": true` and so was never published. `npm i @prosopo/provider` has therefore failed for every release since, on an `E404` for a package that does not exist on the registry. Nobody hit it because provider is consumed through the Docker image and the bundled CLI, both of which build the workspace from source and never resolve the dependency against npm.
+
+Dropping `private` lets `changeset publish` pick the package up like every other workspace package. `repository` is added because the release workflow publishes with `NPM_CONFIG_PROVENANCE=true`, and provenance attestation requires a `repository.url` on the manifest that matches the OIDC claim for `prosopo/captcha`.
+
+The tarball is unchanged in shape: `files` already limited it to `index.js`, `index.d.ts` and the prebuilt `*.node` binary. `napi.targets` is still `x86_64-unknown-linux-gnu` only, so the package resolves on linux-x64-gnu and throws the napi "Unsupported architecture" error elsewhere — the same behaviour it has always had inside the workspace.
+
+`@prosopo/native-merkle` and `@prosopo/puzzle-assets` are also private, also unpublished, and also in provider's `dependencies`, so `npm i @prosopo/provider` still fails until they get the same treatment.

--- a/packages/native-ja4/package.json
+++ b/packages/native-ja4/package.json
@@ -3,7 +3,12 @@
 	"version": "0.0.4",
 	"description": "Rust JA4 TLS fingerprint parser exposed to Node via napi-rs.",
 	"license": "Apache-2.0",
-	"private": true,
+	"author": "Prosopo Limited",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/prosopo/captcha.git",
+		"directory": "packages/native-ja4"
+	},
 	"main": "index.js",
 	"types": "index.d.ts",
 	"files": ["index.js", "index.d.ts", "*.node"],


### PR DESCRIPTION
## Problem

`@prosopo/provider` has listed `@prosopo/native-ja4` in its `dependencies` since 5.5.0, but the package carries `"private": true` and has never been published. So this fails, and has failed for every release since:

```
$ npm i @prosopo/provider@5.7.0
npm error code E404
npm error 404 Not Found - GET https://registry.npmjs.org/@prosopo%2fnative-ja4 - Not found
npm error 404  The requested resource '@prosopo/native-ja4@0.0.4' could not be found
```

It went unnoticed because provider is consumed through the Docker image and the bundled CLI, both of which build the workspace from source and never resolve the dependency against the registry.

## Change

- Drop `"private": true` so `changeset publish` picks the package up like every other workspace package.
- Add `repository`, because the release workflow publishes with `NPM_CONFIG_PROVENANCE=true` and provenance attestation verifies `repository.url` against the OIDC claim for `prosopo/captcha`. Without it the publish step fails.
- Add `author`, matching the other published packages.

`files` already limited the tarball to `index.js`, `index.d.ts` and the prebuilt `*.node`, so the packed contents are unchanged:

```
399B    index.d.ts
9.2kB   index.js
381.9kB index.linux-x64-gnu.node
820B    package.json
```

`napi.targets` stays `x86_64-unknown-linux-gnu` only. The package resolves on linux-x64-gnu and throws napi's "Unsupported architecture" elsewhere — unchanged from its behaviour inside the workspace today.

## Bootstrap publish

npm cannot create a package via OIDC trusted publishing — the trusted-publisher config lives on a package settings page that does not exist until the package does ([npm/cli#8544](https://github.com/npm/cli/issues/8544)). `0.0.4` was therefore published by hand from a clean worktree at `v3.8.5`, so the version `provider@5.7.0` pins now resolves. The trusted publisher must be added on the package settings page before the next release bumps it, or `changeset publish` will fail with `ENEEDAUTH` exactly as `@prosopo/captcha-severity` did in [run 33691307729](https://github.com/prosopo/captcha/actions/runs/33691307729).

## Still outstanding

`npm i @prosopo/provider` will still fail after this lands. `@prosopo/native-merkle` (`0.0.4`) and `@prosopo/puzzle-assets` (`0.1.3`) are also `private: true`, also unpublished, and also in provider's `dependencies`. Same fix, deliberately not bundled in here.

## Testing

- `npm run lint` — clean (biome, license, engines, refs, json, testCheck, workflowNames, tsconfigIncludes)
- Packed the tarball and installed it into a scratch project: `require('@prosopo/native-ja4').calculateJa4` resolves and the prebuilt binding loads.
- Rebuilt the binary from source at the tag with `napi build --platform --release` and compared: same glibc floor (2.34) as the committed artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)