### PR TITLE
fix(types): default abuserScoreThreshold to 0.2

### DIFF
--- a/.changeset/abuser-score-threshold-default.md
+++ b/.changeset/abuser-score-threshold-default.md
@@ -1,0 +1,14 @@
+---
+"@prosopo/types": patch
+"@prosopo/types-database": patch
+---
+
+Default `trafficFilter.abuserScoreThreshold` to 0.2.
+
+The mongoose default was `0`. The abuser score runs 0..1 with 0 meaning "clean", so a `0` threshold applies the `abuser` category to every IP carrying any non-zero score, which is the widest the field can be set. A site that had never opened the traffic filter got that by default.
+
+`trafficFilterAbuserScoreThresholdDefault` moves from 0.5 to 0.2 and `@prosopo/types-database` now reads it instead of its own literal, so the zod default, the mongoose default and the provider's runtime fallbacks (`checkTrafficFilter`, `enrichDnsEvent`) all resolve to one number.
+
+`trafficFilter` is optional on `ClientSettingsSchema` and no create-site path sends one, so the mongoose default is what a new site key actually gets — the zod default only applies once a caller supplies a `trafficFilter` object.
+
+Existing sites keep whatever value is stored; only records with no value are affected.

--- a/packages/types-database/src/types/client.ts
+++ b/packages/types-database/src/types/client.ts
@@ -36,6 +36,7 @@ import {
 	ispChangeActionDefault,
 	powDifficultyDefault,
 	requireAllConditionsDefault,
+	trafficFilterAbuserScoreThresholdDefault,
 } from "@prosopo/types";
 import type mongoose from "mongoose";
 import { Schema as MongooseSchema, Schema } from "mongoose";
@@ -270,7 +271,12 @@ export const UserSettingsSchema = new Schema({
 		proxy: { type: TrafficCategoryPolicySchema, required: false },
 		tor: { type: TrafficCategoryPolicySchema, required: false },
 		abuser: { type: TrafficCategoryPolicySchema, required: false },
-		abuserScoreThreshold: { type: Number, min: 0, max: 1, default: 0 },
+		abuserScoreThreshold: {
+			type: Number,
+			min: 0,
+			max: 1,
+			default: trafficFilterAbuserScoreThresholdDefault,
+		},
 		datacenter: { type: TrafficCategoryPolicySchema, required: false },
 		datacenterNameAllowlist: { type: [String], required: false },
 		datacenterNameDenylist: { type: [String], required: false },

--- a/packages/types/src/client/settings.ts
+++ b/packages/types/src/client/settings.ts
@@ -481,7 +481,9 @@ export const SpamFilterRulesSchema = object({
 	emailRules: EmailSpamRulesSchema.optional(),
 });
 
-export const trafficFilterAbuserScoreThresholdDefault = 0.5;
+// Abuser score at or above which the `abuser` category applies. The scale is
+// 0..1 with 0 meaning "clean", so 0 would act on any non-zero score.
+export const trafficFilterAbuserScoreThresholdDefault = 0.2;
 
 // Operators almost always want the datacenter category to catch
 // scraping/automation traffic but not legitimate consumer relays that exit


### PR DESCRIPTION
## What

`trafficFilter.abuserScoreThreshold` defaulted to `0` in the mongoose schema. The abuser score runs 0..1 with 0 meaning "clean", so a `0` threshold applies the `abuser` category to every IP carrying any non-zero score — the widest the field can be set. A site that never opened the traffic filter got that by default.

- `trafficFilterAbuserScoreThresholdDefault`: 0.5 → 0.2
- `@prosopo/types-database` reads that constant instead of its own literal `0`

One number now backs the zod default, the mongoose default, and the provider's two runtime fallbacks (`checkTrafficFilter`, `enrichDnsEvent`).

## Why the mongoose default is the one that matters

`trafficFilter` is `.optional()` on `ClientSettingsSchema` and no create-site path sends one, so zod's `.default()` never fires for a new site — the value is stamped in when mongoose casts the pushed subdocument. `UserSettingsSchema` is shared by the provider's `client` collection and the portal's `account.sites[].settings` (via `packages/database-private`), so the single literal governed both.

## Scope

Existing records keep their stored value; only records with no value are affected.

## Test

- `@prosopo/types`: 228 passed
- `checkTrafficFilter` unit: 79 passed

Existing tests all set the threshold explicitly, so none were pinned to the old default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)