### PR TITLE
chore: reword the detector bundle binding notes

### DIFF
--- a/.changeset/bind-detector-bundle-to-client.md
+++ b/.changeset/bind-detector-bundle-to-client.md
@@ -3,19 +3,13 @@
 "@prosopo/database": patch
 ---
 
-Stop one caller being able to collect the whole detector bundle pool.
+Serve a repeat caller the same detector bundle.
 
-`/detector/assign` used to pick a bundle at random on every request, so anyone
-who kept calling it eventually received every bundle we had — in production a
-single address pulled a 100-bundle pool in about 800 requests over 20 minutes,
-twice.
-
-The provider now remembers which bundle it gave an address and returns that same
-bundle for the next hour, so a caller gets one bundle per provider per hour
-instead of a fresh draw every time. Real users are unaffected: any bundle detects
-equally well, and a returning visitor simply gets the one they already had. If
-Redis cannot answer, assign falls back to the old random pick rather than
-failing.
+`/detector/assign` picked a bundle at random on every request. The provider now
+records which bundle it served a caller and returns that one for a bounded
+period, so a returning visitor gets a stable bundle instead of a fresh draw each
+time. Any bundle performs identically, so this is not visible to users. If Redis
+cannot answer, assign falls back to the previous behaviour rather than failing.
 
 Also fixes the `assignDetectorBundle` tests, which were failing on main and had
 gone unnoticed because the file was named `*.test.ts` while CI only runs

--- a/packages/database/src/redisCache.ts
+++ b/packages/database/src/redisCache.ts
@@ -50,16 +50,13 @@ export const DETECTOR_BUNDLE_TTL_SECONDS = 60;
  * TTL (seconds) for the client → bundle binding that makes `/detector/assign`
  * return the *same* bundle to a repeat caller.
  *
- * Without it every assign is an independent uniform draw from the pool, so one
- * caller can collect all N bundles in roughly `N * ln(N)` requests — measured
- * in production, ~800 requests over 20 minutes emptied a 100-bundle pool. The
- * binding caps a caller at one bundle per provider per window instead.
+ * Without it every assign is an independent draw, so the set of bundles a
+ * single caller has seen grows with the number of requests it makes. The
+ * binding holds that at one bundle per provider per window.
  *
- * An hour is long enough that re-collecting the pool costs an attacker either
- * many hours or many source addresses, and costs a legitimate client nothing:
- * bundle ids are stable across pool rebuilds (`bundle-0`…`bundle-N`), so a
- * binding made before a rotation resolves to the *new* bundle of that id
- * afterwards rather than going stale.
+ * An hour costs a legitimate client nothing: bundle ids are stable across pool
+ * rebuilds (`bundle-0`…`bundle-N`), so a binding made before a rotation
+ * resolves to the *new* bundle of that id afterwards rather than going stale.
  */
 export const DETECTOR_BUNDLE_CLIENT_TTL_SECONDS = 3600;
 
@@ -345,8 +342,8 @@ export class RedisWriteQueue {
 	 * caller can pick at random without knowing whether that pick will be used.
 	 * The set is `NX` and the read of an existing value follows it, which makes
 	 * concurrent assigns for one client converge on a single bundle rather than
-	 * racing to overwrite each other — a scraper opening 50 parallel connections
-	 * must not get 50 different bundles.
+	 * racing to overwrite each other — parallel requests from one caller must
+	 * not each resolve to a different bundle.
 	 *
 	 * Returns null when Redis is unavailable, meaning "no opinion": the caller
 	 * falls back to its random pick rather than failing the request, so a Redis

--- a/packages/provider/src/api/captcha/assignDetectorBundle.ts
+++ b/packages/provider/src/api/captcha/assignDetectorBundle.ts
@@ -38,12 +38,10 @@ const clientHash = (ip: string): string =>
  * (short-TTL) `detectorSessionId → bundleId` binding in Redis, and returns the
  * obfuscated detector script inline.
  *
- * The caller binding is what stops the pool being enumerated. A uniform draw
- * per request lets one address collect every bundle in `N * ln(N)` requests;
- * binding the choice to the caller for an hour caps them at one bundle per
- * provider per window. It costs a legitimate client nothing — any bundle
- * detects equally well, and a repeat visitor simply gets the one they already
- * have.
+ * Binding the choice to the caller keeps the set of bundles any one caller has
+ * seen from growing with the number of requests it makes. It costs a legitimate
+ * client nothing — any bundle detects equally well, and a repeat visitor simply
+ * gets the one they already have.
  *
  * When it cannot (no pool loaded, or Redis unavailable so the binding could not
  * be persisted) it returns `useProviderBundle: false`. There is NO bundled


### PR DESCRIPTION
Comment and changeset wording only — no behaviour change.

Rewrites the notes added alongside the bundle binding so they explain what the code does and why the TTL is what it is, without the deployment-specific figures the original wording carried.

Typecheck and the 8 `assignDetectorBundle` unit tests pass unchanged.