### PR TITLE
fix(provider): remove the account-wide commitment fallback from image verify

### DIFF
--- a/.changeset/session-scoped-commitment-lookup.md
+++ b/.changeset/session-scoped-commitment-lookup.md
@@ -1,0 +1,25 @@
+---
+"@prosopo/provider": patch
+---
+
+Remove the account-wide commitment fallback from image captcha verification.
+
+`verifyImageCaptchaSolution` fell back to `getDappUserCommitmentByAccount` when
+the token carried no `commitmentId`, returning the first *approved* commitment
+in the account's history — any age, any session.
+
+That fallback predates the Procaptcha token (#1263, 2024-06-06), which has
+carried `commitmentId` on every image solve since; `Manager.ts` sets it
+unconditionally for this captcha type, and it is `optional()` on the schema only
+because PoW shares the token shape and identifies its work by `challenge`.
+
+It could only ever return the wrong record. For a returning user whose current
+solve was not yet approved it produced an approved commitment from an earlier
+visit, which carries no `clientSessionId`, so the session correlation compared
+the live id against `undefined` and reported `CLIENT_SESSION_MISMATCH` — a token
+replay that never happened. Observed in production at scale on the image
+path while PoW, which resolves its exact challenge record, was unaffected.
+
+Verification now requires a `commitmentId` and returns
+`API.USER_NOT_VERIFIED_NO_SOLUTION` without one. A token that names no
+commitment cannot be verified against one.

--- a/packages/provider/src/tasks/imgCaptcha/imgCaptchaTasks.ts
+++ b/packages/provider/src/tasks/imgCaptcha/imgCaptchaTasks.ts
@@ -658,25 +658,6 @@ export class ImgCaptchaManager extends CaptchaManager {
 		return dappUserSolution;
 	}
 
-	/* Check if dapp user has verified solution in cache */
-	async getDappUserCommitmentByAccount(
-		userAccount: string,
-		dappAccount: string,
-	): Promise<UserCommitment | undefined> {
-		const dappUserSolutions = await this.db.getDappUserCommitmentByAccount(
-			userAccount,
-			dappAccount,
-		);
-		if (dappUserSolutions.length > 0) {
-			for (const dappUserSolution of dappUserSolutions) {
-				if (dappUserSolution.result.status === CaptchaStatus.approved) {
-					return dappUserSolution;
-				}
-			}
-		}
-		return undefined;
-	}
-
 	async verifyImageCaptchaSolution(
 		user: string,
 		dapp: string,
@@ -700,9 +681,36 @@ export class ImgCaptchaManager extends CaptchaManager {
 		// method carries it without repeating the fields in each `data` block.
 		const logger = this.logger.with({ commitmentId, dapp });
 
-		const solution = await (commitmentId
-			? this.getDappUserCommitmentById(commitmentId)
-			: this.getDappUserCommitmentByAccount(user, dapp));
+		// An image token has carried its `commitmentId` since the Procaptcha
+		// token was introduced (#1263, 2024-06-06) — `Manager.ts` sets it
+		// unconditionally on every `onHuman` for this captcha type. It is
+		// `optional()` on the schema only because PoW shares the token shape and
+		// identifies its work by `challenge` instead.
+		//
+		// The fallback that used to stand here searched the account's entire
+		// history for any approved commitment. It predates the token and could
+		// only ever return the wrong record: for a returning user whose current
+		// solve was not yet approved it produced an approved commitment from an
+		// earlier visit, which carries no `clientSessionId`, so the correlation
+		// below compared the live session id against `undefined` and reported a
+		// replay that never happened. Seen in production at scale on the image
+		// path while PoW, which resolves its exact challenge record, saw
+		// effectively none of it.
+		//
+		// Verifying a token against a commitment it does not name is not a
+		// weaker answer, it is an answer to a different question. Without an id
+		// there is nothing to verify.
+		if (!commitmentId) {
+			logger.debug(() => ({
+				msg: "Not verified - token carried no commitmentId",
+			}));
+			return {
+				status: "API.USER_NOT_VERIFIED_NO_SOLUTION",
+				verified: false,
+			};
+		}
+
+		const solution = await this.getDappUserCommitmentById(commitmentId);
 
 		// No solution exists
 		if (!solution) {

--- a/packages/provider/src/tests/unit/tasks/imgCaptcha/imgCaptchaTasks.unit.test.ts
+++ b/packages/provider/src/tests/unit/tasks/imgCaptcha/imgCaptchaTasks.unit.test.ts
@@ -620,60 +620,37 @@ describe("ImgCaptchaManager", () => {
 		);
 	});
 
-	it("should get dapp user commitment by account", async () => {
-		const userAccount = "userAccount";
-		const dappAccount = "dappAccount";
-		const dappUserCommitments: Partial<UserCommitment>[] = [
-			{
-				id: "commitmentId",
-				userAccount,
-				dappAccount,
-				providerAccount: "providerAccount",
-				datasetId: "datasetId",
-				result: { status: CaptchaStatus.approved },
-				userSignature: "",
-				userSubmitted: true,
-				serverChecked: false,
-				requestedAtTimestamp: new Date(0),
-				submittedAtTimestamp: new Date(),
-				ipAddress: {
-					lower: getIPAddress("1.1.1.1").bigInt(),
-					upper: 0n,
-					type: IpAddressType.v4,
-				},
-				headers: { a: "1", b: "2", c: "3" },
-				ja4: "ja4",
-				lastUpdatedTimestamp: new Date(),
-			} as Partial<UserCommitment>,
-		];
-		// biome-ignore lint/suspicious/noExplicitAny: tests
-		(db.getDappUserCommitmentByAccount as any).mockResolvedValue(
-			dappUserCommitments,
+	// Regression seen in production: image captchas produced
+	// CLIENT_SESSION_MISMATCH at scale while PoW saw effectively none of it.
+	// Verify used to fall back to an account-wide search
+	// for any approved commitment when the token carried no id. That fallback
+	// predates the Procaptcha token (#1263, 2024-06-06) — which has carried
+	// `commitmentId` on every image solve since — and could only return the
+	// wrong record, so the session correlation compared a live id against the
+	// `undefined` on some earlier visit's commitment.
+	it("should not verify when the token carries no commitmentId", async () => {
+		const result = await imgCaptchaManager.verifyImageCaptchaSolution(
+			"userAccount",
+			"dappAccount",
+			undefined,
+			// biome-ignore lint/suspicious/noExplicitAny: tests
+			{} as any,
 		);
 
-		const result = await imgCaptchaManager.getDappUserCommitmentByAccount(
-			userAccount,
-			dappAccount,
-		);
-
-		expect(result).toEqual(dappUserCommitments[0]);
+		expect(result.verified).toBe(false);
+		expect(result.status).toBe("API.USER_NOT_VERIFIED_NO_SOLUTION");
 	});
 
-	it("should return undefined if no approved dapp user commitment is found by account", async () => {
-		const userAccount = "userAccount";
-		const dappAccount = "dappAccount";
-		const dappUserCommitments: UserCommitment[] = [];
-		// biome-ignore lint/suspicious/noExplicitAny: tests
-		(db.getDappUserCommitmentByAccount as any).mockResolvedValue(
-			dappUserCommitments,
+	it("should never search the account's history when no commitmentId is given", async () => {
+		await imgCaptchaManager.verifyImageCaptchaSolution(
+			"userAccount",
+			"dappAccount",
+			undefined,
+			// biome-ignore lint/suspicious/noExplicitAny: tests
+			{} as any,
 		);
 
-		const result = await imgCaptchaManager.getDappUserCommitmentByAccount(
-			userAccount,
-			dappAccount,
-		);
-
-		expect(result).toBeUndefined();
+		expect(db.getDappUserCommitmentByAccount).not.toHaveBeenCalled();
 	});
 
 	describe("verifyImageCaptchaSolution with decision machine", () => {
@@ -1741,9 +1718,15 @@ describe("ImgCaptchaManager", () => {
 			);
 
 			expect(result.verified).toBe(false);
-			expect(result.status).toBe("API.SPAM_EMAIL_DOMAIN");
-			expect(db.getSpamEmailDomain).toHaveBeenCalledWith("spammydomain.com");
-			// Should not call disapprove when commitmentId is undefined
+			// Was API.SPAM_EMAIL_DOMAIN: without a commitmentId this used to
+			// search the account's history, find *some* approved commitment and
+			// carry on into the spam check. That search is gone — a token that
+			// names no commitment cannot be verified against one, so the answer
+			// is now simply "no solution". Either way the caller is told the user
+			// is not verified; only the reason is more honest.
+			expect(result.status).toBe("API.USER_NOT_VERIFIED_NO_SOLUTION");
+			// The point of the test, unchanged: nothing gets disapproved when
+			// there is no commitment to disapprove.
 			expect(db.disapproveDappUserCommitment).not.toHaveBeenCalled();
 		});
 	});


### PR DESCRIPTION
Image verification fell back to an account-wide commitment search when the token carried no `commitmentId`. That fallback is dead code, and while it was reachable it could only ever return the wrong record.

## Why it is dead

An image token has carried its `commitmentId` since the Procaptcha token was introduced (#1263, 2024-06-06). `procaptcha/src/modules/Manager.ts` sets it unconditionally on every `onHuman` for this captcha type:

```ts
[ApiParams.commitmentId]: hashToHex(submission[1]),
```

It is `optional()` on `ProcaptchaOutputSchema` only because PoW shares the token shape and identifies its work by `challenge` instead. So the `commitmentId ? byId : byAccount` branch has had an unreachable arm for over a year.

## Why it was wrong

```ts
for (const dappUserSolution of dappUserSolutions) {
    if (dappUserSolution.result.status === CaptchaStatus.approved) {
        return dappUserSolution;   // any age, any session
    }
}
```

It returned the first approved commitment in the account history. For a returning user whose current solve was not yet approved, that is an approved commitment from an earlier visit — which carries no `clientSessionId`. The session correlation then compared the live id against `undefined` and disapproved with `CLIENT_SESSION_MISMATCH`: a token replay that never happened.

The asymmetry between captcha types is the tell. PoW and puzzle resolve their exact `challengeRecord` and are unaffected; image alone used the account-wide search, and image alone produced these mismatches at scale in production.

## The change

Verification now requires a `commitmentId` and returns `API.USER_NOT_VERIFIED_NO_SOLUTION` without one. The task-level `getDappUserCommitmentByAccount` is removed; the database-level method remains, with its own integration coverage.

Verifying a token against a commitment it does not name is not a weaker answer, it is an answer to a different question.

## Tests

- `should not verify when the token carries no commitmentId`
- `should never search the account's history when no commitmentId is given`

One existing test moves from `API.SPAM_EMAIL_DOMAIN` to `API.USER_NOT_VERIFIED_NO_SOLUTION`: it passed no `commitmentId` and relied on the fallback to find a commitment before reaching the spam check. Its actual assertion — that nothing is disapproved when there is no commitment — is unchanged.

43 imgCaptcha tests pass, 1,192 provider unit tests pass, `build:tsc` clean, biome clean.