### PR TITLE
ci(release): stop half-published releases and open the private release PR automatically

### DIFF
--- a/.github/scripts/check-publishable.mjs
+++ b/.github/scripts/check-publishable.mjs
@@ -1,0 +1,219 @@
+#!/usr/bin/env node
+// Release preflight: fail BEFORE `changeset publish` runs if any publishable
+// workspace package cannot actually be published or installed.
+//
+// `changeset publish` publishes packages one at a time and does not roll back.
+// When package number 32 fails, the previous 31 are already live and immutable,
+// so the release lands half-applied and the only way out is a fresh patch
+// release. Both checks below exist to turn that mid-publish failure into a
+// cheap pre-publish failure.
+//
+// ---------------------------------------------------------------------------
+// Check 1 — first publish of a new package (the v3.8.8 failure)
+// ---------------------------------------------------------------------------
+// This repo publishes with npm trusted publishing (OIDC), see the `id-token:
+// write` permission and the notes in .github/workflows/publish_release.yml.
+// A trusted publisher is configured per package, on that package's settings
+// page on npmjs.com — which means the package has to already exist before the
+// trusted publisher can be attached to it. A package that has never been
+// published therefore has no trusted publisher, npm rejects the OIDC exchange,
+// and the npm CLI reports the failure as a generic `ENEEDAUTH` that looks like
+// a broken token rather than a missing configuration (npm/cli#9088).
+//
+// `changeset publish` always attempts a brand-new package, because its local
+// version is by definition not on the registry yet. So adding a new publishable
+// package to the workspace silently arms a release failure.
+//
+// The fix is a one-time manual bootstrap publish, after which CI owns every
+// subsequent release of that package. This check makes that requirement loud
+// and early instead of discovering it half way through a release.
+//
+// ---------------------------------------------------------------------------
+// Check 2 — private package leaked into a published package's runtime deps
+// ---------------------------------------------------------------------------
+// A `private: true` workspace package is never published. If a *publishable*
+// package lists one in dependencies / peerDependencies / optionalDependencies,
+// the published tarball is installable only inside this monorepo: every
+// consumer gets E404 on the private name. npm does not catch this at publish
+// time, because the dependency is only resolved when someone installs.
+
+import { readFileSync, readdirSync } from "node:fs";
+import { join, relative, resolve } from "node:path";
+
+const ROOT = process.cwd();
+const REGISTRY = process.env.npm_config_registry || "https://registry.npmjs.org";
+
+// Runtime sections only. A devDependency is not installed by consumers, so a
+// private package there is harmless.
+const RUNTIME_SECTIONS = [
+	"dependencies",
+	"peerDependencies",
+	"optionalDependencies",
+];
+
+// Known, accepted private-dependency leaks. Each entry is uninstallable from
+// the public registry today and is grandfathered in so this check can be
+// enforced for everything else; removing an entry is the fix, not the goal.
+//
+//   @prosopo/fingerprintjs — private vendored fork consumed by
+//   @prosopo/fingerprint, which reaches @prosopo/procaptcha* and
+//   @prosopo/account. Predates this check (@prosopo/fingerprint@2.7.42 on the
+//   registry already carries it). Browser consumers load the prebuilt
+//   procaptcha bundle rather than installing from npm, so this has gone
+//   unnoticed.
+const ALLOWED_PRIVATE_DEPS = new Set(["@prosopo/fingerprintjs"]);
+
+const IGNORE_DIRS = new Set([
+	"node_modules",
+	".git",
+	"dist",
+	"build",
+	".next",
+	".astro",
+	".turbo",
+	".nx",
+	"coverage",
+	".cache",
+]);
+
+// Git submodules are separate repositories that publish on their own schedule.
+function loadSubmodulePaths() {
+	const paths = new Set();
+	try {
+		const txt = readFileSync(join(ROOT, ".gitmodules"), "utf8");
+		for (const m of txt.matchAll(/^\s*path\s*=\s*(.+)\s*$/gm)) {
+			paths.add(resolve(ROOT, m[1].trim()));
+		}
+	} catch {
+		/* no submodules */
+	}
+	return paths;
+}
+const SUBMODULE_PATHS = loadSubmodulePaths();
+
+/** @typedef {{name: string, version: string, private: boolean, file: string, json: Record<string, unknown>}} Pkg */
+
+/** @returns {Pkg[]} */
+function findPackages(dir, out = []) {
+	for (const entry of readdirSync(dir, { withFileTypes: true })) {
+		const full = join(dir, entry.name);
+		if (entry.isDirectory()) {
+			if (IGNORE_DIRS.has(entry.name)) continue;
+			if (SUBMODULE_PATHS.has(resolve(full))) continue;
+			findPackages(full, out);
+		} else if (entry.name === "package.json") {
+			try {
+				const json = JSON.parse(readFileSync(full, "utf8"));
+				if (!json.name) continue;
+				out.push({
+					name: json.name,
+					version: json.version,
+					private: json.private === true,
+					file: full,
+					json,
+				});
+			} catch {
+				/* checked by check-pinned-versions.mjs */
+			}
+		}
+	}
+	return out;
+}
+
+/** Does the package exist on the registry at all (any version)? */
+async function existsOnRegistry(name) {
+	const url = `${REGISTRY.replace(/\/$/, "")}/${name.replace("/", "%2F")}`;
+	const res = await fetch(url, { method: "GET", headers: { accept: "*/*" } });
+	if (res.status === 404) return false;
+	if (!res.ok) {
+		throw new Error(`registry returned ${res.status} for ${name}`);
+	}
+	return true;
+}
+
+const packages = findPackages(ROOT);
+const byName = new Map(packages.map((p) => [p.name, p]));
+const publishable = packages.filter((p) => !p.private);
+
+// --- Check 2 (local, no network) -------------------------------------------
+const leaks = [];
+for (const pkg of publishable) {
+	for (const section of RUNTIME_SECTIONS) {
+		for (const dep of Object.keys(pkg.json[section] || {})) {
+			const target = byName.get(dep);
+			if (!target?.private) continue;
+			if (ALLOWED_PRIVATE_DEPS.has(dep)) continue;
+			leaks.push(
+				`${relative(ROOT, pkg.file)}  ${section} > "${dep}" is a private workspace package and is never published`,
+			);
+		}
+	}
+}
+
+// --- Check 1 (network) ------------------------------------------------------
+// Bounded concurrency so a 50-package workspace does not open 50 sockets.
+const CONCURRENCY = 8;
+const unpublished = [];
+let cursor = 0;
+async function worker() {
+	while (cursor < publishable.length) {
+		const pkg = publishable[cursor++];
+		if (!(await existsOnRegistry(pkg.name))) {
+			unpublished.push(pkg);
+		}
+	}
+}
+await Promise.all(
+	Array.from({ length: Math.min(CONCURRENCY, publishable.length) }, worker),
+);
+
+// --- Report -----------------------------------------------------------------
+let failed = false;
+
+if (unpublished.length > 0) {
+	failed = true;
+	console.error(
+		`✖ ${unpublished.length} package(s) have never been published, so trusted publishing (OIDC) cannot publish them:\n`,
+	);
+	for (const p of unpublished) {
+		console.error(`  ${p.name}@${p.version}  (${relative(ROOT, p.file)})`);
+	}
+	console.error(
+		"\nA trusted publisher is attached to an existing package on npmjs.com, so the" +
+			"\nfirst version has to be published by hand once. `changeset publish` would" +
+			"\notherwise fail on these with a misleading ENEEDAUTH part way through the" +
+			"\nrelease, after the earlier packages are already live and immutable." +
+			"\n\nFor each package above, from a machine logged in to npm as a @prosopo" +
+			"\npublisher:" +
+			"\n  npm run build:all:tsc && npm run build:all && npm run build:all:cjs" +
+			"\n  cd <package dir> && npm publish --access public" +
+			"\nthen on https://www.npmjs.com/package/<name>/access add a GitHub Actions" +
+			"\ntrusted publisher for prosopo/captcha with workflow publish_release.yml," +
+			"\nand re-run this release.",
+	);
+}
+
+if (leaks.length > 0) {
+	if (failed) console.error("");
+	failed = true;
+	console.error(
+		`✖ ${leaks.length} publishable package(s) depend on a private workspace package:\n`,
+	);
+	for (const l of leaks) console.error(`  ${l}`);
+	console.error(
+		"\nThese publish fine but are uninstallable: consumers get E404 on the private" +
+			"\nname. Either publish the dependency, move it to devDependencies if it is" +
+			"\nbundled into dist at build time, or inline it.",
+	);
+}
+
+if (failed) {
+	console.error(
+		"\nRun `node .github/scripts/check-publishable.mjs` locally to reproduce.",
+	);
+	process.exit(1);
+}
+
+console.log(
+	`✔ ${publishable.length} publishable package(s) exist on ${REGISTRY} and declare no unpublished private dependencies.`,
+);

--- a/.github/scripts/check-publishable.mjs
+++ b/.github/scripts/check-publishable.mjs
@@ -41,7 +41,8 @@ import { readFileSync, readdirSync } from "node:fs";
 import { join, relative, resolve } from "node:path";
 
 const ROOT = process.cwd();
-const REGISTRY = process.env.npm_config_registry || "https://registry.npmjs.org";
+const REGISTRY =
+	process.env.npm_config_registry || "https://registry.npmjs.org";
 
 // Runtime sections only. A devDependency is not installed by consumers, so a
 // private package there is harmless.
@@ -122,7 +123,11 @@ function findPackages(dir, out = []) {
 
 /** Does the package exist on the registry at all (any version)? */
 async function existsOnRegistry(name) {
-	const url = `${REGISTRY.replace(/\/$/, "")}/${name.replace("/", "%2F")}`;
+	// The scope separator has to stay percent-encoded or the registry reads it
+	// as a path segment. replaceAll, not replace: a package name only ever has
+	// the one slash, but replace would silently encode just the first if that
+	// ever stopped being true.
+	const url = `${REGISTRY.replace(/\/$/, "")}/${name.replaceAll("/", "%2F")}`;
 	const res = await fetch(url, { method: "GET", headers: { accept: "*/*" } });
 	if (res.status === 404) return false;
 	if (!res.ok) {

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -173,6 +173,32 @@ jobs:
             --title "Release v${{ steps.version.outputs.version }}" \
             --generate-notes
 
+      - name: Open the private release PR
+        # The release is not finished when this repo's packages are out: the
+        # private repo still has to move its captcha submodule to the new tag,
+        # cascade the version bumps through its own packages and repoint the
+        # ansible inventories at the new provider image. Its create_release_pr
+        # workflow does all of that, but it was dispatch-only, so it happened
+        # only when somebody remembered. v3.8.7 and v3.8.8 both shipped from
+        # here with no release PR opened there at all, and production's
+        # compose_provider_image_version was hand-edited to 3.8.7 in an
+        # unrelated PR to paper over it.
+        #
+        # Fired after the GitHub Release exists so the private side never opens
+        # a PR for a release that did not finish. Non-fatal on purpose: at this
+        # point the packages, images and release are already published, and
+        # failing here would both mark a successful release as failed and fire
+        # the failure notification below. A missed dispatch just means running
+        # create_release_pr by hand, which is where this started.
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ steps.app_token.outputs.token }}
+        run: |
+          gh api repos/prosopo/captcha-private/dispatches \
+            --method POST \
+            --field event_type=captcha_released \
+            --field 'client_payload[version]=${{ steps.version.outputs.version }}'
+
       - name: Send success notification
         if: success()
         run: |

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -79,6 +79,21 @@ jobs:
           echo "version=$version" >> $GITHUB_OUTPUT
           echo "Version: $version"
 
+      - name: Preflight publishability check
+        # Runs before the install and build because it needs neither, and a
+        # release that cannot publish should fail in seconds rather than after
+        # three minutes of building artifacts nobody will ship.
+        #
+        # `changeset publish` publishes serially and cannot roll back, so a
+        # package that fails part way through leaves the release half-applied,
+        # with the earlier packages already live and immutable on the registry.
+        # This turns that into a failure before anything is published. It
+        # catches the two ways a package is unpublishable: a first publish
+        # (trusted publishing cannot bootstrap a package that does not exist
+        # yet, and npm reports it as a misleading ENEEDAUTH) and a private
+        # workspace package leaked into a published package's runtime deps.
+        run: node .github/scripts/check-publishable.mjs
+
       - run: npm ci --ignore-scripts --include=dev --no-audit --no-fund --prefer-offline
 
       - name: Build packages


### PR DESCRIPTION
## Why

v3.8.8 published 31 of 32 packages and then failed on the 32nd. `@prosopo/web-bot-auth` was a new package, and an npm trusted publisher is attached to a package that already exists on npmjs.com — so a package that has never been published has none. npm rejected the OIDC exchange and the CLI surfaced it as `ENEEDAUTH`, which reads like a broken token rather than a missing configuration ([npm/cli#9088](https://github.com/npm/cli/issues/9088)).

`changeset publish` does not roll back. The 31 packages that went first were already live and immutable, and four of them — `provider`, `cli`, `scripts`, `provider-mock` — declare a runtime dependency on `web-bot-auth@0.1.0`, so they were uninstallable from npm until it was bootstrapped by hand.

Separately, v3.8.7 and v3.8.8 both shipped from here without a release PR ever being opened in `captcha-private`, because its `create_release_pr` is dispatch-only. Production's `compose_provider_image_version` was eventually hand-edited to `3.8.7` inside an unrelated datasets PR while staging sat on `3.8.6-staging`.

## What

**`check-publishable.mjs`** — refuses to start a release when a publishable package does not exist on the registry, or when a `private: true` workspace package has leaked into a published package's runtime deps. Runs before `npm ci` and the build because it needs neither, so an unpublishable release fails in seconds instead of three minutes in. Against `main` today it flags nothing.

**`Open the private release PR`** — sends a `captcha_released` repository_dispatch to `captcha-private` once the GitHub Release exists, so the private side reacts to a finished release rather than to somebody remembering. `continue-on-error` on purpose: everything is already published by that point, and failing here would mark a good release as failed and fire the failure notification. The matching trigger is in prosopo/captcha-private#4455.

## Note

`@prosopo/fingerprintjs` is allowlisted in the new check. `@prosopo/fingerprint` has depended on that `private: true` package since long before this PR, which is why `fingerprint`, `procaptcha*` and `account` are already uninstallable from npm — `@prosopo/procaptcha-bundle@4.4.1` fails the same way. It is already excluded from `lint:license` and `lint:refs`. Whether those packages are meant to be installable from npm at all is a separate decision, so this PR records the debt rather than changing what ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)