### PR TITLE
feat(provider,ipinfo): optionally answer /healthz with the node nearest the caller

### DIFF
--- a/.changeset/healthz-geo-steering.md
+++ b/.changeset/healthz-geo-steering.md
@@ -1,0 +1,20 @@
+---
+"@prosopo/provider": minor
+"@prosopo/ipinfo": minor
+"@prosopo/types-env": minor
+---
+
+Optionally answer `/healthz` with the node nearest the caller.
+
+`/healthz` tells a client which node to pin its captcha calls to, and a node has always answered with its own name — so the pin is whatever the DNS layer picked. The DNS layer only sees the client's address when the client's resolver forwards it, which many do not. The provider always sees it, because the connection is already open.
+
+Behind `PROSOPO_HEALTHZ_GEO_STEERING`, off by default. With it off nothing in this change runs and the response is unchanged, headers included.
+
+- `IpInfoService.country(ip)` is a new MaxMind-only fast path: an in-process, synchronous read of the memory-mapped database, returning an ISO 3166-1 alpha-2 code or `undefined`. `lookup()` is unchanged and still prefers ipapi.is for its threat data; a country lookup does not need that data and must not pay a network call for it. Added to `IIpInfoService` in `@prosopo/ipinfo` and `@prosopo/types-env`.
+- The country → host map is configuration, supplied by the deployment as JSON in `PROSOPO_HEALTHZ_GEO_ROUTES`. It is also the candidate set: a host that must not receive traffic simply does not appear in it. An unparseable or empty map leaves steering off rather than failing startup.
+- A background poller (`PROSOPO_HEALTHZ_GEO_PROBE_INTERVAL_MS`, `PROSOPO_HEALTHZ_GEO_PROBE_TIMEOUT_MS`) tracks each candidate's health. Every candidate starts down and only becomes up on a successful probe, so a poller that has not run or is failing leaves steering off. The request path reads a boolean and never awaits a probe.
+- The handler never awaits readiness. It reads `ipInfoService.isAvailable()`, which is false before the environment is ready, and answers with its own name. Loopback and private-range callers — deploy gates, container health checks — short-circuit the same way. `/healthz` stays dependency-free.
+- `Cache-Control: no-store, private` is set whenever steering is on, before the decision, so it covers every branch. The answer varies per caller and no intermediary may cache and replay it.
+- `prosopo_healthz_geo_outcomes_total{outcome}` on `/metrics` counts `steered`, `not_steered`, `target_down` and `geo_unavailable`. Every outcome but the first falls back to the node's own name, which is also the behaviour with steering off, so nothing else would show that steering had stopped working.
+
+No client-side change: the load balancer already pins to whatever `host` the response carries.

--- a/packages/ipinfo/src/IpInfoService.ts
+++ b/packages/ipinfo/src/IpInfoService.ts
@@ -117,6 +117,27 @@ export class IpInfoService implements IIpInfoService {
 		);
 	}
 
+	/**
+	 * MaxMind-only country fast path: the ISO 3166-1 alpha-2 code for `ip`, or
+	 * undefined when it cannot be determined.
+	 *
+	 * Deliberately NOT `lookup()`. `lookup()` prefers ipapi.is for its threat
+	 * data, which puts a network call to the sidecar on the caller's path; a
+	 * caller that only wants a country does not need that data and must not pay
+	 * for it. The MaxMind database is memory-mapped and read in-process, so this
+	 * is synchronous and cannot fail on a network or a slow sidecar.
+	 *
+	 * Returns undefined rather than throwing for every failure mode — no
+	 * MaxMind backend configured, backend not initialised yet, non-routable
+	 * address, address absent from the database — so callers have exactly one
+	 * "no answer" case to handle.
+	 */
+	country(ip: string): string | undefined {
+		if (isNonRoutable(ip)) return undefined;
+		if (!this.maxmindBackend?.isAvailable()) return undefined;
+		return this.maxmindBackend.countryCode(ip);
+	}
+
 	async lookup(ip: string): Promise<IPInfoResponse> {
 		if (isNonRoutable(ip)) {
 			return {

--- a/packages/ipinfo/src/backends/maxmind.ts
+++ b/packages/ipinfo/src/backends/maxmind.ts
@@ -109,6 +109,42 @@ export class MaxMindBackend {
 		return this.cityReader !== null || this.asnReader !== null;
 	}
 
+	/**
+	 * ISO 3166-1 alpha-2 country code, or undefined when the reader has no
+	 * answer. Synchronous and allocation-light: the .mmdb is memory-mapped, so
+	 * this is a tree walk with no I/O and no network.
+	 *
+	 * Separate from `lookup()` because callers that only need the country
+	 * should not pay for the ASN read, the threat-field assembly, or the
+	 * `IPInfoResponse` object. The reader-kind latch is shared with `lookup()`
+	 * — `country()` rejects a City database and `city()` rejects a Country one,
+	 * so the accessor has to be chosen from the database's own metadata.
+	 */
+	countryCode(ip: string): string | undefined {
+		if (!this.cityReader) return undefined;
+
+		if (this.geoReaderKind !== "country") {
+			try {
+				const isoCode = this.cityReader.city(ip).country?.isoCode;
+				this.geoReaderKind = "city";
+				return isoCode;
+			} catch (error) {
+				if (!isBadMethodCall(error)) {
+					// Address not in the database, or an invalid address: no
+					// country, and nothing to latch.
+					return undefined;
+				}
+				this.geoReaderKind = "country";
+			}
+		}
+
+		try {
+			return this.cityReader.country(ip).country?.isoCode;
+		} catch {
+			return undefined;
+		}
+	}
+
 	async lookup(ip: string): Promise<IPInfoResponse> {
 		if (!this.isAvailable()) {
 			return {

--- a/packages/ipinfo/src/tests/ipInfoService.unit.test.ts
+++ b/packages/ipinfo/src/tests/ipInfoService.unit.test.ts
@@ -55,15 +55,18 @@ interface StubBackend {
 	initialize: () => Promise<void>;
 	isAvailable: () => boolean;
 	lookup: (ip: string) => Promise<IPInfoResponse>;
+	countryCode: (ip: string) => string | undefined;
 }
 
 const stub = (
 	available: boolean,
 	answer: IPInfoResponse = result("stub"),
+	countryCode: string | undefined = "US",
 ): StubBackend => ({
 	initialize: vi.fn<() => Promise<void>>(async () => {}),
 	isAvailable: vi.fn<() => boolean>(() => available),
 	lookup: vi.fn<(ip: string) => Promise<IPInfoResponse>>(async () => answer),
+	countryCode: vi.fn<(ip: string) => string | undefined>(() => countryCode),
 });
 
 /**
@@ -410,6 +413,7 @@ describe("IpInfoService.lookup", () => {
 			lookup: vi.fn<(ip: string) => Promise<IPInfoResponse>>(async () =>
 				result("recovered"),
 			),
+			countryCode: vi.fn<(ip: string) => string | undefined>(() => undefined),
 		};
 		const svc = service({ ipapi: flaky });
 
@@ -418,5 +422,60 @@ describe("IpInfoService.lookup", () => {
 		);
 		up = true;
 		expect(await svc.lookup(IP)).toEqual(result("recovered"));
+	});
+});
+
+describe("IpInfoService.country", () => {
+	it("answers from MaxMind", () => {
+		expect(
+			service({ maxmind: stub(true, result("maxmind"), "GB") }).country(IP),
+		).toBe("GB");
+	});
+
+	it("never consults ipapi, even when ipapi is the preferred backend", () => {
+		// `lookup()` prefers ipapi for its threat data, which costs a call to
+		// the sidecar. A country lookup does not need that data and must not
+		// pay for it.
+		const ipapi = stub(true, result("ipapi"));
+		const maxmind = stub(true, result("maxmind"), "FR");
+
+		expect(service({ maxmind, ipapi }).country(IP)).toBe("FR");
+
+		expect(ipapi.lookup).not.toHaveBeenCalled();
+		expect(ipapi.isAvailable).not.toHaveBeenCalled();
+	});
+
+	it("has no answer for a loopback caller, without reading the database", () => {
+		// Deploy gates and container health checks call over loopback; they
+		// must cost nothing and must never resolve to a country.
+		const maxmind = stub(true, result("maxmind"), "US");
+
+		expect(service({ maxmind }).country("127.0.0.1")).toBeUndefined();
+		expect(service({ maxmind }).country("::1")).toBeUndefined();
+		expect(service({ maxmind }).country("10.1.2.3")).toBeUndefined();
+
+		expect(maxmind.countryCode).not.toHaveBeenCalled();
+	});
+
+	it("has no answer when no MaxMind backend is configured", () => {
+		expect(service({ ipapi: stub(true) }).country(IP)).toBeUndefined();
+	});
+
+	it("has no answer while MaxMind is still unavailable", () => {
+		// Availability is false until the environment finishes becoming ready,
+		// which is exactly when a caller that cannot await readiness asks.
+		const maxmind = stub(false, result("maxmind"), "DE");
+
+		expect(service({ maxmind }).country(IP)).toBeUndefined();
+		expect(maxmind.countryCode).not.toHaveBeenCalled();
+	});
+
+	it("has no answer when the address is absent from the database", () => {
+		const maxmind: StubBackend = {
+			...stub(true, result("maxmind")),
+			countryCode: vi.fn<(ip: string) => string | undefined>(() => undefined),
+		};
+
+		expect(service({ maxmind }).country(IP)).toBeUndefined();
 	});
 });

--- a/packages/ipinfo/src/tests/maxmind.unit.test.ts
+++ b/packages/ipinfo/src/tests/maxmind.unit.test.ts
@@ -726,3 +726,76 @@ describe("MaxMindBackend default reader", () => {
 		expect(backend.isAvailable()).toBe(false);
 	});
 });
+
+describe("MaxMindBackend.countryCode", () => {
+	it("reads the country from a City database", async () => {
+		const backend = new MaxMindBackend({
+			cityDbPath: CITY_DB,
+			openReader: opens({ city: reader({ city: () => cityData() }) }),
+		});
+		await backend.initialize();
+
+		expect(backend.countryCode(IP)).toBe("US");
+	});
+
+	it("falls back to country() on a Country database and latches the choice", async () => {
+		const city = vi.fn(badMethodCall);
+		const country = vi.fn((): Country => countryData());
+		const backend = new MaxMindBackend({
+			cityDbPath: CITY_DB,
+			openReader: opens({ city: reader({ city, country }) }),
+		});
+		await backend.initialize();
+
+		expect(backend.countryCode(IP)).toBe("US");
+		expect(backend.countryCode(IP)).toBe("US");
+
+		// The mismatched accessor is tried once, not once per call.
+		expect(city).toHaveBeenCalledTimes(1);
+		expect(country).toHaveBeenCalledTimes(2);
+	});
+
+	it("has no answer when the address is absent from the database", async () => {
+		const backend = new MaxMindBackend({
+			cityDbPath: CITY_DB,
+			openReader: opens({
+				city: reader({
+					city: (): never => {
+						throw new Error("The address 8.8.8.8 is not in the database");
+					},
+				}),
+			}),
+		});
+		await backend.initialize();
+
+		expect(backend.countryCode(IP)).toBeUndefined();
+	});
+
+	it("has no answer when no geo database was opened", async () => {
+		const backend = new MaxMindBackend({
+			asnDbPath: ASN_DB,
+			openReader: opens({ asn: reader({ asn: () => asnData() }) }),
+		});
+		await backend.initialize();
+
+		expect(backend.isAvailable()).toBe(true);
+		expect(backend.countryCode(IP)).toBeUndefined();
+	});
+
+	it("does not read the ASN database", async () => {
+		// The country is the whole answer; nothing else is worth a second read.
+		const asn = vi.fn((): Asn => asnData());
+		const backend = new MaxMindBackend({
+			cityDbPath: CITY_DB,
+			asnDbPath: ASN_DB,
+			openReader: opens({
+				city: reader({ city: () => cityData() }),
+				asn: reader({ asn }),
+			}),
+		});
+		await backend.initialize();
+
+		expect(backend.countryCode(IP)).toBe("US");
+		expect(asn).not.toHaveBeenCalled();
+	});
+});

--- a/packages/ipinfo/src/types.ts
+++ b/packages/ipinfo/src/types.ts
@@ -18,6 +18,12 @@ import type { IPInfoResponse } from "@prosopo/types";
 export interface IIpInfoService {
 	initialize(): Promise<void>;
 	lookup(ip: string): Promise<IPInfoResponse>;
+	/**
+	 * ISO 3166-1 alpha-2 country code from the local MaxMind database only.
+	 * Synchronous and network-free, unlike `lookup()`. Undefined whenever no
+	 * answer is available.
+	 */
+	country(ip: string): string | undefined;
 	isAvailable(): boolean;
 }
 

--- a/packages/provider/src/api/healthzGeo.ts
+++ b/packages/provider/src/api/healthzGeo.ts
@@ -1,0 +1,344 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { Logger } from "@prosopo/logger";
+import { PublicApiPaths } from "@prosopo/types";
+import type { IIpInfoService } from "@prosopo/types-env";
+import { z } from "zod";
+
+/**
+ * Geo steering for `/healthz`.
+ *
+ * `/healthz` tells a client which node to pin its captcha calls to. By default
+ * a node answers with its own name, so the pin is whatever the DNS layer
+ * picked. With steering enabled the node instead answers with the node the
+ * caller's country is mapped to, when that node is known to be up.
+ *
+ * Off by default. With the flag off nothing here runs: no lookup, no poller,
+ * no response header, no counter.
+ *
+ * Configuration (all read once, at first use):
+ *
+ *   PROSOPO_HEALTHZ_GEO_STEERING
+ *     "true" enables steering. Anything else, including unset, disables it.
+ *
+ *   PROSOPO_HEALTHZ_GEO_ROUTES
+ *     JSON object mapping ISO 3166-1 alpha-2 country code to hostname, e.g.
+ *     `{"XX":"node1.example.com","YY":"node2.example.com"}`. Keys are
+ *     case-insensitive. Countries absent from the map are not steered.
+ *
+ *     The map is the candidate set: a host that must not receive traffic
+ *     simply does not appear in it. Nothing here derives candidates from
+ *     anywhere else, so the deployment that generates the map is the single
+ *     place that decides which nodes are in rotation.
+ *
+ *   PROSOPO_HEALTHZ_GEO_PROBE_INTERVAL_MS   (default 30000)
+ *   PROSOPO_HEALTHZ_GEO_PROBE_TIMEOUT_MS    (default 2000)
+ *     Background health-probe period and per-probe timeout.
+ *
+ * An invalid or unparseable route map disables steering rather than failing
+ * startup — the fallback is the node's own name, which is the default
+ * behaviour.
+ */
+
+const DEFAULT_PROBE_INTERVAL_MS = 30_000;
+const DEFAULT_PROBE_TIMEOUT_MS = 2_000;
+const MIN_PROBE_INTERVAL_MS = 1_000;
+
+/** Hostname, not a URL: no scheme, no path, no port. */
+const hostnameSchema = z
+	.string()
+	.min(1)
+	.max(253)
+	.regex(/^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$/i);
+
+const routesSchema = z.record(z.string().regex(/^[a-z]{2}$/i), hostnameSchema);
+
+export interface HealthzGeoConfig {
+	enabled: boolean;
+	/** Upper-cased ISO 3166-1 alpha-2 country code -> hostname. */
+	routes: ReadonlyMap<string, string>;
+	probeIntervalMs: number;
+	probeTimeoutMs: number;
+}
+
+/**
+ * Why a given `/healthz` call did or did not get steered. Reported on the
+ * `/metrics` endpoint: every non-`steered` outcome is silent in the response
+ * body — the fallback is the default behaviour — so this counter is the only
+ * signal that steering has stopped working.
+ */
+export type HealthzGeoOutcome =
+	| "steered"
+	| "not_steered"
+	| "target_down"
+	| "geo_unavailable";
+
+export interface HealthzGeoDecision {
+	host: string;
+	outcome: HealthzGeoOutcome;
+}
+
+const parsePositiveInt = (
+	raw: string | undefined,
+	fallback: number,
+): number => {
+	if (raw === undefined) return fallback;
+	const parsed = Number.parseInt(raw, 10);
+	return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+};
+
+const parseRoutes = (
+	raw: string | undefined,
+	logger?: Logger,
+): ReadonlyMap<string, string> => {
+	if (!raw || raw.trim().length === 0) return new Map();
+	try {
+		const parsed = routesSchema.parse(JSON.parse(raw));
+		return new Map(
+			Object.entries(parsed).map(([country, host]) => [
+				country.toUpperCase(),
+				host,
+			]),
+		);
+	} catch (err) {
+		logger?.warn(() => ({
+			msg: "PROSOPO_HEALTHZ_GEO_ROUTES is not a valid country->host map; healthz geo steering stays off",
+			err,
+		}));
+		return new Map();
+	}
+};
+
+export const readHealthzGeoConfig = (
+	envVars: NodeJS.ProcessEnv = process.env,
+	logger?: Logger,
+): HealthzGeoConfig => {
+	const routes = parseRoutes(envVars.PROSOPO_HEALTHZ_GEO_ROUTES, logger);
+	return {
+		// An empty map cannot steer anything, so treat it as off. That keeps
+		// the poller from starting and the response header from being set on a
+		// node that has been given the flag but no map.
+		enabled: envVars.PROSOPO_HEALTHZ_GEO_STEERING === "true" && routes.size > 0,
+		routes,
+		probeIntervalMs: Math.max(
+			MIN_PROBE_INTERVAL_MS,
+			parsePositiveInt(
+				envVars.PROSOPO_HEALTHZ_GEO_PROBE_INTERVAL_MS,
+				DEFAULT_PROBE_INTERVAL_MS,
+			),
+		),
+		probeTimeoutMs: parsePositiveInt(
+			envVars.PROSOPO_HEALTHZ_GEO_PROBE_TIMEOUT_MS,
+			DEFAULT_PROBE_TIMEOUT_MS,
+		),
+	};
+};
+
+/** Resolves to true when the host answered its own health check. */
+export type HealthzProbe = (
+	host: string,
+	timeoutMs: number,
+) => Promise<boolean>;
+
+export const fetchHealthzProbe: HealthzProbe = async (host, timeoutMs) => {
+	try {
+		const response = await fetch(`https://${host}${PublicApiPaths.Healthz}`, {
+			method: "GET",
+			signal: AbortSignal.timeout(timeoutMs),
+		});
+		return response.ok;
+	} catch {
+		return false;
+	}
+};
+
+export interface TargetHealthMonitorOptions {
+	hosts: readonly string[];
+	intervalMs: number;
+	timeoutMs: number;
+	/** Injected in tests; defaults to a real request. */
+	probe?: HealthzProbe;
+	logger?: Logger;
+}
+
+/**
+ * Tracks whether each candidate host is answering, in the background.
+ *
+ * `/healthz` is served before the request pipeline that would otherwise
+ * observe a node's health, so nothing else here knows whether a candidate is
+ * reachable. Every host starts `false` and only becomes `true` on a successful
+ * probe, so a poller that has not run, cannot run, or is failing leaves every
+ * candidate down and steering off — degrading to the default behaviour by
+ * construction rather than by a fallback branch.
+ *
+ * The probe never touches the request path: `isUp()` reads a boolean.
+ */
+export class TargetHealthMonitor {
+	private readonly hosts: readonly string[];
+	private readonly intervalMs: number;
+	private readonly timeoutMs: number;
+	private readonly probe: HealthzProbe;
+	private readonly logger: Logger | undefined;
+	private readonly up = new Map<string, boolean>();
+	private timer: ReturnType<typeof setInterval> | undefined;
+
+	constructor(options: TargetHealthMonitorOptions) {
+		this.hosts = [...new Set(options.hosts)];
+		this.intervalMs = options.intervalMs;
+		this.timeoutMs = options.timeoutMs;
+		this.probe = options.probe ?? fetchHealthzProbe;
+		this.logger = options.logger;
+	}
+
+	isUp(host: string): boolean {
+		return this.up.get(host) === true;
+	}
+
+	start(): void {
+		if (this.timer !== undefined || this.hosts.length === 0) return;
+		void this.pollAll();
+		this.timer = setInterval(() => {
+			void this.pollAll();
+		}, this.intervalMs);
+		// A background probe must never keep the process alive.
+		this.timer.unref?.();
+	}
+
+	stop(): void {
+		if (this.timer !== undefined) {
+			clearInterval(this.timer);
+			this.timer = undefined;
+		}
+	}
+
+	/** One probe round over every candidate. Exposed so tests can await it. */
+	async pollAll(): Promise<void> {
+		await Promise.all(
+			this.hosts.map(async (host: string): Promise<void> => {
+				let healthy = false;
+				try {
+					healthy = await this.probe(host, this.timeoutMs);
+				} catch {
+					healthy = false;
+				}
+				const previous = this.up.get(host);
+				this.up.set(host, healthy);
+				if (previous !== healthy) {
+					this.logger?.info(() => ({
+						msg: "healthz geo target health changed",
+						data: { host, healthy },
+					}));
+				}
+			}),
+		);
+	}
+}
+
+/** The slice of the environment steering needs. */
+export interface HealthzGeoEnv {
+	ipInfoService: IIpInfoService;
+	logger?: Logger;
+}
+
+/**
+ * Picks the host `/healthz` should answer with. Pure apart from reading the
+ * monitor's booleans and the memory-mapped country lookup — it never awaits
+ * anything, so it cannot delay or fail a health check.
+ */
+export class HealthzGeoRouter {
+	readonly enabled: boolean;
+	private readonly routes: ReadonlyMap<string, string>;
+	private readonly ipInfoService: IIpInfoService;
+	private readonly monitor: TargetHealthMonitor;
+
+	constructor(
+		config: HealthzGeoConfig,
+		env: HealthzGeoEnv,
+		monitor?: TargetHealthMonitor,
+	) {
+		this.enabled = config.enabled;
+		this.routes = config.routes;
+		this.ipInfoService = env.ipInfoService;
+		this.monitor =
+			monitor ??
+			new TargetHealthMonitor({
+				hosts: [...new Set(config.routes.values())],
+				intervalMs: config.probeIntervalMs,
+				timeoutMs: config.probeTimeoutMs,
+				logger: env.logger,
+			});
+	}
+
+	start(): void {
+		if (this.enabled) this.monitor.start();
+	}
+
+	stop(): void {
+		this.monitor.stop();
+	}
+
+	resolveHost(
+		clientIp: string | undefined,
+		ownHost: string,
+	): HealthzGeoDecision {
+		if (!this.enabled) return { host: ownHost, outcome: "not_steered" };
+		if (!clientIp) return { host: ownHost, outcome: "geo_unavailable" };
+
+		// `isAvailable()` is false until the environment has finished becoming
+		// ready. healthz answers before then — that is what makes it usable as a
+		// liveness probe and as a deploy gate — so it must be read, never
+		// awaited. Loopback and private-range callers (deploy gates, container
+		// health checks) short-circuit inside `country()` and land here too.
+		if (!this.ipInfoService.isAvailable()) {
+			return { host: ownHost, outcome: "geo_unavailable" };
+		}
+
+		const country = this.ipInfoService.country(clientIp);
+		if (!country) return { host: ownHost, outcome: "geo_unavailable" };
+
+		const target = this.routes.get(country.toUpperCase());
+		if (target === undefined || target === ownHost) {
+			return { host: ownHost, outcome: "not_steered" };
+		}
+
+		if (!this.monitor.isUp(target)) {
+			return { host: ownHost, outcome: "target_down" };
+		}
+
+		return { host: target, outcome: "steered" };
+	}
+}
+
+// The router owns a background timer, so it is built once per process rather
+// than once per router construction — the API is rebuilt on env changes and in
+// tests, and each rebuild must not start another poller.
+let cachedRouter: HealthzGeoRouter | undefined;
+
+export const getHealthzGeoRouter = (env: HealthzGeoEnv): HealthzGeoRouter => {
+	if (!cachedRouter) {
+		cachedRouter = new HealthzGeoRouter(
+			readHealthzGeoConfig(process.env, env.logger),
+			env,
+		);
+		cachedRouter.start();
+	}
+	return cachedRouter;
+};
+
+/** Test-only: stop and drop the memoised router so config is re-read. */
+export const resetHealthzGeoRouter = (): void => {
+	cachedRouter?.stop();
+	cachedRouter = undefined;
+};

--- a/packages/provider/src/api/metrics.ts
+++ b/packages/provider/src/api/metrics.ts
@@ -27,6 +27,7 @@ import {
 	Registry,
 	collectDefaultMetrics,
 } from "prom-client";
+import type { HealthzGeoOutcome } from "./healthzGeo.js";
 
 // Whether the /metrics endpoint and instrumentation are active. Defaults to on;
 // set PROSOPO_METRICS_ENABLED=false to disable. The endpoint only ever listens
@@ -83,6 +84,7 @@ interface ProviderMetrics {
 	spamEmailTotal: Counter<"result">;
 	maintenanceMode: Gauge<never>;
 	redisReady: Gauge<"actor">;
+	healthzGeoOutcomesTotal: Counter<"outcome">;
 }
 
 let metrics: ProviderMetrics | undefined;
@@ -175,6 +177,16 @@ const buildMetrics = (): ProviderMetrics => {
 		labelNames: ["actor"] as const,
 		registers: [registry],
 	});
+	// Every non-"steered" outcome falls back to the node's own name, which is
+	// also the behaviour with steering off — so a degraded geo lookup or an
+	// unreachable target changes nothing observable in the response. This
+	// counter is the only place that difference shows up.
+	const healthzGeoOutcomesTotal = new Counter({
+		name: `${PREFIX}healthz_geo_outcomes_total`,
+		help: "Healthz geo steering outcomes (steered/not_steered/target_down/geo_unavailable)",
+		labelNames: ["outcome"] as const,
+		registers: [registry],
+	});
 
 	return {
 		registry,
@@ -191,6 +203,7 @@ const buildMetrics = (): ProviderMetrics => {
 		spamEmailTotal,
 		maintenanceMode,
 		redisReady,
+		healthzGeoOutcomesTotal,
 	};
 };
 
@@ -263,6 +276,11 @@ export const recordDomainValidation = (result: string): void => {
 export const recordSpamEmail = (result: string): void => {
 	if (!metricsEnabled()) return;
 	getMetrics().spamEmailTotal.inc({ result });
+};
+
+export const recordHealthzGeoOutcome = (outcome: HealthzGeoOutcome): void => {
+	if (!metricsEnabled()) return;
+	getMetrics().healthzGeoOutcomesTotal.inc({ outcome });
 };
 
 export const setMaintenanceModeGauge = (on: boolean): void => {

--- a/packages/provider/src/api/public.ts
+++ b/packages/provider/src/api/public.ts
@@ -18,7 +18,12 @@ import type { ProviderEnvironment } from "@prosopo/env";
 import { type ProviderDetails, PublicApiPaths } from "@prosopo/types";
 import { version } from "@prosopo/util";
 import express, { type Router } from "express";
-import { metricsEnabled, metricsHandler } from "./metrics.js";
+import { getHealthzGeoRouter } from "./healthzGeo.js";
+import {
+	metricsEnabled,
+	metricsHandler,
+	recordHealthzGeoOutcome,
+} from "./metrics.js";
 
 /**
  * Returns a router connected to the database which can interact with the Proposo protocol
@@ -34,12 +39,35 @@ export function publicRouter(env: ProviderEnvironment): Router {
 	// session creation and submission land on the same backend. `config.host`
 	// is set per-pronode via ansible inventory (CADDY_DOMAIN). Falls back to
 	// the request's Host header in the rare case it's unset.
+	//
+	// Optionally the answer is the node the CALLER's country maps to instead —
+	// see `healthzGeo.ts`. Off by default; when off this handler behaves
+	// exactly as it did before, including sending no cache headers.
+	// Built here rather than per request so the target health poller starts
+	// with the API and has converged before real traffic arrives. It is a
+	// no-op, and starts nothing, when steering is off.
+	const geo = getHealthzGeoRouter(env);
+
 	router.get(PublicApiPaths.Healthz, (req, res) => {
-		const host =
+		const ownHost =
 			env.config.host && env.config.host.length > 0
 				? env.config.host
 				: req.hostname;
-		return res.status(200).json({ ok: true, host });
+
+		if (!geo.enabled) {
+			return res.status(200).json({ ok: true, host: ownHost });
+		}
+
+		// The answer now varies per caller, so no intermediary may cache and
+		// replay it — that would hand one client another client's pin. Set
+		// before the decision so it covers every branch, including the
+		// fallbacks. The widget already sends `cache: "no-store"`, but that
+		// only binds the browser.
+		res.set("Cache-Control", "no-store, private");
+
+		const decision = geo.resolveHost(req.ip, ownHost);
+		recordHealthzGeoOutcome(decision.outcome);
+		return res.status(200).json({ ok: true, host: decision.host });
 	});
 
 	// Prometheus metrics endpoint. Lives in the public router so it runs before

--- a/packages/provider/src/tests/integration/trafficFilterHierarchy.integration.test.ts
+++ b/packages/provider/src/tests/integration/trafficFilterHierarchy.integration.test.ts
@@ -149,6 +149,7 @@ describe("Captcha type + params selection hierarchy (integration)", () => {
 			initialize: async () => {},
 			isAvailable: () => true,
 			lookup: async () => currentIpInfo,
+			country: (): string | undefined => undefined,
 		};
 
 		tasks = new Tasks(env);

--- a/packages/provider/src/tests/integration/webBotAuthAuthenticated.integration.test.ts
+++ b/packages/provider/src/tests/integration/webBotAuthAuthenticated.integration.test.ts
@@ -221,6 +221,7 @@ describe("Web Bot Auth authenticated flow (integration)", () => {
 			initialize: async () => {},
 			isAvailable: () => true,
 			lookup: async (ip: string) => cleanIpInfo(ip),
+			country: (): string | undefined => undefined,
 		};
 
 		// The authenticated fast path sits *after* the empty-detector-pool PoW

--- a/packages/provider/src/tests/unit/api/healthzGeo.unit.test.ts
+++ b/packages/provider/src/tests/unit/api/healthzGeo.unit.test.ts
@@ -1,0 +1,424 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {
+	type IpInfoBackends,
+	IpInfoService,
+	type MaxMindBackend,
+} from "@prosopo/ipinfo";
+import type { IPInfoResponse } from "@prosopo/types";
+import type { IIpInfoService } from "@prosopo/types-env";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	type HealthzGeoConfig,
+	HealthzGeoRouter,
+	type HealthzProbe,
+	TargetHealthMonitor,
+	getHealthzGeoRouter,
+	readHealthzGeoConfig,
+	resetHealthzGeoRouter,
+} from "../../../api/healthzGeo.js";
+
+const OWN_HOST = "node-a.example.com";
+const TARGET_HOST = "node-b.example.com";
+const CLIENT_IP = "8.8.8.8";
+
+/**
+ * An ip-info service whose country answers the test controls. `lookup` is
+ * present because the interface requires it and rejects because nothing on
+ * this path may call it — reaching it would mean a request to the sidecar.
+ */
+const ipInfo = (options: {
+	available?: boolean;
+	country?: string | undefined;
+}): IIpInfoService => ({
+	initialize: vi.fn<() => Promise<void>>(async () => {}),
+	lookup: vi.fn<(ip: string) => Promise<IPInfoResponse>>(async () => {
+		throw new Error("lookup() must not be called by healthz");
+	}),
+	country: vi.fn<(ip: string) => string | undefined>(() => options.country),
+	isAvailable: vi.fn<() => boolean>(() => options.available ?? true),
+});
+
+const config = (
+	overrides: Partial<HealthzGeoConfig> = {},
+): HealthzGeoConfig => ({
+	enabled: true,
+	routes: new Map([["US", TARGET_HOST]]),
+	probeIntervalMs: 30_000,
+	probeTimeoutMs: 2_000,
+	...overrides,
+});
+
+/** A monitor that reports the given hosts as up, without probing anything. */
+const monitorWith = (...upHosts: string[]): TargetHealthMonitor => {
+	const monitor = new TargetHealthMonitor({
+		hosts: upHosts,
+		intervalMs: 30_000,
+		timeoutMs: 2_000,
+		probe: vi.fn<HealthzProbe>(async () => true),
+	});
+	// One synchronous round rather than start(): no timer, nothing to clean up.
+	return monitor;
+};
+
+const readyMonitor = async (
+	...upHosts: string[]
+): Promise<TargetHealthMonitor> => {
+	const monitor = monitorWith(...upHosts);
+	await monitor.pollAll();
+	return monitor;
+};
+
+describe("readHealthzGeoConfig", () => {
+	it("is disabled when nothing is set", () => {
+		expect(readHealthzGeoConfig({}).enabled).toBe(false);
+	});
+
+	it("is disabled when the flag is set to anything but 'true'", () => {
+		for (const flag of ["false", "1", "yes", "TRUE", ""]) {
+			expect(
+				readHealthzGeoConfig({
+					PROSOPO_HEALTHZ_GEO_STEERING: flag,
+					PROSOPO_HEALTHZ_GEO_ROUTES: `{"US":"${TARGET_HOST}"}`,
+				}).enabled,
+			).toBe(false);
+		}
+	});
+
+	it("is disabled when the flag is on but no routes are configured", () => {
+		// A node with the flag and no map cannot steer, so it must not start a
+		// poller or mark its responses uncacheable either.
+		expect(
+			readHealthzGeoConfig({ PROSOPO_HEALTHZ_GEO_STEERING: "true" }).enabled,
+		).toBe(false);
+	});
+
+	it("enables steering and upper-cases the country keys", () => {
+		const parsed = readHealthzGeoConfig({
+			PROSOPO_HEALTHZ_GEO_STEERING: "true",
+			PROSOPO_HEALTHZ_GEO_ROUTES: `{"us":"${TARGET_HOST}"}`,
+		});
+
+		expect(parsed.enabled).toBe(true);
+		expect(parsed.routes.get("US")).toBe(TARGET_HOST);
+	});
+
+	it("stays off when the route map is unparseable or malformed", () => {
+		for (const routes of [
+			"not json",
+			"[]",
+			'{"USA":"node-b.example.com"}',
+			'{"US":""}',
+			'{"US":"https://node-b.example.com/healthz"}',
+			'{"US":123}',
+		]) {
+			const parsed = readHealthzGeoConfig({
+				PROSOPO_HEALTHZ_GEO_STEERING: "true",
+				PROSOPO_HEALTHZ_GEO_ROUTES: routes,
+			});
+			expect(parsed.enabled).toBe(false);
+			expect(parsed.routes.size).toBe(0);
+		}
+	});
+
+	it("defaults the probe period and timeout, and rejects nonsense overrides", () => {
+		const defaults = readHealthzGeoConfig({});
+		expect(defaults.probeIntervalMs).toBe(30_000);
+		expect(defaults.probeTimeoutMs).toBe(2_000);
+
+		const overridden = readHealthzGeoConfig({
+			PROSOPO_HEALTHZ_GEO_PROBE_INTERVAL_MS: "5000",
+			PROSOPO_HEALTHZ_GEO_PROBE_TIMEOUT_MS: "500",
+		});
+		expect(overridden.probeIntervalMs).toBe(5_000);
+		expect(overridden.probeTimeoutMs).toBe(500);
+
+		const nonsense = readHealthzGeoConfig({
+			PROSOPO_HEALTHZ_GEO_PROBE_INTERVAL_MS: "0",
+			PROSOPO_HEALTHZ_GEO_PROBE_TIMEOUT_MS: "-1",
+		});
+		expect(nonsense.probeIntervalMs).toBe(30_000);
+		expect(nonsense.probeTimeoutMs).toBe(2_000);
+
+		// A busy-loop period is clamped, not honoured.
+		expect(
+			readHealthzGeoConfig({ PROSOPO_HEALTHZ_GEO_PROBE_INTERVAL_MS: "5" })
+				.probeIntervalMs,
+		).toBe(1_000);
+	});
+});
+
+describe("HealthzGeoRouter.resolveHost", () => {
+	it("steers to the host the caller's country maps to", async () => {
+		const service = ipInfo({ country: "US" });
+		const router = new HealthzGeoRouter(
+			config(),
+			{ ipInfoService: service },
+			await readyMonitor(TARGET_HOST),
+		);
+
+		expect(router.resolveHost(CLIENT_IP, OWN_HOST)).toEqual({
+			host: TARGET_HOST,
+			outcome: "steered",
+		});
+		expect(service.lookup).not.toHaveBeenCalled();
+	});
+
+	it("answers with its own name when the flag is off", async () => {
+		const service = ipInfo({ country: "US" });
+		const router = new HealthzGeoRouter(
+			config({ enabled: false }),
+			{ ipInfoService: service },
+			await readyMonitor(TARGET_HOST),
+		);
+
+		expect(router.resolveHost(CLIENT_IP, OWN_HOST)).toEqual({
+			host: OWN_HOST,
+			outcome: "not_steered",
+		});
+		// Nothing is looked up at all: with the flag off this costs nothing.
+		expect(service.isAvailable).not.toHaveBeenCalled();
+		expect(service.country).not.toHaveBeenCalled();
+	});
+
+	it("answers with its own name when the country has no override", async () => {
+		const router = new HealthzGeoRouter(
+			config(),
+			{ ipInfoService: ipInfo({ country: "GB" }) },
+			await readyMonitor(TARGET_HOST),
+		);
+
+		expect(router.resolveHost(CLIENT_IP, OWN_HOST)).toEqual({
+			host: OWN_HOST,
+			outcome: "not_steered",
+		});
+	});
+
+	it("answers with its own name when the override names this node", async () => {
+		const router = new HealthzGeoRouter(
+			config({ routes: new Map([["US", OWN_HOST]]) }),
+			{ ipInfoService: ipInfo({ country: "US" }) },
+			await readyMonitor(OWN_HOST),
+		);
+
+		expect(router.resolveHost(CLIENT_IP, OWN_HOST)).toEqual({
+			host: OWN_HOST,
+			outcome: "not_steered",
+		});
+	});
+
+	it("reports geo_unavailable when the country is unknown", async () => {
+		const router = new HealthzGeoRouter(
+			config(),
+			{ ipInfoService: ipInfo({ country: undefined }) },
+			await readyMonitor(TARGET_HOST),
+		);
+
+		expect(router.resolveHost(CLIENT_IP, OWN_HOST)).toEqual({
+			host: OWN_HOST,
+			outcome: "geo_unavailable",
+		});
+	});
+
+	it("reports geo_unavailable, without a lookup, while ip info is unavailable", async () => {
+		// This is the pre-readiness case. healthz answers before the
+		// environment is ready and must never wait for it.
+		const service = ipInfo({ available: false, country: "US" });
+		const router = new HealthzGeoRouter(
+			config(),
+			{ ipInfoService: service },
+			await readyMonitor(TARGET_HOST),
+		);
+
+		expect(router.resolveHost(CLIENT_IP, OWN_HOST)).toEqual({
+			host: OWN_HOST,
+			outcome: "geo_unavailable",
+		});
+		expect(service.country).not.toHaveBeenCalled();
+		expect(service.lookup).not.toHaveBeenCalled();
+	});
+
+	it("reports geo_unavailable when the request has no address", async () => {
+		const router = new HealthzGeoRouter(
+			config(),
+			{ ipInfoService: ipInfo({ country: "US" }) },
+			await readyMonitor(TARGET_HOST),
+		);
+
+		expect(router.resolveHost(undefined, OWN_HOST)).toEqual({
+			host: OWN_HOST,
+			outcome: "geo_unavailable",
+		});
+	});
+
+	it("does not steer a loopback caller", async () => {
+		// Deploy gates and container health checks call over loopback. The real
+		// service is used here: the short-circuit lives inside it, and the point
+		// of the test is that healthz inherits it.
+		const maxmind = {
+			initialize: vi.fn<() => Promise<void>>(async () => {}),
+			isAvailable: vi.fn<() => boolean>(() => true),
+			countryCode: vi.fn<(ip: string) => string | undefined>(() => "US"),
+		};
+		const service = new IpInfoService({}, {
+			maxmind: maxmind as unknown as MaxMindBackend,
+		} satisfies IpInfoBackends);
+		const router = new HealthzGeoRouter(
+			config(),
+			{ ipInfoService: service },
+			await readyMonitor(TARGET_HOST),
+		);
+
+		for (const ip of ["127.0.0.1", "::1", "::ffff:127.0.0.1", "172.18.0.4"]) {
+			expect(router.resolveHost(ip, OWN_HOST)).toEqual({
+				host: OWN_HOST,
+				outcome: "geo_unavailable",
+			});
+		}
+		expect(maxmind.countryCode).not.toHaveBeenCalled();
+	});
+
+	it("does not steer to a target that is not confirmed up", async () => {
+		// The monitor has never seen this host answer, so it is down by default.
+		const router = new HealthzGeoRouter(
+			config(),
+			{ ipInfoService: ipInfo({ country: "US" }) },
+			monitorWith(TARGET_HOST),
+		);
+
+		expect(router.resolveHost(CLIENT_IP, OWN_HOST)).toEqual({
+			host: OWN_HOST,
+			outcome: "target_down",
+		});
+	});
+
+	it("stops steering once the target stops answering", async () => {
+		let healthy = true;
+		const monitor = new TargetHealthMonitor({
+			hosts: [TARGET_HOST],
+			intervalMs: 30_000,
+			timeoutMs: 2_000,
+			probe: vi.fn<HealthzProbe>(async () => healthy),
+		});
+		const router = new HealthzGeoRouter(
+			config(),
+			{ ipInfoService: ipInfo({ country: "US" }) },
+			monitor,
+		);
+
+		await monitor.pollAll();
+		expect(router.resolveHost(CLIENT_IP, OWN_HOST).outcome).toBe("steered");
+
+		healthy = false;
+		await monitor.pollAll();
+		expect(router.resolveHost(CLIENT_IP, OWN_HOST).outcome).toBe("target_down");
+	});
+});
+
+describe("TargetHealthMonitor", () => {
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("reports every host down before it has probed anything", () => {
+		const monitor = monitorWith(TARGET_HOST);
+
+		expect(monitor.isUp(TARGET_HOST)).toBe(false);
+		expect(monitor.isUp("never-configured.example.com")).toBe(false);
+	});
+
+	it("keeps a host down when its probe rejects", async () => {
+		const monitor = new TargetHealthMonitor({
+			hosts: [TARGET_HOST],
+			intervalMs: 30_000,
+			timeoutMs: 2_000,
+			probe: vi.fn<HealthzProbe>(async () => {
+				throw new Error("connect ECONNREFUSED");
+			}),
+		});
+
+		await expect(monitor.pollAll()).resolves.toBeUndefined();
+		expect(monitor.isUp(TARGET_HOST)).toBe(false);
+	});
+
+	it("probes each distinct host once per round", async () => {
+		const probe = vi.fn<HealthzProbe>(async () => true);
+		const monitor = new TargetHealthMonitor({
+			hosts: [TARGET_HOST, TARGET_HOST, "node-c.example.com"],
+			intervalMs: 30_000,
+			timeoutMs: 1_500,
+			probe,
+		});
+
+		await monitor.pollAll();
+
+		expect(probe).toHaveBeenCalledTimes(2);
+		expect(probe).toHaveBeenCalledWith(TARGET_HOST, 1_500);
+	});
+
+	it("polls on its interval and stops when told to", async () => {
+		vi.useFakeTimers();
+		const probe = vi.fn<HealthzProbe>(async () => true);
+		const monitor = new TargetHealthMonitor({
+			hosts: [TARGET_HOST],
+			intervalMs: 1_000,
+			timeoutMs: 500,
+			probe,
+		});
+
+		monitor.start();
+		expect(probe).toHaveBeenCalledTimes(1);
+
+		await vi.advanceTimersByTimeAsync(2_500);
+		expect(probe).toHaveBeenCalledTimes(3);
+
+		monitor.stop();
+		await vi.advanceTimersByTimeAsync(5_000);
+		expect(probe).toHaveBeenCalledTimes(3);
+	});
+
+	it("starts no timer when there is nothing to probe", () => {
+		vi.useFakeTimers();
+		const probe = vi.fn<HealthzProbe>(async () => true);
+		const monitor = new TargetHealthMonitor({
+			hosts: [],
+			intervalMs: 1_000,
+			timeoutMs: 500,
+			probe,
+		});
+
+		monitor.start();
+		monitor.stop();
+
+		expect(probe).not.toHaveBeenCalled();
+		expect(vi.getTimerCount()).toBe(0);
+	});
+});
+
+describe("getHealthzGeoRouter", () => {
+	afterEach(() => {
+		resetHealthzGeoRouter();
+	});
+
+	it("is off by default and built once per process", () => {
+		const router = getHealthzGeoRouter({
+			ipInfoService: ipInfo({ country: "US" }),
+		});
+
+		expect(router.enabled).toBe(false);
+		// One router means one poller, however often the API is rebuilt.
+		expect(getHealthzGeoRouter({ ipInfoService: ipInfo({}) })).toBe(router);
+	});
+});

--- a/packages/provider/src/tests/unit/api/public.unit.test.ts
+++ b/packages/provider/src/tests/unit/api/public.unit.test.ts
@@ -15,10 +15,26 @@
 import { handleErrors } from "@prosopo/api-express-router";
 import { ProsopoApiError } from "@prosopo/common";
 import type { ProviderEnvironment } from "@prosopo/env";
-import { PublicApiPaths } from "@prosopo/types";
+import { type IPInfoResponse, PublicApiPaths } from "@prosopo/types";
+import type { IIpInfoService } from "@prosopo/types-env";
 import { version } from "@prosopo/util";
-import type { NextFunction, Request, Response } from "express";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+	NextFunction,
+	Request,
+	RequestHandler,
+	Response,
+	Router,
+} from "express";
+import {
+	type Mock,
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	vi,
+} from "vitest";
+import { resetHealthzGeoRouter } from "../../../api/healthzGeo.js";
 import { metricsHandler } from "../../../api/metrics.js";
 import { publicRouter } from "../../../api/public.js";
 
@@ -373,5 +389,152 @@ describe("publicRouter", () => {
 				]),
 			}),
 		);
+	});
+});
+
+describe("publicRouter /healthz", () => {
+	// Express keeps the registered handlers on the router's layer stack; the
+	// healthz handler is pulled off it and called directly so the assertions
+	// are about the handler and not about express's dispatch.
+	interface RouteLayer {
+		route?: { path?: string; stack: Array<{ handle: RequestHandler }> };
+	}
+
+	const healthzHandler = (router: Router): RequestHandler => {
+		const layers = (router as unknown as { stack: RouteLayer[] }).stack;
+		const handler = layers.find(
+			(layer: RouteLayer) => layer.route?.path === PublicApiPaths.Healthz,
+		)?.route?.stack[0]?.handle;
+		if (!handler) throw new Error("healthz route is not registered");
+		return handler;
+	};
+
+	const ipInfoService: IIpInfoService = {
+		initialize: vi.fn<() => Promise<void>>(async () => {}),
+		lookup: vi.fn<(ip: string) => Promise<IPInfoResponse>>(async () => {
+			throw new Error("lookup() must not be called by healthz");
+		}),
+		country: vi.fn<(ip: string) => string | undefined>(() => "US"),
+		isAvailable: vi.fn<() => boolean>(() => true),
+	};
+
+	const env = (host: string): ProviderEnvironment =>
+		({
+			config: { host },
+			logger: { warn: vi.fn(), info: vi.fn(), error: vi.fn(), debug: vi.fn() },
+			ipInfoService,
+		}) as unknown as ProviderEnvironment;
+
+	interface ResponseSpy {
+		res: Response;
+		set: Mock;
+		json: Mock;
+	}
+
+	const responseSpy = (): ResponseSpy => {
+		const set = vi.fn();
+		const json = vi.fn();
+		return {
+			res: {
+				status: vi.fn().mockReturnThis(),
+				set,
+				json,
+			} as unknown as Response,
+			set,
+			json,
+		};
+	};
+
+	const request = (ip: string): Request =>
+		({ ip, hostname: "lb.example.com" }) as Request;
+
+	const setEnvVars = (vars: Record<string, string | undefined>): void => {
+		for (const [key, value] of Object.entries(vars)) {
+			if (value === undefined) {
+				delete process.env[key];
+			} else {
+				process.env[key] = value;
+			}
+		}
+	};
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		resetHealthzGeoRouter();
+		// Nothing may reach the network from a unit test; the health poller is
+		// the only thing here that would try.
+		vi.stubGlobal(
+			"fetch",
+			vi.fn<typeof fetch>(async () => new Response(null, { status: 503 })),
+		);
+	});
+
+	afterEach(() => {
+		resetHealthzGeoRouter();
+		vi.unstubAllGlobals();
+		setEnvVars({
+			PROSOPO_HEALTHZ_GEO_STEERING: undefined,
+			PROSOPO_HEALTHZ_GEO_ROUTES: undefined,
+		});
+	});
+
+	it("answers with its own name and sets no headers when steering is off", () => {
+		setEnvVars({
+			PROSOPO_HEALTHZ_GEO_STEERING: undefined,
+			PROSOPO_HEALTHZ_GEO_ROUTES: JSON.stringify({
+				US: "node-b.example.com",
+			}),
+		});
+		const { res, set, json } = responseSpy();
+
+		healthzHandler(publicRouter(env("node-a.example.com")))(
+			request("203.0.113.9"),
+			res,
+			vi.fn() as NextFunction,
+		);
+
+		expect(json).toHaveBeenCalledWith({
+			ok: true,
+			host: "node-a.example.com",
+		});
+		// The response has to stay exactly what it was, headers included.
+		expect(set).not.toHaveBeenCalled();
+		expect(ipInfoService.country).not.toHaveBeenCalled();
+	});
+
+	it("falls back to the request hostname when no host is configured", () => {
+		const { res, json } = responseSpy();
+
+		healthzHandler(publicRouter(env("")))(
+			request("203.0.113.9"),
+			res,
+			vi.fn() as NextFunction,
+		);
+
+		expect(json).toHaveBeenCalledWith({ ok: true, host: "lb.example.com" });
+	});
+
+	it("marks the response uncacheable once it can vary per caller", () => {
+		setEnvVars({
+			PROSOPO_HEALTHZ_GEO_STEERING: "true",
+			PROSOPO_HEALTHZ_GEO_ROUTES: JSON.stringify({
+				US: "node-b.example.com",
+			}),
+		});
+		const { res, set, json } = responseSpy();
+
+		healthzHandler(publicRouter(env("node-a.example.com")))(
+			request("203.0.113.9"),
+			res,
+			vi.fn() as NextFunction,
+		);
+
+		expect(set).toHaveBeenCalledWith("Cache-Control", "no-store, private");
+		// The target has not been confirmed up, so this node still answers with
+		// its own name — the header is set regardless of which branch wins.
+		expect(json).toHaveBeenCalledWith({
+			ok: true,
+			host: "node-a.example.com",
+		});
 	});
 });

--- a/packages/provider/src/tests/unit/services/ipComparison.unit.test.ts
+++ b/packages/provider/src/tests/unit/services/ipComparison.unit.test.ts
@@ -54,6 +54,7 @@ const createMockService = (responses: IPInfoResponse[]): IIpInfoService => {
 			}
 			return response;
 		}),
+		country: vi.fn().mockReturnValue(undefined),
 		isAvailable: vi.fn().mockReturnValue(true),
 	};
 };
@@ -320,6 +321,7 @@ describe("compareIPs", () => {
 		const service: IIpInfoService = {
 			initialize: vi.fn(),
 			lookup: vi.fn().mockRejectedValue(new Error("Network error")),
+			country: vi.fn().mockReturnValue(undefined),
 			isAvailable: vi.fn().mockReturnValue(true),
 		};
 

--- a/packages/provider/src/tests/unit/testUtils/mockProviderEnv.ts
+++ b/packages/provider/src/tests/unit/testUtils/mockProviderEnv.ts
@@ -142,6 +142,7 @@ export function createMockProviderEnvironment(): ProviderEnvironment {
 			isSatellite: false,
 			isCrawler: false,
 		}),
+		country: vi.fn().mockReturnValue(undefined),
 		isAvailable: vi.fn().mockReturnValue(true),
 	};
 

--- a/packages/provider/src/tests/unit/util.ipDistance.unit.test.ts
+++ b/packages/provider/src/tests/unit/util.ipDistance.unit.test.ts
@@ -41,6 +41,7 @@ describe("deepValidateIpAddress", () => {
 		mockIpInfoService = {
 			initialize: vi.fn(),
 			lookup: vi.fn(),
+			country: vi.fn().mockReturnValue(undefined),
 			isAvailable: vi.fn().mockReturnValue(true),
 		};
 		vi.clearAllMocks();

--- a/packages/types-env/src/ipinfo.ts
+++ b/packages/types-env/src/ipinfo.ts
@@ -17,5 +17,11 @@ import type { IPInfoResponse } from "@prosopo/types";
 export interface IIpInfoService {
 	initialize(): Promise<void>;
 	lookup(ip: string): Promise<IPInfoResponse>;
+	/**
+	 * ISO 3166-1 alpha-2 country code from the local MaxMind database only.
+	 * Synchronous and network-free, unlike `lookup()`. Undefined whenever no
+	 * answer is available.
+	 */
+	country(ip: string): string | undefined;
 	isAvailable(): boolean;
 }

--- a/packages/types-env/src/tests/typesEnv.test-d.ts
+++ b/packages/types-env/src/tests/typesEnv.test-d.ts
@@ -206,6 +206,7 @@ describe("IIpInfoService", () => {
 			initialize: async (): Promise<void> => undefined,
 			lookup: async (_ip: string): Promise<IPInfoResponse> =>
 				stub<IPInfoResponse>(),
+			country: (_ip: string): string | undefined => undefined,
 			isAvailable: (): boolean => true,
 		});
 	});
@@ -241,9 +242,17 @@ describe("IIpInfoService", () => {
 		>();
 	});
 
-	test("has exactly the three members an implementation must provide", () => {
+	test("a country lookup is synchronous and may have no answer", () => {
+		// It reads a memory-mapped database in-process, so there is nothing to
+		// await; `undefined` is the single "no answer" case callers handle.
+		expectTypeOf<IIpInfoService["country"]>().toEqualTypeOf<
+			(ip: string) => string | undefined
+		>();
+	});
+
+	test("has exactly the four members an implementation must provide", () => {
 		expectTypeOf<keyof IIpInfoService>().toEqualTypeOf<
-			"initialize" | "lookup" | "isAvailable"
+			"initialize" | "lookup" | "country" | "isAvailable"
 		>();
 	});
 });


### PR DESCRIPTION
Refs prosopo/captcha-private#4460

`/healthz` tells a client which node to pin its captcha calls to — `load-balancer/src/providers.ts` takes the returned `host` and pins to it. A node has always answered with its own name, so the pin is whatever the DNS layer picked. The DNS layer only sees the client's address when the client's resolver forwards it; the provider always sees it, because the connection is already open.

This adds the option to answer with the node the caller's country maps to instead. No client-side change: the load balancer already honours whatever `host` comes back.

Behind `PROSOPO_HEALTHZ_GEO_STEERING`, **off by default**. With the flag off nothing here runs — no lookup, no poller, no response header, no counter — and the response is byte-for-byte what it was.

## Changes

**`IpInfoService.country(ip)`** (`@prosopo/ipinfo`, `@prosopo/types-env`) — a MaxMind-only fast path returning an ISO 3166-1 alpha-2 code or `undefined`. The database is memory-mapped and read in-process, so it is synchronous and network-free. `lookup()` is unchanged and still prefers ipapi.is for its threat data; a country lookup does not need that data and must not pay a network call for it.

**`packages/provider/src/api/healthzGeo.ts`** (new) — configuration, target-health poller, and the selection logic.

- The country → host map is supplied by the deployment as JSON in `PROSOPO_HEALTHZ_GEO_ROUTES`; nothing is hardcoded. The map is also the candidate set, so a host that must not receive traffic simply does not appear in it. An unparseable or empty map leaves steering off rather than failing startup.
- A background poller (`PROSOPO_HEALTHZ_GEO_PROBE_INTERVAL_MS`, `PROSOPO_HEALTHZ_GEO_PROBE_TIMEOUT_MS`) flips an up/down boolean per candidate. Every candidate starts **down** and only becomes up on a successful probe, so a poller that has not run or is failing leaves steering off by construction. The request path reads a boolean and never awaits a probe.

**`/healthz` handler** — the only change in `public.ts`, confined to that handler.

- Never awaits readiness. It reads `ipInfoService.isAvailable()`, which is false before the environment is ready, and answers with the node's own name. `isNonRoutable()` already short-circuits loopback and private ranges, which covers the container health check (`curl localhost:9229/healthz`) and every other local caller.
- `Cache-Control: no-store, private` is set whenever steering is on, before the decision, so it covers every branch including the fallbacks. The answer varies per caller and no intermediary may cache and replay it. The widget already sends `cache: "no-store"`, but that only binds the browser.

**`/metrics`** — `prosopo_healthz_geo_outcomes_total{outcome}` counts `steered`, `not_steered`, `target_down` and `geo_unavailable`. Every outcome but the first falls back to the node's own name, which is also the behaviour with steering off, so nothing else would show that steering had stopped working.

## Config

| Variable | Default | Meaning |
| --- | --- | --- |
| `PROSOPO_HEALTHZ_GEO_STEERING` | unset (off) | `"true"` enables steering |
| `PROSOPO_HEALTHZ_GEO_ROUTES` | unset | JSON `{"XX":"node1.example.com"}`, ISO 3166-1 alpha-2 → hostname |
| `PROSOPO_HEALTHZ_GEO_PROBE_INTERVAL_MS` | `30000` | health-probe period |
| `PROSOPO_HEALTHZ_GEO_PROBE_TIMEOUT_MS` | `2000` | per-probe timeout |

## Tests

`healthzGeo.unit.test.ts` covers override hit, no override, override naming this node, unknown country, ip-info unavailable, no client address, loopback caller (against the real `IpInfoService`), target down, target going down after being up, and the flag off. Plus config parsing (malformed maps, nonsense periods) and the poller (defaults down, probe rejection, dedup, interval, stop). `public.unit.test.ts` covers the response and headers with the flag off and on. `maxmind.unit.test.ts` and `ipInfoService.unit.test.ts` cover the new country path.

## Note for reviewers

`country` is a required member of `IIpInfoService`. `prosopo/captcha-private` has ip-info mocks in `job-definitions` and `job-runner` tests that will need the same one-line addition when the submodule is bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
