### PR TITLE
fix(provider): populate abuserScore so ipValidationRules can actually use it

### DIFF
--- a/.changeset/ip-validation-abuse-score.md
+++ b/.changeset/ip-validation-abuse-score.md
@@ -1,0 +1,5 @@
+---
+"@prosopo/provider": patch
+---
+
+Populate `abuserScore` on the IP comparison result so `ipValidationRules` can use it. The field was read when evaluating `abuseScoreExceedAction` but never set, so that rule never fired for any site. Also counts both IPs exceeding the threshold as one condition rather than two, which previously mis-counted under `requireAllConditions`.

--- a/packages/provider/src/services/ipComparison.ts
+++ b/packages/provider/src/services/ipComparison.ts
@@ -175,6 +175,7 @@ export async function compareIPs(
 					countryCode: ip1Info.countryCode,
 					city: ip1Info.city,
 					coordinates: ip1Coordinates,
+					abuserScore: ip1Info.abuserScore,
 				},
 				ip2Details: {
 					provider: ip2Provider,
@@ -184,6 +185,7 @@ export async function compareIPs(
 					countryCode: ip2Info.countryCode,
 					city: ip2Info.city,
 					coordinates: ip2Coordinates,
+					abuserScore: ip2Info.abuserScore,
 				},
 			},
 		};

--- a/packages/provider/src/tests/unit/services/ipComparison.unit.test.ts
+++ b/packages/provider/src/tests/unit/services/ipComparison.unit.test.ts
@@ -345,4 +345,42 @@ describe("compareIPs", () => {
 		expect(service.lookup).toHaveBeenCalledWith("8.8.8.8");
 		expect(service.lookup).toHaveBeenCalledWith("1.1.1.1");
 	});
+
+	// Regression: abuserScore was declared on IPDetails and read by
+	// evaluateIpValidationRules, but never populated here — which silently made
+	// `abuseScoreExceedAction` / `abuseScoreThreshold` dead config for every site.
+	it("should propagate abuserScore onto both IP details", async () => {
+		const ip1Info: IPInfoResponse = createMockIPInfo({
+			ip: "8.8.8.8",
+			abuserScore: 0.0115,
+		});
+		const ip2Info: IPInfoResponse = createMockIPInfo({
+			ip: "1.1.1.1",
+			abuserScore: 0.42,
+		});
+
+		const service = createMockService([ip1Info, ip2Info]);
+
+		const result = await compareIPs("8.8.8.8", "1.1.1.1", service);
+
+		expect("comparison" in result).toBe(true);
+		if ("comparison" in result) {
+			expect(result.comparison?.ip1Details.abuserScore).toBe(0.0115);
+			expect(result.comparison?.ip2Details.abuserScore).toBe(0.42);
+		}
+	});
+
+	it("should leave abuserScore undefined when the feed omits it", async () => {
+		const ip1Info: IPInfoResponse = createMockIPInfo({ ip: "8.8.8.8" });
+		const ip2Info: IPInfoResponse = createMockIPInfo({ ip: "1.1.1.1" });
+
+		const service = createMockService([ip1Info, ip2Info]);
+
+		const result = await compareIPs("8.8.8.8", "1.1.1.1", service);
+
+		if ("comparison" in result) {
+			expect(result.comparison?.ip1Details.abuserScore).toBeUndefined();
+			expect(result.comparison?.ip2Details.abuserScore).toBeUndefined();
+		}
+	});
 });

--- a/packages/provider/src/tests/unit/util.deepValidateIpAddress.rules.unit.test.ts
+++ b/packages/provider/src/tests/unit/util.deepValidateIpAddress.rules.unit.test.ts
@@ -1,0 +1,213 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { Logger } from "@prosopo/logger";
+import type { IIPValidationRules, IPInfoResult } from "@prosopo/types";
+import { IPValidationAction } from "@prosopo/types";
+import type { IIpInfoService } from "@prosopo/types-env";
+import { Address4 } from "ip-address";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { deepValidateIpAddress } from "../../util.js";
+
+// The sibling suite (util.ipDistance) spies compareIPs out and feeds
+// evaluateIpValidationRules a hand-built comparison object. That seam is
+// precisely where `abuserScore` went missing: the producer never set the field,
+// the consumer read it, and both halves passed their own tests for months while
+// abuseScoreExceedAction did nothing on every site that configured it. These
+// tests deliberately run the REAL compareIPs so the join is covered.
+
+const mockIpInfo = (overrides: Partial<IPInfoResult>): IPInfoResult => ({
+	ip: "8.8.8.8",
+	isValid: true,
+	isVPN: false,
+	isTor: false,
+	isProxy: false,
+	isDatacenter: false,
+	isAbuser: false,
+	isMobile: false,
+	isSatellite: false,
+	isCrawler: false,
+	providerName: "Example ISP",
+	providerType: "isp",
+	asnNumber: 1234,
+	asnOrganization: "Example ISP",
+	country: "United Kingdom",
+	countryCode: "GB",
+	city: "London",
+	latitude: 51.5072,
+	longitude: -0.1276,
+	timezone: "Europe/London",
+	...overrides,
+});
+
+// Everything except the abuse rule set to Allow, so a rejection can only have
+// come from the abuse-score branch.
+const abuseOnlyRules = (threshold: number): IIPValidationRules => ({
+	enabled: true,
+	actions: {
+		countryChangeAction: IPValidationAction.Allow,
+		cityChangeAction: IPValidationAction.Allow,
+		ispChangeAction: IPValidationAction.Allow,
+		distanceExceedAction: IPValidationAction.Allow,
+		abuseScoreExceedAction: IPValidationAction.Reject,
+	},
+	distanceThresholdKm: 1000,
+	abuseScoreThreshold: threshold,
+	requireAllConditions: false,
+	forceConsistentIp: false,
+});
+
+describe("deepValidateIpAddress with ipValidationRules", () => {
+	let mockLogger: Logger;
+	let lookup: ReturnType<typeof vi.fn>;
+	let ipInfoService: IIpInfoService;
+
+	beforeEach(() => {
+		const withMock: Logger["with"] = vi.fn(() => mockLogger);
+		mockLogger = {
+			info: vi.fn(),
+			debug: vi.fn(),
+			error: vi.fn(),
+			log: vi.fn(),
+			warn: vi.fn(),
+			with: withMock,
+		} as unknown as Logger;
+		lookup = vi.fn();
+		ipInfoService = {
+			initialize: vi.fn(),
+			lookup: lookup as unknown as IIpInfoService["lookup"],
+			country: vi.fn().mockReturnValue(undefined),
+			isAvailable: vi.fn().mockReturnValue(true),
+		};
+	});
+
+	it("rejects when the verify IP's abuse score exceeds the threshold", async () => {
+		lookup
+			.mockResolvedValueOnce(mockIpInfo({ ip: "1.1.1.1", abuserScore: 0.001 }))
+			.mockResolvedValueOnce(
+				mockIpInfo({ ip: "8.8.8.8", isAbuser: true, abuserScore: 0.42 }),
+			);
+
+		const result = await deepValidateIpAddress(
+			"8.8.8.8",
+			new Address4("1.1.1.1"),
+			mockLogger,
+			ipInfoService,
+			abuseOnlyRules(0.2),
+		);
+
+		expect(result.isValid).toBe(false);
+		expect(result.errorMessage).toContain("Abuse score 0.4200");
+	});
+
+	it("rejects on the challenge IP's abuse score too, not just the verify IP", async () => {
+		lookup
+			.mockResolvedValueOnce(
+				mockIpInfo({ ip: "1.1.1.1", isAbuser: true, abuserScore: 0.42 }),
+			)
+			.mockResolvedValueOnce(mockIpInfo({ ip: "8.8.8.8", abuserScore: 0.001 }));
+
+		const result = await deepValidateIpAddress(
+			"8.8.8.8",
+			new Address4("1.1.1.1"),
+			mockLogger,
+			ipInfoService,
+			abuseOnlyRules(0.2),
+		);
+
+		expect(result.isValid).toBe(false);
+		expect(result.errorMessage).toContain("Abuse score 0.4200");
+	});
+
+	it("allows when both abuse scores sit under the threshold", async () => {
+		lookup
+			.mockResolvedValueOnce(mockIpInfo({ ip: "1.1.1.1", abuserScore: 0.01 }))
+			.mockResolvedValueOnce(mockIpInfo({ ip: "8.8.8.8", abuserScore: 0.19 }));
+
+		const result = await deepValidateIpAddress(
+			"8.8.8.8",
+			new Address4("1.1.1.1"),
+			mockLogger,
+			ipInfoService,
+			abuseOnlyRules(0.2),
+		);
+
+		expect(result.isValid).toBe(true);
+	});
+
+	// The ipinfo feed omits the field for plenty of IPs. `?? 0` would have made
+	// a missing score indistinguishable from a clean one; it must simply not fire.
+	it("allows when the feed omits abuserScore entirely", async () => {
+		lookup
+			.mockResolvedValueOnce(mockIpInfo({ ip: "1.1.1.1" }))
+			.mockResolvedValueOnce(mockIpInfo({ ip: "8.8.8.8" }));
+
+		const result = await deepValidateIpAddress(
+			"8.8.8.8",
+			new Address4("1.1.1.1"),
+			mockLogger,
+			ipInfoService,
+			abuseOnlyRules(0.2),
+		);
+
+		expect(result.isValid).toBe(true);
+	});
+
+	it("short-circuits to valid on an exact IP match without consulting ipinfo", async () => {
+		const result = await deepValidateIpAddress(
+			"1.1.1.1",
+			new Address4("1.1.1.1"),
+			mockLogger,
+			ipInfoService,
+			abuseOnlyRules(0.2),
+		);
+
+		expect(result.isValid).toBe(true);
+		expect(lookup).not.toHaveBeenCalled();
+	});
+
+	it("rejects on forceConsistentIp when the DNS peer IP differs from the client IP", async () => {
+		const result = await deepValidateIpAddress(
+			"8.8.8.8",
+			new Address4("8.8.8.8"),
+			mockLogger,
+			ipInfoService,
+			{ ...abuseOnlyRules(0.2), forceConsistentIp: true },
+			"9.9.9.9",
+		);
+
+		expect(result.isValid).toBe(false);
+		expect(result.errorMessage).toContain("does not match dnsEvent.peerIp");
+		expect(lookup).not.toHaveBeenCalled();
+	});
+
+	// Fail-open is deliberate: an ipinfo outage must not reject real users.
+	it("allows when the ipinfo lookup fails", async () => {
+		lookup.mockResolvedValue({
+			isValid: false,
+			error: "lookup failed",
+			ip: "8.8.8.8",
+		});
+
+		const result = await deepValidateIpAddress(
+			"8.8.8.8",
+			new Address4("1.1.1.1"),
+			mockLogger,
+			ipInfoService,
+			abuseOnlyRules(0.2),
+		);
+
+		expect(result.isValid).toBe(true);
+	});
+});

--- a/packages/provider/src/tests/unit/util.evaluateIpValidationRules.unit.test.ts
+++ b/packages/provider/src/tests/unit/util.evaluateIpValidationRules.unit.test.ts
@@ -470,6 +470,81 @@ describe("evaluateIpValidationRules", () => {
 		expect(result.action).toBe(IPValidationAction.Allow);
 	});
 
+	it("reports the higher of the two abuse scores", () => {
+		const comparison: IPComparisonResult = {
+			ipsMatch: false,
+			ip1: "ip1",
+			ip2: "ip2",
+			comparison: {
+				ip1Details: {
+					country: "A",
+					countryCode: "A",
+					provider: "X",
+					connectionType: "residential",
+					isVpnOrProxy: false,
+					abuserScore: 0.03,
+				},
+				ip2Details: {
+					country: "A",
+					countryCode: "A",
+					provider: "X",
+					connectionType: "residential",
+					isVpnOrProxy: false,
+					abuserScore: 0.01,
+				},
+				differentProviders: false,
+				differentConnectionTypes: false,
+				anyVpnOrProxy: false,
+			},
+		};
+		const result = evaluateIpValidationRules(comparison, baseRules, mockLogger);
+		expect(result.action).toBe(IPValidationAction.Reject);
+		expect(result.errorMessage).toContain(
+			"Abuse score 0.0300 exceeds threshold 0.005",
+		);
+	});
+
+	// Two Reject actions are configured, so one rule being met must not fill the quota.
+	it("counts a both-IPs-exceed abuse score as a single condition under requireAllConditions", () => {
+		const comparison: IPComparisonResult = {
+			ipsMatch: false,
+			ip1: "ip1",
+			ip2: "ip2",
+			comparison: {
+				ip1Details: {
+					country: "A",
+					countryCode: "A",
+					provider: "X",
+					connectionType: "residential",
+					isVpnOrProxy: false,
+					abuserScore: 0.02,
+				},
+				ip2Details: {
+					country: "A",
+					countryCode: "A",
+					provider: "X",
+					connectionType: "residential",
+					isVpnOrProxy: false,
+					abuserScore: 0.03,
+				},
+				differentProviders: false,
+				differentConnectionTypes: false,
+				anyVpnOrProxy: false,
+			},
+		};
+		const rules: IIPValidationRules = {
+			...baseRules,
+			actions: {
+				...baseRules.actions,
+				ispChangeAction: IPValidationAction.Reject,
+				abuseScoreExceedAction: IPValidationAction.Reject,
+			},
+			requireAllConditions: true,
+		};
+		const result = evaluateIpValidationRules(comparison, rules, mockLogger);
+		expect(result.action).toBe(IPValidationAction.Allow);
+	});
+
 	it("applies country override for abuse score threshold", () => {
 		const comparison: IPComparisonResult = {
 			ipsMatch: false,

--- a/packages/provider/src/util.ts
+++ b/packages/provider/src/util.ts
@@ -292,27 +292,23 @@ export const evaluateIpValidationRules = (
 		});
 	}
 
-	// Check for abuse score exceed condition
-	const ip2AbuseScore = comparison.comparison.ip2Details?.abuserScore;
+	// Both IPs count, but they are ONE rule and must contribute at most ONE
+	// condition — a condition per IP double-counts against `rejectActions.length`
+	// in the requireAllConditions branch below.
+	const abuseScores = [
+		comparison.comparison.ip2Details?.abuserScore,
+		comparison.comparison.ip1Details?.abuserScore,
+	].filter((score): score is number => score !== undefined);
+	const worstAbuseScore =
+		abuseScores.length > 0 ? Math.max(...abuseScores) : undefined;
 	if (
-		ip2AbuseScore !== undefined &&
-		ip2AbuseScore > effectiveRules.abuseScoreThreshold
+		worstAbuseScore !== undefined &&
+		worstAbuseScore > effectiveRules.abuseScoreThreshold
 	) {
 		conditions.push({
 			met: true,
 			action: effectiveRules.actions.abuseScoreExceedAction,
-			message: `Abuse score ${ip2AbuseScore.toFixed(4)} exceeds threshold ${effectiveRules.abuseScoreThreshold}`,
-		});
-	}
-	const ip1AbuseScore = comparison.comparison.ip1Details?.abuserScore;
-	if (
-		ip1AbuseScore !== undefined &&
-		ip1AbuseScore > effectiveRules.abuseScoreThreshold
-	) {
-		conditions.push({
-			met: true,
-			action: effectiveRules.actions.abuseScoreExceedAction,
-			message: `Abuse score ${ip1AbuseScore.toFixed(4)} exceeds threshold ${effectiveRules.abuseScoreThreshold}`,
+			message: `Abuse score ${worstAbuseScore.toFixed(4)} exceeds threshold ${effectiveRules.abuseScoreThreshold}`,
 		});
 	}
 


### PR DESCRIPTION
## What changed

One field was missing. `compareIPs` returns details about two IP addresses, but it never filled in `abuserScore`. The code that decides whether to reject a verification reads that exact field.

So `abuseScoreExceedAction` — the setting that says "reject if this IP looks abusive" — has never done anything, for any site that turned it on.

Two lines populate the field.

## Second, smaller thing

When both IPs were over the threshold, the code recorded that as two separate reasons to reject. It is one reason. That miscount only matters for sites using `requireAllConditions`, where it could reject on a single rule being met twice. Now it records one reason, using the higher of the two scores.

This was harmless until now, because the branch could not run at all.

## Effect

Sites with `ipValidationRules.enabled` will start rejecting verifications they previously let through. That is the intended behaviour, but it is new behaviour.

The default threshold is `0.005`. Nobody ever tuned it, because it did nothing. About a quarter of real production sessions score above it, so leaving it there would reject far more than anyone intends. The sites currently using this have already been moved to `0.2`, which matches the equivalent setting in the traffic filter.

## Tests

The bug survived because the two halves were tested separately and never together. The existing tests replace `compareIPs` with a fake that *does* include `abuserScore`, so the real mismatch was invisible.

New test file runs the real `compareIPs` and covers:

- abusive verify IP → reject
- abusive challenge IP → reject
- both scores below the threshold → allow
- score missing from the data feed → allow
- same IP both times → skips the check entirely
- `forceConsistentIp` with a mismatched DNS IP → reject
- IP lookup service fails → allow (deliberate: an outage must not lock users out)

Checked it actually guards the bug: undo the two-line fix and 3 tests fail. 45 pass across the four related files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
