### PR TITLE
fix(database): include clientMetaData in the commitment projection

### DIFF
--- a/.changeset/commitment-projection-client-metadata.md
+++ b/.changeset/commitment-projection-client-metadata.md
@@ -1,0 +1,22 @@
+---
+"@prosopo/database": patch
+---
+
+Include `clientMetaData` in the commitment projection.
+
+`DAPP_USER_COMMITMENT_PROJECTION` enumerates the fields the verify path reads
+off `solution`. `clientMetaData` arrived in 5.5.0 with the client-session
+correlation but was never added, so both `getDappUserCommitmentById` and
+`getDappUserCommitmentByAccount` returned it as `undefined` on every fetch —
+whatever was stored on the record.
+
+`isClientSessionMismatch(expected, undefined)` is therefore true whenever the
+caller supplies a session id, so every image captcha verified through a caller
+that correlates on a session was disapproved with `CLIENT_SESSION_MISMATCH`:
+a token replay reported on solves earned in exactly the session they claimed.
+
+PoW and puzzle were unaffected — they read their own challenge record rather
+than this projection, which is why the failure was confined to image captchas.
+
+The projection's own regression test now asserts the field round-trips; it was
+written to catch this class of bug and did not cover this field.

--- a/packages/database/src/databases/provider.ts
+++ b/packages/database/src/databases/provider.ts
@@ -2318,6 +2318,13 @@ export class ProviderDatabase
 		behavioralDataPacked: 1,
 		deviceCapability: 1,
 		coords: 1,
+		// Read by `verifyImageCaptchaSolution` for the client-session
+		// correlation. Added in 5.5.0 but never added here, so
+		// `solution.clientMetaData` came back `undefined` on every fetch and
+		// `isClientSessionMismatch(id, undefined)` was true for every caller
+		// that supplied a session id — a token replay reported on solves that
+		// were earned in exactly the session they claimed.
+		clientMetaData: 1,
 	} as { [key in keyof Partial<UserCommitmentRecord>]: 1 };
 
 	/**

--- a/packages/database/src/tests/integration/commitmentRecordProjection.integration.test.ts
+++ b/packages/database/src/tests/integration/commitmentRecordProjection.integration.test.ts
@@ -102,6 +102,7 @@ const buildCommitment = (id: string) => ({
 	deadlineTimestamp: new Date(Date.now() + 60_000),
 	threshold: 0.5,
 	sessionId: "session-projection",
+	clientMetaData: { clientSessionId: "bumblebee-session-projection" },
 	ipInfo: {
 		ip: "203.0.113.1",
 		isValid: true as const,
@@ -187,6 +188,17 @@ describe("getDappUserCommitment{ById,ByAccount} projection", () => {
 		expect(got.coords?.[0]?.[0]).toEqual([723, 766]);
 		expect(got.serverChecked).toBe(false);
 		expect(got.sessionId).toBe("session-projection");
+		// Added in 5.5.0 and omitted from the projection until 2026-09-07.
+		// While it was missing, `solution.clientMetaData` was `undefined` on
+		// every fetch, so the client-session correlation compared a live
+		// session id against nothing and disapproved with
+		// CLIENT_SESSION_MISMATCH — reporting a replay on solves earned in
+		// exactly the session they claimed. PoW and puzzle were untouched
+		// because they read their own challenge record, not this projection.
+		expect(got.clientMetaData).toBeDefined();
+		expect(got.clientMetaData?.clientSessionId).toBe(
+			"bumblebee-session-projection",
+		);
 		expect(got.result?.status).toBe(CaptchaStatus.approved);
 		expect(got.ipAddress).toBeDefined();
 		expect(got.submittedAtTimestamp).toBeInstanceOf(Date);


### PR DESCRIPTION
Every image captcha verified through a caller that correlates on a session is being disapproved as a token replay, on solves earned in exactly the session they claimed.

## Cause

`DAPP_USER_COMMITMENT_PROJECTION` enumerates the fields the verify path reads off `solution`. `clientMetaData` arrived in 5.5.0 with the client-session correlation and was never added to it:

```
id, result, serverChecked, requestedAtTimestamp, submittedAtTimestamp,
verifiedAtTimestamp, failedAtTimestamp, ipAddress, sessionId, userAccount,
dappAccount, headers, ipInfo, behavioralDataPacked, deviceCapability, coords
```

Both `getDappUserCommitmentById` and `getDappUserCommitmentByAccount` use it, so `solution.clientMetaData` came back `undefined` on every fetch regardless of what the record held. `isClientSessionMismatch(expected, undefined)` is then true for any caller supplying a session id.

## Why this and not the read path

A previous change removed the account-wide commitment fallback on the theory that verify was resolving a stale commitment from an earlier session. After deploying it, production still logged:

```
hasRecordedClientSessionId": false     19x on one node, 18x on another, zero true
```

with verify resolving strictly by commitment id — while those same commitments in the database plainly carried `clientMetaData.clientSessionId`. A projection is the only thing that makes a stored field absent at read time and present at rest.

The asymmetry corroborates it: PoW and puzzle read their own challenge record rather than this projection, and saw approximately no mismatches while image captchas saw them in the thousands.

## Test

The projection already has a regression test, written for exactly this class of bug ("if a field the verify path reads is absent from the projection it lands as `undefined`, silently degrading downstream behaviour"). It did not cover this field. It now does, and I verified it fails without the fix:

```
AssertionError: expected undefined to be defined
  198|   expect(got.clientMetaData).toBeDefined();
```

4 tests pass with the fix; biome clean. The `make-dir` tsc error in this package reproduces on a clean tree and is unrelated.
