### PR TITLE
fix(database): keep a detector bundle binding as long as its payload is accepted

### DIFF
--- a/.changeset/detector-binding-ttl-matches-payload-age.md
+++ b/.changeset/detector-binding-ttl-matches-payload-age.md
@@ -1,0 +1,30 @@
+---
+"@prosopo/types": patch
+"@prosopo/database": patch
+"@prosopo/provider": patch
+---
+
+Keep a detector bundle binding for as long as its payload is accepted
+
+The `detectorSessionId → bundleId` binding held the only key able to read a
+detector payload, and expired after 60 seconds. The frictionless flow accepts a
+payload for ten minutes (`DEFAULT_MAX_TIMESTAMP_AGE`). For nine of those ten
+minutes the provider would therefore accept a payload it had already discarded
+the means to decrypt: `resolveDecryptAttempts` returns an empty key list, the
+decrypt loop never runs, the score is forced to 1 and the caller is challenged
+despite nothing having been measured about them.
+
+Sixty seconds is ample for the assign → submit gap in the normal case — it is
+around 1.5s — but it only has to stall once to be lost, and a backgrounded
+mobile tab is enough.
+
+The two values are now one value. `DEFAULT_MAX_TIMESTAMP_AGE` moves from a
+private constant in `frictionlessTasks` to `@prosopo/types`, the only package
+both the provider and the database can see, and `DETECTOR_BUNDLE_TTL_SECONDS` is
+derived from it instead of being written down a second time. A unit test pins
+the relationship so they cannot drift apart again.
+
+The TTL cannot now outlive the payload-age check, so this does not widen the
+window in which any payload is usable. Bundle selection is unaffected: which
+bundle a caller receives is derived from their IP and a server secret, not from
+this binding's lifetime.

--- a/packages/database/src/redisCache.ts
+++ b/packages/database/src/redisCache.ts
@@ -14,6 +14,7 @@
 
 import type { Logger } from "@prosopo/logger";
 import type { RedisConnection } from "@prosopo/redis-client";
+import { DEFAULT_MAX_TIMESTAMP_AGE } from "@prosopo/types";
 
 /** The Redis client type returned by RedisConnection.getClient() */
 type RedisClient = Awaited<ReturnType<RedisConnection["getClient"]>>;
@@ -38,13 +39,21 @@ const SESSION_KEY_PATTERNS = [
 ] as const;
 
 /**
- * Default TTL (seconds) for the ephemeral detector-session → bundle mapping.
- * Deliberately short: it only needs to bridge bundle assignment → the first
- * provider call (load + run detector + submit). The bundleId is promoted onto
- * the session record for later (behavioural) hops. An expired mapping makes
- * decryption fail closed (invalid payload).
+ * TTL (seconds) for the ephemeral detector-session → bundle mapping. It bridges
+ * bundle assignment → the first provider call (load + run detector + submit);
+ * the bundleId is promoted onto the session record for later (behavioural) hops.
+ * An expired mapping makes decryption fail closed, which costs the caller a
+ * challenge despite nothing having been measured about them.
+ *
+ * Derived from `DEFAULT_MAX_TIMESTAMP_AGE` rather than set independently. That
+ * is how long the frictionless flow will still read a detector payload, so it is
+ * exactly how long the key that reads it has to survive. Held separately the two
+ * drifted: at 60s against a 10 minute payload window, the provider spent nine of
+ * those ten minutes accepting payloads it had already discarded the means to
+ * decrypt, and the assign → submit gap only has to be stalled once — a
+ * backgrounded mobile tab is enough — to lose the binding.
  */
-export const DETECTOR_BUNDLE_TTL_SECONDS = 60;
+export const DETECTOR_BUNDLE_TTL_SECONDS = DEFAULT_MAX_TIMESTAMP_AGE / 1000;
 
 /**
  * Redis-backed write queue and read cache for reducing MongoDB load.
@@ -289,12 +298,13 @@ export class RedisWriteQueue {
 		}
 	}
 
-	// ── Detector bundle assignment (short-TTL ephemeral mapping) ─────────
+	// ── Detector bundle assignment (ephemeral mapping) ───────────────────
 
 	/**
-	 * Bind a detector session id to the precomputed bundle assigned to it. Short
-	 * TTL by design (see {@link DETECTOR_BUNDLE_TTL_SECONDS}). Returns false if
-	 * Redis is unavailable so the caller can fail closed.
+	 * Bind a detector session id to the precomputed bundle assigned to it. Lives
+	 * as long as a detector payload is still accepted (see
+	 * {@link DETECTOR_BUNDLE_TTL_SECONDS}). Returns false if Redis is unavailable
+	 * so the caller can fail closed.
 	 */
 	async cacheDetectorBundle(
 		detectorSessionId: string,

--- a/packages/database/src/tests/unit/detectorBundleTtl.unit.test.ts
+++ b/packages/database/src/tests/unit/detectorBundleTtl.unit.test.ts
@@ -1,0 +1,32 @@
+// Copyright 2021-2026 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { DEFAULT_MAX_TIMESTAMP_AGE } from "@prosopo/types";
+import { describe, expect, it } from "vitest";
+import { DETECTOR_BUNDLE_TTL_SECONDS } from "../../redisCache.js";
+
+describe("DETECTOR_BUNDLE_TTL_SECONDS", () => {
+	// The binding holds the only key that can read a detector payload. If it
+	// expires first, the frictionless flow still accepts the payload and then
+	// fails to decrypt it, costing the caller a challenge for nothing. Held as
+	// two independent numbers these drifted to 60s against a 10 minute window.
+	it("covers the whole window in which a payload is still accepted", () => {
+		expect(DETECTOR_BUNDLE_TTL_SECONDS * 1000).toBe(DEFAULT_MAX_TIMESTAMP_AGE);
+	});
+
+	it("is a whole number of seconds, as Redis EX requires", () => {
+		expect(Number.isInteger(DETECTOR_BUNDLE_TTL_SECONDS)).toBe(true);
+		expect(DETECTOR_BUNDLE_TTL_SECONDS).toBeGreaterThan(0);
+	});
+});

--- a/packages/provider/src/tasks/frictionless/frictionlessTasks.ts
+++ b/packages/provider/src/tasks/frictionless/frictionlessTasks.ts
@@ -19,6 +19,7 @@ import {
 	ApiParams,
 	CaptchaType,
 	type CompositeIpAddress,
+	DEFAULT_MAX_TIMESTAMP_AGE,
 	FrictionlessReason,
 	type GetFrictionlessCaptchaResponse,
 	type IPInfoResponse,
@@ -52,8 +53,6 @@ import { getBotScore } from "../detection/getBotScore.js";
 import { samplePuzzleDifficulty } from "../puzzle/puzzleDifficulty.js";
 import { ipMatchesSession } from "./ipMatch.js";
 import { type RoutingContext, applyRouter } from "./routingMachine.js";
-
-const DEFAULT_MAX_TIMESTAMP_AGE = 60 * 10 * 1000; // 10 minutes
 
 const getSessionIDPrefix = (host?: string): string => {
 	return host ? host.replace(".prosopo.io", "") : "local";

--- a/packages/types/src/config/timeouts.ts
+++ b/packages/types/src/config/timeouts.ts
@@ -42,3 +42,10 @@ export const DEFAULT_PUZZLE_CAPTCHA_CACHED_TIMEOUT =
 // The time in milliseconds since the last correct captcha recorded in the contract (15 minutes), after which point, the
 // user will be required to complete another captcha
 export const DEFAULT_MAX_VERIFIED_TIME_CONTRACT = ONE_MINUTE * 15;
+// How old a detector payload may be before the frictionless flow penalises it
+// as stale (10 minutes). This is the window in which a payload is still worth
+// reading, so it is also the window in which the provider must keep the key
+// that reads it — see `DETECTOR_BUNDLE_TTL_SECONDS`, which is derived from this
+// rather than set independently. A binding shorter than this makes the provider
+// accept payloads it has already thrown away the means to decrypt.
+export const DEFAULT_MAX_TIMESTAMP_AGE = ONE_MINUTE * 10;


### PR DESCRIPTION
## What's wrong

When the widget starts up it calls `/detector/assign`. The provider picks a bundle, writes a `detectorSessionId → bundleId` note in Redis, and hands back the detector script. That note is the **only** thing that can tell the provider which key decrypts the payload the script produces.

The note was thrown away after **60 seconds**. But the frictionless flow will happily accept a detector payload for **ten minutes** (`DEFAULT_MAX_TIMESTAMP_AGE`).

So for nine of those ten minutes the provider accepted a payload it had already destroyed the means to read. When that happens `resolveDecryptAttempts` returns an empty list of keys, the decrypt loop never runs once, the score is forced to 1, and the visitor gets a challenge — even though we measured nothing at all about them and have no reason to think they're a bot.

Sixty seconds is plenty for the normal case: the gap between assign and submit is about 1.5s. But it only has to stall once to be lost, and a phone tab being backgrounded is enough to do it.

## What changed

The two numbers become one number.

`DEFAULT_MAX_TIMESTAMP_AGE` was a private constant inside `frictionlessTasks`. It moves to `@prosopo/types` — the only package both the provider and the database can import — and `DETECTOR_BUNDLE_TTL_SECONDS` is now derived from it rather than written down a second time:

```ts
export const DETECTOR_BUNDLE_TTL_SECONDS = DEFAULT_MAX_TIMESTAMP_AGE / 1000;
```

Now the key survives exactly as long as the payload it unlocks is worth reading, and there's no second value to fall out of step.

## Is this safe?

- **It can't widen anything.** The TTL is now pinned *to* the payload-age check, so it cannot outlive it. Nothing becomes usable for longer than it already was.
- **Bundle selection is untouched.** Which bundle a caller gets is derived from their IP plus a server secret, not from how long this binding lives, so pool enumeration is unaffected by the change.
- **Memory is a rounding error.** A busy node assigns ~10/s and holds a few hundred of these keys. At the new TTL that's ~6k keys, a few hundred KB, on an instance with no `maxmemory` set that currently holds 627k keys in 164MB and has evicted nothing.

## Test coverage

New `detectorBundleTtl.unit.test.ts` pins the invariant — the TTL must cover the whole window in which a payload is accepted, and must be a whole number of seconds since Redis `EX` requires one. That test is the guard against these two drifting apart again.

`build:tsc` clean on all three packages. Database unit tests 42 pass; frictionless provider tests 172 pass.