### PR TITLE
fix(docker): bound staging mongo memory and restart it on crash

### DIFF
--- a/.changeset/staging-mongo-oom.md
+++ b/.changeset/staging-mongo-oom.md
@@ -1,0 +1,18 @@
+---
+"@prosopo/client-example-server": patch
+---
+
+Stop the staging database being killed by the host, and let it come back on its own.
+
+The `database1` mongo container had no memory limit and no restart policy. The
+staging host has 5.8GB of RAM and no swap, so mongod grew until the kernel
+OOM-killer took it — three times, on 18 August, 5 September and 8 September.
+Because it was the only service in this compose file without
+`restart: unless-stopped`, nothing brought it back, and the last crash left the
+database down for two days.
+
+It now has `mem_limit: 3g`, which keeps it clear of the host limit, and a
+WiredTiger cache pinned to 1.5GB so the rest of the budget is left for
+connections and sorts rather than being handed to the cache. `restart:
+unless-stopped` matches the other two services, so a crash costs seconds
+instead of days.

--- a/docker/docker-compose.client-example-server.yml
+++ b/docker/docker-compose.client-example-server.yml
@@ -66,6 +66,12 @@ services:
     database1:
         container_name: database1
         image: mongo:8.2.3
+        restart: unless-stopped # unless the container has been stopped, it will be restarted, even on reboot
+        # The staging host has 5.8GB and no swap. Left unbounded, mongod grows past it
+        # and the kernel OOM-killer takes the whole container, so cap it well clear of
+        # the host limit and size the WiredTiger cache to leave room for connections.
+        mem_limit: 3g
+        command: ["mongod", "--wiredTigerCacheSizeGB", "1.5"]
         volumes:
             - /data/client-example-server:/data/db
         ports:


### PR DESCRIPTION
## What was wrong

The staging database container (`database1`) kept dying and staying dead.

It had no memory limit and no restart policy. The staging host has 5.8GB of RAM and no swap, so mongod just grew until the Linux OOM-killer shot it. That happened three times: 18 August, 5 September, and 8 September.

`database1` was also the only service in this compose file without `restart: unless-stopped` — `caddy` and `server1` both have it, which is why they've been up for months. So when it got killed on 8 September, nothing brought it back and staging had no database for two days.

## What changed

Three lines on the `database1` service:

- `restart: unless-stopped` — same as the other two services, so a crash costs seconds instead of days.
- `mem_limit: 3g` — keeps the container well clear of the 5.8GB host limit, so it can never take the host down with it.
- `--wiredTigerCacheSizeGB 1.5` — mongod sizes its cache from total host RAM by default, which grabbed 2.4GB. Pinning it to 1.5GB leaves the rest of the 3GB budget for connections and sorts, which is where the overrun actually came from (it reached 5.5GB RSS, well above the cache).

## Test coverage

None — this is deploy config, there's nothing to unit test.

Verified by hand instead:
- `docker compose config` renders the service correctly (`mem_limit: "3221225472"`, `restart: unless-stopped`, cache flag present).
- The equivalent settings are already applied live on staging via `docker update` plus a runtime `wiredTigerEngineRuntimeConfig` change, so the database is up now rather than waiting on this merge. It's been stable since: WiredTiger cache reporting 1.5GB, container at ~690MB of its 3GB cap, 40 clients reconnected on their own.

This PR is so the fix survives the next redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)