### PR TITLE
fix(provider): derive the detector bundle for a caller

### DIFF
--- a/.changeset/derive-detector-bundle-assignment.md
+++ b/.changeset/derive-detector-bundle-assignment.md
@@ -1,0 +1,14 @@
+---
+"@prosopo/provider": patch
+"@prosopo/database": patch
+---
+
+Derive the detector bundle for a caller instead of storing it.
+
+`assignDetectorBundle` now picks the bundle with a keyed hash of the caller's
+address, using a per-provider secret kept on the pool volume. Same caller, same
+bundle, with nothing recorded and nothing to expire — which also means the
+result no longer changes when the cache is unavailable.
+
+Replaces the Redis client → bundle entry added in the previous patch, so
+`bindDetectorBundleToClient` and its TTL constant are gone.

--- a/packages/database/src/redisCache.ts
+++ b/packages/database/src/redisCache.ts
@@ -47,20 +47,6 @@ const SESSION_KEY_PATTERNS = [
 export const DETECTOR_BUNDLE_TTL_SECONDS = 60;
 
 /**
- * TTL (seconds) for the client → bundle binding that makes `/detector/assign`
- * return the *same* bundle to a repeat caller.
- *
- * Without it every assign is an independent draw, so the set of bundles a
- * single caller has seen grows with the number of requests it makes. The
- * binding holds that at one bundle per provider per window.
- *
- * An hour costs a legitimate client nothing: bundle ids are stable across pool
- * rebuilds (`bundle-0`…`bundle-N`), so a binding made before a rotation
- * resolves to the *new* bundle of that id afterwards rather than going stale.
- */
-export const DETECTOR_BUNDLE_CLIENT_TTL_SECONDS = 3600;
-
-/**
  * Redis-backed write queue and read cache for reducing MongoDB load.
  *
  * Provides:
@@ -331,47 +317,6 @@ export class RedisWriteQueue {
 				detectorSessionId,
 			}));
 			return false;
-		}
-	}
-
-	/**
-	 * Bind `clientHash` to a bundle for {@link DETECTOR_BUNDLE_CLIENT_TTL_SECONDS},
-	 * and return the bundle it is bound to.
-	 *
-	 * `candidateBundleId` is only used if the client has no binding yet, so the
-	 * caller can pick at random without knowing whether that pick will be used.
-	 * The set is `NX` and the read of an existing value follows it, which makes
-	 * concurrent assigns for one client converge on a single bundle rather than
-	 * racing to overwrite each other — parallel requests from one caller must
-	 * not each resolve to a different bundle.
-	 *
-	 * Returns null when Redis is unavailable, meaning "no opinion": the caller
-	 * falls back to its random pick rather than failing the request, so a Redis
-	 * outage degrades this to the previous behaviour instead of breaking assign.
-	 */
-	async bindDetectorBundleToClient(
-		clientHash: string,
-		candidateBundleId: string,
-		ttlSeconds: number = DETECTOR_BUNDLE_CLIENT_TTL_SECONDS,
-	): Promise<string | null> {
-		const client = await this.getClient();
-		if (!client) {
-			return null;
-		}
-		try {
-			const key = `cache:detector:client:${clientHash}`;
-			const stored = await client.set(key, candidateBundleId, {
-				NX: true,
-				EX: ttlSeconds,
-			});
-			return stored === null ? await client.get(key) : candidateBundleId;
-		} catch (error) {
-			this.logger.warn(() => ({
-				msg: "Failed to bind detector bundle to client in Redis",
-				err: error,
-				clientHash,
-			}));
-			return null;
 		}
 	}
 

--- a/packages/provider/src/api/captcha/assignDetectorBundle.ts
+++ b/packages/provider/src/api/captcha/assignDetectorBundle.ts
@@ -12,41 +12,38 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { createHash } from "node:crypto";
+import { createHmac } from "node:crypto";
 import { ApiParams, type AssignDetectorBundleResponse } from "@prosopo/types";
 import type { ProviderEnvironment } from "@prosopo/types-env";
 import type { NextFunction, Request, Response } from "express";
 import { v4 as uuidv4 } from "uuid";
 import type { AugmentedRequest } from "../../express.js";
-import { getDetectorBundlePool } from "../../tasks/detection/bundlePool.js";
+import { getAssignSecret } from "../../tasks/detection/assignSecret.js";
+import {
+	getDetectorBundlePool,
+	getDetectorBundlePoolDir,
+} from "../../tasks/detection/bundlePool.js";
 import { Tasks } from "../../tasks/index.js";
 import { normalizeRequestIp } from "../../utils/normalizeRequestIp.js";
 
-/**
- * Identifies the caller for the purposes of the client → bundle binding.
- * Hashed so that Redis keys carry no raw addresses; truncated because 128 bits
- * is far past collision relevance for a one-hour keyspace.
- */
-const clientHash = (ip: string): string =>
-	createHash("sha256").update(ip).digest("hex").slice(0, 32);
+/** Pool position for this caller: a keyed hash of their address. */
+const clientIndex = (ip: string, secret: Buffer): number =>
+	createHmac("sha256", secret).update(ip).digest().readUIntBE(0, 6);
 
 /**
  * Assigns a precomputed detector bundle for this detection session.
  *
- * When the provider has a non-empty pool it resolves the bundle bound to this
- * caller (picking a random one if there is no binding yet), records the
- * (short-TTL) `detectorSessionId → bundleId` binding in Redis, and returns the
- * obfuscated detector script inline.
+ * The bundle is derived from the caller's address and this provider's secret,
+ * so a repeat caller keeps getting the same one with nothing stored and nothing
+ * to expire. Any bundle detects equally well, so this is not visible to users.
  *
- * Binding the choice to the caller keeps the set of bundles any one caller has
- * seen from growing with the number of requests it makes. It costs a legitimate
- * client nothing — any bundle detects equally well, and a repeat visitor simply
- * gets the one they already have.
+ * The `detectorSessionId → bundleId` binding is still written to Redis; the
+ * decrypt side resolves the session's bundle from it on the next hop.
  *
- * When it cannot (no pool loaded, or Redis unavailable so the binding could not
- * be persisted) it returns `useProviderBundle: false`. There is NO bundled
- * detector and no legacy key pool to fall back to — the client sends an empty
- * token on the frictionless hop and the provider decides what to serve.
+ * Returns `useProviderBundle: false` when there is no pool, no secret, or Redis
+ * could not store that binding. There is NO bundled detector to fall back to —
+ * the client sends an empty token on the frictionless hop and the provider
+ * decides what to serve.
  */
 export default (env: ProviderEnvironment) =>
 	async (
@@ -65,7 +62,14 @@ export default (env: ProviderEnvironment) =>
 				return res.json(noBundle);
 			}
 
-			const candidate = pool.pickRandom();
+			const secret = getAssignSecret(getDetectorBundlePoolDir(), {
+				info: (msg, data) => req.logger.info(() => ({ msg, data })),
+				warn: (msg, data) => req.logger.warn(() => ({ msg, data })),
+			});
+
+			const { bundleId, bundle } = pool.at(
+				clientIndex(normalizeRequestIp(req.ip, req.logger), secret),
+			);
 			const detectorSessionId = `det-${uuidv4()}`;
 
 			// Persist the ephemeral session→bundle binding. If Redis is
@@ -77,20 +81,6 @@ export default (env: ProviderEnvironment) =>
 			if (!writeQueue) {
 				return res.json(noBundle);
 			}
-
-			// Reuse whatever this caller was last given. A binding can outlive the
-			// pool it was made against, so anything it names that is no longer
-			// loaded falls back to the fresh pick rather than serving nothing.
-			const bound = await writeQueue.bindDetectorBundleToClient(
-				clientHash(normalizeRequestIp(req.ip, req.logger)),
-				candidate.bundleId,
-			);
-			const boundBundle = bound ? pool.get(bound) : undefined;
-			const { bundleId, bundle } =
-				bound && boundBundle
-					? { bundleId: bound, bundle: boundBundle }
-					: candidate;
-
 			const cached = await writeQueue.cacheDetectorBundle(
 				detectorSessionId,
 				bundleId,

--- a/packages/provider/src/api/captcha/assignDetectorBundle.unit.test.ts
+++ b/packages/provider/src/api/captcha/assignDetectorBundle.unit.test.ts
@@ -12,37 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	statSync,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { ProviderEnvironment } from "@prosopo/types-env";
 import type { NextFunction, Request, Response } from "express";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AugmentedRequest } from "../../express.js";
+import { resetAssignSecretCache } from "../../tasks/detection/assignSecret.js";
 import { initDetectorBundlePool } from "../../tasks/detection/bundlePool.js";
 import assignDetectorBundle from "./assignDetectorBundle.js";
 
 const cacheDetectorBundle = vi.fn(
 	async (_detectorSessionId: string, _bundleId: string) => true,
-);
-
-/**
- * Stands in for Redis with the same `SET NX` semantics the real binding relies
- * on: first writer for a client wins, everyone after reads that value back.
- */
-const bindings = new Map<string, string>();
-const bindDetectorBundleToClient = vi.fn(
-	async (
-		clientHash: string,
-		candidateBundleId: string,
-	): Promise<string | null> => {
-		const existing = bindings.get(clientHash);
-		if (existing !== undefined) {
-			return existing;
-		}
-		bindings.set(clientHash, candidateBundleId);
-		return candidateBundleId;
-	},
 );
 
 // A class rather than `vi.fn().mockImplementation`: the afterEach
@@ -52,7 +40,7 @@ const bindDetectorBundleToClient = vi.fn(
 vi.mock("../../tasks/index.js", () => ({
 	Tasks: class {
 		frictionlessManager = {
-			writeQueue: { cacheDetectorBundle, bindDetectorBundleToClient },
+			writeQueue: { cacheDetectorBundle },
 		};
 	},
 }));
@@ -83,6 +71,17 @@ const writePool = (dir: string, count: number): string[] => {
 const assignedBundleId = (): string =>
 	cacheDetectorBundle.mock.calls.at(-1)?.[1] as string;
 
+const assignOnceWith = async (
+	ip?: string,
+): Promise<{ res: Response; json: ReturnType<typeof vi.fn> }> => {
+	const r = makeRes();
+	await assignDetectorBundle(env)(makeReq(ip), r.res, next);
+	return r;
+};
+const assignOnce = async (ip?: string): Promise<void> => {
+	await assignOnceWith(ip);
+};
+
 const makeRes = (): { res: Response; json: ReturnType<typeof vi.fn> } => {
 	const json = vi.fn((body: unknown) => body);
 	return { res: { json } as unknown as Response, json };
@@ -97,8 +96,7 @@ describe("assignDetectorBundle", () => {
 	beforeEach(() => {
 		dir = mkdtempSync(join(tmpdir(), "assign-"));
 		cacheDetectorBundle.mockClear();
-		bindDetectorBundleToClient.mockClear();
-		bindings.clear();
+		resetAssignSecretCache();
 	});
 
 	afterEach(() => {
@@ -171,78 +169,74 @@ describe("assignDetectorBundle", () => {
 
 		const served = new Set<string>();
 		for (let i = 0; i < 200; i++) {
-			await assignDetectorBundle(env)(makeReq(), makeRes().res, next);
+			await assignOnce();
 			served.add(assignedBundleId());
 		}
 
-		// Without the binding this is a uniform draw per request, so 200 draws on
-		// a 50-bundle pool would return essentially the whole pool.
 		expect(served.size).toBe(1);
 	});
 
-	it("returns the bundle body matching the bound id, not the fresh pick", async () => {
+	it("keeps serving that bundle after the secret is re-read from disk", async () => {
 		writePool(dir, 50);
 		initDetectorBundlePool(dir);
 
-		const first = makeRes();
-		await assignDetectorBundle(env)(makeReq(), first.res, next);
-		const boundId = assignedBundleId();
+		await assignOnce();
+		const first = assignedBundleId();
 
-		const second = makeRes();
-		await assignDetectorBundle(env)(makeReq(), second.res, next);
+		// Same volume, fresh process: the mapping must survive a restart.
+		resetAssignSecretCache();
+		await assignOnce();
 
-		const body = second.json.mock.calls[0]?.[0] as { detectorScript: string };
-		expect(assignedBundleId()).toBe(boundId);
+		expect(assignedBundleId()).toBe(first);
+	});
+
+	it("returns the bundle body matching the id it recorded", async () => {
+		writePool(dir, 50);
+		initDetectorBundlePool(dir);
+
+		const { json } = await assignOnceWith();
+		const body = json.mock.calls[0]?.[0] as { detectorScript: string };
 		expect(body.detectorScript).toBe(
-			`export default ${boundId.replace("bundle-", "")};`,
+			`export default ${assignedBundleId().replace("bundle-", "")};`,
 		);
 	});
 
-	it("binds per caller, so distinct addresses are not pinned together", async () => {
+	it("spreads distinct callers across the pool", async () => {
 		writePool(dir, 50);
 		initDetectorBundlePool(dir);
 
 		const served = new Set<string>();
 		for (let i = 0; i < 60; i++) {
-			await assignDetectorBundle(env)(
-				makeReq(`203.0.113.${i}`),
-				makeRes().res,
-				next,
-			);
+			await assignOnce(`203.0.113.${i}`);
 			served.add(assignedBundleId());
 		}
 
-		expect(bindings.size).toBe(60);
 		expect(served.size).toBeGreaterThan(1);
 	});
 
-	it("falls back to the random pick when Redis cannot answer", async () => {
+	it("still assigns when Redis holds no client state", async () => {
+		// The mapping is derived, so there is no lookup to miss.
 		writePool(dir, 50);
 		initDetectorBundlePool(dir);
-		bindDetectorBundleToClient.mockResolvedValueOnce(null);
 
-		const { res, json } = makeRes();
-		await assignDetectorBundle(env)(makeReq(), res, next);
-
+		const { json } = await assignOnceWith();
 		const body = json.mock.calls[0]?.[0] as { useProviderBundle: boolean };
 		expect(body.useProviderBundle).toBe(true);
 		expect(assignedBundleId()).toMatch(/^bundle-\d+$/);
 	});
 
-	it("ignores a binding naming a bundle the current pool no longer has", async () => {
-		writePool(dir, 5);
+	it("writes the secret 0600 and leaves it alone on reload", async () => {
+		writePool(dir, 50);
 		initDetectorBundlePool(dir);
-		bindDetectorBundleToClient.mockResolvedValueOnce("bundle-999");
 
-		const { res, json } = makeRes();
-		await assignDetectorBundle(env)(makeReq(), res, next);
+		await assignOnce();
+		const secretPath = join(dir, ".assign-secret");
+		const first = readFileSync(secretPath);
+		expect(first.length).toBe(32);
+		expect(statSync(secretPath).mode & 0o777).toBe(0o600);
 
-		const body = json.mock.calls[0]?.[0] as {
-			useProviderBundle: boolean;
-			detectorScript: string;
-		};
-		expect(body.useProviderBundle).toBe(true);
-		expect(assignedBundleId()).not.toBe("bundle-999");
-		expect(body.detectorScript).toMatch(/^export default \d+;$/);
+		resetAssignSecretCache();
+		await assignOnce();
+		expect(readFileSync(secretPath)).toEqual(first);
 	});
 });

--- a/packages/provider/src/api/captcha/getFrictionlessCaptchaChallenge/handler.ts
+++ b/packages/provider/src/api/captcha/getFrictionlessCaptchaChallenge/handler.ts
@@ -383,10 +383,9 @@ export default (
 				// use to decrypt every later behavioural / SIMD payload for
 				// this session (via resolveBundleBySessionId). But the client
 				// on this request just did a fresh /detector/assign that
-				// bound `detectorSessionId` to whichever bundle
-				// DetectorBundlePool.pickRandom returned — almost never the
-				// same one the cached session stored, because the pick is
-				// uniform-random across the pool. If we hand the client the
+				// bound `detectorSessionId` to the bundle this caller now
+				// resolves to, which need not be the one the cached session
+				// stored. If we hand the client the
 				// cached sessionId, every later hop encrypts with the fresh
 				// detector's public key and the provider tries to decrypt
 				// with the cached bundle's private key, yielding

--- a/packages/provider/src/tasks/detection/assignSecret.ts
+++ b/packages/provider/src/tasks/detection/assignSecret.ts
@@ -1,0 +1,83 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Per-provider key for the client → bundle mapping in `assignDetectorBundle`.
+ * Generated once and kept on the pool volume so a restart does not change the
+ * mapping. Treat it as a credential.
+ */
+
+import { randomBytes } from "node:crypto";
+import {
+	chmodSync,
+	mkdirSync,
+	readFileSync,
+	renameSync,
+	writeFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+
+const SECRET_BYTES = 32;
+
+/**
+ * Dot-prefixed so a pool replace leaves it alone: `loadFromDir` and
+ * `persistDetectorBundlePool` only touch `.js`/`.json`.
+ */
+const SECRET_FILENAME = ".assign-secret";
+
+interface SecretLogger {
+	info?: (msg: string, data?: Record<string, unknown>) => void;
+	warn?: (msg: string, data?: Record<string, unknown>) => void;
+}
+
+let cached: { path: string; secret: Buffer } | null = null;
+
+export function getAssignSecret(
+	poolDir: string,
+	logger: SecretLogger = {},
+): Buffer {
+	const path = join(poolDir, SECRET_FILENAME);
+	if (cached && cached.path === path) {
+		return cached.secret;
+	}
+
+	try {
+		const existing = readFileSync(path);
+		if (existing.length === SECRET_BYTES) {
+			cached = { path, secret: existing };
+			return existing;
+		}
+		logger.warn?.("assign secret has unexpected length, regenerating", {
+			bytes: existing.length,
+		});
+	} catch {
+		// Absent on first boot.
+	}
+
+	const secret = randomBytes(SECRET_BYTES);
+	mkdirSync(dirname(path), { recursive: true });
+	const tmp = `${path}.tmp`;
+	writeFileSync(tmp, secret, { mode: 0o600 });
+	chmodSync(tmp, 0o600);
+	renameSync(tmp, path);
+	logger.info?.("generated a new assign secret", { path });
+
+	cached = { path, secret };
+	return secret;
+}
+
+/** Test seam. */
+export function resetAssignSecretCache(): void {
+	cached = null;
+}

--- a/packages/provider/src/tasks/detection/bundlePool.test.ts
+++ b/packages/provider/src/tasks/detection/bundlePool.test.ts
@@ -116,10 +116,10 @@ describe("DetectorBundlePool", () => {
 		const pool = new DetectorBundlePool();
 		pool.loadFromDir(join(dir, "does-not-exist"));
 		expect(pool.size()).toBe(0);
-		expect(() => pool.pickRandom()).toThrow(/empty/);
+		expect(() => pool.at(0)).toThrow(/empty/);
 	});
 
-	it("pickRandom returns valid pool members and covers the pool over many draws", () => {
+	it("at returns valid pool members and is stable for a given index", () => {
 		for (let i = 0; i < 5; i++) {
 			writeBundle(dir, `bundle-${i}`, `JS${i}`, {
 				privateKey: `PK${i}`,
@@ -131,11 +131,12 @@ describe("DetectorBundlePool", () => {
 
 		const seen = new Set<string>();
 		for (let i = 0; i < 500; i++) {
-			const { bundleId, bundle } = pool.pickRandom();
+			const { bundleId, bundle } = pool.at(i);
 			expect(pool.get(bundleId)).toBe(bundle);
+			expect(pool.at(i).bundleId).toBe(bundleId);
 			seen.add(bundleId);
 		}
-		// With 5 bundles over 500 uniform draws every id should appear.
+		// Successive indices walk the whole pool.
 		expect(seen.size).toBe(5);
 	});
 

--- a/packages/provider/src/tasks/detection/bundlePool.ts
+++ b/packages/provider/src/tasks/detection/bundlePool.ts
@@ -21,14 +21,13 @@
  * (`{ privateKey, innerConfig }`, kept server-side) produced by the catcher
  * `bundle:pool` build script.
  *
- * A bundle is assigned per detector session by {@link DetectorBundlePool.pickRandom},
+ * A bundle is assigned per detector session by {@link DetectorBundlePool.at},
  * served by id, and resolved again at decryption time so the provider uses the
  * single correct keypair + inner config rather than brute-forcing a key pool.
  * The session→bundle binding lives in Redis (short TTL); this module only holds
  * the immutable pool.
  */
 
-import { randomInt } from "node:crypto";
 import {
 	existsSync,
 	mkdirSync,
@@ -179,15 +178,15 @@ export class DetectorBundlePool {
 	}
 
 	/**
-	 * Pick a uniformly-random bundle. Throws if the pool is empty — the caller
-	 * must surface this as a hard failure (no bundle ⇒ no valid payload can be
-	 * produced).
+	 * Select by position. `ids` is sorted by {@link replace}, so an index means
+	 * the same bundle until the pool contents change. Reduced modulo the size, so
+	 * callers need not know how many bundles are loaded.
 	 */
-	pickRandom(): { bundleId: string; bundle: PoolBundle } {
+	at(index: number): { bundleId: string; bundle: PoolBundle } {
 		if (this.ids.length === 0) {
 			throw new Error("detector bundle pool is empty");
 		}
-		const bundleId = this.ids[randomInt(this.ids.length)];
+		const bundleId = this.ids[index % this.ids.length];
 		const bundle =
 			bundleId !== undefined ? this.bundles.get(bundleId) : undefined;
 		if (bundleId === undefined || !bundle) {
@@ -291,6 +290,11 @@ export function persistDetectorBundlePool(
 /** Get the global pool, or `null` if {@link initDetectorBundlePool} was never called. */
 export function getDetectorBundlePool(): DetectorBundlePool | null {
 	return globalPool;
+}
+
+/** Where the global pool was last loaded from — the host-mounted volume. */
+export function getDetectorBundlePoolDir(): string {
+	return globalPoolDir;
 }
 
 /**


### PR DESCRIPTION
Derives the bundle from the caller's address and a per-provider secret instead of storing a Redis entry per caller.

Same caller resolves to the same bundle, with nothing recorded and nothing to expire. Removes `bindDetectorBundleToClient`, its TTL constant, and `pickRandom`.

Tests: 9 in `assignDetectorBundle.unit.test.ts`, 15 in `bundlePool.test.ts`, full provider suite (1,296) and database suite (101) pass.