### PR TITLE
feat(provider): persist cg/sm opaque payload keys

### DIFF
--- a/.changeset/persist-cg-sm.md
+++ b/.changeset/persist-cg-sm.md
@@ -1,0 +1,7 @@
+---
+"@prosopo/types-database": patch
+"@prosopo/provider": patch
+"@prosopo/types": patch
+---
+
+Persist cg and sm opaque payload keys

--- a/packages/provider/src/tasks/detection/getBotScore.ts
+++ b/packages/provider/src/tasks/detection/getBotScore.ts
@@ -95,6 +95,8 @@ export const getBotScore = async (
 	const i: boolean | undefined = result.i;
 	const cv: number | undefined = result.cv;
 	const sq: number | undefined = result.sq;
+	const cg: string | undefined = result.cg;
+	const sm: string | undefined = result.sm;
 	const sw: boolean | undefined = result.sw;
 	const md: boolean | undefined = result.md;
 	const bn: boolean | undefined = result.bn;
@@ -126,6 +128,8 @@ export const getBotScore = async (
 		i,
 		cv,
 		sq,
+		cg,
+		sm,
 		sw,
 		md,
 		bn,

--- a/packages/provider/src/tasks/frictionless/frictionlessTasks.ts
+++ b/packages/provider/src/tasks/frictionless/frictionlessTasks.ts
@@ -172,6 +172,8 @@ export class FrictionlessManager extends CaptchaManager {
 			i: params.i,
 			cv: params.cv,
 			sq: params.sq,
+			cg: params.cg,
+			sm: params.sm,
 			b: params.b,
 			tcpToChelloUs: params.tcpToChelloUs,
 			chelloToHandshakeUs: params.chelloToHandshakeUs,
@@ -240,6 +242,8 @@ export class FrictionlessManager extends CaptchaManager {
 			i,
 			cv,
 			sq,
+			cg,
+			sm,
 			b,
 			sw,
 			md,
@@ -312,6 +316,8 @@ export class FrictionlessManager extends CaptchaManager {
 			i,
 			cv,
 			sq,
+			cg,
+			sm,
 			b,
 			sw,
 			md,
@@ -840,6 +846,8 @@ export class FrictionlessManager extends CaptchaManager {
 		let ii: boolean | undefined;
 		let cvv: number | undefined;
 		let sqq: number | undefined;
+		let cgg: string | undefined;
+		let smm: string | undefined;
 		let bb: Record<string, string[]> | undefined;
 		let sw: boolean | undefined;
 		let md: boolean | undefined;
@@ -876,6 +884,8 @@ export class FrictionlessManager extends CaptchaManager {
 				const iv = decrypted.i;
 				const cvv2 = decrypted.cv;
 				const sqq2 = decrypted.sq;
+				const cgg2 = decrypted.cg;
+				const smm2 = decrypted.sm;
 				const bv = decrypted.b;
 				const swv = decrypted.sw;
 				const mdv = decrypted.md;
@@ -919,6 +929,8 @@ export class FrictionlessManager extends CaptchaManager {
 				ii = iv;
 				cvv = cvv2;
 				sqq = sqq2;
+				cgg = cgg2;
+				smm = smm2;
 				bb = bv;
 				sw = swv;
 				md = mdv;
@@ -991,6 +1003,8 @@ export class FrictionlessManager extends CaptchaManager {
 			i: ii,
 			cv: cvv,
 			sq: sqq,
+			cg: cgg,
+			sm: smm,
 			b: bb,
 			sw,
 			md,

--- a/packages/types-database/src/types/provider.ts
+++ b/packages/types-database/src/types/provider.ts
@@ -829,6 +829,8 @@ export const SessionRecordSchema = new Schema<SessionRecord>({
 	i: { type: Boolean, required: false },
 	cv: { type: Number, required: false },
 	sq: { type: Number, required: false },
+	cg: { type: String, required: false },
+	sm: { type: String, required: false },
 	b: { type: Schema.Types.Mixed, required: false },
 	// Raw iOS WKWebView-vs-Safari DOM signals that the client-side
 	// classifier folds into `webView` (see @prosopo/types Session for
@@ -1091,6 +1093,8 @@ export const SESSION_PROJECTION = {
 	i: 1,
 	cv: 1,
 	sq: 1,
+	cg: 1,
+	sm: 1,
 	b: 1,
 	sw: 1,
 	md: 1,

--- a/packages/types/src/provider/database.ts
+++ b/packages/types/src/provider/database.ts
@@ -505,6 +505,8 @@ export const SessionSchema = object({
 	i: boolean().optional(),
 	cv: number().optional(),
 	sq: number().optional(),
+	cg: string().optional(),
+	sm: string().optional(),
 	b: record(string(), array(string())).optional(),
 	// Raw iOS WKWebView-vs-Safari DOM signals that the client-side
 	// classifier folds into `webView`. Persisted per session so
@@ -664,6 +666,8 @@ export type Session = {
 	i?: boolean;
 	cv?: number;
 	sq?: number;
+	cg?: string;
+	sm?: string;
 	b?: Record<string, string[]>;
 	// Raw iOS WKWebView-vs-Safari DOM signals — see SessionSchema above.
 	sw?: boolean;

--- a/packages/types/src/provider/detection.ts
+++ b/packages/types/src/provider/detection.ts
@@ -59,6 +59,8 @@ export type DetectorResult = {
 	i?: boolean;
 	cv?: number;
 	sq?: number;
+	cg?: string;
+	sm?: string;
 	// Raw iOS WKWebView-vs-Safari DOM signals (positions 14-17 in the client
 	// payload). Undefined for clients that predate the fields, or on non-iOS
 	// / non-WebKit engines where the classifier gate returns early. Shipped


### PR DESCRIPTION
Carries two additional opaque payload keys through the provider decrypt path and storage, following the existing `cv`/`sq`/`g`/`i`/`b` precedent.

- `cg` — opaque string
- `sm` — opaque string

## Sites touched (mirror cv/sq exactly)
- `types/src/provider/detection.ts` — `DetectorResult` fields
- `types/src/provider/database.ts` — zod schema + TS type
- `types-database/src/types/provider.ts` — Mongoose schema + projection
- `provider/src/tasks/detection/getBotScore.ts` — decrypt extract + return
- `provider/src/tasks/frictionless/frictionlessTasks.ts` — both pass-throughs

Both keys stay opaque single/double-letter names all the way through to Mongo, forwarded verbatim so server-side rules can consume them without a client release.