### PR TITLE
fix(procaptcha): stop the image captcha losing its top on mobile

### DIFF
--- a/.changeset/image-captcha-clipped-top-on-mobile.md
+++ b/.changeset/image-captcha-clipped-top-on-mobile.md
@@ -1,0 +1,19 @@
+---
+"@prosopo/procaptcha-common": patch
+"@prosopo/procaptcha-react": patch
+---
+
+Stop the image captcha losing its instruction line and top row of images on mobile.
+
+On iOS the challenge panel was being shifted up by 100% of its own height, so
+anything taller than half the screen ran off the top with no way to scroll back
+to it. Users saw nine images and a Next button but no "Select all containing
+..." prompt, which made the challenge unsolvable.
+
+The lift was compensating for the layer underneath it being sized with
+`100vh` — on iOS Safari that is the height the page would have if the browser
+toolbars retracted, so the centring box was taller than the visible area and
+pushed the panel down under the bottom bar. Sizing that box with `100dvh`
+instead centres correctly on its own, so the lift is gone. The panel is now
+centred as a flex item and capped at the viewport height, scrolling when it
+does not fit rather than overflowing off both edges.

--- a/packages/procaptcha-common/src/reactComponents/ChallengeSurface.tsx
+++ b/packages/procaptcha-common/src/reactComponents/ChallengeSurface.tsx
@@ -42,37 +42,13 @@ interface ChallengeSurfaceProps {
 	scrim?: SurfaceScrim;
 	/** Called on Escape, and on an outside click when floating. */
 	onDismiss?: () => void;
-	/** Lifts the popup content on iOS, where Safari's bottom bar overlaps a centred dialog. */
-	popupIosLift?: boolean;
 	className?: string;
 }
 
 const SURFACE_Z_INDEX = 2147483646;
 const CONTENT_Z_INDEX = 2147483647;
 
-// `@supports` cannot be expressed inline, so the iOS lift is a stylesheet rule.
-const IOS_LIFT_STYLE_ID = "prosopo-challenge-surface-ios-lift";
-
-const IOS_LIFT_CSS = `
-.prosopo-challenge-content--ios-lift {
-	transform: translate(-50%, -50%);
-}
-@supports (-webkit-touch-callout: none) {
-	.prosopo-challenge-content--ios-lift {
-		transform: translate(-50%, -100%);
-	}
-}
-`;
-
-const ensureIosLiftStyles = (): void => {
-	if (typeof document === "undefined") return;
-	if (document.getElementById(IOS_LIFT_STYLE_ID)) return;
-
-	const style = document.createElement("style");
-	style.id = IOS_LIFT_STYLE_ID;
-	style.textContent = IOS_LIFT_CSS;
-	document.head.appendChild(style);
-};
+const POPUP_EDGE_GAP_PX = 8;
 
 const FLOAT_GAP_PX = 8;
 
@@ -113,7 +89,6 @@ const ChallengeSurface = React.memo((props: ChallengeSurfaceProps) => {
 		anchor,
 		scrim = "none",
 		onDismiss,
-		popupIosLift = false,
 		className,
 	} = props;
 
@@ -198,10 +173,6 @@ const ChallengeSurface = React.memo((props: ChallengeSurfaceProps) => {
 		return () => document.removeEventListener("pointerdown", onPointerDown);
 	}, [show, isFloating, anchor, onDismiss]);
 
-	useEffect(() => {
-		if (popupIosLift && !isFloating) ensureIosLiftStyles();
-	}, [popupIosLift, isFloating]);
-
 	if (typeof document === "undefined") return null;
 
 	const layerStyle: CSSProperties = isFloating
@@ -227,7 +198,12 @@ const ChallengeSurface = React.memo((props: ChallengeSurfaceProps) => {
 				display: show ? "flex" : "none",
 				alignItems: "center",
 				justifyContent: "center",
-				minHeight: "100vh",
+				// `dvh`, not `vh`: on iOS Safari `100vh` is the toolbar-retracted
+				// height, which would make this box taller than the visible area and
+				// centre the challenge underneath the bottom bar.
+				minHeight: "100dvh",
+				padding: `${POPUP_EDGE_GAP_PX}px`,
+				boxSizing: "border-box",
 				backgroundColor:
 					scrim === "dim" && show ? "rgba(0, 0, 0, 0.4)" : "transparent",
 				transition: "background-color 0.3s ease",
@@ -244,13 +220,17 @@ const ChallengeSurface = React.memo((props: ChallengeSurfaceProps) => {
 				visibility: floatPosition ? "visible" : "hidden",
 			}
 		: {
-				position: "absolute",
-				top: "50%",
-				left: "50%",
-				// When lifting, the stylesheet rule owns the transform.
-				transform: popupIosLift ? undefined : "translate(-50%, -50%)",
+				// Centred as a flex item by the layer rather than by
+				// `top/left: 50%` and a translate. An out-of-flow panel taller than
+				// the viewport overflows off both edges and its top is unreachable;
+				// in flow it is bounded by `maxHeight` and scrolls instead.
+				position: "relative",
 				zIndex: CONTENT_Z_INDEX,
 				boxSizing: "border-box",
+				maxWidth: "100%",
+				maxHeight: "100%",
+				overflowY: "auto",
+				overscrollBehavior: "contain",
 			};
 
 	return createPortal(
@@ -266,11 +246,7 @@ const ChallengeSurface = React.memo((props: ChallengeSurfaceProps) => {
 		>
 			<div
 				ref={contentRef}
-				className={
-					popupIosLift && !isFloating
-						? "prosopo-challenge-content prosopo-challenge-content--ios-lift"
-						: "prosopo-challenge-content"
-				}
+				className="prosopo-challenge-content"
 				style={contentStyle}
 			>
 				{children}

--- a/packages/procaptcha-common/src/tests/challengeSurfaceRender.unit.test.tsx
+++ b/packages/procaptcha-common/src/tests/challengeSurfaceRender.unit.test.tsx
@@ -100,6 +100,29 @@ describe("popup", () => {
 		expect(layer()?.style.pointerEvents).toBe("");
 	});
 
+	it("keeps a tall challenge inside the viewport rather than clipping its top", () => {
+		// A panel taller than the viewport used to be translated out of flow by
+		// its own full height, putting the instruction ("Select all containing
+		// ...") and the first row of images above the top of the screen with no
+		// way to scroll back to them. In flow it is bounded and scrolls instead.
+		render({ placement: PlacementEnum.popup });
+
+		const style = content()?.style;
+		expect(style?.position).not.toBe("absolute");
+		expect(style?.transform).toBe("");
+		expect(style?.maxHeight).toBe("100%");
+		expect(style?.overflowY).toBe("auto");
+	});
+
+	it("sizes the layer to the visible viewport, not the retracted-toolbar one", () => {
+		// `100vh` on iOS Safari is the toolbar-retracted height. Forcing the
+		// centring box to it put the challenge's lower half under the bottom bar,
+		// which is what the removed translate hack was compensating for.
+		render({ placement: PlacementEnum.popup });
+
+		expect(layer()?.style.minHeight).toBe("100dvh");
+	});
+
 	it("ignores an outside click", () => {
 		const onDismiss = vi.fn();
 		render({ placement: PlacementEnum.popup, onDismiss });

--- a/packages/procaptcha-react/src/components/Modal.tsx
+++ b/packages/procaptcha-react/src/components/Modal.tsx
@@ -35,13 +35,13 @@ const ModalComponent = React.memo((props: ModalProps) => {
 			anchor={anchor}
 			onDismiss={onDismiss}
 			scrim="none"
-			popupIosLift
 			className="prosopo-modalOuter"
 		>
 			<div
 				className="prosopo-modalInner"
 				style={{
 					maxWidth: "500px",
+					maxHeight: "100%",
 					backgroundColor: "transparent",
 					border: "none",
 					borderRadius: "28px",

--- a/packages/procaptcha-react/src/tests/modal.unit.test.tsx
+++ b/packages/procaptcha-react/src/tests/modal.unit.test.tsx
@@ -102,6 +102,33 @@ describe("stacking", () => {
 	test("covers the viewport so the page behind cannot be clicked", () => {
 		render(true);
 		expect(outer().style.position).toBe("fixed");
-		expect(outer().style.minHeight).toBe("100vh");
+		expect(outer().style.minHeight).toBe("100dvh");
+	});
+
+	test("does not lift the challenge by its own height on iOS", () => {
+		// The panel used to be translated up by a full 100% of its height, so a
+		// challenge taller than half the viewport lost its instruction line and
+		// top row of images off the top of the screen, with no way to scroll to
+		// them. Centring is the layer's job now.
+		render(true);
+		const panel = outer().querySelector<HTMLElement>(
+			".prosopo-challenge-content",
+		);
+
+		expect(panel?.className).not.toContain("ios-lift");
+		expect(panel?.style.transform).toBe("");
+		expect(
+			document.getElementById("prosopo-challenge-surface-ios-lift"),
+		).toBeNull();
+	});
+
+	test("lets a challenge taller than the viewport scroll instead of clipping", () => {
+		render(true);
+		const panel = outer().querySelector<HTMLElement>(
+			".prosopo-challenge-content",
+		);
+
+		expect(panel?.style.maxHeight).toBe("100%");
+		expect(panel?.style.overflowY).toBe("auto");
 	});
 });


### PR DESCRIPTION
## What was broken

On iOS, the image captcha panel was pushed up off the top of the screen. Users saw nine images and a Next button, but not the "Select all containing ..." line telling them what to pick. There was no way to scroll up to it. The challenge was unsolvable.

Reported on a live customer site from a real iPhone.

## Why

Two lines were fighting each other, both added in #1757:

- The panel sat in a centring box sized with `100vh`. On iOS Safari `100vh` is the height the page *would* be if the browser toolbars retracted, so that box was taller than the visible screen and the centred panel ended up under the bottom bar.
- To compensate, the panel was then shifted up by `translate(-50%, -100%)` — a full 100% of its own height, not half. Any panel taller than about half the screen therefore lost its top.

So the second line was covering for the first, and overshot.

## What changed

- Size the centring box with `100dvh` (the *visible* viewport) instead of `100vh`. That fixes the original iOS problem at its cause, so the shift is no longer needed and is removed, along with the `popupIosLift` prop.
- Centre the panel as a normal flex item instead of positioning it absolutely and transforming it. An absolutely positioned panel taller than the screen overflows off both edges and its top can't be scrolled to; an in-flow one can be bounded.
- Cap the panel at the screen height and let it scroll if it doesn't fit.

## Effect

The prompt and the top row of images are visible again. A challenge too tall for the screen now scrolls instead of being cut off.

Only affects how the challenge is positioned. No change to the captcha flow, the images, or verification.

## Test coverage

4 new tests. Each was run against the old code first to confirm it fails there:

- panel is not absolutely positioned and has no transform
- panel is capped at the viewport height and scrolls
- no iOS lift class or stylesheet is injected
- the layer is sized with `100dvh`, not `100vh`

Suites green: `procaptcha-common` 11/11, `procaptcha-react` 10/10, plus `procaptcha-puzzle` 6/6 and `procaptcha-frictionless` 11/11 since the puzzle shares the same surface.

## Verified on a device

Checked on an iPhone 16 simulator running iOS 18, against a local provider, with the real built bundle. The challenge renders in full, prompt included. Measured in the page:

```
layer=flex  minH=659px
panel top=62  h=535  bot=597
maxH=100%  tf=none
vh=659
```

`minH` matches the visible viewport, the panel starts at a positive offset and ends inside the screen, and there is no transform.

## Note

`100dvh` needs Safari 15.4+ / Chrome 108+. Older browsers ignore it and fall back to `min-height: auto`, which is harmless — `position: fixed; inset: 0` already sizes the layer to the viewport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)