### PR TITLE
chore(deps): combine open dependabot updates

### DIFF
--- a/.changeset/dependabot-3171.md
+++ b/.changeset/dependabot-3171.md
@@ -1,0 +1,6 @@
+---
+"@prosopo/redis-client": patch
+"@prosopo/user-access-policy": patch
+---
+
+chore(deps): bump @redis/search from 5.0.0 to 6.2.1

--- a/.changeset/dependabot-3171.md
+++ b/.changeset/dependabot-3171.md
@@ -1,6 +1,0 @@
----
-"@prosopo/redis-client": patch
-"@prosopo/user-access-policy": patch
----
-
-chore(deps): bump @redis/search from 5.0.0 to 6.2.1

--- a/.changeset/dependabot-3172.md
+++ b/.changeset/dependabot-3172.md
@@ -1,0 +1,8 @@
+---
+"@prosopo/cli": patch
+"@prosopo/datasets-fs": patch
+"@prosopo/scripts": patch
+"@prosopo/user-access-policy": patch
+---
+
+chore(deps): bump yargs from 17.7.2 to 18.1.0

--- a/.changeset/dependabot-3173.md
+++ b/.changeset/dependabot-3173.md
@@ -1,0 +1,4 @@
+---
+---
+
+chore(deps): bump @actions/core from 1.10.1 to 3.0.1

--- a/.changeset/dependabot-3174.md
+++ b/.changeset/dependabot-3174.md
@@ -1,0 +1,5 @@
+---
+"@prosopo/database": patch
+---
+
+chore(deps): bump make-dir from 3.1.0 to 5.1.0

--- a/.changeset/dependabot-3176.md
+++ b/.changeset/dependabot-3176.md
@@ -1,0 +1,5 @@
+---
+"@prosopo/provider": patch
+---
+
+chore(deps-dev): bump @types/uuid from 10.0.0 to 11.0.0

--- a/.changeset/dependabot-3177.md
+++ b/.changeset/dependabot-3177.md
@@ -1,0 +1,6 @@
+---
+"@prosopo/native-ja4": patch
+"@prosopo/native-merkle": patch
+---
+
+chore(deps-dev): bump @napi-rs/cli from 2.18.4 to 3.8.6

--- a/.changeset/dependabot-3178.md
+++ b/.changeset/dependabot-3178.md
@@ -1,0 +1,4 @@
+---
+---
+
+chore(deps-dev): bump cypress-visual-regression from 5.3.0 to 6.0.0

--- a/.changeset/dependabot-3188.md
+++ b/.changeset/dependabot-3188.md
@@ -1,0 +1,10 @@
+---
+"@prosopo/config": patch
+"@prosopo/database": patch
+"@prosopo/provider": patch
+"@prosopo/types": patch
+"@prosopo/user-access-policy": patch
+"@prosopo/util": patch
+---
+
+chore(deps): bump the npm-minor-and-patch group across 1 directory with 3 updates

--- a/.github/workflows/android-webview.yml
+++ b/.github/workflows/android-webview.yml
@@ -42,7 +42,7 @@ jobs:
       # 17, not the app's own jvmTarget: that is the bytecode level the app
       # compiles *to*, while the Android Gradle Plugin itself needs a JDK 17.
       - name: Set up JDK 17
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           distribution: temurin
           java-version: "17"

--- a/demos/cypress-shared/package.json
+++ b/demos/cypress-shared/package.json
@@ -34,7 +34,7 @@
 		"concurrently": "9.0.1",
 		"cypress": "15.21.1",
 		"cypress-real-events": "1.15.0",
-		"cypress-visual-regression": "5.3.0",
+		"cypress-visual-regression": "6.0.0",
 		"cypress-vite": "1.10.2",
 		"del-cli": "6.0.0",
 		"npm-run-all": "4.1.5",

--- a/dev/config/package.json
+++ b/dev/config/package.json
@@ -67,7 +67,7 @@
 		"vite-plugin-node-polyfills": "0.28.0",
 		"vite-tsconfig-paths": "6.1.1",
 		"vitest": "4.1.11",
-		"webpack": "5.110.1",
+		"webpack": "5.110.2",
 		"webpack-cli": "7.2.3",
 		"webpack-dev-server": "6.0.0"
 	},

--- a/dev/lint/package.json
+++ b/dev/lint/package.json
@@ -46,7 +46,7 @@
 		"@prosopo/util": "3.3.8",
 		"@prosopo/workspace": "3.2.1",
 		"fast-glob": "3.3.3",
-		"yargs": "17.7.2",
+		"yargs": "18.1.0",
 		"zod": "3.23.8"
 	}
 }

--- a/dev/prosoponator-bot/package.json
+++ b/dev/prosoponator-bot/package.json
@@ -18,7 +18,7 @@
 	"author": "",
 	"license": "ISC",
 	"dependencies": {
-		"@actions/core": "1.10.1",
+		"@actions/core": "3.0.1",
 		"@actions/github": "9.1.1",
 		"undici": "6.28.0"
 	},

--- a/dev/prosoponator-bot/src/tests/main.unit.test.ts
+++ b/dev/prosoponator-bot/src/tests/main.unit.test.ts
@@ -18,6 +18,25 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { type BotDeps, defaultDeps, main } from "../bot.js";
 
 /**
+ * @actions/core 3 is native ESM, so its exports are non-configurable and
+ * vi.spyOn cannot replace them. Replacing the module is the only way to
+ * observe the two functions bot.ts calls; getInput keeps its real behaviour
+ * because the defaultDeps tests drive it through INPUT_* in the environment.
+ */
+vi.mock("@actions/core", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@actions/core")>();
+	return {
+		...actual,
+		getInput: vi.fn<typeof actual.getInput>(actual.getInput),
+		setFailed: vi.fn<typeof actual.setFailed>(),
+	};
+});
+
+const realGetInput: typeof core.getInput = (
+	await vi.importActual<typeof import("@actions/core")>("@actions/core")
+).getInput;
+
+/**
  * `context.repo` falls back to the event payload's `repository` when
  * GITHUB_REPOSITORY is unset, and inside a workflow that payload is populated —
  * so clearing the variable alone does not reach the throwing path.
@@ -56,6 +75,8 @@ beforeEach(() => {
 	set("GITHUB_TOKEN", undefined);
 	set("GH_TOKEN", undefined);
 	set("GITHUB_REPOSITORY", "prosopo/captcha");
+	vi.mocked(core.setFailed).mockReset();
+	vi.mocked(core.getInput).mockReset().mockImplementation(realGetInput);
 });
 
 afterEach(() => {
@@ -108,9 +129,7 @@ describe("defaultDeps", () => {
 
 describe("main", () => {
 	test("fails the action when the dependencies cannot be built", async () => {
-		const setFailed = vi
-			.spyOn(core, "setFailed")
-			.mockImplementation((): void => undefined);
+		const setFailed = vi.mocked(core.setFailed);
 		vi.spyOn(console, "error").mockImplementation((): void => undefined);
 		await main();
 		expect(setFailed).toHaveBeenCalledWith(
@@ -119,7 +138,6 @@ describe("main", () => {
 	});
 
 	test("does not reject — a thrown error would lose the annotation", async () => {
-		vi.spyOn(core, "setFailed").mockImplementation((): void => undefined);
 		vi.spyOn(console, "error").mockImplementation((): void => undefined);
 		await expect(main()).resolves.toBeUndefined();
 	});
@@ -127,7 +145,6 @@ describe("main", () => {
 	test("logs the whole error, not just its message", async () => {
 		// The message alone is what the annotation shows; the stack goes to the
 		// job log, which is the only place it can be read afterwards.
-		vi.spyOn(core, "setFailed").mockImplementation((): void => undefined);
 		const error = vi
 			.spyOn(console, "error")
 			.mockImplementation((): void => undefined);
@@ -139,9 +156,7 @@ describe("main", () => {
 		// The happy path that makes no requests: a token is present, the context
 		// is readable, and run() bails on the event name.
 		set("GITHUB_TOKEN", "ghp_notarealtoken");
-		const setFailed = vi
-			.spyOn(core, "setFailed")
-			.mockImplementation((): void => undefined);
+		const setFailed = vi.mocked(core.setFailed);
 		vi.spyOn(console, "log").mockImplementation((): void => undefined);
 		await main();
 		expect(setFailed).not.toHaveBeenCalled();
@@ -150,12 +165,10 @@ describe("main", () => {
 	test("fails the action when something that is not an Error is thrown", async () => {
 		// core.getInput throws on a malformed action input, and a thrown string
 		// has no .message — the annotation used to read "undefined".
-		vi.spyOn(core, "getInput").mockImplementation((): string => {
+		vi.mocked(core.getInput).mockImplementation((): string => {
 			throw "input is not valid";
 		});
-		const setFailed = vi
-			.spyOn(core, "setFailed")
-			.mockImplementation((): void => undefined);
+		const setFailed = vi.mocked(core.setFailed);
 		vi.spyOn(console, "error").mockImplementation((): void => undefined);
 		await main();
 		expect(setFailed).toHaveBeenCalledWith("input is not valid");

--- a/dev/scripts/package.json
+++ b/dev/scripts/package.json
@@ -49,7 +49,7 @@
 		"dotenv": "16.4.5",
 		"fast-glob": "3.3.3",
 		"fs-extra": "11.4.0",
-		"yargs": "17.7.2"
+		"yargs": "18.1.0"
 	},
 	"devDependencies": {
 		"@prosopo/config": "3.3.13",

--- a/package-lock.json
+++ b/package-lock.json
@@ -34807,7 +34807,7 @@
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@prosopo/logger": "2.0.8",
-				"@redis/search": "5.0.0",
+				"@redis/search": "6.2.1",
 				"redis": "5.0.0"
 			},
 			"devDependencies": {
@@ -34828,6 +34828,18 @@
 			"engines": {
 				"node": "^24",
 				"npm": "^11"
+			}
+		},
+		"packages/redis-client/node_modules/@redis/search": {
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/@redis/search/-/search-6.2.1.tgz",
+			"integrity": "sha512-2vfOAOyYFE7UUw3sBBlkqqruBtOUS4HRY5MtW4hp83llrwvtrTE4r22CEqXddlV+54zkLxBE4nmsIJ/dpezQrQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 20.0.0"
+			},
+			"peerDependencies": {
+				"@redis/client": "^6.2.1"
 			}
 		},
 		"packages/redis-client/node_modules/@types/node": {
@@ -35031,7 +35043,7 @@
 				"@prosopo/redis-client": "1.0.34",
 				"@prosopo/types": "5.6.0",
 				"@prosopo/util": "3.3.8",
-				"@redis/search": "5.0.0",
+				"@redis/search": "6.2.1",
 				"cidr-calc": "1.0.4",
 				"dotenv": "16.4.5",
 				"ip-address": "10.5.0",
@@ -35051,6 +35063,18 @@
 			"engines": {
 				"node": "^24",
 				"npm": "^11"
+			}
+		},
+		"packages/user-access-policy/node_modules/@redis/search": {
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/@redis/search/-/search-6.2.1.tgz",
+			"integrity": "sha512-2vfOAOyYFE7UUw3sBBlkqqruBtOUS4HRY5MtW4hp83llrwvtrTE4r22CEqXddlV+54zkLxBE4nmsIJ/dpezQrQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 20.0.0"
+			},
+			"peerDependencies": {
+				"@redis/client": "^6.2.1"
 			}
 		},
 		"packages/user-access-policy/node_modules/@types/node": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -609,7 +609,7 @@
 				"vite-plugin-node-polyfills": "0.28.0",
 				"vite-tsconfig-paths": "6.1.1",
 				"vitest": "4.1.11",
-				"webpack": "5.110.1",
+				"webpack": "5.110.2",
 				"webpack-cli": "7.2.3",
 				"webpack-dev-server": "6.0.0"
 			},
@@ -20709,9 +20709,9 @@
 			}
 		},
 		"node_modules/ip-address": {
-			"version": "10.5.0",
-			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
-			"integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
+			"version": "10.7.0",
+			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.7.0.tgz",
+			"integrity": "sha512-BGFsyJd5mpXp3rK6jIdADLNgpJUK1jnjzvYF8lK+VyDab9JAmqN0YOKDdP17HlgKb2+ehPgDc8EtnRLbGCAMhA==",
 			"license": "MIT",
 			"engines": {
 				"node": ">= 12"
@@ -29277,9 +29277,9 @@
 			}
 		},
 		"node_modules/webpack": {
-			"version": "5.110.1",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.110.1.tgz",
-			"integrity": "sha512-gInQB+jxXxgnZyvPwuzT5NGQmECDqeu85oxcrjinrYHqPoBex0hCAN2SFTJVyPVrK0Pq9E44VFP+e89fAc10/w==",
+			"version": "5.110.2",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.110.2.tgz",
+			"integrity": "sha512-TciLrfM7zgEjqGdY851HkirDsSPQgTFsWQpl9oHqMAMYsHhEC0bKjscvjpnz+pzx10hLC8qISApGrsnrCP4UtQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -31353,7 +31353,7 @@
 				"@prosopo/util": "3.3.8",
 				"bson": "7.3.2",
 				"make-dir": "3.1.0",
-				"mongodb": "7.5.0",
+				"mongodb": "7.6.0",
 				"mongodb-memory-server": "10.3.0",
 				"mongoose": "9.9.4"
 			},
@@ -31404,9 +31404,9 @@
 			}
 		},
 		"packages/database/node_modules/mongodb": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-7.5.0.tgz",
-			"integrity": "sha512-5FnrEDLnvp6ycUOGLNLLU33BfCx2qmp2mJjGPDwKLruYsVzXVSK5fsGpoDXvsXJwBfBsD7ebMRdawbDxC2814g==",
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-7.6.0.tgz",
+			"integrity": "sha512-WbZ6OCjYw2c53LOjfkQa+reXr7kIiOVpXXglnASFuiMtif0BvsMwHe3ClJHLm1/r7wJFwaasfFtD6iYIktB01g==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@mongodb-js/saslprep": "^1.4.11",
@@ -34554,7 +34554,7 @@
 				"express-rate-limit": "7.4.0",
 				"geolib": "3.3.14",
 				"i18next": "24.1.0",
-				"ip-address": "10.5.0",
+				"ip-address": "10.7.0",
 				"mongoose": "9.9.4",
 				"prom-client": "15.1.3",
 				"uuid": "14.0.2",
@@ -34908,7 +34908,7 @@
 				"@prosopo/locale": "3.4.1",
 				"@prosopo/util": "3.3.8",
 				"@prosopo/util-crypto": "13.5.31",
-				"ip-address": "10.5.0",
+				"ip-address": "10.7.0",
 				"scale-ts": "1.6.1",
 				"zod": "3.23.8"
 			},
@@ -35034,7 +35034,7 @@
 				"@redis/search": "5.0.0",
 				"cidr-calc": "1.0.4",
 				"dotenv": "16.4.5",
-				"ip-address": "10.5.0",
+				"ip-address": "10.7.0",
 				"redis": "5.0.0",
 				"zod": "3.23.8"
 			},
@@ -35081,7 +35081,7 @@
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@noble/hashes": "1.8.0",
-				"ip-address": "10.5.0",
+				"ip-address": "10.7.0",
 				"lodash": "4.18.1",
 				"seedrandom": "3.0.5"
 			},

--- a/package-lock.json
+++ b/package-lock.json
@@ -14497,11 +14497,15 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/uuid": {
-			"version": "10.0.0",
-			"resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
-			"integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+			"version": "11.0.0",
+			"resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-11.0.0.tgz",
+			"integrity": "sha512-HVyk8nj2m+jcFRNazzqyVKiZezyhDKrGUA3jlEcg/nZ6Ms+qHwocba1Y/AaVaznJTAM9xpdFSh+ptbNrhOGvZA==",
+			"deprecated": "This is a stub types definition. uuid provides its own type definitions, so you do not need this installed.",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"dependencies": {
+				"uuid": "*"
+			}
 		},
 		"node_modules/@types/webidl-conversions": {
 			"version": "7.0.3",
@@ -34564,7 +34568,7 @@
 				"@prosopo/config": "3.3.13",
 				"@types/node": "22.5.5",
 				"@types/pg": "8.23.1",
-				"@types/uuid": "10.0.0",
+				"@types/uuid": "11.0.0",
 				"@vitest/coverage-v8": "4.1.11",
 				"concurrently": "9.0.1",
 				"cors": "2.8.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -31352,7 +31352,7 @@
 				"@prosopo/user-access-policy": "3.12.33",
 				"@prosopo/util": "3.3.8",
 				"bson": "7.3.2",
-				"make-dir": "3.1.0",
+				"make-dir": "5.1.0",
 				"mongodb": "7.5.0",
 				"mongodb-memory-server": "10.3.0",
 				"mongoose": "9.9.4"
@@ -31401,6 +31401,18 @@
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=20.19.0"
+			}
+		},
+		"packages/database/node_modules/make-dir": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-5.1.0.tgz",
+			"integrity": "sha512-IfpFq6UM39dUNiphpA6uDezNx/AvWyhwfICWPR3t1VspkgkMZrL+Rk1RbN1bx+aeNYwOrqGJgEgV3yotk+ZUVw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"packages/database/node_modules/mongodb": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1166,7 +1166,7 @@
 			"version": "2.6.29",
 			"license": "ISC",
 			"dependencies": {
-				"@actions/core": "1.10.1",
+				"@actions/core": "3.0.1",
 				"@actions/github": "9.1.1",
 				"undici": "6.28.0"
 			},
@@ -1342,23 +1342,22 @@
 			}
 		},
 		"node_modules/@actions/core": {
-			"version": "1.10.1",
-			"resolved": "https://registry.npmjs.org/@actions/core/-/core-1.10.1.tgz",
-			"integrity": "sha512-3lBR9EDAY+iYIpTnTIXmWcNbX3T2kCkAEQGIQx4NVQ0575nk2k3GRZDTPQG+vVtS2izSLmINlxXf0uLtnrTP+g==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@actions/core/-/core-3.0.1.tgz",
+			"integrity": "sha512-a6d/Nwahm9fliVGRhdhofo40HjHQasUPusmc7vBfyky+7Z+P2A1J68zyFVaNcEclc/Se+eO595oAr5nwEIoIUA==",
 			"license": "MIT",
 			"dependencies": {
-				"@actions/http-client": "^2.0.1",
-				"uuid": "^8.3.2"
+				"@actions/exec": "^3.0.0",
+				"@actions/http-client": "^4.0.0"
 			}
 		},
-		"node_modules/@actions/core/node_modules/uuid": {
-			"version": "8.3.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-			"deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+		"node_modules/@actions/exec": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@actions/exec/-/exec-3.0.0.tgz",
+			"integrity": "sha512-6xH/puSoNBXb72VPlZVm7vQ+svQpFyA96qdDBvhB8eNZOE8LtPf9L4oAsfzK/crCL8YZ+19fKYVnM63Sl+Xzlw==",
 			"license": "MIT",
-			"bin": {
-				"uuid": "dist/bin/uuid"
+			"dependencies": {
+				"@actions/io": "^3.0.2"
 			}
 		},
 		"node_modules/@actions/github": {
@@ -1387,26 +1386,20 @@
 			}
 		},
 		"node_modules/@actions/http-client": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.2.3.tgz",
-			"integrity": "sha512-mx8hyJi/hjFvbPokCg4uRd4ZX78t+YyRPtnKWwIl+RzNaVuFpQHfmlGVfsKEJN8LwTCvL+DfVgAM04XaHkm6bA==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-4.0.1.tgz",
+			"integrity": "sha512-+Nvd1ImaOZBSoPbsUtEhv+1z99H12xzncCkz0a3RuehINE81FZSe2QTj3uvAPTcJX/SCzUQHQ0D1GrPMbrPitg==",
 			"license": "MIT",
 			"dependencies": {
 				"tunnel": "^0.0.6",
-				"undici": "^5.25.4"
+				"undici": "^6.23.0"
 			}
 		},
-		"node_modules/@actions/http-client/node_modules/undici": {
-			"version": "5.29.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-			"integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
-			"license": "MIT",
-			"dependencies": {
-				"@fastify/busboy": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=14.0"
-			}
+		"node_modules/@actions/io": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@actions/io/-/io-3.0.2.tgz",
+			"integrity": "sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw==",
+			"license": "MIT"
 		},
 		"node_modules/@asamuzakjp/css-color": {
 			"version": "3.2.0",
@@ -8747,15 +8740,6 @@
 			],
 			"engines": {
 				"node": ">=18"
-			}
-		},
-		"node_modules/@fastify/busboy": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
-			"integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=14"
 			}
 		},
 		"node_modules/@grpc/grpc-js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -336,7 +336,7 @@
 				"concurrently": "9.0.1",
 				"cypress": "15.21.1",
 				"cypress-real-events": "1.15.0",
-				"cypress-visual-regression": "5.3.0",
+				"cypress-visual-regression": "6.0.0",
 				"cypress-vite": "1.10.2",
 				"del-cli": "6.0.0",
 				"npm-run-all": "4.1.5",
@@ -17689,22 +17689,35 @@
 			}
 		},
 		"node_modules/cypress-visual-regression": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/cypress-visual-regression/-/cypress-visual-regression-5.3.0.tgz",
-			"integrity": "sha512-vnGOcoty61JibQ6LMYmYXQ0MIdoiQzuRtLpL+iuGE3aalVaYecC9AUfQfrOJL1eRtC2hsvrmPRfgHBZ/MXe75A==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/cypress-visual-regression/-/cypress-visual-regression-6.0.0.tgz",
+			"integrity": "sha512-cpkUHNggIbC8lt7xIz+XY+Gg5m9vsfNbQO9FqNORAzprBVBfXsUpboqWWt1ITCmkOaFwIdpwc+yt/TJ5rSr6Yw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"chalk": "4.1.2",
-				"pixelmatch": "5.3.0",
+				"chalk": "5.6.2",
+				"pixelmatch": "7.2.0",
 				"pngjs": "7.0.0",
-				"sanitize-filename": "1.6.3"
+				"sanitize-filename": "1.6.4"
 			},
 			"engines": {
 				"node": ">=18"
 			},
 			"peerDependencies": {
-				"cypress": ">=12"
+				"cypress": ">=15"
+			}
+		},
+		"node_modules/cypress-visual-regression/node_modules/chalk": {
+			"version": "5.6.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+			"integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^12.17.0 || ^14.13 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
 			}
 		},
 		"node_modules/cypress-vite": {
@@ -24504,26 +24517,16 @@
 			}
 		},
 		"node_modules/pixelmatch": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-5.3.0.tgz",
-			"integrity": "sha512-o8mkY4E/+LNUf6LzX96ht6k6CEDi65k9G2rjMtBe9Oo+VPKSvl+0GKHuH/AlG+GA5LPG/i5hrekkxUc3s2HU+Q==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-7.2.0.tgz",
+			"integrity": "sha512-xhcb4yHu9sM/G7foGzoLtXYcC0zHEaOXXjRKhGup0fw78Nf2Tkiapv4EQyMzrbcmQPsllAI7DbFY2UT7PlI9Pg==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
-				"pngjs": "^6.0.0"
+				"pngjs": "^7.0.0"
 			},
 			"bin": {
 				"pixelmatch": "bin/pixelmatch"
-			}
-		},
-		"node_modules/pixelmatch/node_modules/pngjs": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/pngjs/-/pngjs-6.0.0.tgz",
-			"integrity": "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12.13.0"
 			}
 		},
 		"node_modules/pkg-dir": {
@@ -26194,9 +26197,9 @@
 			"license": "MIT"
 		},
 		"node_modules/sanitize-filename": {
-			"version": "1.6.3",
-			"resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
-			"integrity": "sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==",
+			"version": "1.6.4",
+			"resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.4.tgz",
+			"integrity": "sha512-9ZyI08PsvdQl2r/bBIGubpVdR3RR9sY6RDiWFPreA21C/EFlQhmgo20UZlNjZMMZNubusLhAQozkA0Od5J21Eg==",
 			"dev": true,
 			"license": "WTFPL OR ISC",
 			"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1140,7 +1140,7 @@
 				"@prosopo/util": "3.3.8",
 				"@prosopo/workspace": "3.2.1",
 				"fast-glob": "3.3.3",
-				"yargs": "17.7.2",
+				"yargs": "18.1.0",
 				"zod": "3.23.8"
 			},
 			"devDependencies": {
@@ -1159,6 +1159,158 @@
 			"engines": {
 				"node": "^24",
 				"npm": "^11"
+			}
+		},
+		"dev/lint/node_modules/ansi-regex": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+			"integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"dev/lint/node_modules/ansi-styles": {
+			"version": "6.2.3",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+			"integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"dev/lint/node_modules/cliui": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+			"integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+			"license": "ISC",
+			"dependencies": {
+				"string-width": "^7.2.0",
+				"strip-ansi": "^7.1.0",
+				"wrap-ansi": "^9.0.0"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"dev/lint/node_modules/cliui/node_modules/string-width": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+			"integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^10.3.0",
+				"get-east-asian-width": "^1.0.0",
+				"strip-ansi": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"dev/lint/node_modules/emoji-regex": {
+			"version": "10.6.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+			"integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+			"license": "MIT"
+		},
+		"dev/lint/node_modules/string-width": {
+			"version": "8.2.2",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+			"integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
+			"license": "MIT",
+			"dependencies": {
+				"get-east-asian-width": "^1.5.0",
+				"strip-ansi": "^7.1.2"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"dev/lint/node_modules/strip-ansi": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+			"integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^6.2.2"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+			}
+		},
+		"dev/lint/node_modules/wrap-ansi": {
+			"version": "9.0.2",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+			"integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^6.2.1",
+				"string-width": "^7.0.0",
+				"strip-ansi": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"dev/lint/node_modules/wrap-ansi/node_modules/string-width": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+			"integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^10.3.0",
+				"get-east-asian-width": "^1.0.0",
+				"strip-ansi": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"dev/lint/node_modules/yargs": {
+			"version": "18.1.0",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-18.1.0.tgz",
+			"integrity": "sha512-2rAgRKu54VsHkqI0/tYkmluGXHD4KW7yZoycuqDQ15QOTnc2VVfy0nN/1eMhnQLO00A+dwtK20xuCnc1YGeUyg==",
+			"license": "MIT",
+			"dependencies": {
+				"cliui": "^9.0.1",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"string-width": "^8.2.1",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^22.0.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=23"
+			}
+		},
+		"dev/lint/node_modules/yargs-parser": {
+			"version": "22.0.0",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+			"integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+			"license": "ISC",
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=23"
 			}
 		},
 		"dev/prosoponator-bot": {
@@ -1224,7 +1376,7 @@
 				"dotenv": "16.4.5",
 				"fast-glob": "3.3.3",
 				"fs-extra": "11.4.0",
-				"yargs": "17.7.2"
+				"yargs": "18.1.0"
 			},
 			"devDependencies": {
 				"@prosopo/config": "3.3.13",
@@ -1255,6 +1407,61 @@
 				"undici-types": "~6.20.0"
 			}
 		},
+		"dev/scripts/node_modules/ansi-regex": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+			"integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"dev/scripts/node_modules/ansi-styles": {
+			"version": "6.2.3",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+			"integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"dev/scripts/node_modules/cliui": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+			"integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+			"license": "ISC",
+			"dependencies": {
+				"string-width": "^7.2.0",
+				"strip-ansi": "^7.1.0",
+				"wrap-ansi": "^9.0.0"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"dev/scripts/node_modules/cliui/node_modules/string-width": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+			"integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^10.3.0",
+				"get-east-asian-width": "^1.0.0",
+				"strip-ansi": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"dev/scripts/node_modules/dotenv": {
 			"version": "16.4.5",
 			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
@@ -1265,6 +1472,103 @@
 			},
 			"funding": {
 				"url": "https://dotenvx.com"
+			}
+		},
+		"dev/scripts/node_modules/emoji-regex": {
+			"version": "10.6.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+			"integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+			"license": "MIT"
+		},
+		"dev/scripts/node_modules/string-width": {
+			"version": "8.2.2",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+			"integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
+			"license": "MIT",
+			"dependencies": {
+				"get-east-asian-width": "^1.5.0",
+				"strip-ansi": "^7.1.2"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"dev/scripts/node_modules/strip-ansi": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+			"integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^6.2.2"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+			}
+		},
+		"dev/scripts/node_modules/wrap-ansi": {
+			"version": "9.0.2",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+			"integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^6.2.1",
+				"string-width": "^7.0.0",
+				"strip-ansi": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"dev/scripts/node_modules/wrap-ansi/node_modules/string-width": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+			"integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^10.3.0",
+				"get-east-asian-width": "^1.0.0",
+				"strip-ansi": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"dev/scripts/node_modules/yargs": {
+			"version": "18.1.0",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-18.1.0.tgz",
+			"integrity": "sha512-2rAgRKu54VsHkqI0/tYkmluGXHD4KW7yZoycuqDQ15QOTnc2VVfy0nN/1eMhnQLO00A+dwtK20xuCnc1YGeUyg==",
+			"license": "MIT",
+			"dependencies": {
+				"cliui": "^9.0.1",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"string-width": "^8.2.1",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^22.0.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=23"
+			}
+		},
+		"dev/scripts/node_modules/yargs-parser": {
+			"version": "22.0.0",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+			"integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+			"license": "ISC",
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=23"
 			}
 		},
 		"dev/workspace": {
@@ -19665,7 +19969,6 @@
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
 			"integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
@@ -31071,7 +31374,7 @@
 				"@prosopo/workspace": "3.2.1",
 				"cron-parser": "4.9.0",
 				"dotenv": "16.4.5",
-				"yargs": "17.7.2",
+				"yargs": "18.1.0",
 				"zod": "3.23.8"
 			},
 			"devDependencies": {
@@ -31107,6 +31410,30 @@
 				"undici-types": "~6.20.0"
 			}
 		},
+		"packages/cli/node_modules/ansi-regex": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+			"integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"packages/cli/node_modules/ansi-styles": {
+			"version": "6.2.3",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+			"integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
 		"packages/cli/node_modules/body-parser": {
 			"version": "1.20.6",
 			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
@@ -31132,6 +31459,37 @@
 				"npm": "1.2.8000 || >= 1.4.16"
 			}
 		},
+		"packages/cli/node_modules/cliui": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+			"integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+			"license": "ISC",
+			"dependencies": {
+				"string-width": "^7.2.0",
+				"strip-ansi": "^7.1.0",
+				"wrap-ansi": "^9.0.0"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"packages/cli/node_modules/cliui/node_modules/string-width": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+			"integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^10.3.0",
+				"get-east-asian-width": "^1.0.0",
+				"strip-ansi": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"packages/cli/node_modules/debug": {
 			"version": "2.6.9",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -31153,6 +31511,12 @@
 			"funding": {
 				"url": "https://dotenvx.com"
 			}
+		},
+		"packages/cli/node_modules/emoji-regex": {
+			"version": "10.6.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+			"integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+			"license": "MIT"
 		},
 		"packages/cli/node_modules/express": {
 			"version": "4.22.2",
@@ -31283,6 +31647,97 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.8"
+			}
+		},
+		"packages/cli/node_modules/string-width": {
+			"version": "8.2.2",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+			"integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
+			"license": "MIT",
+			"dependencies": {
+				"get-east-asian-width": "^1.5.0",
+				"strip-ansi": "^7.1.2"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"packages/cli/node_modules/strip-ansi": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+			"integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^6.2.2"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+			}
+		},
+		"packages/cli/node_modules/wrap-ansi": {
+			"version": "9.0.2",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+			"integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^6.2.1",
+				"string-width": "^7.0.0",
+				"strip-ansi": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"packages/cli/node_modules/wrap-ansi/node_modules/string-width": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+			"integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^10.3.0",
+				"get-east-asian-width": "^1.0.0",
+				"strip-ansi": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"packages/cli/node_modules/yargs": {
+			"version": "18.1.0",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-18.1.0.tgz",
+			"integrity": "sha512-2rAgRKu54VsHkqI0/tYkmluGXHD4KW7yZoycuqDQ15QOTnc2VVfy0nN/1eMhnQLO00A+dwtK20xuCnc1YGeUyg==",
+			"license": "MIT",
+			"dependencies": {
+				"cliui": "^9.0.1",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"string-width": "^8.2.1",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^22.0.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=23"
+			}
+		},
+		"packages/cli/node_modules/yargs-parser": {
+			"version": "22.0.0",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+			"integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+			"license": "ISC",
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=23"
 			}
 		},
 		"packages/common": {
@@ -31508,7 +31963,7 @@
 				"bcrypt": "6.0.0",
 				"cli-progress": "3.12.0",
 				"sharp": "0.35.4",
-				"yargs": "17.7.2",
+				"yargs": "18.1.0",
 				"zod": "3.23.8"
 			},
 			"devDependencies": {
@@ -31542,6 +31997,61 @@
 				"undici-types": "~6.20.0"
 			}
 		},
+		"packages/datasets-fs/node_modules/ansi-regex": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+			"integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"packages/datasets-fs/node_modules/ansi-styles": {
+			"version": "6.2.3",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+			"integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"packages/datasets-fs/node_modules/cliui": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+			"integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+			"license": "ISC",
+			"dependencies": {
+				"string-width": "^7.2.0",
+				"strip-ansi": "^7.1.0",
+				"wrap-ansi": "^9.0.0"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"packages/datasets-fs/node_modules/cliui/node_modules/string-width": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+			"integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^10.3.0",
+				"get-east-asian-width": "^1.0.0",
+				"strip-ansi": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"packages/datasets-fs/node_modules/dotenv": {
 			"version": "16.4.5",
 			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
@@ -31553,6 +32063,103 @@
 			},
 			"funding": {
 				"url": "https://dotenvx.com"
+			}
+		},
+		"packages/datasets-fs/node_modules/emoji-regex": {
+			"version": "10.6.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+			"integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+			"license": "MIT"
+		},
+		"packages/datasets-fs/node_modules/string-width": {
+			"version": "8.2.2",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+			"integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
+			"license": "MIT",
+			"dependencies": {
+				"get-east-asian-width": "^1.5.0",
+				"strip-ansi": "^7.1.2"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"packages/datasets-fs/node_modules/strip-ansi": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+			"integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^6.2.2"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+			}
+		},
+		"packages/datasets-fs/node_modules/wrap-ansi": {
+			"version": "9.0.2",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+			"integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^6.2.1",
+				"string-width": "^7.0.0",
+				"strip-ansi": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"packages/datasets-fs/node_modules/wrap-ansi/node_modules/string-width": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+			"integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^10.3.0",
+				"get-east-asian-width": "^1.0.0",
+				"strip-ansi": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"packages/datasets-fs/node_modules/yargs": {
+			"version": "18.1.0",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-18.1.0.tgz",
+			"integrity": "sha512-2rAgRKu54VsHkqI0/tYkmluGXHD4KW7yZoycuqDQ15QOTnc2VVfy0nN/1eMhnQLO00A+dwtK20xuCnc1YGeUyg==",
+			"license": "MIT",
+			"dependencies": {
+				"cliui": "^9.0.1",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"string-width": "^8.2.1",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^22.0.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=23"
+			}
+		},
+		"packages/datasets-fs/node_modules/yargs-parser": {
+			"version": "22.0.0",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+			"integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+			"license": "ISC",
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=23"
 			}
 		},
 		"packages/datasets/node_modules/@types/node": {
@@ -35046,7 +35653,7 @@
 				"mongoose": "9.9.4",
 				"vite": "8.1.5",
 				"vitest": "4.1.11",
-				"yargs": "17.7.2"
+				"yargs": "18.1.0"
 			},
 			"engines": {
 				"node": "^24",
@@ -35063,6 +35670,65 @@
 				"undici-types": "~6.20.0"
 			}
 		},
+		"packages/user-access-policy/node_modules/ansi-regex": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+			"integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"packages/user-access-policy/node_modules/ansi-styles": {
+			"version": "6.2.3",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+			"integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"packages/user-access-policy/node_modules/cliui": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+			"integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"string-width": "^7.2.0",
+				"strip-ansi": "^7.1.0",
+				"wrap-ansi": "^9.0.0"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"packages/user-access-policy/node_modules/cliui/node_modules/string-width": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+			"integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^10.3.0",
+				"get-east-asian-width": "^1.0.0",
+				"strip-ansi": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"packages/user-access-policy/node_modules/dotenv": {
 			"version": "16.4.5",
 			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
@@ -35073,6 +35739,110 @@
 			},
 			"funding": {
 				"url": "https://dotenvx.com"
+			}
+		},
+		"packages/user-access-policy/node_modules/emoji-regex": {
+			"version": "10.6.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+			"integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"packages/user-access-policy/node_modules/string-width": {
+			"version": "8.2.2",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+			"integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"get-east-asian-width": "^1.5.0",
+				"strip-ansi": "^7.1.2"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"packages/user-access-policy/node_modules/strip-ansi": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+			"integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^6.2.2"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+			}
+		},
+		"packages/user-access-policy/node_modules/wrap-ansi": {
+			"version": "9.0.2",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+			"integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^6.2.1",
+				"string-width": "^7.0.0",
+				"strip-ansi": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"packages/user-access-policy/node_modules/wrap-ansi/node_modules/string-width": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+			"integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^10.3.0",
+				"get-east-asian-width": "^1.0.0",
+				"strip-ansi": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"packages/user-access-policy/node_modules/yargs": {
+			"version": "18.1.0",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-18.1.0.tgz",
+			"integrity": "sha512-2rAgRKu54VsHkqI0/tYkmluGXHD4KW7yZoycuqDQ15QOTnc2VVfy0nN/1eMhnQLO00A+dwtK20xuCnc1YGeUyg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"cliui": "^9.0.1",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"string-width": "^8.2.1",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^22.0.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=23"
+			}
+		},
+		"packages/user-access-policy/node_modules/yargs-parser": {
+			"version": "22.0.0",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+			"integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=23"
 			}
 		},
 		"packages/util": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9316,6 +9316,156 @@
 				"url": "https://opencollective.com/libvips"
 			}
 		},
+		"node_modules/@inquirer/ansi": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.7.tgz",
+			"integrity": "sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+			}
+		},
+		"node_modules/@inquirer/checkbox": {
+			"version": "5.2.3",
+			"resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.2.3.tgz",
+			"integrity": "sha512-XEYX2WA8SBkLPczL6/yXPHLPCvDoptmh9v56Cy05BSV1Smk1vWy19bTC4qJBuIffw7+6l4CcaYYzGqG60RfW1g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/ansi": "^2.0.7",
+				"@inquirer/core": "^12.0.1",
+				"@inquirer/figures": "^2.0.8",
+				"@inquirer/type": "^4.1.0"
+			},
+			"engines": {
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/confirm": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.3.0.tgz",
+			"integrity": "sha512-pZHXJImFtERmSNMBHcjwuz8Ck5vEFEYNUZnwbb8aJpjHv/TwGuFErNxF2Hp8+V+pNJs2EYPMlyWscvFEqO9jOQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/core": "^12.0.1",
+				"@inquirer/type": "^4.1.0"
+			},
+			"engines": {
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/core": {
+			"version": "12.0.1",
+			"resolved": "https://registry.npmjs.org/@inquirer/core/-/core-12.0.1.tgz",
+			"integrity": "sha512-JMD5Jy/ScL5TZE18m83Nw25HjqGFLoWXwnEkW7IdwwAhZpB9Bus55/WU7zn3UqR1MOCjjTQOIYpiD4vjWA3LPw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/ansi": "^2.0.7",
+				"@inquirer/figures": "^2.0.8",
+				"@inquirer/type": "^4.1.0",
+				"cli-width": "^4.1.0",
+				"fast-wrap-ansi": "^0.2.0",
+				"mute-stream": "^3.0.0",
+				"signal-exit": "^4.1.0"
+			},
+			"engines": {
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/editor": {
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.3.1.tgz",
+			"integrity": "sha512-y43COoyVUjPWIobn2Qep/uI1drPS78aaZZZ9kVi94Tyu/GuW2N8d8Q4rifJXGAXCEAXCPTTMjD8gC1HyvM5ukA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/core": "^12.0.1",
+				"@inquirer/external-editor": "^3.0.4",
+				"@inquirer/type": "^4.1.0"
+			},
+			"engines": {
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/editor/node_modules/@inquirer/external-editor": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-3.0.4.tgz",
+			"integrity": "sha512-tZbbaK2ovq6vlrRBNQvjrypmrED/p5x2ncIHQ79cD55tei3dD96v5glMMA+6tiq7K104i/25DVYKWVPJuV6ptA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"chardet": "^2.1.1",
+				"iconv-lite": "^0.7.2"
+			},
+			"engines": {
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/expand": {
+			"version": "5.1.3",
+			"resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.1.3.tgz",
+			"integrity": "sha512-3NQJiXNJ/aj9wiAsr7pECdp5Qe9J0X9YUJCKsaFXS+ddOxfL6J4AIl3w3T4Gq3kK0WsQY5GMoDokK5X94m6lHw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/core": "^12.0.1",
+				"@inquirer/type": "^4.1.0"
+			},
+			"engines": {
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@inquirer/external-editor": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.3.tgz",
@@ -9328,6 +9478,200 @@
 			},
 			"engines": {
 				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/figures": {
+			"version": "2.0.8",
+			"resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.8.tgz",
+			"integrity": "sha512-tApbon79GM9ry56ja/Ud3SY2CL4TQsao9fIwDQbgTeNY55025GdMzQ2+UdegV/lx51VNGUB59M0v0nMpybYY4Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+			}
+		},
+		"node_modules/@inquirer/input": {
+			"version": "5.1.4",
+			"resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.1.4.tgz",
+			"integrity": "sha512-3xQkQrOvgOzpSN2ciTVdRDlg1FWMCA8l+0KfB6SNlILoTCGzJTzO/gc0Rwjcb3usuGyKdaGtI6OiyMdeMeLWkg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/core": "^12.0.1",
+				"@inquirer/type": "^4.1.0"
+			},
+			"engines": {
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/number": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.2.1.tgz",
+			"integrity": "sha512-5KaqwZNLRpUuWcoCrYghPP9TMaXL5v2Sk4xqePM7RCVegcJStoXdWibio60YIC1bec+z1fCyb67N6XPJIkZtGA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/core": "^12.0.1",
+				"@inquirer/type": "^4.1.0"
+			},
+			"engines": {
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/password": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.2.0.tgz",
+			"integrity": "sha512-CvVcW09emkBESEOW+4R8CjLNkP3fB3XrjeL8CDvfpjgrJN+V9oerXmJAXXM3l+4xqYPD5Yaujzy/Ph0PLOdDuA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/ansi": "^2.0.7",
+				"@inquirer/core": "^12.0.1",
+				"@inquirer/type": "^4.1.0"
+			},
+			"engines": {
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/prompts": {
+			"version": "8.7.0",
+			"resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.7.0.tgz",
+			"integrity": "sha512-yQwBMYvpJ6jqrXtKiOwRD5XezjJoyt3VQvIyjsr5Arqb519nfIohOQymWVJ8/vEgg8xtZerrCsqlSaqt/LPC9A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/checkbox": "^5.2.3",
+				"@inquirer/confirm": "^6.3.0",
+				"@inquirer/editor": "^5.3.1",
+				"@inquirer/expand": "^5.1.3",
+				"@inquirer/input": "^5.1.4",
+				"@inquirer/number": "^4.2.1",
+				"@inquirer/password": "^5.2.0",
+				"@inquirer/rawlist": "^5.3.3",
+				"@inquirer/search": "^4.3.1",
+				"@inquirer/select": "^5.2.3"
+			},
+			"engines": {
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/rawlist": {
+			"version": "5.3.3",
+			"resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.3.3.tgz",
+			"integrity": "sha512-Mu7WrtmDLaXBDEyrRLS70SZgX9ZSm4Up1w0ZxiH8C1OOp9oaVCn2k8q3QGgmlnhsKYUhuaU3zFWhAP6wxkVIMA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/core": "^12.0.1",
+				"@inquirer/type": "^4.1.0"
+			},
+			"engines": {
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/search": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.3.1.tgz",
+			"integrity": "sha512-0VWOvsHWI0rPj6CG70MoP4oXNCB6adcyN8bVFZXnh11eLDdPIK2f2XCmva78acPPDfJisfab7qNakwBh7hdBXw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/core": "^12.0.1",
+				"@inquirer/figures": "^2.0.8",
+				"@inquirer/type": "^4.1.0"
+			},
+			"engines": {
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/select": {
+			"version": "5.2.3",
+			"resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.2.3.tgz",
+			"integrity": "sha512-KuRTodDa6xBXX2noIpjuitpX/QT7Sfav7dIZ/OfUY54Hxg95nrGoshSzxx6Ey7qqLbImKdiGkSDt7KjPXjQgmA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/ansi": "^2.0.7",
+				"@inquirer/core": "^12.0.1",
+				"@inquirer/figures": "^2.0.8",
+				"@inquirer/type": "^4.1.0"
+			},
+			"engines": {
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/type": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.1.0.tgz",
+			"integrity": "sha512-FMiJpuHUG3Dk0ex+UIXkre7i+i4OcwHWk9YdcVtZHFwb/r2rnrU2ipTCNAB7A+QOP0ryzIcqOfy76fRyyvOEAw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
 			},
 			"peerDependencies": {
 				"@types/node": ">=18"
@@ -9996,20 +10340,374 @@
 			}
 		},
 		"node_modules/@napi-rs/cli": {
-			"version": "2.18.4",
-			"resolved": "https://registry.npmjs.org/@napi-rs/cli/-/cli-2.18.4.tgz",
-			"integrity": "sha512-SgJeA4df9DE2iAEpr3M2H0OKl/yjtg1BnRI5/JyowS71tUWhrfSu2LT0V3vlHET+g1hBVlrO60PmEXwUEKp8Mg==",
+			"version": "3.8.6",
+			"resolved": "https://registry.npmjs.org/@napi-rs/cli/-/cli-3.8.6.tgz",
+			"integrity": "sha512-FnJ9fghsV9Q4zh2aJGPSvQiUlJRC27B6KhzAXcIW2rlSD8keak3mhXw4tJYa3KJkP9whETfsPwqp/DJRnQg5ng==",
 			"dev": true,
 			"license": "MIT",
+			"dependencies": {
+				"@inquirer/prompts": "^8.5.2",
+				"@napi-rs/cross-toolchain": "^1.0.3",
+				"@napi-rs/wasm-tools": "^1.1.0",
+				"@octokit/rest": "^22.0.1",
+				"clipanion": "^4.0.0-rc.4",
+				"colorette": "^2.0.20",
+				"es-toolkit": "^1.47.0",
+				"js-yaml": "^4.2.0",
+				"obug": "^2.1.2",
+				"semver": "^7.8.2",
+				"typanion": "^3.14.0",
+				"typescript": "^6.0.3"
+			},
 			"bin": {
-				"napi": "scripts/index.js"
+				"napi": "dist/cli.js",
+				"napi-raw": "cli.mjs"
 			},
 			"engines": {
-				"node": ">= 10"
+				"node": "^20.17.0 || ^22.13.0 || >= 23.5.0"
 			},
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/Brooooooklyn"
+			},
+			"peerDependencies": {
+				"@emnapi/core": "^1.7.1 || ^2.0.0-alpha.4",
+				"@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.4",
+				"emnapi": "^1.7.1 || ^2.0.0-alpha.4"
+			},
+			"peerDependenciesMeta": {
+				"@emnapi/core": {
+					"optional": true
+				},
+				"@emnapi/runtime": {
+					"optional": true
+				},
+				"emnapi": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@napi-rs/cli/node_modules/semver": {
+			"version": "7.8.5",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+			"integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@napi-rs/cli/node_modules/typescript": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+			"integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=14.17"
+			}
+		},
+		"node_modules/@napi-rs/cross-toolchain": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@napi-rs/cross-toolchain/-/cross-toolchain-1.0.3.tgz",
+			"integrity": "sha512-ENPfLe4937bsKVTDA6zdABx4pq9w0tHqRrJHyaGxgaPq03a2Bd1unD5XSKjXJjebsABJ+MjAv1A2OvCgK9yehg==",
+			"dev": true,
+			"license": "MIT",
+			"workspaces": [
+				".",
+				"arm64/*",
+				"x64/*"
+			],
+			"dependencies": {
+				"@napi-rs/lzma": "^1.4.5",
+				"@napi-rs/tar": "^1.1.0",
+				"debug": "^4.4.1"
+			},
+			"peerDependencies": {
+				"@napi-rs/cross-toolchain-arm64-target-aarch64": "^1.0.3",
+				"@napi-rs/cross-toolchain-arm64-target-armv7": "^1.0.3",
+				"@napi-rs/cross-toolchain-arm64-target-ppc64le": "^1.0.3",
+				"@napi-rs/cross-toolchain-arm64-target-s390x": "^1.0.3",
+				"@napi-rs/cross-toolchain-arm64-target-x86_64": "^1.0.3",
+				"@napi-rs/cross-toolchain-x64-target-aarch64": "^1.0.3",
+				"@napi-rs/cross-toolchain-x64-target-armv7": "^1.0.3",
+				"@napi-rs/cross-toolchain-x64-target-ppc64le": "^1.0.3",
+				"@napi-rs/cross-toolchain-x64-target-s390x": "^1.0.3",
+				"@napi-rs/cross-toolchain-x64-target-x86_64": "^1.0.3"
+			},
+			"peerDependenciesMeta": {
+				"@napi-rs/cross-toolchain-arm64-target-aarch64": {
+					"optional": true
+				},
+				"@napi-rs/cross-toolchain-arm64-target-armv7": {
+					"optional": true
+				},
+				"@napi-rs/cross-toolchain-arm64-target-ppc64le": {
+					"optional": true
+				},
+				"@napi-rs/cross-toolchain-arm64-target-s390x": {
+					"optional": true
+				},
+				"@napi-rs/cross-toolchain-arm64-target-x86_64": {
+					"optional": true
+				},
+				"@napi-rs/cross-toolchain-x64-target-aarch64": {
+					"optional": true
+				},
+				"@napi-rs/cross-toolchain-x64-target-armv7": {
+					"optional": true
+				},
+				"@napi-rs/cross-toolchain-x64-target-ppc64le": {
+					"optional": true
+				},
+				"@napi-rs/cross-toolchain-x64-target-s390x": {
+					"optional": true
+				},
+				"@napi-rs/cross-toolchain-x64-target-x86_64": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@napi-rs/lzma": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/@napi-rs/lzma/-/lzma-1.5.1.tgz",
+			"integrity": "sha512-sgOZ89+y8cDbY+3WbzR8CtIhCuFRWotZ9/2PjPVDJHz6np5KFTAev0DrwiyTJTgFsCRDhfGlbmhMgyhHbWdZ6g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.20 || ^24.12 || >=25"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Brooooooklyn"
+			},
+			"optionalDependencies": {
+				"@napi-rs/lzma-android-arm-eabi": "1.5.1",
+				"@napi-rs/lzma-android-arm64": "1.5.1",
+				"@napi-rs/lzma-darwin-arm64": "1.5.1",
+				"@napi-rs/lzma-darwin-x64": "1.5.1",
+				"@napi-rs/lzma-freebsd-x64": "1.5.1",
+				"@napi-rs/lzma-linux-arm-gnueabihf": "1.5.1",
+				"@napi-rs/lzma-linux-arm64-gnu": "1.5.1",
+				"@napi-rs/lzma-linux-arm64-musl": "1.5.1",
+				"@napi-rs/lzma-linux-ppc64-gnu": "1.5.1",
+				"@napi-rs/lzma-linux-riscv64-gnu": "1.5.1",
+				"@napi-rs/lzma-linux-s390x-gnu": "1.5.1",
+				"@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+				"@napi-rs/lzma-linux-x64-musl": "1.5.1",
+				"@napi-rs/lzma-wasm32-wasi": "1.5.1",
+				"@napi-rs/lzma-win32-arm64-msvc": "1.5.1",
+				"@napi-rs/lzma-win32-ia32-msvc": "1.5.1",
+				"@napi-rs/lzma-win32-x64-msvc": "1.5.1"
+			}
+		},
+		"node_modules/@napi-rs/lzma-android-arm-eabi": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/@napi-rs/lzma-android-arm-eabi/-/lzma-android-arm-eabi-1.5.1.tgz",
+			"integrity": "sha512-sahBe4ko2Z69NPTddaX6ZgbQZu9SDoITxw1S3dWl1gAGynZG34qHHCT8UaUMFxf3h3zMhCJjEzz4basaBxiTuQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": "^22.20 || ^24.12 || >=25"
+			}
+		},
+		"node_modules/@napi-rs/lzma-android-arm64": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/@napi-rs/lzma-android-arm64/-/lzma-android-arm64-1.5.1.tgz",
+			"integrity": "sha512-7tkQAJJuBHxAxiEBNFgSTpvrtGpbwZYYJUSOmGEK3OfbdbNeoT2rdBxpM/gY1s+itEVbtOSlpaRPPG19MnwOzA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": "^22.20 || ^24.12 || >=25"
+			}
+		},
+		"node_modules/@napi-rs/lzma-darwin-arm64": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/@napi-rs/lzma-darwin-arm64/-/lzma-darwin-arm64-1.5.1.tgz",
+			"integrity": "sha512-XWX8gtF+GHGk3nH3Wm3QUZNcxw9QHsFVZz3MzVLhWWHhceede1J4/vD+3dj3E1iKB9G6mualaZxOoD08R3E+7g==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^22.20 || ^24.12 || >=25"
+			}
+		},
+		"node_modules/@napi-rs/lzma-darwin-x64": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/@napi-rs/lzma-darwin-x64/-/lzma-darwin-x64-1.5.1.tgz",
+			"integrity": "sha512-CfsqUpMTI1z8enrA/b+GcHM6YDI8D0kqCiqPYEnst4rbOABQ9KZ92ybTTNnlnZ7A017WoMZKUEWc36KXDwi0xg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^22.20 || ^24.12 || >=25"
+			}
+		},
+		"node_modules/@napi-rs/lzma-freebsd-x64": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/@napi-rs/lzma-freebsd-x64/-/lzma-freebsd-x64-1.5.1.tgz",
+			"integrity": "sha512-bTyNfg90FXIgE61U7l14aMmVOqRQ6AyP5JMT3jmCStaZI18apLNPdzZ8i7yqxZfKvRMVfPjE2brXIw27c+RRgA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": "^22.20 || ^24.12 || >=25"
+			}
+		},
+		"node_modules/@napi-rs/lzma-linux-arm-gnueabihf": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-arm-gnueabihf/-/lzma-linux-arm-gnueabihf-1.5.1.tgz",
+			"integrity": "sha512-vNE+D8nrw+eOkBsdKCsmDhowDV3pIMKXEhedvXfbgrWbrO7GlZJH+RXL+X+RYLxGwi8Ym61ZMt15sIOnNmh9Sw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^22.20 || ^24.12 || >=25"
+			}
+		},
+		"node_modules/@napi-rs/lzma-linux-arm64-gnu": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-arm64-gnu/-/lzma-linux-arm64-gnu-1.5.1.tgz",
+			"integrity": "sha512-csUem4WgoKGTprv/pOPm9UIWbb+hrfUwYXefpTHPAEGVFLl5behEFabisJ7FtihCa3yG2Efcl+yw25rlhhrIYw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^22.20 || ^24.12 || >=25"
+			}
+		},
+		"node_modules/@napi-rs/lzma-linux-arm64-musl": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-arm64-musl/-/lzma-linux-arm64-musl-1.5.1.tgz",
+			"integrity": "sha512-kB/xhlVN1eLvVmDJSKZEjp5Gg2xDYexNrB5jwpSMbOkeGS6N9AasByPBg5VqCpMYC+zZi7DM458DRhtWYhqXTQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^22.20 || ^24.12 || >=25"
+			}
+		},
+		"node_modules/@napi-rs/lzma-linux-ppc64-gnu": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-ppc64-gnu/-/lzma-linux-ppc64-gnu-1.5.1.tgz",
+			"integrity": "sha512-s28RW0W1yBWQc1nbPdF7tp14koqslY3ZWLVI8uaanX292Dc6ezd4NPVwxEoCNBVON/oD7BmUbWGtyFvmm7dQ5A==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^22.20 || ^24.12 || >=25"
+			}
+		},
+		"node_modules/@napi-rs/lzma-linux-riscv64-gnu": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-riscv64-gnu/-/lzma-linux-riscv64-gnu-1.5.1.tgz",
+			"integrity": "sha512-+lGNwYlIN14YPMTNvYtIJJqHFevDTd6Juw/1NmXbWx/iRd/LLrjhlM/yluMX6pxs6NkOGsuuEXJJrbbEUS59OQ==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^22.20 || ^24.12 || >=25"
+			}
+		},
+		"node_modules/@napi-rs/lzma-linux-s390x-gnu": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-s390x-gnu/-/lzma-linux-s390x-gnu-1.5.1.tgz",
+			"integrity": "sha512-PB44FFWWFrLeQowhcep1hPD1YcLqKlnnY60RMU74qrxTlr4YGEyzeMItJqh2uivBfv9kQScOF/B0J9+Vab/oyw==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^22.20 || ^24.12 || >=25"
 			}
 		},
 		"node_modules/@napi-rs/lzma-linux-x64-gnu": {
@@ -10026,6 +10724,462 @@
 			],
 			"engines": {
 				"node": "^22.20 || ^24.12 || >=25"
+			}
+		},
+		"node_modules/@napi-rs/lzma-linux-x64-musl": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-musl/-/lzma-linux-x64-musl-1.5.1.tgz",
+			"integrity": "sha512-I3nsYrWtrW9JpeCr+mkJIVDt0HY3m6qVUBs5vTtoIvJQxwqf1PBXSy5IS7T53ksQFH2kd2UX8rLxJ7B4WISpZg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^22.20 || ^24.12 || >=25"
+			}
+		},
+		"node_modules/@napi-rs/lzma-wasm32-wasi": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/@napi-rs/lzma-wasm32-wasi/-/lzma-wasm32-wasi-1.5.1.tgz",
+			"integrity": "sha512-gy3wwPBa6+XEyA4fUzq6CClrXA1ajXjuVf5zbnHytJRgoHznj+mvpU3+co2fxXwqTCmIpn6KrzqH5bRDztBPhA==",
+			"cpu": [
+				"wasm32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/core": "1.11.2",
+				"@emnapi/runtime": "1.11.2",
+				"@napi-rs/wasm-runtime": "^1.1.6"
+			},
+			"engines": {
+				"node": "^22.20 || ^24.12 || >=25"
+			}
+		},
+		"node_modules/@napi-rs/lzma-wasm32-wasi/node_modules/@emnapi/core": {
+			"version": "1.11.2",
+			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
+			"integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/wasi-threads": "1.2.2",
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@napi-rs/lzma-wasm32-wasi/node_modules/@emnapi/runtime": {
+			"version": "1.11.2",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+			"integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@napi-rs/lzma-win32-arm64-msvc": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/@napi-rs/lzma-win32-arm64-msvc/-/lzma-win32-arm64-msvc-1.5.1.tgz",
+			"integrity": "sha512-dK+huOsHiyH6oJjij+cnjqFCakk2HgWmpI12Xm4pLUyPphe4ebYoJBgehaNAxprmjFqBQ7nL95YPVz9BHyqmPg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^22.20 || ^24.12 || >=25"
+			}
+		},
+		"node_modules/@napi-rs/lzma-win32-ia32-msvc": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/@napi-rs/lzma-win32-ia32-msvc/-/lzma-win32-ia32-msvc-1.5.1.tgz",
+			"integrity": "sha512-dGE8L+0EQ+GyU9ap9InqB/t/PmPG/bLj918q7OsJ29FuTdn8fK4OX3U4IQZhylHIA+/dQ/SXJk5n4yfah2XVvA==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^22.20 || ^24.12 || >=25"
+			}
+		},
+		"node_modules/@napi-rs/lzma-win32-x64-msvc": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/@napi-rs/lzma-win32-x64-msvc/-/lzma-win32-x64-msvc-1.5.1.tgz",
+			"integrity": "sha512-EKW4t/iqdCT/xnd5t9oXLvVER/PMNAWXKqUAl3fgvUcOILeZIIht77/dVnfFcc9htA/DCBXC/6YQWdW+LusjFA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^22.20 || ^24.12 || >=25"
+			}
+		},
+		"node_modules/@napi-rs/tar": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@napi-rs/tar/-/tar-1.1.1.tgz",
+			"integrity": "sha512-p6q2HhUc5vwH1CNwfOcrhLoxfgn8ust8Sqlfx+sA4VzAcp1cMbvbkl99tZZlDqOjCHgQNSiTfk/yWPjl/D42qA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 10"
+			},
+			"optionalDependencies": {
+				"@napi-rs/tar-android-arm-eabi": "1.1.1",
+				"@napi-rs/tar-android-arm64": "1.1.1",
+				"@napi-rs/tar-darwin-arm64": "1.1.1",
+				"@napi-rs/tar-darwin-x64": "1.1.1",
+				"@napi-rs/tar-freebsd-x64": "1.1.1",
+				"@napi-rs/tar-linux-arm-gnueabihf": "1.1.1",
+				"@napi-rs/tar-linux-arm64-gnu": "1.1.1",
+				"@napi-rs/tar-linux-arm64-musl": "1.1.1",
+				"@napi-rs/tar-linux-ppc64-gnu": "1.1.1",
+				"@napi-rs/tar-linux-s390x-gnu": "1.1.1",
+				"@napi-rs/tar-linux-x64-gnu": "1.1.1",
+				"@napi-rs/tar-linux-x64-musl": "1.1.1",
+				"@napi-rs/tar-wasm32-wasi": "1.1.1",
+				"@napi-rs/tar-win32-arm64-msvc": "1.1.1",
+				"@napi-rs/tar-win32-ia32-msvc": "1.1.1",
+				"@napi-rs/tar-win32-x64-msvc": "1.1.1"
+			}
+		},
+		"node_modules/@napi-rs/tar-android-arm-eabi": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@napi-rs/tar-android-arm-eabi/-/tar-android-arm-eabi-1.1.1.tgz",
+			"integrity": "sha512-cAhnA10cSusAUbcE9HtjQY/tZ9BH/0w2sKtRcQc94TzIlnm7QSr1htJSd/PPrbWNPtrv1orXb2CkrHlVlbnlHA==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@napi-rs/tar-android-arm64": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@napi-rs/tar-android-arm64/-/tar-android-arm64-1.1.1.tgz",
+			"integrity": "sha512-EslUWHCDBY/g5abTPBiHLsMaML4GagV0TXLm5WL9hAjx/DDtlxz9fegMb77RJ+f7nFLOIsUxF/3QWFvgOT0sMQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@napi-rs/tar-darwin-arm64": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@napi-rs/tar-darwin-arm64/-/tar-darwin-arm64-1.1.1.tgz",
+			"integrity": "sha512-+A42/6ES5G9CQ35BOwzwA+WBjLID28r2jNPgc0dteD2hhClIhng0mva7D2ujUlXBNmgNOsr1LHn3stA4uTf4NQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@napi-rs/tar-darwin-x64": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@napi-rs/tar-darwin-x64/-/tar-darwin-x64-1.1.1.tgz",
+			"integrity": "sha512-RYtE8w1dkEvj8hSJCDV5Jw0Rz2i13fsM7u893zv5O9n/4Ad5GNsw/f4RQ7/0YGSFaenkVxqPFrjmEvUHlKzsrg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@napi-rs/tar-freebsd-x64": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@napi-rs/tar-freebsd-x64/-/tar-freebsd-x64-1.1.1.tgz",
+			"integrity": "sha512-rEepBvCJUwcuvUYkY83e8aot8RsR5Jcnal4PsG3tbWGKW1yAvcXhyMXf0fN6ZGpVRZFnB+FJqDyBxvsCPEXKhw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@napi-rs/tar-linux-arm-gnueabihf": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@napi-rs/tar-linux-arm-gnueabihf/-/tar-linux-arm-gnueabihf-1.1.1.tgz",
+			"integrity": "sha512-an1bJdfyhI5FpZYyTQ20mrqwR+a676i8GkaYc4Uy12dH/a7TJIfrK6Qa2Gm46arZvxUvx56qxoRKXbpOjUPvwA==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@napi-rs/tar-linux-arm64-gnu": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@napi-rs/tar-linux-arm64-gnu/-/tar-linux-arm64-gnu-1.1.1.tgz",
+			"integrity": "sha512-w++Vtx36T2yHTKws7GVnmHHcUT1ybB59xLWSh9A8bwEpJVG4dG7Qub9mFe5cpcbfrJ+XP2mKKxC3oUJSunK3iQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@napi-rs/tar-linux-arm64-musl": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@napi-rs/tar-linux-arm64-musl/-/tar-linux-arm64-musl-1.1.1.tgz",
+			"integrity": "sha512-Rh6UFhNtj3i4deJHOBINFIeRL0072mgbeyuK5rl1HokKnNoMKx8qKIZNEzBTTqpogMfDHWGvzyTQdnVxes5dpA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@napi-rs/tar-linux-ppc64-gnu": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@napi-rs/tar-linux-ppc64-gnu/-/tar-linux-ppc64-gnu-1.1.1.tgz",
+			"integrity": "sha512-Cp+AxFbv9zcyAXtnzQi0OzmgDnQgy2w9D4Ubr+iwzMtVgJcztzcEoCcCrN1k2ATdEB01LX2Vb49IaocGOZhC9Q==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@napi-rs/tar-linux-s390x-gnu": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@napi-rs/tar-linux-s390x-gnu/-/tar-linux-s390x-gnu-1.1.1.tgz",
+			"integrity": "sha512-ZyscC3SYKTBWyDRYjLOKAd5TyJ7q0KACRdQ8bWrb3rgrra1CCIJD66CsGTH6Dh0AVSdfLwZ8MfIIXU6+14BMjQ==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@napi-rs/tar-linux-x64-gnu": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@napi-rs/tar-linux-x64-gnu/-/tar-linux-x64-gnu-1.1.1.tgz",
+			"integrity": "sha512-LlIv+zg4fiOQge9LQX/ieBdRWE2fhVDjCTHxnunZkbugNmdhdelxWf1RpZb/6ZujWpNF4LPu4N/MW7ygg2oYAQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@napi-rs/tar-linux-x64-musl": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@napi-rs/tar-linux-x64-musl/-/tar-linux-x64-musl-1.1.1.tgz",
+			"integrity": "sha512-gZBeoKLjanOVj55qk4EMu13P2i9M0SuINmlGQkOxm1niIJofexzddHUYtqO5o/5QqtyL8lADmAcZplLILMLhHA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@napi-rs/tar-wasm32-wasi": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@napi-rs/tar-wasm32-wasi/-/tar-wasm32-wasi-1.1.1.tgz",
+			"integrity": "sha512-rwtQ1Mdt/ft6g6I54fJzbUeLspl4yTwj6I3UJ6mitKnrN42soJkcDrdh3Y/FGvlpqZTad2YMQ96fGJl3EtAm2Q==",
+			"cpu": [
+				"wasm32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/core": "1.11.2",
+				"@emnapi/runtime": "1.11.2",
+				"@napi-rs/wasm-runtime": "^1.1.6"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@napi-rs/tar-wasm32-wasi/node_modules/@emnapi/core": {
+			"version": "1.11.2",
+			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
+			"integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/wasi-threads": "1.2.2",
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@napi-rs/tar-wasm32-wasi/node_modules/@emnapi/runtime": {
+			"version": "1.11.2",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+			"integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@napi-rs/tar-win32-arm64-msvc": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@napi-rs/tar-win32-arm64-msvc/-/tar-win32-arm64-msvc-1.1.1.tgz",
+			"integrity": "sha512-30PVp1AehRpfwxmv5wI4cg0yj3WmWBsZ+1QnLGnvEELu7Eu/+dhNU0nrmhI7VfPgLwSRK2eg9DQTB3tP7Wv9bA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@napi-rs/tar-win32-ia32-msvc": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@napi-rs/tar-win32-ia32-msvc/-/tar-win32-ia32-msvc-1.1.1.tgz",
+			"integrity": "sha512-aI3/rmz+izUChiSeaPxcasAOxhf3FpJNuIHMXlxS/vpW+HIxUsSDR5+XV61PEG5DL4L/75iENVUxmSGM5l2yaw==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@napi-rs/tar-win32-x64-msvc": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@napi-rs/tar-win32-x64-msvc/-/tar-win32-x64-msvc-1.1.1.tgz",
+			"integrity": "sha512-yJsB2IsrODQVLKbm2Fg1nHiVRbEj49mSPbj4x7JPZWJI0jGVPjohE2Sif0FBbx8OxsVoUODvS0BwksZZ8jl/OA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10"
 			}
 		},
 		"node_modules/@napi-rs/wasm-runtime": {
@@ -10047,6 +11201,300 @@
 			"peerDependencies": {
 				"@emnapi/core": "^1.7.1 || ^2.0.0-alpha.4",
 				"@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.4"
+			}
+		},
+		"node_modules/@napi-rs/wasm-tools": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools/-/wasm-tools-1.1.0.tgz",
+			"integrity": "sha512-VjHyKEqXAwYZK+HY7iJctYvRm3TFEbaQxeZwvAG1QRkoo1a39phMY8J6x9tUEqJI03W6MysB8F2jacI6wvcx+w==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 12.22.0"
+			},
+			"optionalDependencies": {
+				"@napi-rs/wasm-tools-android-arm-eabi": "1.1.0",
+				"@napi-rs/wasm-tools-android-arm64": "1.1.0",
+				"@napi-rs/wasm-tools-darwin-arm64": "1.1.0",
+				"@napi-rs/wasm-tools-darwin-x64": "1.1.0",
+				"@napi-rs/wasm-tools-freebsd-x64": "1.1.0",
+				"@napi-rs/wasm-tools-linux-arm64-gnu": "1.1.0",
+				"@napi-rs/wasm-tools-linux-arm64-musl": "1.1.0",
+				"@napi-rs/wasm-tools-linux-x64-gnu": "1.1.0",
+				"@napi-rs/wasm-tools-linux-x64-musl": "1.1.0",
+				"@napi-rs/wasm-tools-wasm32-wasi": "1.1.0",
+				"@napi-rs/wasm-tools-win32-arm64-msvc": "1.1.0",
+				"@napi-rs/wasm-tools-win32-ia32-msvc": "1.1.0",
+				"@napi-rs/wasm-tools-win32-x64-msvc": "1.1.0"
+			}
+		},
+		"node_modules/@napi-rs/wasm-tools-android-arm-eabi": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools-android-arm-eabi/-/wasm-tools-android-arm-eabi-1.1.0.tgz",
+			"integrity": "sha512-p6J8PB59I8d/XItXB/go5JH6nKW+xIbpzaL43EBTV0hi7mrS/Z4gs+MsB04ZrlqZN29BdZV8fChRyasuXLhRaA==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">= 12.22.0"
+			}
+		},
+		"node_modules/@napi-rs/wasm-tools-android-arm64": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools-android-arm64/-/wasm-tools-android-arm64-1.1.0.tgz",
+			"integrity": "sha512-lWoKN3suypeBSCIRPIw+++sH9V2K6nQkhtdt1opu7XY3v9JwLs6Gw063HWRqkNjphlYpkd/Qy8XcfSPGbJj7nQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">= 12.22.0"
+			}
+		},
+		"node_modules/@napi-rs/wasm-tools-darwin-arm64": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools-darwin-arm64/-/wasm-tools-darwin-arm64-1.1.0.tgz",
+			"integrity": "sha512-jfw5vyNDUf6oe0kP8lMveFN9U7cLk1cUosS7uMIfw/xmqmopYfKQ198DAx2g/6aEF7Tm+CqER2gpMpYKui30LA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 12.22.0"
+			}
+		},
+		"node_modules/@napi-rs/wasm-tools-darwin-x64": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools-darwin-x64/-/wasm-tools-darwin-x64-1.1.0.tgz",
+			"integrity": "sha512-R+pjeudAB7BYdH1vKkOJM61Tfv5jB6uXkxmFscYd+KKpdUpWBlNG+s4hr0w4i1rMBM91VhIAETZn2pz+MDHK9A==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 12.22.0"
+			}
+		},
+		"node_modules/@napi-rs/wasm-tools-freebsd-x64": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools-freebsd-x64/-/wasm-tools-freebsd-x64-1.1.0.tgz",
+			"integrity": "sha512-hQJTe+aazrT++Vgm6I4lUd9099ItUCFYdd+aKg6Ys6nax6d/cZ1barDLTwA2lwOoVDsXMekJI/FOL6ZvVlIYBg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">= 12.22.0"
+			}
+		},
+		"node_modules/@napi-rs/wasm-tools-linux-arm64-gnu": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools-linux-arm64-gnu/-/wasm-tools-linux-arm64-gnu-1.1.0.tgz",
+			"integrity": "sha512-1TAXJxUHsWGar90k3W/MknavvBMwOWzjh7Q6Spxo8twRcWJbBD5Kow/Q2KhhDq5hxh2sKGDXn3uLc1tdtz4WUg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.22.0"
+			}
+		},
+		"node_modules/@napi-rs/wasm-tools-linux-arm64-musl": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools-linux-arm64-musl/-/wasm-tools-linux-arm64-musl-1.1.0.tgz",
+			"integrity": "sha512-7rw3nlubTjNAVRH2LwphCxHy1b/N2/TerXocQ6XRn4Q+buaY1Z7P/hbdALy1i1ex2yfOU2Xcij7ib7ZLi/lKfw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.22.0"
+			}
+		},
+		"node_modules/@napi-rs/wasm-tools-linux-x64-gnu": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools-linux-x64-gnu/-/wasm-tools-linux-x64-gnu-1.1.0.tgz",
+			"integrity": "sha512-1sel0t9MRjI/tdT89M8Dd6gPfANeeFP24Xa46R11WeHNwhjsXXZh+xUk50uWCRTSGcaCy3ugm3AMK/lmHYQJkg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.22.0"
+			}
+		},
+		"node_modules/@napi-rs/wasm-tools-linux-x64-musl": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools-linux-x64-musl/-/wasm-tools-linux-x64-musl-1.1.0.tgz",
+			"integrity": "sha512-o2jH5AMfor4EKF2HII1LBnMQxoWu7+usPifTEY8Zk6e9OiSi4EJkAXf9v3ANlX7TI2V/cUEV34OEW7r10GiVIA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.22.0"
+			}
+		},
+		"node_modules/@napi-rs/wasm-tools-wasm32-wasi": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools-wasm32-wasi/-/wasm-tools-wasm32-wasi-1.1.0.tgz",
+			"integrity": "sha512-s6YDtDR1UWrsqJPtaxf+JLYLceWVyn3l8OpQYElHkDhf3Qfz9R6Ba3S0OgznTBv38L5/TIHysQ9Q4yO73Z0csg==",
+			"cpu": [
+				"wasm32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/core": "1.9.2",
+				"@emnapi/runtime": "1.9.2",
+				"@napi-rs/wasm-runtime": "^1.1.6"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@napi-rs/wasm-tools-wasm32-wasi/node_modules/@emnapi/core": {
+			"version": "1.9.2",
+			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+			"integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/wasi-threads": "1.2.1",
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@napi-rs/wasm-tools-wasm32-wasi/node_modules/@emnapi/runtime": {
+			"version": "1.9.2",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+			"integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@napi-rs/wasm-tools-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+			"integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@napi-rs/wasm-tools-win32-arm64-msvc": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools-win32-arm64-msvc/-/wasm-tools-win32-arm64-msvc-1.1.0.tgz",
+			"integrity": "sha512-x+NuxbG84VxU68tU8w7Rf5lSyq0l584M6dVlke5DTweHYFZoMyeqkpbwEq+qsyAX6ivfipK8xRsmFwamb5uDnA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 12.22.0"
+			}
+		},
+		"node_modules/@napi-rs/wasm-tools-win32-ia32-msvc": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools-win32-ia32-msvc/-/wasm-tools-win32-ia32-msvc-1.1.0.tgz",
+			"integrity": "sha512-mdD96QDEp70SX67rXFTY6c725nVYeqEEjyDqzzbNh6u1APj7CI7IMNpMmvE75XbCRl4C2MHZVU4U6AWdAzvyQQ==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 12.22.0"
+			}
+		},
+		"node_modules/@napi-rs/wasm-tools-win32-x64-msvc": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools-win32-x64-msvc/-/wasm-tools-win32-x64-msvc-1.1.0.tgz",
+			"integrity": "sha512-bVVjuvhlyVX++3eJXfDR63cXdw1ay5QYac6iq0MKQw8wZARInTM+bXCtByDT4fzVFI3+7ZthYb/ERWRdBNIqgQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 12.22.0"
 			}
 		},
 		"node_modules/@noble/curves": {
@@ -10201,6 +11649,19 @@
 				"@octokit/openapi-types": "^27.0.0"
 			}
 		},
+		"node_modules/@octokit/plugin-request-log": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-6.0.0.tgz",
+			"integrity": "sha512-UkOzeEN3W91/eBq9sPZNQ7sUBvYCqYbrrD8gTbBuGtHEuycE4/awMXcYvx6sVYo7LypPhmQwwpUe4Yyu4QZN5Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 20"
+			},
+			"peerDependencies": {
+				"@octokit/core": ">=6"
+			}
+		},
 		"node_modules/@octokit/plugin-rest-endpoint-methods": {
 			"version": "17.0.0",
 			"resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-17.0.0.tgz",
@@ -10271,6 +11732,22 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/@octokit/rest": {
+			"version": "22.0.1",
+			"resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-22.0.1.tgz",
+			"integrity": "sha512-Jzbhzl3CEexhnivb1iQ0KJ7s5vvjMWcmRtq5aUsKmKDrRW6z3r84ngmiFKFvpZjpiU/9/S6ITPFRpn5s/3uQJw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/core": "^7.0.6",
+				"@octokit/plugin-paginate-rest": "^14.0.0",
+				"@octokit/plugin-request-log": "^6.0.0",
+				"@octokit/plugin-rest-endpoint-methods": "^17.0.0"
+			},
+			"engines": {
+				"node": ">= 20"
 			}
 		},
 		"node_modules/@octokit/types": {
@@ -16848,6 +18325,32 @@
 				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
 			}
 		},
+		"node_modules/cli-width": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+			"integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">= 12"
+			}
+		},
+		"node_modules/clipanion": {
+			"version": "4.0.0-rc.4",
+			"resolved": "https://registry.npmjs.org/clipanion/-/clipanion-4.0.0-rc.4.tgz",
+			"integrity": "sha512-CXkMQxU6s9GklO/1f714dkKBMu1lopS1WFF0B8o4AxPykR1hpozxSiUZ5ZUeBjfPgCWqbcNOtZVFhB8Lkfp1+Q==",
+			"dev": true,
+			"license": "MIT",
+			"workspaces": [
+				"website"
+			],
+			"dependencies": {
+				"typanion": "^3.8.0"
+			},
+			"peerDependencies": {
+				"typanion": "*"
+			}
+		},
 		"node_modules/cliui": {
 			"version": "8.0.1",
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -18833,6 +20336,19 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/es-toolkit": {
+			"version": "1.52.0",
+			"resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.52.0.tgz",
+			"integrity": "sha512-XTNEJQh1tY1ZJVcf6ayP/2n4ZPyaHlW2FWs7xvw5ddPuhUVjLD3olQVQS7kf58JbAB48iL0uL/jerTrjtV3lDA==",
+			"dev": true,
+			"license": "MIT",
+			"workspaces": [
+				"docs",
+				"benchmarks",
+				"tests/types",
+				"tests/browser-compat"
+			]
+		},
 		"node_modules/esbuild": {
 			"version": "0.28.2",
 			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
@@ -19205,6 +20721,23 @@
 				"node": ">=8.6.0"
 			}
 		},
+		"node_modules/fast-string-truncated-width": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+			"integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/fast-string-width": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+			"integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fast-string-truncated-width": "^3.0.2"
+			}
+		},
 		"node_modules/fast-uri": {
 			"version": "3.1.6",
 			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
@@ -19220,6 +20753,16 @@
 				}
 			],
 			"license": "BSD-3-Clause"
+		},
+		"node_modules/fast-wrap-ansi": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz",
+			"integrity": "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fast-string-width": "^3.0.2"
+			}
 		},
 		"node_modules/fastq": {
 			"version": "1.20.1",
@@ -23431,6 +24974,16 @@
 			},
 			"engines": {
 				"node": "*"
+			}
+		},
+		"node_modules/mute-stream": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
+			"integrity": "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/nan": {
@@ -28465,6 +30018,16 @@
 			"integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
 			"dev": true,
 			"license": "Unlicense"
+		},
+		"node_modules/typanion": {
+			"version": "3.14.0",
+			"resolved": "https://registry.npmjs.org/typanion/-/typanion-3.14.0.tgz",
+			"integrity": "sha512-ZW/lVMRabETuYCd9O9ZvMhAh8GslSqaUjxmK/JLPCh6l73CvLBiuXswj/+7LdnWOgYsQ130FqLzFz5aGT4I3Ug==",
+			"dev": true,
+			"license": "MIT",
+			"workspaces": [
+				"website"
+			]
 		},
 		"node_modules/type-fest": {
 			"version": "4.41.0",
@@ -33958,7 +35521,7 @@
 			"version": "0.0.4",
 			"license": "Apache-2.0",
 			"devDependencies": {
-				"@napi-rs/cli": "2.18.4"
+				"@napi-rs/cli": "3.8.6"
 			},
 			"engines": {
 				"node": "^24",
@@ -33970,7 +35533,7 @@
 			"version": "0.0.4",
 			"license": "Apache-2.0",
 			"devDependencies": {
-				"@napi-rs/cli": "2.18.4"
+				"@napi-rs/cli": "3.8.6"
 			},
 			"engines": {
 				"node": "^24",

--- a/package-lock.json
+++ b/package-lock.json
@@ -36980,7 +36980,7 @@
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@prosopo/logger": "2.0.8",
-				"@redis/search": "6.2.1",
+				"@redis/search": "5.0.0",
 				"redis": "5.0.0"
 			},
 			"devDependencies": {
@@ -37001,18 +37001,6 @@
 			"engines": {
 				"node": "^24",
 				"npm": "^11"
-			}
-		},
-		"packages/redis-client/node_modules/@redis/search": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/@redis/search/-/search-6.2.1.tgz",
-			"integrity": "sha512-2vfOAOyYFE7UUw3sBBlkqqruBtOUS4HRY5MtW4hp83llrwvtrTE4r22CEqXddlV+54zkLxBE4nmsIJ/dpezQrQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 20.0.0"
-			},
-			"peerDependencies": {
-				"@redis/client": "^6.2.1"
 			}
 		},
 		"packages/redis-client/node_modules/@types/node": {
@@ -37216,7 +37204,7 @@
 				"@prosopo/redis-client": "1.0.34",
 				"@prosopo/types": "5.6.0",
 				"@prosopo/util": "3.3.8",
-				"@redis/search": "6.2.1",
+				"@redis/search": "5.0.0",
 				"cidr-calc": "1.0.4",
 				"dotenv": "16.4.5",
 				"ip-address": "10.7.0",
@@ -37236,18 +37224,6 @@
 			"engines": {
 				"node": "^24",
 				"npm": "^11"
-			}
-		},
-		"packages/user-access-policy/node_modules/@redis/search": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/@redis/search/-/search-6.2.1.tgz",
-			"integrity": "sha512-2vfOAOyYFE7UUw3sBBlkqqruBtOUS4HRY5MtW4hp83llrwvtrTE4r22CEqXddlV+54zkLxBE4nmsIJ/dpezQrQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 20.0.0"
-			},
-			"peerDependencies": {
-				"@redis/client": "^6.2.1"
 			}
 		},
 		"packages/user-access-policy/node_modules/@types/node": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -609,7 +609,7 @@
 				"vite-plugin-node-polyfills": "0.28.0",
 				"vite-tsconfig-paths": "6.1.1",
 				"vitest": "4.1.11",
-				"webpack": "5.110.1",
+				"webpack": "5.110.2",
 				"webpack-cli": "7.2.3",
 				"webpack-dev-server": "6.0.0"
 			},
@@ -22556,9 +22556,9 @@
 			}
 		},
 		"node_modules/ip-address": {
-			"version": "10.5.0",
-			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
-			"integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
+			"version": "10.7.0",
+			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.7.0.tgz",
+			"integrity": "sha512-BGFsyJd5mpXp3rK6jIdADLNgpJUK1jnjzvYF8lK+VyDab9JAmqN0YOKDdP17HlgKb2+ehPgDc8EtnRLbGCAMhA==",
 			"license": "MIT",
 			"engines": {
 				"node": ">= 12"
@@ -31134,9 +31134,9 @@
 			}
 		},
 		"node_modules/webpack": {
-			"version": "5.110.1",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.110.1.tgz",
-			"integrity": "sha512-gInQB+jxXxgnZyvPwuzT5NGQmECDqeu85oxcrjinrYHqPoBex0hCAN2SFTJVyPVrK0Pq9E44VFP+e89fAc10/w==",
+			"version": "5.110.2",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.110.2.tgz",
+			"integrity": "sha512-TciLrfM7zgEjqGdY851HkirDsSPQgTFsWQpl9oHqMAMYsHhEC0bKjscvjpnz+pzx10hLC8qISApGrsnrCP4UtQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -33362,7 +33362,7 @@
 				"@prosopo/util": "3.3.8",
 				"bson": "7.3.2",
 				"make-dir": "5.1.0",
-				"mongodb": "7.5.0",
+				"mongodb": "7.6.0",
 				"mongodb-memory-server": "10.3.0",
 				"mongoose": "9.9.4"
 			},
@@ -33425,9 +33425,9 @@
 			}
 		},
 		"packages/database/node_modules/mongodb": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-7.5.0.tgz",
-			"integrity": "sha512-5FnrEDLnvp6ycUOGLNLLU33BfCx2qmp2mJjGPDwKLruYsVzXVSK5fsGpoDXvsXJwBfBsD7ebMRdawbDxC2814g==",
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-7.6.0.tgz",
+			"integrity": "sha512-WbZ6OCjYw2c53LOjfkQa+reXr7kIiOVpXXglnASFuiMtif0BvsMwHe3ClJHLm1/r7wJFwaasfFtD6iYIktB01g==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@mongodb-js/saslprep": "^1.4.11",
@@ -36727,7 +36727,7 @@
 				"express-rate-limit": "7.4.0",
 				"geolib": "3.3.14",
 				"i18next": "24.1.0",
-				"ip-address": "10.5.0",
+				"ip-address": "10.7.0",
 				"mongoose": "9.9.4",
 				"prom-client": "15.1.3",
 				"uuid": "14.0.2",
@@ -37093,7 +37093,7 @@
 				"@prosopo/locale": "3.4.1",
 				"@prosopo/util": "3.3.8",
 				"@prosopo/util-crypto": "13.5.31",
-				"ip-address": "10.5.0",
+				"ip-address": "10.7.0",
 				"scale-ts": "1.6.1",
 				"zod": "3.23.8"
 			},
@@ -37219,7 +37219,7 @@
 				"@redis/search": "6.2.1",
 				"cidr-calc": "1.0.4",
 				"dotenv": "16.4.5",
-				"ip-address": "10.5.0",
+				"ip-address": "10.7.0",
 				"redis": "5.0.0",
 				"zod": "3.23.8"
 			},
@@ -37441,7 +37441,7 @@
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@noble/hashes": "1.8.0",
-				"ip-address": "10.5.0",
+				"ip-address": "10.7.0",
 				"lodash": "4.18.1",
 				"seedrandom": "3.0.5"
 			},

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -48,7 +48,7 @@
 		"@prosopo/workspace": "3.2.1",
 		"cron-parser": "4.9.0",
 		"dotenv": "16.4.5",
-		"yargs": "17.7.2",
+		"yargs": "18.1.0",
 		"zod": "3.23.8"
 	},
 	"devDependencies": {

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -46,7 +46,7 @@
 		"@prosopo/user-access-policy": "3.12.33",
 		"@prosopo/util": "3.3.8",
 		"bson": "7.3.2",
-		"make-dir": "3.1.0",
+		"make-dir": "5.1.0",
 		"mongodb": "7.5.0",
 		"mongodb-memory-server": "10.3.0",
 		"mongoose": "9.9.4"

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -47,7 +47,7 @@
 		"@prosopo/util": "3.3.8",
 		"bson": "7.3.2",
 		"make-dir": "3.1.0",
-		"mongodb": "7.5.0",
+		"mongodb": "7.6.0",
 		"mongodb-memory-server": "10.3.0",
 		"mongoose": "9.9.4"
 	},

--- a/packages/database/src/index.ts
+++ b/packages/database/src/index.ts
@@ -11,9 +11,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-import makeDir from "make-dir";
+import { makeDirectory } from "make-dir";
 // This is just to stop the linter from complaining about an unused import
-console.debug(makeDir);
+console.debug(makeDirectory);
 export * from "./base/index.js";
 export * from "./databases/index.js";
 export * from "./mongooseOptions.js";

--- a/packages/datasets-fs/package.json
+++ b/packages/datasets-fs/package.json
@@ -39,7 +39,7 @@
 		"bcrypt": "6.0.0",
 		"cli-progress": "3.12.0",
 		"sharp": "0.35.4",
-		"yargs": "17.7.2",
+		"yargs": "18.1.0",
 		"zod": "3.23.8"
 	},
 	"devDependencies": {

--- a/packages/native-ja4/package.json
+++ b/packages/native-ja4/package.json
@@ -27,6 +27,6 @@
 		"clean": "cargo clean && rm -f *.node index.js index.d.ts"
 	},
 	"devDependencies": {
-		"@napi-rs/cli": "2.18.4"
+		"@napi-rs/cli": "3.8.6"
 	}
 }

--- a/packages/native-merkle/package.json
+++ b/packages/native-merkle/package.json
@@ -27,6 +27,6 @@
 		"clean": "cargo clean && rm -f *.node index.js index.d.ts"
 	},
 	"devDependencies": {
-		"@napi-rs/cli": "2.18.4"
+		"@napi-rs/cli": "3.8.6"
 	}
 }

--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -51,7 +51,7 @@
 		"express-rate-limit": "7.4.0",
 		"geolib": "3.3.14",
 		"i18next": "24.1.0",
-		"ip-address": "10.5.0",
+		"ip-address": "10.7.0",
 		"mongoose": "9.9.4",
 		"prom-client": "15.1.3",
 		"uuid": "14.0.2",

--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -61,7 +61,7 @@
 		"@prosopo/config": "3.3.13",
 		"@types/node": "22.5.5",
 		"@types/pg": "8.23.1",
-		"@types/uuid": "10.0.0",
+		"@types/uuid": "11.0.0",
 		"@vitest/coverage-v8": "4.1.11",
 		"concurrently": "9.0.1",
 		"cors": "2.8.6",

--- a/packages/redis-client/package.json
+++ b/packages/redis-client/package.json
@@ -39,7 +39,7 @@
 	"homepage": "https://github.com/prosopo/captcha#readme",
 	"dependencies": {
 		"@prosopo/logger": "2.0.8",
-		"@redis/search": "5.0.0",
+		"@redis/search": "6.2.1",
 		"redis": "5.0.0"
 	},
 	"devDependencies": {

--- a/packages/redis-client/package.json
+++ b/packages/redis-client/package.json
@@ -39,7 +39,7 @@
 	"homepage": "https://github.com/prosopo/captcha#readme",
 	"dependencies": {
 		"@prosopo/logger": "2.0.8",
-		"@redis/search": "6.2.1",
+		"@redis/search": "5.0.0",
 		"redis": "5.0.0"
 	},
 	"devDependencies": {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -43,7 +43,7 @@
 		"@prosopo/locale": "3.4.1",
 		"@prosopo/util": "3.3.8",
 		"@prosopo/util-crypto": "13.5.31",
-		"ip-address": "10.5.0",
+		"ip-address": "10.7.0",
 		"scale-ts": "1.6.1",
 		"zod": "3.23.8"
 	},

--- a/packages/user-access-policy/package.json
+++ b/packages/user-access-policy/package.json
@@ -65,7 +65,7 @@
 		"mongoose": "9.9.4",
 		"vite": "8.1.5",
 		"vitest": "4.1.11",
-		"yargs": "17.7.2"
+		"yargs": "18.1.0"
 	},
 	"author": "PROSOPO LIMITED <info@prosopo.io>",
 	"license": "Apache-2.0",

--- a/packages/user-access-policy/package.json
+++ b/packages/user-access-policy/package.json
@@ -50,7 +50,7 @@
 		"@prosopo/redis-client": "1.0.34",
 		"@prosopo/types": "5.6.0",
 		"@prosopo/util": "3.3.8",
-		"@redis/search": "5.0.0",
+		"@redis/search": "6.2.1",
 		"cidr-calc": "1.0.4",
 		"dotenv": "16.4.5",
 		"ip-address": "10.5.0",

--- a/packages/user-access-policy/package.json
+++ b/packages/user-access-policy/package.json
@@ -53,7 +53,7 @@
 		"@redis/search": "5.0.0",
 		"cidr-calc": "1.0.4",
 		"dotenv": "16.4.5",
-		"ip-address": "10.5.0",
+		"ip-address": "10.7.0",
 		"redis": "5.0.0",
 		"zod": "3.23.8"
 	},

--- a/packages/user-access-policy/package.json
+++ b/packages/user-access-policy/package.json
@@ -50,7 +50,7 @@
 		"@prosopo/redis-client": "1.0.34",
 		"@prosopo/types": "5.6.0",
 		"@prosopo/util": "3.3.8",
-		"@redis/search": "6.2.1",
+		"@redis/search": "5.0.0",
 		"cidr-calc": "1.0.4",
 		"dotenv": "16.4.5",
 		"ip-address": "10.7.0",

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -42,7 +42,7 @@
 	"types": "dist/index.d.ts",
 	"dependencies": {
 		"@noble/hashes": "1.8.0",
-		"ip-address": "10.5.0",
+		"ip-address": "10.7.0",
 		"lodash": "4.18.1",
 		"seedrandom": "3.0.5"
 	},


### PR DESCRIPTION
Combines the open Dependabot PRs into a single branch so they build, review and merge once instead of nine times.

## Included

| PR | Update |
| --- | --- |
| #3169 | `actions/setup-java` 5 → 6 (github-actions group) |
| #3172 | `yargs` 17.7.2 → 18.1.0 |
| #3173 | `@actions/core` 1.10.1 → 3.0.1 |
| #3174 | `make-dir` 3.1.0 → 5.1.0 |
| #3176 | `@types/uuid` 10.0.0 → 11.0.0 |
| #3177 | `@napi-rs/cli` 2.18.4 → 3.8.6 |
| #3178 | `cypress-visual-regression` 5.3.0 → 6.0.0 |
| #3188 | npm-minor-and-patch group: `mongodb` 7.5.0 → 7.6.0, `ip-address` 10.5.0 → 10.7.0, `webpack` 5.110.1 → 5.110.2 |

Each source branch is merged in, so the individual Dependabot commits and their changesets are preserved.

## Excluded: `@redis/search` (#3171)

Dropped, and its changeset with it. `@redis/search@6.2.1` peer-depends on `@redis/client@^6.2.1`, but `redis@5.0.0` pins the whole `@redis/*` family at 5.0.0. Bumping the standalone package resolved a second nested copy at 6.2.1 alongside the hoisted 5.0.0, and `packages/redis-client/src/redisIndex.ts:62` then failed typecheck passing a `RediSearchSchema` from one copy into a method typed by the other:

```
error TS2345: Argument of type 'RediSearchSchema' (packages/redis-client/node_modules/@redis/search)
is not assignable to parameter of type 'RediSearchSchema' (node_modules/@redis/search)
```

This bump only makes sense as part of a `redis` 5 → 6 upgrade, which is its own piece of work. Reverted to 5.0.0; the lockfile is back to byte-parity with `main` on everything `@redis/*`.

## Fixes needed to make the rest pass

Two of the bumps needed a code change, both in this branch:

- **`make-dir` (#3174)** — v4 dropped the default export. `packages/database/src/index.ts` now imports the named `makeDirectory`. This was breaking `tests`, `cypress` and `provider_image` at the setup step with `SyntaxError: The requested module 'make-dir' does not provide an export named 'default'`.
- **`@actions/core` (#3173)** — v3 is native ESM, so its exports are non-configurable and `vi.spyOn(core, "setFailed")` fails with `Cannot redefine property`. `dev/prosoponator-bot/src/tests/main.unit.test.ts` now replaces the module with `vi.mock`/`importOriginal` (the idiom already used in `puzzleTasks.unit.test.ts`) and asserts through `vi.mocked`. `getInput` keeps its real implementation because the `defaultDeps` tests drive it through `INPUT_*`. Test-only change — `bot.ts` calls just `getInput` and `setFailed`, both unaffected.

## Lockfile

Resolved in place rather than regenerated, then reconciled with `npm install --package-lock-only`. All platforms' optional native deps are intact, including the linux rollup binaries CI needs, and the `libc` discriminators npm 11.6.2 wanted to strip were kept.

Supersedes #3169, #3171, #3172, #3173, #3174, #3176, #3177, #3178 and #3188, all now closed.
