### PR TITLE
fix(database): flatten sites in getUpdatedClients

### DIFF
--- a/.changeset/get-updated-clients-flatten-sites.md
+++ b/.changeset/get-updated-clients-flatten-sites.md
@@ -1,0 +1,16 @@
+---
+"@prosopo/database": patch
+"@prosopo/types-database": patch
+---
+
+Fix the client-list poll, which has never carried site settings to a provider.
+
+`getUpdatedClients` read `record.sites.siteKey` off the portal's `accounts` documents, where `sites` is an array. That property does not exist on an array, so every record came back as `{ account: undefined }`. `updateClientRecords` upserts filtered on `account`, so a whole poll's worth of sites matched nothing, inserted, and collapsed into a single `account: null` row that each run overwrote. An `as ClientRecord` cast on the mapping is what kept tsc quiet about it.
+
+Observed on a production node: `GetClientList` completing every 2 minutes with `clientRecords: 1247`, one `account: null` row in `clients`, and 1,610 site keys still holding settings the portal had changed. Direct registration via the admin `SiteKeyRegister` endpoint was the only path actually updating providers.
+
+- `getUpdatedClients` now flattens account → sites and emits one record per site, applying the `updatedAt` cutoff per site rather than relying on the document-level match. The account's `tier` is projected and attached; it was previously projected as `sites.tier`, which does not exist, so `tier` was undefined too.
+- The cast is gone. `getUpdatedClients` returns `IUserDataSlim[]` and `updateClientRecords` accepts it — these are plain objects built from portal documents, never mongoose Documents, and the declared types now say so.
+- `updateClientRecords` drops records with no account and logs the count instead of upserting them, so a future mapping bug cannot silently overwrite one row with every client's settings.
+
+Adds an integration test covering the flattening, the per-site cutoff, and the active-user filter; it fails with `account: undefined` against the old mapping.

--- a/packages/database/src/databases/client.ts
+++ b/packages/database/src/databases/client.ts
@@ -14,15 +14,27 @@
 
 import { ProsopoDBError } from "@prosopo/common";
 import type { Logger } from "@prosopo/logger";
-import type { Timestamp } from "@prosopo/types";
+import type { IUserSettings, Tier, Timestamp } from "@prosopo/types";
 import {
 	AccountSchema,
-	type ClientRecord,
 	type IClientDatabase,
+	type IUserDataSlim,
 	TableNames,
 	type Tables,
 } from "@prosopo/types-database";
 import { MongoDatabase } from "../base/index.js";
+
+// The projected shape of an account returned by `getUpdatedClients`. Stated
+// here rather than reusing the full account type so the projection and the
+// fields read below cannot drift apart.
+interface UpdatedClientAccount {
+	tier: Tier;
+	sites?: {
+		siteKey?: string;
+		settings?: IUserSettings;
+		updatedAt?: Timestamp;
+	}[];
+}
 
 const CLIENT_TABLES = [
 	{
@@ -66,11 +78,16 @@ export class ClientDatabase extends MongoDatabase implements IClientDatabase {
 
 	async getUpdatedClients(
 		updatedAtTimestamp: Timestamp,
-	): Promise<ClientRecord[]> {
+	): Promise<IUserDataSlim[]> {
 		await this.connect();
 		// get remote client records that have been updated since the last task
-		const newClientRecords = await this.tables.accounts
-			.find<ClientRecord>(
+		//
+		// The query matches at document level, so an account is returned when
+		// ANY of its sites is new — the per-site test below is what decides
+		// which of them are actually carried across. `tier` is projected from
+		// the account: it does not exist on a site.
+		const accounts = await this.tables.accounts
+			.find<UpdatedClientAccount>(
 				{
 					$or: [
 						{ "sites.updatedAt": { $gt: updatedAtTimestamp } },
@@ -78,19 +95,33 @@ export class ClientDatabase extends MongoDatabase implements IClientDatabase {
 					],
 					"users.status": "active",
 				},
-				{ "sites.siteKey": 1, "sites.settings": 1, "sites.tier": 1 },
+				{
+					tier: 1,
+					"sites.siteKey": 1,
+					"sites.settings": 1,
+					"sites.updatedAt": 1,
+				},
 			)
-			.lean()
-			.then((records) =>
-				records.map(
-					(record) =>
-						({
-							account: record.sites.siteKey, // Rename "sites.siteKey" to "account"
-							settings: record.sites.settings, // Rename "sites.settings" to "settings"
-							tier: record.tier, // Keep "tier" as is
-						}) as ClientRecord,
-				),
-			);
+			.lean();
+
+		// `sites` is an array. Reading `.siteKey` off it yields undefined, so
+		// every record has to be flattened site by site — otherwise they all
+		// arrive at `updateClientRecords` with no account and upsert into a
+		// single row keyed on `account: undefined`.
+		const newClientRecords: IUserDataSlim[] = [];
+		for (const account of accounts) {
+			for (const site of account.sites ?? []) {
+				if (!site.siteKey || !site.settings) continue;
+				const isNew =
+					site.updatedAt === undefined || site.updatedAt > updatedAtTimestamp;
+				if (!isNew) continue;
+				newClientRecords.push({
+					account: site.siteKey,
+					settings: site.settings,
+					tier: account.tier,
+				});
+			}
+		}
 
 		await this.close();
 		return newClientRecords;

--- a/packages/database/src/databases/provider.ts
+++ b/packages/database/src/databases/provider.ts
@@ -2621,8 +2621,20 @@ export class ProviderDatabase
 	/**
 	 * @description Update the client records
 	 */
-	async updateClientRecords(clientRecords: ClientRecord[]): Promise<void> {
-		const ops = clientRecords.map((record) => {
+	async updateClientRecords(clientRecords: IUserDataSlim[]): Promise<void> {
+		// An upsert filtered on a missing account matches nothing and inserts,
+		// so a batch of records with no account collapses into a single row
+		// keyed on `account: undefined` and silently replaces every site's
+		// settings with the last one in the batch. Drop them instead.
+		const usable = clientRecords.filter((record) => !!record.account);
+		const skipped = clientRecords.length - usable.length;
+		if (skipped > 0) {
+			await this.logger.error(() => ({
+				msg: "Refusing to upsert client records with no account",
+				data: { skipped, received: clientRecords.length },
+			}));
+		}
+		const ops = usable.map((record) => {
 			const clientRecord: IUserDataSlim = {
 				account: record.account,
 				settings: record.settings,

--- a/packages/database/src/tests/integration/getUpdatedClients.integration.test.ts
+++ b/packages/database/src/tests/integration/getUpdatedClients.integration.test.ts
@@ -57,7 +57,7 @@ describe("ClientDatabase.getUpdatedClients", () => {
 		const db = await seed();
 		await db.tables.accounts.create({
 			signupEmail: "two-sites@example.com",
-			tier: Tier.professional,
+			tier: Tier.Professional,
 			users: [{ email: "two-sites@example.com", status: "active" }],
 			sites: [
 				{
@@ -91,8 +91,8 @@ describe("ClientDatabase.getUpdatedClients", () => {
 		]);
 		expect(records.every((r) => r.account !== undefined)).toBe(true);
 		expect(records.map((r) => r.tier)).toEqual([
-			Tier.professional,
-			Tier.professional,
+			Tier.Professional,
+			Tier.Professional,
 		]);
 		const a = records.find((r) => r.account === "siteKeyA");
 		expect(a?.settings.domains).toEqual(["a.example.com"]);
@@ -102,7 +102,7 @@ describe("ClientDatabase.getUpdatedClients", () => {
 		const db = await seed();
 		await db.tables.accounts.create({
 			signupEmail: "mixed@example.com",
-			tier: Tier.free,
+			tier: Tier.Free,
 			users: [{ email: "mixed@example.com", status: "active" }],
 			sites: [
 				{
@@ -137,7 +137,7 @@ describe("ClientDatabase.getUpdatedClients", () => {
 		const db = await seed();
 		await db.tables.accounts.create({
 			signupEmail: "inactive@example.com",
-			tier: Tier.free,
+			tier: Tier.Free,
 			users: [{ email: "inactive@example.com", status: "pending" }],
 			sites: [
 				{

--- a/packages/database/src/tests/integration/getUpdatedClients.integration.test.ts
+++ b/packages/database/src/tests/integration/getUpdatedClients.integration.test.ts
@@ -1,0 +1,157 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { LogLevel, getLogger } from "@prosopo/logger";
+import { ClientSettingsSchema, Tier } from "@prosopo/types";
+import { MongoMemoryServer } from "mongodb-memory-server";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { ClientDatabase } from "../../databases/client.js";
+
+// `getUpdatedClients` reads the portal's `accounts` collection, where `sites`
+// is an ARRAY. It used to map `record.sites.siteKey` — a property that does
+// not exist on an array — so every record came back as
+// `{ account: undefined }`. Downstream, `updateClientRecords` upserts filtered
+// on `account`, so an entire poll's worth of sites collapsed into one row and
+// no site's settings were ever carried to a provider.
+//
+// These tests pin the flattening: one record per site, with the account's
+// tier attached and the site's own settings.
+
+const logger = getLogger(LogLevel.enum.error, "getUpdatedClients.test");
+
+const settingsFor = (domain: string) =>
+	ClientSettingsSchema.parse({ domains: [domain] });
+
+describe("ClientDatabase.getUpdatedClients", () => {
+	let mongo: MongoMemoryServer;
+	let uri: string;
+
+	beforeAll(async () => {
+		mongo = await MongoMemoryServer.create();
+		uri = mongo.getUri();
+	});
+
+	afterAll(async () => {
+		await mongo.stop();
+	});
+
+	const seed = async (): Promise<ClientDatabase> => {
+		const db = new ClientDatabase(uri, "prosopo", undefined, logger);
+		await db.connect();
+		await db.tables.accounts.deleteMany({});
+		return db;
+	};
+
+	it("returns one record per site, not one per account", async () => {
+		const db = await seed();
+		await db.tables.accounts.create({
+			signupEmail: "two-sites@example.com",
+			tier: Tier.professional,
+			users: [{ email: "two-sites@example.com", status: "active" }],
+			sites: [
+				{
+					name: "a",
+					siteKey: "siteKeyA",
+					secretKey: "secretA",
+					settings: settingsFor("a.example.com"),
+					createdAt: 1,
+					updatedAt: 500,
+					active: true,
+				},
+				{
+					name: "b",
+					siteKey: "siteKeyB",
+					secretKey: "secretB",
+					settings: settingsFor("b.example.com"),
+					createdAt: 1,
+					updatedAt: 500,
+					active: true,
+				},
+			],
+		});
+
+		const records = await db.getUpdatedClients(100);
+
+		expect(records).toHaveLength(2);
+		// The original bug produced `undefined` here for every record.
+		expect(records.map((r) => r.account).sort()).toEqual([
+			"siteKeyA",
+			"siteKeyB",
+		]);
+		expect(records.every((r) => r.account !== undefined)).toBe(true);
+		expect(records.map((r) => r.tier)).toEqual([
+			Tier.professional,
+			Tier.professional,
+		]);
+		const a = records.find((r) => r.account === "siteKeyA");
+		expect(a?.settings.domains).toEqual(["a.example.com"]);
+	});
+
+	it("carries only the sites newer than the cutoff", async () => {
+		const db = await seed();
+		await db.tables.accounts.create({
+			signupEmail: "mixed@example.com",
+			tier: Tier.free,
+			users: [{ email: "mixed@example.com", status: "active" }],
+			sites: [
+				{
+					name: "stale",
+					siteKey: "staleKey",
+					secretKey: "s1",
+					settings: settingsFor("stale.example.com"),
+					createdAt: 1,
+					updatedAt: 100,
+					active: true,
+				},
+				{
+					name: "fresh",
+					siteKey: "freshKey",
+					secretKey: "s2",
+					settings: settingsFor("fresh.example.com"),
+					createdAt: 1,
+					updatedAt: 900,
+					active: true,
+				},
+			],
+		});
+
+		const records = await db.getUpdatedClients(500);
+
+		// The account matches at document level because of `freshKey`; the
+		// per-site test is what keeps `staleKey` out.
+		expect(records.map((r) => r.account)).toEqual(["freshKey"]);
+	});
+
+	it("skips accounts with no active user", async () => {
+		const db = await seed();
+		await db.tables.accounts.create({
+			signupEmail: "inactive@example.com",
+			tier: Tier.free,
+			users: [{ email: "inactive@example.com", status: "pending" }],
+			sites: [
+				{
+					name: "x",
+					siteKey: "inactiveKey",
+					secretKey: "s",
+					settings: settingsFor("x.example.com"),
+					createdAt: 1,
+					updatedAt: 900,
+					active: true,
+				},
+			],
+		});
+
+		expect(await db.getUpdatedClients(100)).toHaveLength(0);
+	});
+});

--- a/packages/types-database/src/types/client.ts
+++ b/packages/types-database/src/types/client.ts
@@ -41,7 +41,7 @@ import {
 import type mongoose from "mongoose";
 import { Schema as MongooseSchema, Schema } from "mongoose";
 import type { IDatabase } from "./mongo.js";
-import type { ClientRecord, Tables } from "./provider.js";
+import type { IUserDataSlim, Tables } from "./provider.js";
 
 export type UserDataRecord = mongoose.Document & IUserData;
 
@@ -391,5 +391,7 @@ export enum TableNames {
 
 export interface IClientDatabase extends IDatabase {
 	getTables(): Tables<TableNames>;
-	getUpdatedClients(updatedAtTimestamp: Timestamp): Promise<ClientRecord[]>;
+	// Plain objects built from the portal's account documents, not mongoose
+	// Documents — `IUserDataSlim` is what this actually returns.
+	getUpdatedClients(updatedAtTimestamp: Timestamp): Promise<IUserDataSlim[]>;
 }

--- a/packages/types-database/src/types/provider.ts
+++ b/packages/types-database/src/types/provider.ts
@@ -1406,7 +1406,9 @@ export interface IProviderDatabase extends IDatabase {
 		updates: Partial<PuzzleCaptchaRecord>,
 	): Promise<void>;
 
-	updateClientRecords(clientRecords: ClientRecord[]): Promise<void>;
+	// Accepts plain records: the client-list poll builds these from the
+	// portal's account documents and they are never mongoose Documents.
+	updateClientRecords(clientRecords: IUserDataSlim[]): Promise<void>;
 
 	removeClientRecords(accounts: string[]): Promise<void>;
 


### PR DESCRIPTION
## The bug

`getUpdatedClients` reads the portal's `accounts` collection, where `sites` is an **array**. It mapped:

```ts
account: record.sites.siteKey,   // undefined — `sites` is an array
```

So every record came back as `{ account: undefined }`. `updateClientRecords` upserts filtered on `account`, so a whole poll's worth of sites matched nothing, inserted, and collapsed into a single `account: null` row that each subsequent run overwrote. The `as ClientRecord` cast on the mapping is what kept tsc quiet about it.

Net effect: **the client-list poll has never carried site settings to a provider.** Everything that works goes through the admin `SiteKeyRegister` endpoint instead.

## Evidence from a production node

- `GetClientList` completing every 2 minutes, `result.data.clientRecords: 1247` immediately after a portal-side settings change
- exactly one row in `clients` with `account: null` — still carrying the pre-migration `blockVpn`/`blockAbuser` filter shape, because it is overwritten wholesale on every run
- 1,610 site keys still holding the settings the portal had already changed

## Changes

- `getUpdatedClients` flattens account → sites and emits one record per site. The `updatedAt` cutoff is now applied **per site**: the query matches at document level, so an account is returned when any one of its sites is new, and without the per-site test its untouched sites would be republished too.
- The account's `tier` is projected and attached. It was projected as `sites.tier`, which does not exist on a site, so `tier` was `undefined` as well.
- The cast is gone. `getUpdatedClients` returns `IUserDataSlim[]` and `updateClientRecords` accepts it — these are plain objects built from portal documents, never mongoose `Document`s, and the declared types now say so. `ClientRecord[]` is assignable to `IUserDataSlim[]`, so other callers are unaffected.
- `updateClientRecords` drops records with no account and logs the count rather than upserting them, so a future mapping bug cannot silently overwrite one row with every client's settings.

## Test

New integration test pins the flattening, the per-site cutoff, and the active-user filter. Verified it reproduces the production symptom against the old mapping:

```
AssertionError: expected [ { account: undefined, …(2) } ] to have a length of 2 but got 1
AssertionError: expected [ undefined ] to deeply equal [ 'freshKey' ]
```

- `@prosopo/database`: 16 files, 101 passed
- `@prosopo/provider` unit: 78 files, 1192 passed

## Note

The 1,907 site keys affected by this in production have already been pushed directly via the bulk `SiteKeysRegister` endpoint, so providers are consistent with the portal today. This restores the poll so it stops being necessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)