### PR TITLE
fix(procaptcha,procaptcha-frictionless): recover from NO_SESSION_FOUND instead of dead-ending

### DIFF
--- a/.changeset/no-session-found-recovery-dead-end.md
+++ b/.changeset/no-session-found-recovery-dead-end.md
@@ -1,0 +1,16 @@
+---
+"@prosopo/procaptcha": patch
+"@prosopo/procaptcha-frictionless": patch
+---
+
+Stop `CAPTCHA.NO_SESSION_FOUND` leaving the widget on a dead checkbox.
+
+Users reported a checkbox reading "No session found" that never recovered, usually after pressing the image-challenge reload button. Provider logs show the shape clearly: `POST /captcha/image` returns 200 and issues a challenge, then 2-6 seconds later the *same* sessionId is POSTed again and the provider answers 400 `CAPTCHA.NO_SESSION_FOUND` — `checkAndRemoveSession` consumed the session when it issued the first challenge, so a second challenge fetch on that id can never succeed.
+
+Three defects combined to turn that into a permanent dead end.
+
+- **The manager re-sent a sessionId it had already spent.** `defaultState()` doesn't clear `sessionId` and `buildUpdateState` skips `undefined`, so a stale id survives `resetState()` and any path that re-enters `start()` re-sends it. `Manager` now remembers the id it exchanged for a challenge and, rather than making a request it knows the provider will reject, routes straight to the `CAPTCHA.NO_SESSION_FOUND` state the wrapper already listens for.
+
+- **Recovery was one-shot per outer widget lifetime and had no terminal branch.** `ProcaptchaWidget` always takes the `onSessionInvalidated` branch and returns before its own `frictionlessState.restart()` fallback, and its guard ref is fresh on every re-mount because the wrapper bumps the mount key. So once the wrapper's one-shot was spent, the second failure was handled by nobody: no re-mint, no restart, no message — just a stuck checkbox. `handleSessionInvalidated` is now a bounded counter (`MAX_SESSION_INVALIDATED_RETRIES`) rather than a boolean, it reports `exhausted` to the caller, a reload press clears it (a reload mints a genuinely new session, so it shouldn't spend the budget for the old one), and exhaustion falls over visibly through `fallOverWithStyle` — which schedules the existing 10-second full restart, so there is always a way back.
+
+- **`resetState(0)` never reset anything.** `0 || stateRef.current.attemptCount` kept the old count, so `attemptCount` accumulated across every re-mint and `start()`'s own `attemptCount >= 5` fall-over fired after five *cumulative* runs in a widget lifetime. Five successful reload presses were enough to drop the user onto the error placeholder. Now `??`, so callers passing literal `0` get the reset they asked for.

--- a/packages/procaptcha-frictionless/src/ProcaptchaFrictionless.tsx
+++ b/packages/procaptcha-frictionless/src/ProcaptchaFrictionless.tsx
@@ -42,6 +42,8 @@ import {
 	normaliseRetryCoords,
 } from "./sessionInvalidatedRecovery.js";
 
+const NO_SESSION_FOUND_KEY = "CAPTCHA.NO_SESSION_FOUND";
+
 // Each session uses exactly one solver — chosen by the /frictionless response.
 const ProcaptchaLoader = async () =>
 	(await import("@prosopo/procaptcha-react")).Procaptcha;
@@ -94,7 +96,7 @@ const defaultLoadingState = (
 	attemptCount: number,
 ): FrictionlessLoadingState => ({
 	loading: false,
-	attemptCount: attemptCount || 0,
+	attemptCount,
 });
 
 export const ProcaptchaFrictionless = ({
@@ -113,10 +115,14 @@ export const ProcaptchaFrictionless = ({
 	// to click the checkbox a second time and the checkbox click position is
 	// preserved in the eventual solution salt.
 	const pendingRetryCoordsRef = useRef<RetryCoords | null>(null);
-	// One-shot outer guard so a persistently broken session doesn't loop.
-	// After we've retried once, a second NO_SESSION_FOUND falls back to the
-	// inner widget's own `frictionlessState.restart()` path.
-	const sessionInvalidatedFiredRef = useRef(false);
+	// Bounded outer guard so a persistently broken session doesn't loop. Each
+	// re-mint costs a /frictionless round trip, so the count is capped — but
+	// it is a count rather than a one-shot, because a widget legitimately
+	// mints a new session every time the user presses reload. `onReload`
+	// clears it for the same reason. When the budget is spent we fall over
+	// visibly (see `onSessionInvalidated`) instead of leaving the user on a
+	// dead "No session found" checkbox.
+	const sessionInvalidatedAttemptsRef = useRef(0);
 	// Bumped on every mount so the replacement widget gets a fresh React
 	// `key`. Without it a re-render for the same captcha type reconciles onto
 	// the existing element, and the inner widget keeps the manager it built on
@@ -161,9 +167,14 @@ export const ProcaptchaFrictionless = ({
 		),
 	);
 
+	// `??`, not `||`: every caller that wants the counter back at zero passes
+	// literal 0, and `0 || current` silently kept the old count. `start()` then
+	// tripped its own `attemptCount >= 5` fall-over after five *cumulative*
+	// runs in a widget lifetime — five reload presses were enough to strand the
+	// user on the error placeholder even though every one of them succeeded.
 	const resetState = (attemptCount?: number) => {
 		stateRef.current = defaultLoadingState(
-			attemptCount || stateRef.current.attemptCount,
+			attemptCount ?? stateRef.current.attemptCount,
 		);
 	};
 
@@ -225,23 +236,38 @@ export const ProcaptchaFrictionless = ({
 
 		// The provider returned NO_SESSION_FOUND on the inner widget's
 		// challenge fetch — the sessionId minted upstream is no longer usable
-		// (usually because a duplicate /captcha/{type} POST from a WebView
-		// mount storm consumed it first). Re-run the frictionless flow to
+		// (a duplicate /captcha/{type} POST consumed it first, or the widget
+		// re-sent an id it had already spent). Re-run the frictionless flow to
 		// mint a fresh session, then re-mount the inner widget with the
 		// preserved checkbox click coords so the user is not asked to click a
-		// second time. One-shot per outer widget lifetime — if the retry
-		// also fails, fall through to the inner widget's existing
-		// `frictionlessState.restart()` path.
+		// second time.
+		//
+		// The inner widget cannot recover on its own here: it always takes
+		// this branch and returns before its own `frictionlessState.restart()`
+		// fallback, and its guard ref is fresh on every re-mount. So whatever
+		// this handler declines to do, nothing else does — hence the terminal
+		// `fallOverWithStyle` rather than a silent return once the retry
+		// budget is spent.
 		const onSessionInvalidated = (x?: number, y?: number) => {
 			const { shouldRestart } = handleSessionInvalidated(
 				x,
 				y,
-				sessionInvalidatedFiredRef,
+				sessionInvalidatedAttemptsRef,
 				pendingRetryCoordsRef,
 			);
-			if (!shouldRestart) return;
-			resetState(0);
-			void start();
+			if (shouldRestart) {
+				resetState(0);
+				void start();
+				return;
+			}
+			// Budget spent. Surface the error on the checkbox and let
+			// `fallOverWithStyle`'s NO_SESSION_FOUND branch schedule the
+			// 10-second full restart, so the user always has a way back.
+			const message = i18n.isInitialized
+				? i18n.t(NO_SESSION_FOUND_KEY)
+				: "No session found";
+			events.onError(new Error(message));
+			fallOverWithStyle(message, NO_SESSION_FOUND_KEY);
 		};
 
 		// The user pressed reload on the challenge. The provider consumed this
@@ -253,6 +279,9 @@ export const ProcaptchaFrictionless = ({
 		const onReload = (x?: number, y?: number) => {
 			pendingRetryCoordsRef.current = normaliseRetryCoords(x, y);
 			nextMountAutoStartRef.current = true;
+			// A reload mints a genuinely new session, so the invalidation
+			// budget for the *previous* one shouldn't count against it.
+			sessionInvalidatedAttemptsRef.current = 0;
 			resetState(0);
 			void start();
 		};

--- a/packages/procaptcha-frictionless/src/sessionInvalidatedRecovery.ts
+++ b/packages/procaptcha-frictionless/src/sessionInvalidatedRecovery.ts
@@ -49,23 +49,43 @@ export const normaliseRetryCoords = (
 };
 
 /**
- * Semantics of the outer recovery handler. Returns whether the caller
- * should proceed to re-run the frictionless flow (`start()`), and mutates
- * the passed refs to record the one-shot fire + pending coords.
+ * How many times a single outer widget will re-mint a session in response to
+ * `CAPTCHA.NO_SESSION_FOUND` on the inner widget before giving up and handing
+ * over to the terminal fallback.
  *
- * Second calls are ignored (one-shot per outer widget lifetime) so a
- * persistently broken session doesn't loop.
+ * This used to be one-shot per outer widget lifetime, which stranded users:
+ * the inner widget always takes the `onSessionInvalidated` branch (its own
+ * guard ref is fresh on every re-mount, because the outer widget bumps its
+ * mount key) and returns without touching its own `restart()` fallback. Once
+ * the outer one-shot was spent nothing at all handled the second failure, so
+ * the checkbox sat on "No session found" forever. A widget legitimately mints
+ * many sessions over its lifetime — every reload press is a new one — so a
+ * single lifetime-wide attempt is far too coarse a bound.
+ */
+export const MAX_SESSION_INVALIDATED_RETRIES = 3;
+
+/**
+ * Semantics of the outer recovery handler. Returns whether the caller should
+ * proceed to re-run the frictionless flow (`start()`), and mutates the passed
+ * refs to record the attempt + pending coords.
+ *
+ * Bounded rather than one-shot: a persistently broken session still stops
+ * looping, but the caller is told (`exhausted`) so it can fall back visibly
+ * instead of silently doing nothing.
  */
 export const handleSessionInvalidated = (
 	x: number | undefined,
 	y: number | undefined,
-	firedRef: MutableRef<boolean>,
+	attemptsRef: MutableRef<number>,
 	pendingCoordsRef: MutableRef<RetryCoords | null>,
-): { shouldRestart: boolean } => {
-	if (firedRef.current) return { shouldRestart: false };
-	firedRef.current = true;
+	maxAttempts: number = MAX_SESSION_INVALIDATED_RETRIES,
+): { shouldRestart: boolean; exhausted: boolean } => {
+	if (attemptsRef.current >= maxAttempts) {
+		return { shouldRestart: false, exhausted: true };
+	}
+	attemptsRef.current += 1;
 	pendingCoordsRef.current = normaliseRetryCoords(x, y);
-	return { shouldRestart: true };
+	return { shouldRestart: true, exhausted: false };
 };
 
 /**

--- a/packages/procaptcha-frictionless/src/tests/sessionInvalidatedRecovery.test.ts
+++ b/packages/procaptcha-frictionless/src/tests/sessionInvalidatedRecovery.test.ts
@@ -14,6 +14,7 @@
 
 import { describe, expect, it } from "vitest";
 import {
+	MAX_SESSION_INVALIDATED_RETRIES,
 	type MutableRef,
 	type RetryCoords,
 	consumeRetryMountProps,
@@ -25,70 +26,97 @@ const ref = <T>(initial: T): MutableRef<T> => ({ current: initial });
 
 describe("handleSessionInvalidated", () => {
 	it("records both coords and signals a restart on the first fire", () => {
-		const firedRef = ref(false);
+		const attemptsRef = ref(0);
 		const coordsRef = ref<RetryCoords | null>(null);
 
-		const result = handleSessionInvalidated(120, 340, firedRef, coordsRef);
+		const result = handleSessionInvalidated(120, 340, attemptsRef, coordsRef);
 
-		expect(result).toEqual({ shouldRestart: true });
-		expect(firedRef.current).toBe(true);
+		expect(result).toEqual({ shouldRestart: true, exhausted: false });
+		expect(attemptsRef.current).toBe(1);
 		expect(coordsRef.current).toEqual({ x: 120, y: 340 });
 	});
 
 	it("treats (0, 0) as 'no coords' — that's the autoStart / untrusted-event default, not a real click", () => {
-		const firedRef = ref(false);
+		const attemptsRef = ref(0);
 		const coordsRef = ref<RetryCoords | null>(null);
 
-		const result = handleSessionInvalidated(0, 0, firedRef, coordsRef);
+		const result = handleSessionInvalidated(0, 0, attemptsRef, coordsRef);
 
-		expect(result).toEqual({ shouldRestart: true });
+		expect(result).toEqual({ shouldRestart: true, exhausted: false });
 		expect(coordsRef.current).toBeNull();
 	});
 
 	it("carries a real click even if only one axis is at the origin", () => {
-		const firedRef = ref(false);
+		const attemptsRef = ref(0);
 		const coordsRef = ref<RetryCoords | null>(null);
 
-		handleSessionInvalidated(0, 340, firedRef, coordsRef);
+		handleSessionInvalidated(0, 340, attemptsRef, coordsRef);
 
 		expect(coordsRef.current).toEqual({ x: 0, y: 340 });
 	});
 
 	it("stores no coords when x or y is undefined (autoStart / non-trusted event)", () => {
-		const firedRef = ref(false);
+		const attemptsRef = ref(0);
 		const coordsRef = ref<RetryCoords | null>(null);
 
 		const result = handleSessionInvalidated(
 			undefined,
 			undefined,
-			firedRef,
+			attemptsRef,
 			coordsRef,
 		);
 
-		expect(result).toEqual({ shouldRestart: true });
-		expect(firedRef.current).toBe(true);
+		expect(result).toEqual({ shouldRestart: true, exhausted: false });
+		expect(attemptsRef.current).toBe(1);
 		expect(coordsRef.current).toBeNull();
 	});
 
 	it("stores no coords when only one axis is present — never emit NaN into the salt", () => {
-		const firedRef = ref(false);
+		const attemptsRef = ref(0);
 		const coordsRef = ref<RetryCoords | null>(null);
 
-		handleSessionInvalidated(120, undefined, firedRef, coordsRef);
+		handleSessionInvalidated(120, undefined, attemptsRef, coordsRef);
 
 		expect(coordsRef.current).toBeNull();
 	});
 
-	it("is one-shot per outer widget lifetime — a second call is a no-op", () => {
-		const firedRef = ref(false);
+	it("keeps re-minting up to the retry budget — a reload press is a legitimate new session", () => {
+		const attemptsRef = ref(0);
 		const coordsRef = ref<RetryCoords | null>(null);
 
-		handleSessionInvalidated(100, 200, firedRef, coordsRef);
-		const second = handleSessionInvalidated(500, 600, firedRef, coordsRef);
+		for (let i = 0; i < MAX_SESSION_INVALIDATED_RETRIES; i++) {
+			expect(
+				handleSessionInvalidated(100 + i, 200 + i, attemptsRef, coordsRef),
+			).toEqual({ shouldRestart: true, exhausted: false });
+		}
 
-		expect(second).toEqual({ shouldRestart: false });
-		// The second call must not overwrite the first attempt's coords.
+		expect(attemptsRef.current).toBe(MAX_SESSION_INVALIDATED_RETRIES);
+	});
+
+	it("reports exhausted once the budget is spent so the caller can fall over visibly", () => {
+		const attemptsRef = ref(MAX_SESSION_INVALIDATED_RETRIES);
+		const coordsRef = ref<RetryCoords | null>({ x: 100, y: 200 });
+
+		const result = handleSessionInvalidated(500, 600, attemptsRef, coordsRef);
+
+		expect(result).toEqual({ shouldRestart: false, exhausted: true });
+		// An exhausted call must not overwrite the pending attempt's coords.
 		expect(coordsRef.current).toEqual({ x: 100, y: 200 });
+		expect(attemptsRef.current).toBe(MAX_SESSION_INVALIDATED_RETRIES);
+	});
+
+	it("honours a caller-supplied budget", () => {
+		const attemptsRef = ref(0);
+		const coordsRef = ref<RetryCoords | null>(null);
+
+		expect(handleSessionInvalidated(1, 2, attemptsRef, coordsRef, 1)).toEqual({
+			shouldRestart: true,
+			exhausted: false,
+		});
+		expect(handleSessionInvalidated(3, 4, attemptsRef, coordsRef, 1)).toEqual({
+			shouldRestart: false,
+			exhausted: true,
+		});
 	});
 });
 

--- a/packages/procaptcha-frictionless/src/tests/sessionInvalidatedRemint.test.tsx
+++ b/packages/procaptcha-frictionless/src/tests/sessionInvalidatedRemint.test.tsx
@@ -14,6 +14,8 @@
 
 import type { Ti18n } from "@prosopo/locale";
 import {
+	type Account,
+	type BotDetectionFunction,
 	CaptchaType,
 	ModeEnum,
 	type ProcaptchaClientConfigInput,
@@ -22,7 +24,15 @@ import {
 } from "@prosopo/types";
 import { type ReactElement, act, createElement } from "react";
 import { type Root, createRoot } from "react-dom/client";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	type Mock,
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	vi,
+} from "vitest";
 import { MAX_SESSION_INVALIDATED_RETRIES } from "../sessionInvalidatedRecovery.js";
 
 declare global {
@@ -68,22 +78,30 @@ const i18nStub = {
 	changeLanguage: vi.fn(),
 } as unknown as Ti18n;
 
+const provider: RandomProvider = {
+	providerAccount: "provider-account",
+	provider: { url: "https://provider.test" },
+};
+
+const userAccount: Account = { account: { address: "user-address" } };
+
 // Each /frictionless run mints a new session, exactly as the provider does.
 let sessionCounter = 0;
-const detectBot = vi.fn(async () => {
+const detectBot: Mock<BotDetectionFunction> = vi.fn(async () => {
 	sessionCounter += 1;
 	return {
 		captchaType: CaptchaType.image,
 		sessionId: `provider-session-${sessionCounter}`,
-		provider: { provider: { url: "https://provider.test" } } as RandomProvider,
-		userAccount: "userAccount",
+		status: "ok",
+		provider,
+		userAccount,
 	};
 });
 
 let container: HTMLDivElement;
 let root: Root;
-let restart: ReturnType<typeof vi.fn>;
-let onError: ReturnType<typeof vi.fn>;
+let restart: Mock<() => void>;
+let onError: Mock<(error: Error) => void>;
 
 const lastMount = () => {
 	const mount = mocks.mounts.at(-1);
@@ -106,8 +124,8 @@ beforeEach(async () => {
 	mocks.mounts.length = 0;
 	sessionCounter = 0;
 	detectBot.mockClear();
-	restart = vi.fn();
-	onError = vi.fn();
+	restart = vi.fn<() => void>();
+	onError = vi.fn<(error: Error) => void>();
 	container = document.createElement("div");
 	document.body.appendChild(container);
 	act(() => {

--- a/packages/procaptcha-frictionless/src/tests/sessionInvalidatedRemint.test.tsx
+++ b/packages/procaptcha-frictionless/src/tests/sessionInvalidatedRemint.test.tsx
@@ -1,0 +1,227 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { Ti18n } from "@prosopo/locale";
+import {
+	CaptchaType,
+	ModeEnum,
+	type ProcaptchaClientConfigInput,
+	type ProcaptchaProps,
+	type RandomProvider,
+} from "@prosopo/types";
+import { type ReactElement, act, createElement } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MAX_SESSION_INVALIDATED_RETRIES } from "../sessionInvalidatedRecovery.js";
+
+declare global {
+	var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const mocks = vi.hoisted(() => ({
+	mounts: [] as { props: ProcaptchaProps }[],
+}));
+
+const imageStub = (props: ProcaptchaProps) => {
+	mocks.mounts.push({ props });
+	return createElement("div", { "data-widget": "image" });
+};
+
+vi.mock("@prosopo/procaptcha-react", () => ({ Procaptcha: imageStub }));
+vi.mock("@prosopo/procaptcha-pow", () => ({ ProcaptchaPow: imageStub }));
+vi.mock("@prosopo/procaptcha-puzzle", () => ({ ProcaptchaPuzzle: imageStub }));
+
+vi.mock("@prosopo/procaptcha-common", async (importOriginal) => {
+	const actual =
+		await importOriginal<typeof import("@prosopo/procaptcha-common")>();
+	return { ...actual, isSecureBrowserContext: () => true };
+});
+
+const { ProcaptchaFrictionless } = await import("../ProcaptchaFrictionless.js");
+
+const SITE_KEY = "5siteKey";
+
+const config = (): ProcaptchaClientConfigInput => ({
+	account: { address: SITE_KEY },
+	userAccountAddress: "",
+	web2: true,
+	mode: ModeEnum.visible,
+});
+
+const i18nStub = {
+	isInitialized: true,
+	language: "en",
+	t: (key: string) => key,
+	changeLanguage: vi.fn(),
+} as unknown as Ti18n;
+
+// Each /frictionless run mints a new session, exactly as the provider does.
+let sessionCounter = 0;
+const detectBot = vi.fn(async () => {
+	sessionCounter += 1;
+	return {
+		captchaType: CaptchaType.image,
+		sessionId: `provider-session-${sessionCounter}`,
+		provider: { provider: { url: "https://provider.test" } } as RandomProvider,
+		userAccount: "userAccount",
+	};
+});
+
+let container: HTMLDivElement;
+let root: Root;
+let restart: ReturnType<typeof vi.fn>;
+let onError: ReturnType<typeof vi.fn>;
+
+const lastMount = () => {
+	const mount = mocks.mounts.at(-1);
+	if (!mount) throw new Error("expected the image widget to have mounted");
+	return mount;
+};
+
+/** The inner widget reporting `CAPTCHA.NO_SESSION_FOUND` on its challenge fetch. */
+const reportSessionInvalidated = async (): Promise<void> => {
+	const { onSessionInvalidated } = lastMount().props;
+	await act(async () => {
+		onSessionInvalidated?.(120, 340);
+	});
+};
+
+const isCheckboxPlaceholder = (): boolean =>
+	container.querySelector('[data-widget="image"]') === null;
+
+beforeEach(async () => {
+	mocks.mounts.length = 0;
+	sessionCounter = 0;
+	detectBot.mockClear();
+	restart = vi.fn();
+	onError = vi.fn();
+	container = document.createElement("div");
+	document.body.appendChild(container);
+	act(() => {
+		root = createRoot(container);
+	});
+	await act(async () => {
+		root.render(
+			createElement(ProcaptchaFrictionless, {
+				config: config(),
+				callbacks: { onError },
+				restart,
+				i18n: i18nStub,
+				detectBot,
+			}) as ReactElement,
+		);
+	});
+});
+
+afterEach(() => {
+	act(() => {
+		root.unmount();
+	});
+	container.remove();
+	vi.clearAllMocks();
+});
+
+// Production, 2026-09-07: the widget re-sent an already-consumed sessionId to
+// /captcha/image, the provider answered 400 CAPTCHA.NO_SESSION_FOUND, and the
+// user was left staring at a checkbox reading "No session found" with nothing
+// behind it. The outer recovery guard was one-shot per widget lifetime and the
+// inner widget always returns through this handler, so the second failure was
+// handled by nobody at all.
+describe("NO_SESSION_FOUND recovery in ProcaptchaFrictionless", () => {
+	it("re-mints a session and re-mounts the widget on the first failure", async () => {
+		expect(detectBot).toHaveBeenCalledTimes(1);
+		expect(lastMount().props.frictionlessState?.sessionId).toBe(
+			"provider-session-1",
+		);
+
+		await reportSessionInvalidated();
+
+		expect(detectBot).toHaveBeenCalledTimes(2);
+		expect(lastMount().props.frictionlessState?.sessionId).toBe(
+			"provider-session-2",
+		);
+	});
+
+	it("resumes with autoStart and the original click coords, so the user needn't click twice", async () => {
+		await reportSessionInvalidated();
+
+		expect(lastMount().props.autoStart).toBe(true);
+		expect(lastMount().props.startCoords).toEqual({ x: 120, y: 340 });
+	});
+
+	it("keeps recovering past the first failure rather than dead-ending", async () => {
+		for (let i = 0; i < MAX_SESSION_INVALIDATED_RETRIES; i++) {
+			await reportSessionInvalidated();
+		}
+
+		// One initial run plus one re-mint per failure.
+		expect(detectBot).toHaveBeenCalledTimes(
+			MAX_SESSION_INVALIDATED_RETRIES + 1,
+		);
+		expect(isCheckboxPlaceholder()).toBe(false);
+	});
+
+	it("falls over visibly once the retry budget is spent instead of stranding the user", async () => {
+		for (let i = 0; i <= MAX_SESSION_INVALIDATED_RETRIES; i++) {
+			await reportSessionInvalidated();
+		}
+
+		// The budget-exceeding failure must not silently do nothing: the error
+		// reaches the host page and the widget renders the error placeholder,
+		// whose NO_SESSION_FOUND branch schedules the full restart.
+		expect(onError).toHaveBeenCalled();
+		expect(isCheckboxPlaceholder()).toBe(true);
+		expect(detectBot).toHaveBeenCalledTimes(
+			MAX_SESSION_INVALIDATED_RETRIES + 1,
+		);
+	});
+
+	// `resetState(0)` used to be `0 || stateRef.current.attemptCount`, so the
+	// counter never went back to zero and `start()`'s own `attemptCount >= 5`
+	// fall-over fired after five cumulative runs — five successful reload
+	// presses were enough to strand the user on the error placeholder.
+	it("does not fall over after repeated successful reloads", async () => {
+		for (let i = 0; i < 8; i++) {
+			const { onReload } = lastMount().props;
+			await act(async () => {
+				onReload?.(10, 20);
+			});
+		}
+
+		expect(isCheckboxPlaceholder()).toBe(false);
+		expect(onError).not.toHaveBeenCalled();
+		expect(detectBot).toHaveBeenCalledTimes(9);
+	});
+
+	it("gives a reload press a fresh retry budget — it mints a genuinely new session", async () => {
+		for (let i = 0; i < MAX_SESSION_INVALIDATED_RETRIES; i++) {
+			await reportSessionInvalidated();
+		}
+		const beforeReload = detectBot.mock.calls.length;
+
+		const { onReload } = lastMount().props;
+		await act(async () => {
+			onReload?.(10, 20);
+		});
+		expect(detectBot).toHaveBeenCalledTimes(beforeReload + 1);
+
+		// Without the reset this failure would land on the exhausted branch.
+		await reportSessionInvalidated();
+
+		expect(detectBot).toHaveBeenCalledTimes(beforeReload + 2);
+		expect(isCheckboxPlaceholder()).toBe(false);
+	});
+});

--- a/packages/procaptcha/src/modules/Manager.ts
+++ b/packages/procaptcha/src/modules/Manager.ts
@@ -94,6 +94,15 @@ export function Manager(
 	// URL of the provider used on the previous attempt. On a retry we exclude it
 	// from the candidate pool so the fallback lands on a different provider.
 	let previousProviderUrl: string | undefined;
+	// The sessionId this manager has already exchanged for a challenge. The
+	// provider consumes a session the moment it issues a challenge against it
+	// (`checkAndRemoveSession`), so asking for a second challenge with the same
+	// id is a guaranteed 400 CAPTCHA.NO_SESSION_FOUND. `defaultState()` doesn't
+	// clear `sessionId` and `buildUpdateState` skips `undefined`, so a stale id
+	// survives `resetState()` — any path that re-enters `start()` (a
+	// providerRetry after a late failure, a `procaptcha:execute` event, a
+	// non-delegated reload) would otherwise re-send it.
+	let spentSessionId: string | undefined;
 
 	/**
 	 * Build the config on demand, using the optional config passed in from the outside. State may override various
@@ -189,13 +198,38 @@ export function Manager(
 					updateState({ captchaApi });
 				}
 
+				// Short-circuit a challenge fetch we already know the provider
+				// will reject, and route straight to the recovery path the
+				// wrapper listens for — re-minting a session is the only way
+				// forward, and the doomed round trip only delays it.
+				if (state.sessionId && state.sessionId === spentSessionId) {
+					updateState({
+						loading: false,
+						error: {
+							message: "No session found",
+							key: "CAPTCHA.NO_SESSION_FOUND",
+						},
+					});
+					events.onError(new Error("No session found"));
+					return;
+				}
+
 				// Non-blocking check — attach SIMD readings only if the
 				// prefetched benchmark has already resolved by this point.
 				const simdReadingsOnChallenge = frictionlessState?.getSimdReadings
 					? await frictionlessState.getSimdReadings(0)
 					: undefined;
+				// Mark the id spent as soon as the request goes out: once the
+				// provider has seen it we must assume it is consumed, whether
+				// the response is a challenge, a 4xx, or never arrives. A
+				// transport failure is the only case where it may still be
+				// live, and treating it as spent there costs one extra
+				// /frictionless on the retry — cheaper than re-sending a dead
+				// id and stranding the user on "No session found".
+				const challengeSessionId = state.sessionId;
+				if (challengeSessionId) spentSessionId = challengeSessionId;
 				const challenge = await captchaApi?.getCaptchaChallenge(
-					state.sessionId,
+					challengeSessionId,
 					simdReadingsOnChallenge,
 				);
 

--- a/packages/procaptcha/src/tests/manager.unit.test.ts
+++ b/packages/procaptcha/src/tests/manager.unit.test.ts
@@ -471,6 +471,54 @@ describe("start", () => {
 		);
 	});
 
+	// The provider consumes a session the moment it issues a challenge for it,
+	// so a second challenge fetch on the same id is a guaranteed 400
+	// CAPTCHA.NO_SESSION_FOUND. Production saw the widget do exactly that —
+	// /captcha/image 200 followed 2-6s later by /captcha/image 400 on the same
+	// sessionId — and the user was left on a dead "No session found" checkbox.
+	test("does not ask for a second challenge on a session it already spent", async () => {
+		const harness = build({
+			frictionlessState: frictionless({ sessionId: "session-9" }),
+		});
+		await harness.manager.start();
+		expect(mocks.getCaptchaChallenge).toHaveBeenCalledTimes(1);
+
+		await harness.manager.start();
+
+		expect(mocks.getCaptchaChallenge).toHaveBeenCalledTimes(1);
+	});
+
+	test("surfaces NO_SESSION_FOUND for a spent session so the wrapper re-mints", async () => {
+		const harness = build({
+			frictionlessState: frictionless({ sessionId: "session-9" }),
+		});
+		await harness.manager.start();
+		Object.assign(harness.state, { loading: false, isHuman: false });
+
+		await harness.manager.start();
+
+		expect(lastUpdate(harness, "error")).toEqual({
+			message: "No session found",
+			key: "CAPTCHA.NO_SESSION_FOUND",
+		});
+		expect(harness.events.onError).toHaveBeenCalledTimes(1);
+	});
+
+	test("marks the session spent even when the challenge request fails", async () => {
+		// A 400 means the session was already gone; re-sending the id can only
+		// produce the same 400, so the retry has to take the re-mint path.
+		const harness = build({
+			frictionlessState: frictionless({ sessionId: "session-9" }),
+		});
+		mocks.getCaptchaChallenge.mockRejectedValueOnce(
+			new Error("No session found"),
+		);
+
+		await harness.manager.start();
+
+		expect(mocks.getCaptchaChallenge).toHaveBeenCalledTimes(1);
+	});
+
 	test("shows the modal and seeds an empty solution per captcha", async () => {
 		const harness = build();
 		mocks.getCaptchaChallenge.mockResolvedValue(


### PR DESCRIPTION
Fixes the "No session found" stuck-checkbox report (prosopo/captcha-private#4431).

## What users saw

A checkbox reading **No session found** that never recovered — usually after pressing the reload button on an image challenge. Reported "once out of four attempts", which fits: you need *two* `NO_SESSION_FOUND`s in one widget lifetime to hit the dead end.

## What the provider logs show

`checkAndRemoveSession` consumes a session the moment `/captcha/image` issues a challenge for it, so a second challenge fetch on that id can never succeed. Production, one affected user, repeated ~40× over 45 minutes:

```
11:34:41.198  POST /captcha/frictionless   200  -> session 295cf6d1291c
11:34:41.404  POST /captcha/image          200  "Image captcha challenge issued"
11:34:45.014  POST /captcha/image          400  CAPTCHA.NO_SESSION_FOUND   (same sessionId)
11:34:45.442  POST /captcha/frictionless   200  -> new session ...
```

## Three defects, all client-side

**1. The manager re-sent a sessionId it had already spent.**
`defaultState()` doesn't clear `sessionId`, and `buildUpdateState` skips `undefined`, so a stale id survives `resetState()`. Any path that re-enters `start()` re-sends it. `Manager` now remembers the id it exchanged for a challenge and, instead of making a request it knows will 400, sets `CAPTCHA.NO_SESSION_FOUND` directly — the state the wrapper already listens for.

**2. Recovery was one-shot per outer widget lifetime, with no terminal branch.**
`ProcaptchaWidget` always takes the `onSessionInvalidated` branch and `return`s before its own `frictionlessState.restart()` fallback, and its guard ref is fresh on every re-mount because the wrapper bumps the mount key. So once the wrapper's one-shot was spent, the second failure was handled by **nobody**: no re-mint, no restart, no message. That is the stuck checkbox.

`handleSessionInvalidated` is now a bounded counter (`MAX_SESSION_INVALIDATED_RETRIES`) that reports `exhausted`; a reload press clears it (a reload mints a genuinely new session, so it shouldn't spend the budget for the old one); and exhaustion falls over visibly through `fallOverWithStyle`, whose `NO_SESSION_FOUND` branch schedules the existing 10-second full restart. There is always a way back.

**3. `resetState(0)` never reset anything.**
`0 || stateRef.current.attemptCount` kept the old count, so `attemptCount` accumulated across every re-mint and `start()`'s own `attemptCount >= 5` fall-over fired after five *cumulative* runs in a widget lifetime. Five successful reload presses were enough to drop the user onto the error placeholder. Now `??`.

## Tests

- `packages/procaptcha/src/tests/manager.unit.test.ts` — the manager doesn't re-request a challenge on a spent session, surfaces `NO_SESSION_FOUND` so the wrapper re-mints, and marks the id spent even when the request fails.
- `packages/procaptcha-frictionless/src/tests/sessionInvalidatedRemint.test.tsx` (new) — component-level: re-mints and resumes with the original click coords, keeps recovering past the first failure, falls over visibly once the budget is spent, gives a reload press a fresh budget, and doesn't fall over after repeated successful reloads.
- `sessionInvalidatedRecovery.test.ts` updated for the counter.

`@prosopo/procaptcha` 148 pass, `@prosopo/procaptcha-frictionless` 67 pass. Pre-existing failures in `procaptcha-common` / `-react` / `-puzzle` / `-bundle` are identical with these changes stashed (stale local build artifacts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)