### PR TITLE
feat(types,provider): carry the client's `b` signal map on DetectorResult

### DIFF
--- a/.changeset/detector-result-b-field.md
+++ b/.changeset/detector-result-b-field.md
@@ -1,0 +1,21 @@
+---
+"@prosopo/types": patch
+"@prosopo/provider": patch
+---
+
+feat(types,provider): carry the client's `b` signal map on DetectorResult
+
+`DetectorResult` grows an optional `b?: Record<string, string[]>`, and
+`getBotScore` forwards it, following the same shape as the existing `g`, `i`,
+`sw`, `md`, `bn` and `fs` fields: read off the decoded payload, passed through
+untouched, absent for clients that predate it.
+
+Typing it is the whole change. Without it the field arrives on the provider
+untyped and any rule reading it has to assert its shape at the call site.
+
+The map is keyed by signal name with a short list of strings per key. It is
+empty for the great majority of sessions, so anything consuming it should
+treat absent and empty as the same thing. Adding a key is a client-side
+change and needs no deploy here — an existing decoder passes through keys it
+predates rather than dropping the ones it knows, which is the property that
+lets the two sides move independently.

--- a/packages/provider/src/tasks/detection/getBotScore.ts
+++ b/packages/provider/src/tasks/detection/getBotScore.ts
@@ -50,6 +50,7 @@ export const getBotScore = async (
 	const md: boolean | undefined = result.md;
 	const bn: boolean | undefined = result.bn;
 	const fs: boolean | undefined = result.fs;
+	const b: Record<string, string[]> | undefined = result.b;
 
 	if (baseBotScore === undefined || Number.isNaN(baseBotScore)) {
 		return {
@@ -78,5 +79,6 @@ export const getBotScore = async (
 		md,
 		bn,
 		fs,
+		b,
 	};
 };

--- a/packages/types/src/provider/detection.ts
+++ b/packages/types/src/provider/detection.ts
@@ -71,4 +71,9 @@ export type DetectorResult = {
 	md?: boolean;
 	bn?: boolean;
 	fs?: boolean;
+	// Opaque client-reported signals, keyed by signal name. Forwarded verbatim
+	// so server-side rules can consume them without a client release.
+	// Undefined for clients that predate the field, and empty for the great
+	// majority of sessions.
+	b?: Record<string, string[]>;
 };


### PR DESCRIPTION
Adds an optional `b?: Record<string, string[]>` to `DetectorResult` and forwards it through `getBotScore`.

It follows the shape of the existing `g`, `i`, `sw`, `md`, `bn` and `fs` fields exactly: read off the decoded payload, passed through untouched, absent for clients that predate it. The early-return path is a minimal fallback and carries none of the optional fields, so `b` is correctly not on it either.

Typing it is the whole change. Without it the field arrives on the provider untyped, and every rule that wants to read it has to assert the shape at its own call site.

Two things worth knowing for anything consuming it:

- **Absent and empty mean the same thing**, and that is the common case by a wide margin. Treat `undefined` and `{}` identically.
- **Keys can be added by the producing side without a change here.** The decoder passes through keys it predates rather than dropping the ones it already knows, which is what lets the two sides move independently. The producing change ships separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)