### PR TITLE
fix(provider): give the routing machine the request user agent, not the hashed one

### DIFF
--- a/.changeset/routing-platform-raw-user-agent.md
+++ b/.changeset/routing-platform-raw-user-agent.md
@@ -1,0 +1,41 @@
+---
+"@prosopo/provider": patch
+---
+
+fix(provider): give the routing machine the request user agent, not the hashed one
+
+`decryptPayload` returns `userAgent` already hashed — it exists so
+`runUserAgentMismatchCheck` can compare it against `hashUserAgent(request UA)`.
+The frictionless handler was also passing that hash into `derivePlatform` and
+`raw.userAgent` on the routing context, so every UA-derived signal the routing
+machine sees was computed from a 32-character hex digest.
+
+`platform.isApple` was therefore always false on the fresh frictionless path.
+Not usually — always: the regex matches `iPhone` / `iPad` / `Macintosh`, and
+every one of those contains a letter outside `[0-9a-f]`, so no hash can match.
+The UA fallback inside `isMobile` was dead for the same reason and only worked
+when ipInfo supplied the bit.
+
+The dedup replay a few hundred lines above already read
+`req.headers["user-agent"]` directly, so the two paths disagreed about the same
+request. The fresh path now reads the header too. The hashed value is untouched
+where it belongs — it still goes to the decision machine for the mismatch check.
+
+Two live consequences, both of which restore intended behaviour:
+
+- `pow-baseline-apple-passthrough` in the global routing machine could never
+  fire on a fresh session. Apple devices on a PoW baseline fell through to the
+  rate ladder and were escalated to image captchas on volume alone. This is
+  what put a genuine iPhone — bot score 0.219 against a 0.5 threshold, zero
+  triggered detectors — into an image challenge.
+- `isUndeclaredMiddlebox` in the shared route checks gates on
+  `isAppleUa(raw.userAgent)`, so the `UNDECLARED_VPN_TCP_STACK` escalation was
+  unreachable on that path. It is not new or untested logic — it already fires
+  on the paths that carry the real UA — it simply becomes reachable here too.
+
+Rules classifying on `platform.osNameIn` / `browserNameIn` / `deviceTypeIn` were
+misclassifying on this path for the same reason, and now resolve correctly.
+
+Covered by a regression test that asserts the routing context receives the real
+user agent and resolves `isApple` for an iPhone UA; it fails against the old
+code with `isApple: false`.

--- a/packages/provider/src/api/captcha/getFrictionlessCaptchaChallenge/handler.ts
+++ b/packages/provider/src/api/captcha/getFrictionlessCaptchaChallenge/handler.ts
@@ -733,7 +733,11 @@ export default (
 				req.ipInfo && "isValid" in req.ipInfo && req.ipInfo.isValid
 					? req.ipInfo.isMobile
 					: undefined;
-			const safeUserAgent = userAgent ?? "";
+			// `userAgent` is hashed and only meaningful to
+			// `runUserAgentMismatchCheck`; passing it here left `isApple` and any
+			// UA classification permanently false. The dedup replay above already
+			// reads the header directly.
+			const requestUserAgent = String(req.headers["user-agent"] ?? "");
 			const trafficPolicies = deriveTrafficPolicies(
 				clientRecord.settings?.trafficFilter,
 			);
@@ -749,12 +753,12 @@ export default (
 				// puzzle chosen in place of a disabled image challenge.
 				frictionlessTypes: clientRecord.settings.frictionlessTypes,
 				baseImageRounds: env.config.captchas.solved.count,
-				platform: derivePlatform(safeUserAgent, webView, {
+				platform: derivePlatform(requestUserAgent, webView, {
 					...(typeof ipInfoMobile === "boolean" && { isMobile: ipInfoMobile }),
 				}),
 				raw: {
 					headers: flatHeaders,
-					userAgent: safeUserAgent,
+					userAgent: requestUserAgent,
 					...(req.ja4 && { ja4: req.ja4 }),
 					...(req.tcpToChelloUs !== undefined && {
 						tcpToChelloUs: req.tcpToChelloUs,

--- a/packages/provider/src/tests/unit/api/getFrictionlessCaptchaChallenge.unit.test.ts
+++ b/packages/provider/src/tests/unit/api/getFrictionlessCaptchaChallenge.unit.test.ts
@@ -564,6 +564,47 @@ describe("getFrictionlessCaptchaChallenge - context selection", () => {
 		);
 	});
 
+	// `decryptPayload` returns `userAgent` hashed, for the mismatch check only.
+	// Routing it into `derivePlatform` pinned `platform.isApple` to false, so
+	// the global machine's Apple passthrough never fired on a fresh session and
+	// genuine iPhones fell through to the rate ladder.
+	it("gives the routing machine the request user agent, not the hashed one", async () => {
+		const clientRecord = {
+			account: "siteRoutingUa",
+			settings: {
+				captchaType: CaptchaType.frictionless,
+				frictionlessThreshold: 0.5,
+				disallowWebView: false,
+			},
+		};
+		tasksInstance.db.getClientRecord.mockResolvedValue(clientRecord);
+		tasksInstance.frictionlessManager.decryptPayload.mockResolvedValue(
+			payload(false),
+		);
+
+		const body = {
+			token: "tRoutingUa",
+			headHash: "hhRoutingUa",
+			dapp: "siteRoutingUa",
+			user: "u",
+		};
+		const { req, res, next } = buildReqRes(body);
+		req.headers["user-agent"] = IPHONE_UA;
+
+		// biome-ignore lint/suspicious/noExplicitAny: mock request
+		await handler(req as any, res as any, next);
+
+		expect(next).not.toHaveBeenCalled();
+		expect(
+			tasksInstance.frictionlessManager.setRoutingContext,
+		).toHaveBeenCalledWith(
+			expect.objectContaining({
+				platform: expect.objectContaining({ isApple: true }),
+				raw: expect.objectContaining({ userAgent: IPHONE_UA }),
+			}),
+		);
+	});
+
 	it("reuses the cached session when the routing machine returns the same captchaType", async () => {
 		const clientRecord = {
 			account: "siteDedupRoutingAgrees",


### PR DESCRIPTION
## The bug

`decryptPayload` returns `userAgent` **already hashed** — it exists so `runUserAgentMismatchCheck` can compare it against `hashUserAgent(request UA)`. The frictionless handler was also feeding that hash into `derivePlatform` and `raw.userAgent` on the routing context, so every UA-derived signal the routing machine saw was computed from a 32-character hex digest.

```ts
const safeUserAgent = userAgent ?? "";          // ← the hash
platform: derivePlatform(safeUserAgent, ...),
raw: { userAgent: safeUserAgent, ... }
```

`platform.isApple` was therefore always false on the fresh frictionless path. Not usually — **always**. `APPLE_UA_REGEX` matches `iPhone` / `iPad` / `iPod` / `Macintosh` / `Mac OS X`, and every one of those contains a letter outside `[0-9a-f]`, so no hex digest can ever match it. The UA fallback inside `isMobile` was dead for the same reason and only worked when ipInfo supplied the bit.

The dedup replay a few hundred lines earlier already read the header directly (`dedupUserAgent`, line 262), so the two paths disagreed about the same request.

Confirmed against a real production session — the logged `data_useragent` reproduces exactly as `sha256(iPhone UA).slice(0, 32)`:

```
sha256("Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) …").slice(0,32)
  = 0b5bf65a3c87672ee6bd66722063c699   ← byte-for-byte the logged value
```

## The fix

Read the header on the fresh path too. The hashed value is untouched where it belongs — it still goes to the decision machine for the mismatch check.

## Behaviour change

Both of these restore intended behaviour that was silently unreachable:

- **`pow-baseline-apple-passthrough`** (global routing machine) could never fire on a fresh session. Apple devices on a PoW baseline fell through to the rate ladder and were escalated to image captchas on volume alone. This is what put a genuine iPhone — bot score `0.219` against a `0.5` threshold, `triggeredDetectors: []`, clean UK ISP — into an image challenge while the provider log for that same request read `decision: "default_pow"`.
- **`isUndeclaredMiddlebox`** in the shared route checks gates on `isAppleUa(raw.userAgent)`, so the `UNDECLARED_VPN_TCP_STACK` escalation was unreachable on this path. Not new or untested logic — it already fires on the paths carrying the real UA (954 sessions recorded) — it simply becomes reachable here too. Worth knowing this PR activates it for fresh sessions.

Rules classifying on `platform.osNameIn` / `browserNameIn` / `deviceTypeIn` were misclassifying on this path for the same reason and now resolve correctly. Note a hashed UA almost certainly classified as `unknown`, which is *in* the `osNameIn` list of the DSL's `pow-served-user-10m` rule — so a rule written to exclude iOS was matching iOS anyway.

## Testing

Added a regression test asserting the routing context receives the real user agent and resolves `isApple` for an iPhone UA. Verified red-green — against the old code it fails with:

```
-       "isApple": true,
+       "isApple": false,
```

Full provider unit suite: **1193 passed (78 files)**. biome clean.

One note: `npm run -w @prosopo/provider build:tsc` fails locally on `database/src/index.ts(14,10): Module '"make-dir"' has no exported member 'makeDirectory'` — `make-dir` is pinned at 5.1.0 and that file is untouched by this PR, so it looks like a local resolution issue rather than anything here. Flagging it in case CI sees it too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)