### PR TITLE
feat(types,provider): report `host` in /details

### DIFF
--- a/.changeset/provider-details-host.md
+++ b/.changeset/provider-details-host.md
@@ -1,0 +1,19 @@
+---
+"@prosopo/types": patch
+"@prosopo/provider": patch
+---
+
+feat(types,provider): report `host` in `/details`
+
+`providerDetailsSchema` grows an optional `host`, and the `/details` handler
+populates it from `config.host`, falling back to the request's hostname when
+that is unset — the same shape `/healthz` already uses.
+
+`/details` already reports the version and Redis readiness; it just did not
+say which node answered. Callers that want the answering node's identity can
+now read it there instead of inferring it from a liveness endpoint.
+
+The field is optional on purpose. A fleet is mixed-version part-way through a
+rolling deploy, so a required field would fail validation against a node that
+has not been upgraded yet. Consumers should treat it as absent-or-string.
+Purely additive: nothing existing changes shape.

--- a/packages/provider/src/api/public.ts
+++ b/packages/provider/src/api/public.ts
@@ -59,9 +59,17 @@ export function publicRouter(env: ProviderEnvironment): Router {
 			const redisConnection = db.getRedisConnection();
 			const redisAccessRulesConnection = db.getRedisAccessRulesConnection();
 
+			// Identity of the node answering this request, so callers can tell
+			// which node they reached without relying on /healthz.
+			const host =
+				env.config.host && env.config.host.length > 0
+					? env.config.host
+					: req.hostname;
+
 			const response: ProviderDetails = {
 				version,
 				message: "Provider online",
+				host,
 				redis: [
 					{
 						actor: "General",

--- a/packages/provider/src/tests/unit/api/public.unit.test.ts
+++ b/packages/provider/src/tests/unit/api/public.unit.test.ts
@@ -15,9 +15,15 @@
 import { handleErrors } from "@prosopo/api-express-router";
 import { ProsopoApiError } from "@prosopo/common";
 import type { ProviderEnvironment } from "@prosopo/env";
-import { PublicApiPaths } from "@prosopo/types";
+import { PublicApiPaths, providerDetailsSchema } from "@prosopo/types";
 import { version } from "@prosopo/util";
-import type { NextFunction, Request, Response } from "express";
+import type {
+	NextFunction,
+	Request,
+	RequestHandler,
+	Response,
+	Router,
+} from "express";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { metricsHandler } from "../../../api/metrics.js";
 import { publicRouter } from "../../../api/public.js";
@@ -33,6 +39,27 @@ vi.mock("@prosopo/util", async (importActual) => {
 		version: "1.0.0-test",
 	};
 });
+
+// Express does not expose its layer stack in its public types, so describe the
+// slice of it these tests read rather than reaching for `any`.
+type RouteLayer = {
+	route?: {
+		path?: string;
+		stack: { handle: RequestHandler }[];
+	};
+};
+
+const getRouteHandler = (router: Router, path: string): RequestHandler => {
+	const { stack } = router as unknown as { stack: RouteLayer[] };
+	const handler = stack.find((layer) => layer.route?.path === path)?.route
+		?.stack[0]?.handle;
+
+	if (!handler) {
+		throw new Error(`no handler registered for ${path}`);
+	}
+
+	return handler;
+};
 
 describe("publicRouter", () => {
 	let mockEnv: ProviderEnvironment;
@@ -373,5 +400,60 @@ describe("publicRouter", () => {
 				]),
 			}),
 		);
+	});
+
+	describe("the details endpoint reports the answering node", () => {
+		const envWithConfiguredHost = (host: string): ProviderEnvironment =>
+			({
+				getDb: vi.fn().mockReturnValue(mockDb),
+				logger: mockLogger,
+				config: { host },
+			}) as unknown as ProviderEnvironment;
+
+		const callDetails = async (
+			env: ProviderEnvironment,
+			hostname: string,
+		): Promise<unknown> => {
+			const handler = getRouteHandler(
+				publicRouter(env),
+				PublicApiPaths.GetProviderDetails,
+			);
+			const req = { hostname, params: {} } as unknown as Request;
+
+			await handler(req, mockRes, mockNext);
+
+			return vi.mocked(mockRes.json).mock.calls[0]?.[0];
+		};
+
+		it("reports the configured host", async () => {
+			const body = await callDetails(
+				envWithConfiguredHost("provider.example.com"),
+				"proxied.example.com",
+			);
+
+			expect(body).toEqual(
+				expect.objectContaining({ host: "provider.example.com" }),
+			);
+		});
+
+		it("falls back to the request hostname when no host is configured", async () => {
+			const body = await callDetails(
+				envWithConfiguredHost(""),
+				"req.example.com",
+			);
+
+			expect(body).toEqual(
+				expect.objectContaining({ host: "req.example.com" }),
+			);
+		});
+
+		it("returns a body the shared schema still accepts", async () => {
+			const body = await callDetails(
+				envWithConfiguredHost("provider.example.com"),
+				"proxied.example.com",
+			);
+
+			expect(providerDetailsSchema.safeParse(body).success).toBe(true);
+		});
 	});
 });

--- a/packages/types/src/provider/api.test.ts
+++ b/packages/types/src/provider/api.test.ts
@@ -1,0 +1,53 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import { describe, expect, it } from "vitest";
+import { type ProviderDetails, providerDetailsSchema } from "./api.js";
+
+describe("providerDetailsSchema", () => {
+	const redis: ProviderDetails["redis"] = [
+		{ actor: "General", isReady: true, awaitingTimeSeconds: 0 },
+	];
+
+	it("accepts a host", () => {
+		const parsed = providerDetailsSchema.parse({
+			version: "1.0.0",
+			message: "Provider online",
+			host: "provider.example.com",
+			redis,
+		});
+
+		expect(parsed.host).toBe("provider.example.com");
+	});
+
+	it("accepts a payload without a host, so a node that has not been upgraded still validates", () => {
+		const parsed = providerDetailsSchema.parse({
+			version: "1.0.0",
+			message: "Provider online",
+			redis,
+		});
+
+		expect(parsed.host).toBeUndefined();
+	});
+
+	it("rejects a non-string host", () => {
+		const result = providerDetailsSchema.safeParse({
+			version: "1.0.0",
+			message: "Provider online",
+			host: 1,
+			redis,
+		});
+
+		expect(result.success).toBe(false);
+	});
+});

--- a/packages/types/src/provider/api.ts
+++ b/packages/types/src/provider/api.ts
@@ -112,6 +112,9 @@ export enum PublicApiPaths {
 export const providerDetailsSchema = object({
 	version: string(),
 	message: string(),
+	// Identity of the node that answered. Optional because the fleet is
+	// mixed-version during a rolling deploy and older nodes omit it.
+	host: string().optional(),
 	redis: object({
 		actor: string(),
 		isReady: boolean(),


### PR DESCRIPTION
Closes prosopo/captcha-private#4458

## What

- `providerDetailsSchema` (`@prosopo/types`) gains `host: string().optional()`.
- The `/details` handler (`@prosopo/provider`) populates it from `config.host`, falling back to the request hostname when that is unset — the same shape `/healthz` already uses.

## Why

`/details` already reports the version and Redis readiness; it just did not say which node answered. Callers that want the answering node's identity had to read it off a liveness endpoint instead. This gives identity its own home.

## Why optional

A fleet is mixed-version part-way through a rolling deploy, so a required field would fail validation against a node that has not been upgraded yet. Consumers should treat it as absent-or-string. It can be tightened in a later release once the fleet is uniform.

Purely additive — no existing field changes shape, and the only consumers (`ProviderApi.getProviderDetails()` and the rate-limiter config) are unaffected.

## Tests

- `packages/types/src/provider/api.test.ts` (new): schema accepts a host, accepts a payload without one, rejects a non-string.
- `packages/provider/src/tests/unit/api/public.unit.test.ts`: the real `/details` handler is now pulled off the router stack and invoked — asserts the configured host, the request-hostname fallback, and that the body still parses against the shared schema.

Changeset included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)