### PR TITLE
fix(provider): stop the puzzle ladder overriding a site's own puzzle settings

### DIFF
--- a/.changeset/puzzle-max-difficulty.md
+++ b/.changeset/puzzle-max-difficulty.md
@@ -1,0 +1,17 @@
+---
+"@prosopo/types": patch
+"@prosopo/types-database": patch
+"@prosopo/provider": patch
+---
+
+Stop the puzzle difficulty ladder silently replacing a site's own puzzle settings.
+
+An escalated puzzle session samples its render settings from a difficulty band, and a sampled band sets every knob — decoy count, edge darkness, hole darken, piece scale and tolerance. While that is happening the site's configured `puzzle` block and `puzzleTolerance` are not consulted at all. For a site using escalation that is the intent; for a site that deliberately configured an easier puzzle it means the settings it saved never render, which reads as "my settings aren't being saved".
+
+Two changes:
+
+`puzzleMaxDifficulty` is a new client setting — the puzzle counterpart to `imageMaxRounds`. It caps how far automatic escalation may climb the ladder, and `0` pins the site to level 0, the documented "nothing escalated" case where the session is left bare and the site's own settings render every time. It defaults to `MAX_AUTO_ESCALATION_LEVEL`, so sites that never set it keep the behaviour they have.
+
+Separately, the paths that measured nothing about a client — `MISSING_TOKEN`, `MISSING_HEAD_HASH` and `DECRYPTION_FAILED` — no longer feed the ladder. Each sizes its challenge from a fixed constant chosen to be short ("prove you're human quickly", per their own comments), not from any signal the client produced, but those constants sit above the default baseline of `DEFAULT_SOLVED_COUNT` and so scored as an escalation. A site whose CSP blocks the detector bundle sends no token on every request, so every one of its users was permanently escalated. `OLD_TIMESTAMP` deliberately keeps the ladder: its round count comes from `timestampDecayFunction`, which scales with staleness and is a real graduated measurement.
+
+Explicit router and traffic-filter overrides are unaffected in both cases — an operator naming a value still gets it.

--- a/packages/cli/src/commands/siteKeyRegister.ts
+++ b/packages/cli/src/commands/siteKeyRegister.ts
@@ -21,6 +21,7 @@ import {
 	frictionlessTypesDefault,
 	imageMaxRoundsDefault,
 	imageMinRoundsDefault,
+	puzzleMaxDifficultyDefault,
 	puzzleToleranceDefault,
 } from "@prosopo/types";
 import {
@@ -154,6 +155,7 @@ export default (
 					imageMaxRounds: image_max_rounds as number,
 					imageMinRounds: image_min_rounds as number,
 					puzzleTolerance: puzzleToleranceDefault,
+					puzzleMaxDifficulty: puzzleMaxDifficultyDefault,
 					disallowWebView: false,
 					verifiedTimeout: 60000,
 					solutionTimeout: 60000,

--- a/packages/cli/src/commands/siteKeyRegisterApi.ts
+++ b/packages/cli/src/commands/siteKeyRegisterApi.ts
@@ -22,6 +22,7 @@ import {
 	Tier,
 	frictionlessImageThresholdDefault,
 	frictionlessTypesDefault,
+	puzzleMaxDifficultyDefault,
 	puzzleToleranceDefault,
 } from "@prosopo/types";
 import type { ArgumentsCamelCase, Argv } from "yargs";
@@ -142,6 +143,7 @@ export default (
 						imageMaxRounds: image_max_rounds as number,
 						imageMinRounds: image_min_rounds as number,
 						puzzleTolerance: puzzleToleranceDefault,
+						puzzleMaxDifficulty: puzzleMaxDifficultyDefault,
 						disallowWebView: false,
 						verifiedTimeout: 60000,
 						solutionTimeout: 60000,

--- a/packages/provider/src/api/captcha/getFrictionlessCaptchaChallenge/handler.ts
+++ b/packages/provider/src/api/captcha/getFrictionlessCaptchaChallenge/handler.ts
@@ -840,6 +840,7 @@ export default (
 				// puzzle chosen in place of a disabled image challenge.
 				frictionlessTypes: clientRecord.settings.frictionlessTypes,
 				baseImageRounds: env.config.captchas.solved.count,
+				puzzleMaxDifficulty: clientRecord.settings.puzzleMaxDifficulty,
 				platform: derivePlatform(requestUserAgent, webView, {
 					...(typeof ipInfoMobile === "boolean" && { isMobile: ipInfoMobile }),
 				}),

--- a/packages/provider/src/tasks/frictionless/frictionlessTasks.ts
+++ b/packages/provider/src/tasks/frictionless/frictionlessTasks.ts
@@ -25,6 +25,7 @@ import {
 	type ImageRoundsBounds,
 	type KeyringPair,
 	type ModeEnum,
+	NO_MEASUREMENT_REASONS,
 	type ProsopoConfigOutput,
 	type RequestHeaders,
 	type RoutingMachineBaseline,
@@ -33,6 +34,7 @@ import {
 	type Session,
 	SimdReadingsStage,
 	clampImageRounds,
+	puzzleMaxDifficultyDefault,
 } from "@prosopo/types";
 import type { IProviderDatabase } from "@prosopo/types-database";
 import type { AccessPolicy } from "@prosopo/user-access-policy";
@@ -606,6 +608,19 @@ export class FrictionlessManager extends CaptchaManager {
 			finalCaptchaType === CaptchaType.pow
 				? (routed.powDifficulty ?? effectiveParams.powDifficulty)
 				: undefined;
+		// A router that overrode the captcha type is the more specific
+		// explanation of what was served, so its reason wins over the one the
+		// score ladder left on the session params. Mirrors the postPow path,
+		// which already does `routed.reason ?? originSession.reason`. Without
+		// this a route-phase selection reason never reached the session and
+		// was invisible in the portal.
+		//
+		// Resolved here rather than beside its use on the session record below,
+		// because the puzzle overrides need it to tell an escalation from a
+		// missing measurement.
+		const finalReason =
+			(routed.reason as FrictionlessReason | undefined) ??
+			(effectiveParams.reason as FrictionlessReason | undefined);
 		// Puzzle tunables persisted on the session so getPuzzleCaptchaChallenge
 		// can layer them over the site defaults — that endpoint re-derives its
 		// overrides from a live trafficFilter verdict, and a router- or
@@ -625,11 +640,30 @@ export class FrictionlessManager extends CaptchaManager {
 		const finalPuzzleOverrides: Pick<Session, "puzzleTolerance" | "puzzle"> =
 			finalCaptchaType === CaptchaType.puzzle
 				? (() => {
-						const level = severityToPuzzleDifficulty(
-							requestedSolvedImagesCount,
-							this.routingContext?.baseImageRounds ??
-								this.config.captchas.solved.count,
-						);
+						// Paths that measured nothing carry a fixed fallback round
+						// count, not a severity — see NO_MEASUREMENT_REASONS. Reading
+						// one as an escalation silently replaces the site's puzzle
+						// config with ladder values for every user of a site whose
+						// detector cannot run at all (CSP blocking the bundle, say),
+						// which is the opposite of what an operator configuring an
+						// easier puzzle asked for.
+						// The site's own ceiling on automatic escalation. 0 pins it to
+						// level 0, so its configured puzzle settings render every
+						// time — the puzzle counterpart to `imageMaxRounds` holding
+						// every round-count source to the site's bound.
+						const maxLevel =
+							this.routingContext?.puzzleMaxDifficulty ??
+							puzzleMaxDifficultyDefault;
+						const level =
+							finalReason !== undefined &&
+							NO_MEASUREMENT_REASONS.has(finalReason)
+								? 0
+								: severityToPuzzleDifficulty(
+										requestedSolvedImagesCount,
+										this.routingContext?.baseImageRounds ??
+											this.config.captchas.solved.count,
+										maxLevel,
+									);
 						// Level 0 means "nothing escalated this session". Sampling a
 						// band here would override the site's own configured
 						// puzzleTolerance / puzzle settings with ladder values, which
@@ -654,15 +688,6 @@ export class FrictionlessManager extends CaptchaManager {
 						};
 					})()
 				: {};
-		// A router that overrode the captcha type is the more specific
-		// explanation of what was served, so its reason wins over the one the
-		// score ladder left on the session params. Mirrors the postPow path,
-		// which already does `routed.reason ?? originSession.reason`. Without
-		// this a route-phase selection reason never reached the session and
-		// was invisible in the portal.
-		const finalReason =
-			(routed.reason as FrictionlessReason | undefined) ??
-			(effectiveParams.reason as FrictionlessReason | undefined);
 		const blocked =
 			finalCaptchaType === CaptchaType.image
 				? effectiveParams.blocked

--- a/packages/provider/src/tasks/frictionless/routingMachine.ts
+++ b/packages/provider/src/tasks/frictionless/routingMachine.ts
@@ -56,6 +56,12 @@ export interface RoutingContext {
 	// puzzle difficulty level — severity is "rounds above normal", which
 	// means the same thing across sites where an absolute count does not.
 	baseImageRounds?: number;
+	// Ceiling on that difficulty level, from the sitekey's
+	// `puzzleMaxDifficulty`. Same rationale as `imageMaxRounds` above: this is
+	// the site's own bound on how far a rule may escalate it, and 0 keeps the
+	// site's configured puzzle settings on every challenge. Optional for the
+	// dedup replay; absent falls back to `puzzleMaxDifficultyDefault`.
+	puzzleMaxDifficulty?: number;
 }
 
 /**

--- a/packages/provider/src/tests/integration/api/admin/apiRegisterSiteKeyEndpoint.integration.test.ts
+++ b/packages/provider/src/tests/integration/api/admin/apiRegisterSiteKeyEndpoint.integration.test.ts
@@ -14,7 +14,12 @@
 
 import { ApiEndpointResponseStatus } from "@prosopo/api-route";
 import type { Logger } from "@prosopo/logger";
-import { CaptchaType, type ProsopoConfigOutput, Tier } from "@prosopo/types";
+import {
+	CaptchaType,
+	type ProsopoConfigOutput,
+	Tier,
+	puzzleMaxDifficultyDefault,
+} from "@prosopo/types";
 import type { ClientRecord, IProviderDatabase } from "@prosopo/types-database";
 import { describe, expect, it, vi } from "vitest";
 import { ApiRegisterSiteKeyEndpoint } from "../../../../api/admin/apiRegisterSiteKeyEndpoint.js";
@@ -71,6 +76,7 @@ describe("apiRegisterSiteKeyEndpoint", () => {
 				verifiedTimeout: 120000,
 				solutionTimeout: 60000,
 				puzzleTolerance: 15,
+				puzzleMaxDifficulty: puzzleMaxDifficultyDefault,
 				disallowWebView: false,
 			},
 		};
@@ -107,6 +113,7 @@ describe("apiRegisterSiteKeyEndpoint", () => {
 				verifiedTimeout: 120000,
 				solutionTimeout: 60000,
 				puzzleTolerance: 15,
+				puzzleMaxDifficulty: puzzleMaxDifficultyDefault,
 				disallowWebView: false,
 			},
 		};

--- a/packages/provider/src/tests/integration/clientSettingsPersistence.integration.test.ts
+++ b/packages/provider/src/tests/integration/clientSettingsPersistence.integration.test.ts
@@ -37,6 +37,7 @@ import {
 	ProsopoConfigSchema,
 	Tier,
 	TrafficFilterAction,
+	puzzleMaxDifficultyDefault,
 } from "@prosopo/types";
 import { GenericContainer, type StartedTestContainer } from "testcontainers";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -60,6 +61,7 @@ const FULLY_POPULATED_SETTINGS = {
 	verifiedTimeout: 120000,
 	solutionTimeout: 60000,
 	puzzleTolerance: 20,
+	puzzleMaxDifficulty: puzzleMaxDifficultyDefault,
 	disallowWebView: true,
 	ipValidationRules: {
 		enabled: true,

--- a/packages/provider/src/tests/unit/api/admin/apiRegisterSiteKeyEndpoint.unit.test.ts
+++ b/packages/provider/src/tests/unit/api/admin/apiRegisterSiteKeyEndpoint.unit.test.ts
@@ -13,7 +13,12 @@
 // limitations under the License.
 
 import { ApiEndpointResponseStatus } from "@prosopo/api-route";
-import { CaptchaType, type IUserSettings, Tier } from "@prosopo/types";
+import {
+	CaptchaType,
+	type IUserSettings,
+	Tier,
+	puzzleMaxDifficultyDefault,
+} from "@prosopo/types";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ApiRegisterSiteKeyEndpoint } from "../../../../api/admin/apiRegisterSiteKeyEndpoint.js";
 
@@ -70,6 +75,7 @@ describe("ApiRegisterSiteKeyEndpoint", () => {
 			verifiedTimeout: 120000,
 			solutionTimeout: 60000,
 			puzzleTolerance: 15,
+			puzzleMaxDifficulty: puzzleMaxDifficultyDefault,
 			disallowWebView: false,
 		};
 

--- a/packages/provider/src/tests/unit/tasks/captchaManager.unit.test.ts
+++ b/packages/provider/src/tests/unit/tasks/captchaManager.unit.test.ts
@@ -21,6 +21,7 @@ import {
 	ResultReason,
 	Tier,
 	TrafficFilterAction,
+	puzzleMaxDifficultyDefault,
 } from "@prosopo/types";
 import type { ClientRecord, IProviderDatabase } from "@prosopo/types-database";
 import type { ProviderEnvironment } from "@prosopo/types-env";
@@ -54,6 +55,7 @@ const defaultUserSettings: IUserSettings = {
 	verifiedTimeout: 120000,
 	solutionTimeout: 60000,
 	puzzleTolerance: 15,
+	puzzleMaxDifficulty: puzzleMaxDifficultyDefault,
 	disallowWebView: false,
 };
 

--- a/packages/provider/src/tests/unit/tasks/frictionless/routerPuzzleOverrides.unit.test.ts
+++ b/packages/provider/src/tests/unit/tasks/frictionless/routerPuzzleOverrides.unit.test.ts
@@ -22,6 +22,7 @@
 import {
 	CaptchaType,
 	FrictionlessPenalties,
+	FrictionlessReason,
 	type KeyringPair,
 	type ProsopoConfigOutput,
 	type RoutingMachineOutput,
@@ -176,5 +177,138 @@ describe("router-supplied puzzle overrides reach the session record", () => {
 		expect(storedSession().captchaType).toBe(CaptchaType.pow);
 		expect(storedSession().puzzleTolerance).toBeUndefined();
 		expect(storedSession().puzzle).toBeUndefined();
+	});
+
+	// The difficulty ladder reads the requested round count as severity. The
+	// no-measurement paths carry a fixed fallback count that happens to sit
+	// above `captchas.solved.count`, so before NO_MEASUREMENT_REASONS they
+	// scored as an escalation and the sampled band replaced the site's own
+	// puzzle config. A site whose CSP blocks the detector bundle sends no
+	// token on every request, so every one of its users was permanently
+	// escalated and its configured puzzle never rendered.
+	describe.each([
+		FrictionlessReason.MISSING_TOKEN,
+		FrictionlessReason.MISSING_HEAD_HASH,
+		FrictionlessReason.DECRYPTION_FAILED,
+	])("no-measurement reason %s", (reason: FrictionlessReason) => {
+		it("leaves the session bare so the site's own puzzle settings render", async () => {
+			routerReturns({ captchaType: CaptchaType.puzzle });
+
+			// MISSING_TOKEN_IMAGE_ROUNDS is 3 against a baseline of 2 — one
+			// rung above, which is exactly what used to trip level 1.
+			await manager.sendPuzzleCaptcha({ solvedImagesCount: 3, reason });
+
+			expect(storedSession().reason).toBe(reason);
+			expect(storedSession().puzzle).toBeUndefined();
+			expect(storedSession().puzzleTolerance).toBeUndefined();
+		});
+
+		it("still honours an explicit router override", async () => {
+			routerReturns({
+				captchaType: CaptchaType.puzzle,
+				puzzleTolerance: 9,
+				puzzle: { decoyCount: 14 },
+			});
+
+			await manager.sendPuzzleCaptcha({ solvedImagesCount: 3, reason });
+
+			expect(storedSession().puzzleTolerance).toBe(9);
+			expect(storedSession().puzzle).toEqual({ decoyCount: 14 });
+		});
+	});
+
+	// The guard is scoped to reasons that measured nothing. A genuine
+	// escalation must still get its graduated puzzle.
+	it("still escalates when the round count came from a real signal", async () => {
+		routerReturns({ captchaType: CaptchaType.puzzle });
+
+		await manager.sendPuzzleCaptcha({
+			solvedImagesCount: 3,
+			reason: FrictionlessReason.BOT_SCORE_PUZZLE_BAND,
+		});
+
+		expect(storedSession().puzzle).toBeDefined();
+		expect(storedSession().puzzleTolerance).toBeDefined();
+	});
+
+	// OLD_TIMESTAMP sizes itself from timestampDecayFunction, which scales
+	// with staleness — a real graduated measurement, so it keeps the ladder.
+	it("still escalates on an old timestamp", async () => {
+		routerReturns({ captchaType: CaptchaType.puzzle });
+
+		await manager.sendPuzzleCaptcha({
+			solvedImagesCount: 3,
+			reason: FrictionlessReason.OLD_TIMESTAMP,
+		});
+
+		expect(storedSession().puzzle).toBeDefined();
+	});
+
+	// The site's own ceiling on escalation — the puzzle counterpart to
+	// imageMaxRounds. A site that configured an easier puzzle and set the cap
+	// to 0 must get exactly that, no matter how severe the session looked.
+	describe("puzzleMaxDifficulty", () => {
+		const withCap = (puzzleMaxDifficulty: number): void => {
+			manager.setRoutingContext({ ...context, puzzleMaxDifficulty });
+		};
+
+		it("pins the session to the site's own settings at 0", async () => {
+			withCap(0);
+			routerReturns({ captchaType: CaptchaType.puzzle });
+
+			// Six rounds above the baseline of 2 — level 3 without the cap.
+			await manager.sendPuzzleCaptcha({
+				solvedImagesCount: 8,
+				reason: FrictionlessReason.BOT_SCORE_PUZZLE_BAND,
+			});
+
+			expect(storedSession().puzzle).toBeUndefined();
+			expect(storedSession().puzzleTolerance).toBeUndefined();
+		});
+
+		it("still allows escalation below the cap", async () => {
+			withCap(2);
+			routerReturns({ captchaType: CaptchaType.puzzle });
+
+			await manager.sendPuzzleCaptcha({
+				solvedImagesCount: 4,
+				reason: FrictionlessReason.BOT_SCORE_PUZZLE_BAND,
+			});
+
+			expect(storedSession().puzzle).toBeDefined();
+		});
+
+		// A cap of 0 bounds the ladder, not the operator. An explicitly routed
+		// override is a deliberate instruction and still applies.
+		it("does not suppress an explicit router override", async () => {
+			withCap(0);
+			routerReturns({
+				captchaType: CaptchaType.puzzle,
+				puzzleTolerance: 7,
+				puzzle: { decoyCount: 20 },
+			});
+
+			await manager.sendPuzzleCaptcha({
+				solvedImagesCount: 8,
+				reason: FrictionlessReason.BOT_SCORE_PUZZLE_BAND,
+			});
+
+			expect(storedSession().puzzleTolerance).toBe(7);
+			expect(storedSession().puzzle).toEqual({ decoyCount: 20 });
+		});
+
+		// Sites saved before the setting existed carry no value, and must keep
+		// the escalation behaviour they had.
+		it("falls back to the default ceiling when the site never set one", async () => {
+			manager.setRoutingContext(context);
+			routerReturns({ captchaType: CaptchaType.puzzle });
+
+			await manager.sendPuzzleCaptcha({
+				solvedImagesCount: 4,
+				reason: FrictionlessReason.BOT_SCORE_PUZZLE_BAND,
+			});
+
+			expect(storedSession().puzzle).toBeDefined();
+		});
 	});
 });

--- a/packages/provider/src/tests/unit/tasks/puzzleMaxDifficultyMatchesLadder.unit.test.ts
+++ b/packages/provider/src/tests/unit/tasks/puzzleMaxDifficultyMatchesLadder.unit.test.ts
@@ -1,0 +1,53 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// `puzzleMaxDifficulty` is a site setting, so its bounds live on the schema in
+// @prosopo/types. The ladder it bounds lives in @prosopo/captcha-severity,
+// which @prosopo/types deliberately does not depend on — that package's
+// zero-dependency, browser-safe property is load-bearing. So the two numbers
+// are written out twice and nothing in either package can catch them drifting.
+//
+// @prosopo/provider depends on both, so the pin lives here. If this fails,
+// the ladder changed and `settings.ts` needs the same edit — not the other way
+// round.
+
+import {
+	MAX_AUTO_ESCALATION_LEVEL,
+	PUZZLE_DIFFICULTY_LEVELS,
+} from "@prosopo/captcha-severity";
+import {
+	puzzleMaxDifficultyDefault,
+	puzzleMaxDifficultyMax,
+} from "@prosopo/types";
+import { describe, expect, it } from "vitest";
+
+describe("puzzleMaxDifficulty bounds track the puzzle difficulty ladder", () => {
+	it("defaults to the automatic escalation ceiling, preserving behaviour for sites that never set it", () => {
+		expect(puzzleMaxDifficultyDefault).toBe(MAX_AUTO_ESCALATION_LEVEL);
+	});
+
+	it("allows every level the ladder defines", () => {
+		expect(puzzleMaxDifficultyMax).toBe(PUZZLE_DIFFICULTY_LEVELS.length - 1);
+	});
+
+	// 0 has to stay reachable: it is the whole point of the setting — the
+	// documented "nothing escalated" level, where the session is left bare and
+	// the site's own puzzle settings render.
+	it("keeps level 0 within bounds", () => {
+		expect(puzzleMaxDifficultyMax).toBeGreaterThanOrEqual(0);
+		expect(PUZZLE_DIFFICULTY_LEVELS.some((band) => band.level === 0)).toBe(
+			true,
+		);
+	});
+});

--- a/packages/types-database/src/types/client.ts
+++ b/packages/types-database/src/types/client.ts
@@ -35,6 +35,7 @@ import {
 	imageThresholdDefault,
 	ispChangeActionDefault,
 	powDifficultyDefault,
+	puzzleMaxDifficultyMax,
 	requireAllConditionsDefault,
 	trafficFilterAbuserScoreThresholdDefault,
 } from "@prosopo/types";
@@ -227,6 +228,17 @@ export const UserSettingsSchema = new Schema({
 	},
 	puzzleTolerance: {
 		type: Number,
+		required: false,
+	},
+	// Ceiling on automatic puzzle escalation, in difficulty-ladder levels.
+	// No default: an absent value means "site never set this", and the
+	// provider falls back to `puzzleMaxDifficultyDefault` at read time. A
+	// schema default would be indistinguishable from an operator explicitly
+	// choosing that level.
+	puzzleMaxDifficulty: {
+		type: Number,
+		min: 0,
+		max: puzzleMaxDifficultyMax,
 		required: false,
 	},
 	// Site-wide puzzle render overrides. No default: an absent block means

--- a/packages/types/src/client/settings.ts
+++ b/packages/types/src/client/settings.ts
@@ -51,6 +51,29 @@ export const imageMaxRoundsDefault = 32;
 export const imageMinRoundsDefault = 2;
 export const puzzleToleranceDefault = 15;
 
+/**
+ * Ceiling on the puzzle difficulty ladder for a site, in ladder levels.
+ *
+ * The puzzle equivalent of `imageMaxRounds`. An escalated session samples its
+ * render settings from a difficulty band, and a sampled band sets EVERY knob —
+ * so while the ladder is active the site's own `puzzle` block and
+ * `puzzleTolerance` are not consulted at all. That is intended for a site
+ * using escalation, and wrong for a site that has deliberately configured an
+ * easier puzzle and expects to get it.
+ *
+ * `0` pins the site to level 0, which is the documented "nothing escalated"
+ * case: the session is left bare and the site's own settings render every
+ * time. Higher values cap how far automatic escalation may climb.
+ *
+ * The default matches `MAX_AUTO_ESCALATION_LEVEL` in `@prosopo/captcha-severity`,
+ * and the maximum matches that package's ladder length. Those live there
+ * because the ladder does, and this package deliberately does not depend on it
+ * — `puzzleMaxDifficultyMatchesLadder` in @prosopo/provider pins the pair so
+ * they cannot drift.
+ */
+export const puzzleMaxDifficultyDefault = 3;
+export const puzzleMaxDifficultyMax = 4;
+
 // Puzzle render defaults, mirrored from `packages/puzzle-assets`'s
 // `DEFAULT_RENDER_SETTINGS`. Kept here so the schema layer owns the
 // authoritative bounds and defaults; the renderer just receives resolved
@@ -199,6 +222,10 @@ export const imageMaxRoundsFieldSchema = number().int().min(2);
 // enforced across the pair on `ClientSettingsSchema`.
 export const imageMinRoundsFieldSchema = number().int().min(1);
 export const puzzleToleranceFieldSchema = number().int().min(5).max(1000);
+export const puzzleMaxDifficultyFieldSchema = number()
+	.int()
+	.min(0)
+	.max(puzzleMaxDifficultyMax);
 export const puzzleDecoyCountFieldSchema = number().int().min(0).max(200);
 export const puzzleDecoyEdgeDarknessFieldSchema = number().int().min(0).max(40);
 export const puzzleDecoyBodyBrightnessFieldSchema = number()
@@ -649,6 +676,13 @@ export const ClientSettingsSchema = object({
 	puzzleTolerance: puzzleToleranceFieldSchema
 		.optional()
 		.default(puzzleToleranceDefault),
+	// Ceiling on automatic puzzle escalation, in difficulty-ladder levels —
+	// the puzzle counterpart to `imageMaxRounds`. Set to 0 to pin the site to
+	// its own `puzzle` / `puzzleTolerance` settings on every challenge; the
+	// ladder otherwise replaces all of them whenever a session escalates.
+	puzzleMaxDifficulty: puzzleMaxDifficultyFieldSchema
+		.optional()
+		.default(puzzleMaxDifficultyDefault),
 	// Site-wide puzzle render settings. Fields not set here fall back to
 	// the asset package's defaults. Traffic-filter category policies may
 	// further override any of these on a per-request basis.

--- a/packages/types/src/provider/reasons.ts
+++ b/packages/types/src/provider/reasons.ts
@@ -54,6 +54,34 @@ export enum FrictionlessReason {
 }
 
 /**
+ * Reasons that mean "we measured nothing", as opposed to "we measured
+ * something bad".
+ *
+ * Each of these paths sizes its challenge from a fixed constant
+ * (`MISSING_TOKEN_IMAGE_ROUNDS` and friends) chosen to be short — "prove
+ * you're human quickly", per their own doc comments — not from any signal the
+ * client produced. Those constants nonetheless sit above the default baseline
+ * of `DEFAULT_SOLVED_COUNT`, so anything reading a round count as severity
+ * scores them as an escalation and applies a graduated response to a session
+ * that never produced a measurement to grade.
+ *
+ * That is wrong wherever the "severity" changes what a legitimate user
+ * experiences rather than what a suspected bot pays. The concrete case: a site
+ * whose CSP blocks the detector bundle sends no token on EVERY request, so
+ * every one of its users was permanently escalated and the site's own puzzle
+ * settings were never rendered.
+ *
+ * `OLD_TIMESTAMP` is deliberately absent: its round count comes from
+ * `timestampDecayFunction`, which scales with how stale the payload is. That
+ * is a real graduated measurement, not a fixed fallback.
+ */
+export const NO_MEASUREMENT_REASONS: ReadonlySet<FrictionlessReason> = new Set([
+	FrictionlessReason.MISSING_TOKEN,
+	FrictionlessReason.MISSING_HEAD_HASH,
+	FrictionlessReason.DECRYPTION_FAILED,
+]);
+
+/**
  * Reason persisted at `result.reason` to record the outcome of a captcha
  * verification. Provider task code previously inlined these as string
  * literals — the enum lifts the canonical set into one place so callers


### PR DESCRIPTION
## Problem

A customer reported their puzzle settings "not saving". They were saving — verified in mongo and on all 11 pronodes, byte-identical. They were being discarded at render time.

An escalated puzzle session samples its render settings from a difficulty band, and a sampled band sets **every** knob. While the ladder is active the site's configured `puzzle` block and `puzzleTolerance` are not consulted at all.

Measured on one production site over 7 days — 25/25 puzzle sessions rendered ladder values:

| knob | site setting | actually served |
|---|---|---|
| decoyCount | 2 | 8–9 |
| pieceScale | 0.40–0.45 | 0.14–0.40 |
| puzzleTolerance | 30px | 14px |

## Changes

**`puzzleMaxDifficulty`** — a new client setting, the puzzle counterpart to `imageMaxRounds`. Caps how far automatic escalation may climb; `0` pins the site to level 0, the documented "nothing escalated" case where the session is left bare and the site's own settings render every time. Defaults to `MAX_AUTO_ESCALATION_LEVEL`, so sites that never set it are unaffected.

`severityToPuzzleDifficulty` already accepted a `maxLevel`, so the value only had to reach it — threaded through `RoutingContext` alongside `imageMaxRounds`.

**No-measurement reasons stop feeding the ladder.** `MISSING_TOKEN`, `MISSING_HEAD_HASH` and `DECRYPTION_FAILED` each size their challenge from a fixed constant chosen to be short — *"prove you're human quickly"*, per their own doc comments — not from anything the client produced. Those constants sit one rung above the default baseline of `DEFAULT_SOLVED_COUNT`, so they read as an escalation. A site whose CSP blocks the detector bundle sends no token on **every** request, so every one of its users was permanently escalated.

`OLD_TIMESTAMP` deliberately keeps the ladder: its count comes from `timestampDecayFunction`, which scales with staleness and is a real graduated measurement.

Explicit router and traffic-filter overrides are untouched in both cases — an operator naming a tolerance still gets it.

## Notes

The new setting's bounds live on the schema in `@prosopo/types`, while the ladder lives in `@prosopo/captcha-severity` — which `types` deliberately does not depend on, since that package's zero-dependency browser-safe property is load-bearing. `puzzleMaxDifficultyMatchesLadder` pins the two so they cannot drift.

## Testing

Provider unit suite: 81 files, 1234 tests passing. 15 new cases covering the cap at 0 / below the cap / explicit-override precedence / unset fallback, and each no-measurement reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)