### PR TITLE
fix(native-merkle,puzzle-assets): publish both packages to npm instead of keeping them private

### DIFF
--- a/.changeset/publish-native-merkle-puzzle-assets.md
+++ b/.changeset/publish-native-merkle-puzzle-assets.md
@@ -1,0 +1,12 @@
+---
+"@prosopo/native-merkle": patch
+"@prosopo/puzzle-assets": patch
+---
+
+Publish `@prosopo/native-merkle` and `@prosopo/puzzle-assets` to npm instead of keeping them private.
+
+These are the last two entries in `@prosopo/provider`'s `dependencies` that carried `"private": true` and so were never published. With `@prosopo/native-ja4` already fixed, dropping `private` here makes `npm i @prosopo/provider` resolve for the first time since 5.5.0 — until now it failed with an `E404` on whichever unpublished dependency npm reached first. The Docker image and the bundled CLI build the workspace from source and never resolve these against the registry, which is why the breakage stayed invisible.
+
+`native-merkle` also gains `repository`, because the release workflow publishes with `NPM_CONFIG_PROVENANCE=true` and provenance attestation verifies `repository.url` against the OIDC claim for `prosopo/captcha`. `puzzle-assets` already declared `repository`, `author`, `bugs` and `homepage`, so it needed only the `private` line removed.
+
+Neither tarball changes shape. `native-merkle` keeps its `files` allowlist of `index.js`, `index.d.ts` and the prebuilt `*.node`, and stays `x86_64-unknown-linux-gnu` only — it resolves on linux-x64-gnu and throws napi's "Unsupported architecture" elsewhere, exactly as it does inside the workspace today. `puzzle-assets` ships `dist/` with both the root and `./browser` subpath exports, and keeps its `sharp` runtime dependency.

--- a/packages/native-merkle/package.json
+++ b/packages/native-merkle/package.json
@@ -3,7 +3,12 @@
 	"version": "0.0.4",
 	"description": "Rust merkle tree + blake2b hashing helpers for the Prosopo captcha provider (napi-rs).",
 	"license": "Apache-2.0",
-	"private": true,
+	"author": "Prosopo Limited",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/prosopo/captcha.git",
+		"directory": "packages/native-merkle"
+	},
 	"main": "index.js",
 	"types": "index.d.ts",
 	"files": ["index.js", "index.d.ts", "*.node"],

--- a/packages/puzzle-assets/package.json
+++ b/packages/puzzle-assets/package.json
@@ -42,7 +42,6 @@
 		"url": "https://github.com/prosopo/captcha/issues"
 	},
 	"homepage": "https://github.com/prosopo/captcha#readme",
-	"private": true,
 	"dependencies": {
 		"sharp": "0.35.4"
 	},


### PR DESCRIPTION
Follow-up to #3189. These are the last two `private: true` entries in `@prosopo/provider`'s `dependencies`.

## Problem

`npm i @prosopo/provider` has failed for every release since 5.5.0, on an `E404` for whichever unpublished dependency npm reached first. #3189 published `@prosopo/native-ja4`; `@prosopo/native-merkle@0.0.4` and `@prosopo/puzzle-assets@0.1.3` are the remaining two. It stayed invisible because provider is consumed through the Docker image and the bundled CLI, both of which build the workspace from source and never resolve these against the registry.

## Change

**`packages/native-merkle/package.json`** — drop `"private": true`; add `repository` (the release workflow publishes with `NPM_CONFIG_PROVENANCE=true`, and provenance verifies `repository.url` against the OIDC claim) and `author`.

**`packages/puzzle-assets/package.json`** — drop `"private": true` only. It already declared `repository`, `author`, `bugs` and `homepage`.

Neither tarball changes shape:

- `native-merkle` keeps its `files` allowlist (`index.js`, `index.d.ts`, `*.node`) and stays `x86_64-unknown-linux-gnu` only — resolves on linux-x64-gnu, throws napi's "Unsupported architecture" elsewhere, unchanged from its behaviour inside the workspace.
- `puzzle-assets` ships `dist/` with both the root and `./browser` subpath exports, and keeps `sharp` as a runtime dependency.

## Bootstrap publish

Same constraint as #3189: npm cannot create a package via OIDC trusted publishing, because the trusted-publisher config lives on a package settings page that does not exist until the package does ([npm/cli#8544](https://github.com/npm/cli/issues/8544)). Both versions were published by hand from a clean worktree at `v3.8.5`, at the exact versions `provider@5.7.0` pins. The trusted publisher must be added on each package's settings page before the next release bumps them, or `changeset publish` fails with `ENEEDAUTH` as `@prosopo/captcha-severity` did in [run 33691307729](https://github.com/prosopo/captcha/actions/runs/33691307729).

## Testing

- `npm run lint` — clean (biome, license, engines, refs, json, testCheck, workflowNames, tsconfigIncludes)
- Built both from source at `v3.8.5` (`napi build --platform --release`; `build:tsc` + vite esm/cjs), packed, and installed the tarballs into a scratch project:
  - `native-merkle` → `hexHash, hexHashArray, computeCaptchaSolutionHash, buildMerkleLayers`
  - `puzzle-assets` → 15 ESM exports, 15 CJS exports, and `@prosopo/puzzle-assets/browser` resolves to its 10
  - `sharp` resolved cleanly as a transitive install

🤖 Generated with [Claude Code](https://claude.com/claude-code)