### PR TITLE
feat(provider): sign captcha image URLs with short-lived tokens

### DIFF
--- a/.changeset/signed-captcha-image-urls.md
+++ b/.changeset/signed-captcha-image-urls.md
@@ -1,0 +1,39 @@
+---
+"@prosopo/provider": patch
+---
+
+feat(provider): sign captcha image URLs with short-lived tokens
+
+Captcha image URLs are permanent, unauthenticated and cacheable. Harvest the
+URLs once and the entire image pool can be refetched indefinitely, offline and
+unattributably — which is what makes scraping the demo dataset cheap, and why
+regenerating the dataset alone never fixes it.
+
+`AssetsResolver` has been declared in `@prosopo/types` and called by
+`parseCaptchaAssets` since the image flow was written, but nothing ever assigned
+it. `env.assetsResolver` was always `undefined`, so `item.data` went out exactly
+as stored. This fills that hook with a bunny.net token-authentication signer.
+
+Signing happens strictly below `item.data`. The item hash stays
+`blake2b(image bytes)`, so `captchaId`, `captchaContentId` and `datasetId` are
+untouched and no dataset has to be rebuilt to adopt this — a signed URL is never
+itself hashed. The resolver is constructed per request rather than per process,
+so each challenge's URLs expire on their own clock and can optionally be bound
+to the requesting IP via `ZoneSecurityIncludeHashRemoteIP`.
+
+The scheme was checked against a live token-auth pull zone before being written:
+a correctly signed URL returns 200, while a tampered token, an expired token,
+and a token replayed against a different path all return 403. The token is bound
+to its exact path, so one harvested URL cannot be rewritten across the pool.
+
+Inactive unless `PROSOPO_ASSET_TOKEN_KEY` is set. Without it the resolver is
+`undefined` and the response is byte-for-byte what it is today, so this can ship
+ahead of the infrastructure change.
+
+Ordering matters when it is switched on. The pull zone only excludes
+`token`/`expires` from its cache key while token authentication is enabled: with
+it on, repeated requests carrying different tokens still hit cache; with it off,
+every distinct `expires` becomes its own cache entry and every image misses.
+Enabling the zone first is worse still — unsigned requests 403 and image
+captchas break — so the zone has to be switched over promptly after providers
+begin signing, not before.

--- a/packages/provider/src/api/captcha/getImageCaptchaChallenge.ts
+++ b/packages/provider/src/api/captcha/getImageCaptchaChallenge.ts
@@ -40,6 +40,7 @@ import { recordCaptchaIssueError, recordCaptchaIssued } from "../metrics.js";
 import { isReservedTestSiteKey } from "../testSiteKey.js";
 import { validateAddr, validateSiteKey } from "../validateAddress.js";
 import { buildImageMaintenanceResponse } from "./maintenanceModeResponses.js";
+import { getSignedAssetsResolver } from "./signedAssetsResolver.js";
 import { applyTrafficFilterAtRequestTime } from "./trafficFilterRequestTime.js";
 
 export default (
@@ -294,13 +295,20 @@ export default (
 					// flat fields.
 					req.ipInfo,
 				);
+			// Signed URLs are minted per request so each challenge's images
+			// expire on their own clock (and can be bound to the requesting
+			// IP). Falls back to the env resolver, and thence to passing
+			// `item.data` through untouched, when no signing key is set.
+			const assetsResolver =
+				getSignedAssetsResolver(ipAddress.toString()) ?? env.assetsResolver;
+
 			const captchaResponse: CaptchaResponseBody = {
 				[ApiParams.status]: "ok",
 				[ApiParams.captchas]: taskData.captchas.map((captcha: Captcha) => ({
 					...captcha,
 					target: req.t(`TARGET.${captcha.target}`),
 					items: captcha.items.map((item) =>
-						parseCaptchaAssets(item, env.assetsResolver),
+						parseCaptchaAssets(item, assetsResolver),
 					),
 				})),
 				[ApiParams.requestHash]: taskData.requestHash,

--- a/packages/provider/src/api/captcha/signedAssetsResolver.ts
+++ b/packages/provider/src/api/captcha/signedAssetsResolver.ts
@@ -1,0 +1,140 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Rewrites captcha image URLs into short-lived signed URLs at serve time.
+//
+// The dataset stores one canonical CDN URL per item and commits to
+// `blake2b(image bytes)` as the item hash. Signing happens strictly below
+// `item.data` — the hash, the captchaId and the datasetId are untouched, so
+// enabling this changes nothing about the dataset or its verification.
+//
+// Without it, a captcha image URL is permanent, unauthenticated and
+// cacheable: harvest the URLs once and the pool can be refetched forever,
+// offline and unattributably. With it, a harvested URL is dead within
+// `ttlSeconds` and every image has to be requested through the provider API,
+// which is rate limited, logged and attributable.
+//
+// Bunny's token scheme (verified against a live zone):
+//   token   = base64url(sha256(securityKey + path + expires [+ clientIp]))
+//             with `+`->`-`, `/`->`_`, `=` stripped
+//   url     = <origin><path>?token=<token>&expires=<expires>
+// A token is bound to its exact path, so it cannot be replayed against a
+// different image.
+
+import { createHash } from "node:crypto";
+import type { Asset, AssetsResolver } from "@prosopo/types";
+
+export const DEFAULT_ASSET_TOKEN_TTL_SECONDS = 300;
+
+export interface SignedAssetsResolverOptions {
+	securityKey: string;
+	ttlSeconds?: number;
+	// Only set this when the pull zone has `ZoneSecurityIncludeHashRemoteIP`
+	// enabled. The two must agree or every URL 403s.
+	clientIp?: string;
+	// Injectable so tests do not depend on the wall clock.
+	now?: () => number;
+}
+
+export class SignedAssetsResolver implements AssetsResolver {
+	private readonly securityKey: string;
+	private readonly ttlSeconds: number;
+	private readonly clientIp: string | undefined;
+	private readonly now: () => number;
+
+	constructor(options: SignedAssetsResolverOptions) {
+		this.securityKey = options.securityKey;
+		this.ttlSeconds = options.ttlSeconds ?? DEFAULT_ASSET_TOKEN_TTL_SECONDS;
+		this.clientIp = options.clientIp;
+		this.now = options.now ?? (() => Date.now());
+	}
+
+	private sign(path: string, expires: number): string {
+		const base = `${this.securityKey}${path}${expires}${this.clientIp ?? ""}`;
+		return createHash("sha256")
+			.update(base)
+			.digest("base64")
+			.replace(/\+/g, "-")
+			.replace(/\//g, "_")
+			.replace(/=/g, "");
+	}
+
+	resolveAsset(assetURI: string): Asset {
+		const url = this.toUrl(assetURI);
+
+		// Local paths (dev/test fixtures) and anything unparseable are passed
+		// through untouched rather than silently mangled.
+		if (!url) {
+			return { URI: assetURI, getURL: (): string => assetURI };
+		}
+
+		// Bunny folds existing query parameters into the hash, which this
+		// simple form does not reproduce. Dataset URLs never carry one; if
+		// that ever changes, signing would silently start producing 403s, so
+		// refuse rather than emit a URL that cannot be fetched.
+		if (url.search !== "") {
+			throw new Error(
+				`Cannot sign an asset URL that already has a query string: ${assetURI}`,
+			);
+		}
+
+		const expires = Math.floor(this.now() / 1000) + this.ttlSeconds;
+		const token = this.sign(url.pathname, expires);
+		const signed = `${url.origin}${url.pathname}?token=${token}&expires=${expires}`;
+
+		return { URI: assetURI, getURL: (): string => signed };
+	}
+
+	private toUrl(assetURI: string): URL | undefined {
+		try {
+			const url = new URL(assetURI);
+			return url.protocol === "http:" || url.protocol === "https:"
+				? url
+				: undefined;
+		} catch {
+			return undefined;
+		}
+	}
+}
+
+/**
+ * Build the resolver from the environment, or `undefined` when it is not
+ * configured. Undefined means `parseCaptchaAssets` passes `item.data`
+ * through unchanged — the behaviour before this existed — so the feature is
+ * off until a key is deliberately supplied.
+ */
+export function getSignedAssetsResolver(
+	clientIp?: string,
+): AssetsResolver | undefined {
+	const securityKey = process.env.PROSOPO_ASSET_TOKEN_KEY;
+	if (!securityKey) {
+		return undefined;
+	}
+
+	const ttlSeconds =
+		Number.parseInt(process.env.PROSOPO_ASSET_TOKEN_TTL_SECONDS ?? "", 10) ||
+		DEFAULT_ASSET_TOKEN_TTL_SECONDS;
+
+	// Binding a URL to the requesting IP is stronger, but it has to match the
+	// zone's `ZoneSecurityIncludeHashRemoteIP` setting exactly, and it breaks
+	// any client whose image requests egress from a different address than
+	// its API call. Off unless explicitly turned on.
+	const bindIp = process.env.PROSOPO_ASSET_TOKEN_BIND_IP === "true";
+
+	return new SignedAssetsResolver({
+		securityKey,
+		ttlSeconds,
+		...(bindIp && clientIp ? { clientIp } : {}),
+	});
+}

--- a/packages/provider/src/tests/unit/signedAssetsResolver.unit.test.ts
+++ b/packages/provider/src/tests/unit/signedAssetsResolver.unit.test.ts
@@ -24,7 +24,10 @@ const KEY = "test-security-key";
 const NOW_MS = 1_700_000_000_000;
 const IMAGE = "https://prosopoimages.b-cdn.net/v5_dataset_flat/images/abc.webp";
 
-const resolver = (ttlSeconds?: number, clientIp?: string): SignedAssetsResolver =>
+const resolver = (
+	ttlSeconds?: number,
+	clientIp?: string,
+): SignedAssetsResolver =>
 	new SignedAssetsResolver({
 		securityKey: KEY,
 		now: () => NOW_MS,
@@ -79,7 +82,9 @@ describe("SignedAssetsResolver", () => {
 	});
 
 	test("includes the client IP when bound", () => {
-		const url = new URL(resolver(300, "203.0.113.9").resolveAsset(IMAGE).getURL());
+		const url = new URL(
+			resolver(300, "203.0.113.9").resolveAsset(IMAGE).getURL(),
+		);
 		const expires = NOW_MS / 1000 + 300;
 		expect(url.searchParams.get("token")).toBe(
 			expected("/v5_dataset_flat/images/abc.webp", expires, "203.0.113.9"),

--- a/packages/provider/src/tests/unit/signedAssetsResolver.unit.test.ts
+++ b/packages/provider/src/tests/unit/signedAssetsResolver.unit.test.ts
@@ -1,0 +1,133 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { createHash } from "node:crypto";
+import { afterEach, describe, expect, test } from "vitest";
+import {
+	DEFAULT_ASSET_TOKEN_TTL_SECONDS,
+	SignedAssetsResolver,
+	getSignedAssetsResolver,
+} from "../../api/captcha/signedAssetsResolver.js";
+
+const KEY = "test-security-key";
+const NOW_MS = 1_700_000_000_000;
+const IMAGE = "https://prosopoimages.b-cdn.net/v5_dataset_flat/images/abc.webp";
+
+const resolver = (ttlSeconds?: number, clientIp?: string): SignedAssetsResolver =>
+	new SignedAssetsResolver({
+		securityKey: KEY,
+		now: () => NOW_MS,
+		...(ttlSeconds !== undefined ? { ttlSeconds } : {}),
+		...(clientIp !== undefined ? { clientIp } : {}),
+	});
+
+// The reference implementation, matching bunny.net's documented scheme.
+const expected = (path: string, expires: number, ip = ""): string =>
+	createHash("sha256")
+		.update(`${KEY}${path}${expires}${ip}`)
+		.digest("base64")
+		.replace(/\+/g, "-")
+		.replace(/\//g, "_")
+		.replace(/=/g, "");
+
+describe("SignedAssetsResolver", () => {
+	test("signs the URL with a token and expiry", () => {
+		const url = new URL(resolver(300).resolveAsset(IMAGE).getURL());
+		const expires = NOW_MS / 1000 + 300;
+
+		expect(url.origin + url.pathname).toBe(IMAGE);
+		expect(url.searchParams.get("expires")).toBe(String(expires));
+		expect(url.searchParams.get("token")).toBe(
+			expected("/v5_dataset_flat/images/abc.webp", expires),
+		);
+	});
+
+	test("preserves the original URI on the asset", () => {
+		expect(resolver().resolveAsset(IMAGE).URI).toBe(IMAGE);
+	});
+
+	test("defaults to a short TTL", () => {
+		const url = new URL(resolver().resolveAsset(IMAGE).getURL());
+		expect(url.searchParams.get("expires")).toBe(
+			String(NOW_MS / 1000 + DEFAULT_ASSET_TOKEN_TTL_SECONDS),
+		);
+	});
+
+	// A token that worked for any path would let a scraper harvest one URL
+	// and rewrite it across the whole pool.
+	test("binds the token to its exact path", () => {
+		const a = resolver().resolveAsset(IMAGE).getURL();
+		const b = resolver()
+			.resolveAsset(
+				"https://prosopoimages.b-cdn.net/v5_dataset_flat/images/def.webp",
+			)
+			.getURL();
+		const tokenOf = (u: string): string | null =>
+			new URL(u).searchParams.get("token");
+		expect(tokenOf(a)).not.toBe(tokenOf(b));
+	});
+
+	test("includes the client IP when bound", () => {
+		const url = new URL(resolver(300, "203.0.113.9").resolveAsset(IMAGE).getURL());
+		const expires = NOW_MS / 1000 + 300;
+		expect(url.searchParams.get("token")).toBe(
+			expected("/v5_dataset_flat/images/abc.webp", expires, "203.0.113.9"),
+		);
+	});
+
+	test("passes non-http URIs through untouched", () => {
+		const local = "/home/prosopo/images/abc.webp";
+		expect(resolver().resolveAsset(local).getURL()).toBe(local);
+	});
+
+	// Silently emitting an unfetchable URL would surface as a broken captcha
+	// rather than an error, so this must throw.
+	test("refuses to sign a URL that already has a query string", () => {
+		expect(() => resolver().resolveAsset(`${IMAGE}?w=100`)).toThrow(
+			/already has a query string/,
+		);
+	});
+});
+
+describe("getSignedAssetsResolver", () => {
+	afterEach(() => {
+		process.env.PROSOPO_ASSET_TOKEN_KEY = undefined;
+		process.env.PROSOPO_ASSET_TOKEN_BIND_IP = undefined;
+	});
+
+	// The feature must stay off until a key is deliberately supplied,
+	// otherwise deploying this would 403 every image.
+	test("is undefined when no key is configured", () => {
+		process.env.PROSOPO_ASSET_TOKEN_KEY = "";
+		expect(getSignedAssetsResolver()).toBeUndefined();
+	});
+
+	test("is constructed when a key is configured", () => {
+		process.env.PROSOPO_ASSET_TOKEN_KEY = KEY;
+		expect(getSignedAssetsResolver()).toBeInstanceOf(SignedAssetsResolver);
+	});
+
+	test("ignores the client IP unless binding is enabled", () => {
+		process.env.PROSOPO_ASSET_TOKEN_KEY = KEY;
+		const unbound = getSignedAssetsResolver("203.0.113.9");
+		process.env.PROSOPO_ASSET_TOKEN_BIND_IP = "true";
+		const bound = getSignedAssetsResolver("203.0.113.9");
+
+		const tokenOf = (u: string): string | null =>
+			new URL(u).searchParams.get("token");
+		expect(tokenOf(unbound?.resolveAsset(IMAGE).getURL() ?? "")).not.toBe(
+			tokenOf(bound?.resolveAsset(IMAGE).getURL() ?? ""),
+		);
+	});
+});


### PR DESCRIPTION
Captcha image URLs are currently permanent, unauthenticated and cacheable. Harvest them once and the pool can be refetched forever — offline and unattributably. That is what makes scraping the demo image dataset cheap, and no amount of regenerating the dataset fixes it.

This adds a bunny.net token-authentication signer behind the **existing** `AssetsResolver` seam. The hook is declared in `packages/types/src/datasets/assets.ts` and called by `parseCaptchaAssets`, but was never assigned anywhere — `env.assetsResolver` has always been `undefined`, so `item.data` passed through untouched.

### Why this does not touch the dataset

Signing happens strictly below `item.data`. The item hash remains `blake2b(image bytes)`, so `captchaId`, `captchaContentId` and `datasetId` are all unchanged. No dataset needs rebuilding to adopt this, and a signed URL is never hashed.

The resolver is built **per request**, so each challenge’s URLs expire on their own clock and can optionally be bound to the requesting IP.

### Verified against a live zone

The signing scheme was validated against a real token-auth pull zone before this was written, not after:

| case | result |
|---|---|
| correctly signed URL | 200 |
| tampered token | 403 |
| expired token | 403 |
| token replayed on a different path | 403 |

Plus 10 unit tests covering the same properties.

### Safe to merge and deploy on its own

Off unless `PROSOPO_ASSET_TOKEN_KEY` is set. Without it the resolver is `undefined` and behaviour is byte-for-byte what it is today.

### Rollout note (matters)

The pull zone only strips `token`/`expires` from its cache key **while token auth is enabled**. Measured both ways:

- token auth **on** → repeated requests with different tokens still `cdn-cache: HIT`
- token auth **off** → every unique `expires` is a distinct cache entry, `MISS` every time

So enabling signing before switching the zone over means images miss cache on every request. The zone must be switched promptly after the providers start signing. Switching the zone *first* is worse — every unsigned request 403s and image captchas break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)